### PR TITLE
BAD_IDEA: Reduce setup friction for known OAuth device providers

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -351,6 +351,9 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain(
         "route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts')",
       )
+      expect(routeConfig).toContain(
+        "route(routePattern('workspaceSourceOAuthImport'), 'routes/source-oauth-import.ts')",
+      )
       // Onboarding is a hidden, manually visited flow outside the normal app chrome.
       expect(routeConfig).toContain("route('onboarding', 'routes/onboarding.tsx')")
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
@@ -379,7 +382,7 @@ describe('Architectural Tests', () => {
       // outside the app shell, while canonical workspace routes and settings
       // stay inside it.
       expect(routeConfig).toMatch(
-        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
+        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\(routePattern\('workspaceSourceOAuthImport'\), 'routes\/source-oauth-import\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/components/sources/install/oauth-progress.tsx
+++ b/apps/reef/app/components/sources/install/oauth-progress.tsx
@@ -1,17 +1,23 @@
+import classNames from 'classnames'
+
 import { Icon } from '@/wax/components/icon'
 import { Typography } from '@/wax/components/typography'
+
+import type { OAuthInstallProgress } from '@/lib/source-oauth-install-flow'
 
 import * as styles from './oauth-progress.css'
 import * as statusStyles from './oauth-status.css'
 
 export function OAuthProgress({
   authorizationUrl,
+  className,
   inputLabel,
   userCode,
   verificationUri,
   verificationUriComplete,
 }: {
   authorizationUrl: string
+  className?: string
   inputLabel: string
   userCode: string
   verificationUri: string
@@ -21,7 +27,7 @@ export function OAuthProgress({
   const displayUri = verificationUri || authorizationUrl
 
   return (
-    <div className={statusStyles.box}>
+    <div className={classNames(statusStyles.box, className)}>
       <Icon name="Loader" size="16" color="secondary" />
       <div>
         <Typography.BodySmall variant="primary">
@@ -50,6 +56,70 @@ export function OAuthProgress({
           </Typography.BodySmall>
         )}
       </div>
+    </div>
+  )
+}
+
+export function OAuthInstallStatus({
+  className,
+  inputLabel,
+  progress,
+}: {
+  className?: string
+  inputLabel: (inputKey: string) => string
+  progress: OAuthInstallProgress
+}) {
+  if (progress.kind === 'awaiting-oauth') {
+    return (
+      <OAuthProgress
+        authorizationUrl={progress.authorizationUrl}
+        className={className}
+        inputLabel={inputLabel(progress.inputKey)}
+        userCode={progress.userCode}
+        verificationUri={progress.verificationUri}
+        verificationUriComplete={progress.verificationUriComplete}
+      />
+    )
+  }
+  if (progress.kind === 'oauth-completed') {
+    return (
+      <OAuthStatus className={className} icon="CircleCheck" iconColor="success">
+        {inputLabel(progress.inputKey)} authorized. Finishing install…
+      </OAuthStatus>
+    )
+  }
+  if (progress.kind === 'oauth-callback-received') {
+    return (
+      <OAuthStatus className={className} icon="Loader" iconColor="secondary">
+        {inputLabel(progress.inputKey)} authorization received. Exchanging token…
+      </OAuthStatus>
+    )
+  }
+  if (progress.kind === 'success') {
+    return (
+      <OAuthStatus className={className} icon="CircleCheck" iconColor="success">
+        {inputLabel(progress.name)} configured.
+      </OAuthStatus>
+    )
+  }
+  return null
+}
+
+function OAuthStatus({
+  className,
+  children,
+  icon,
+  iconColor,
+}: {
+  className?: string
+  children: React.ReactNode
+  icon: 'CircleCheck' | 'Loader'
+  iconColor: 'secondary' | 'success'
+}) {
+  return (
+    <div className={classNames(statusStyles.box, className)}>
+      <Icon name={icon} size="16" color={iconColor} />
+      <Typography.BodySmall variant="primary">{children}</Typography.BodySmall>
     </div>
   )
 }

--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -34,6 +34,7 @@ const meta = {
   args: {
     actionData: undefined,
     discoveryPath: DISCOVERY_PATH,
+    oauthImportPath: '/workspaces/default/sources/oauth-import',
     onOpenChange: fn(),
     open: true,
   },

--- a/apps/reef/app/lib/source-oauth-install-flow.ts
+++ b/apps/reef/app/lib/source-oauth-install-flow.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { readOAuthInstallStream } from './source-oauth-install-stream'
+
+export type OAuthInstallProgress =
+  | { kind: 'idle' }
+  | { kind: 'busy' }
+  | {
+      kind: 'awaiting-oauth'
+      authorizationUrl: string
+      inputKey: string
+      userCode: string
+      verificationUri: string
+      verificationUriComplete: string
+    }
+  | { kind: 'oauth-callback-received'; inputKey: string }
+  | { kind: 'oauth-completed'; inputKey: string }
+  | { kind: 'success'; name: string }
+
+export function useOAuthInstallFlow({
+  fetchOAuthInstall,
+  onComplete,
+  openAuthorization,
+}: {
+  fetchOAuthInstall: typeof fetch
+  onComplete: (name: string) => Promise<void> | void
+  openAuthorization: (url: string) => unknown
+}) {
+  const abortRef = useRef<AbortController | null>(null)
+  const [progress, setProgress] = useState<OAuthInstallProgress>({ kind: 'idle' })
+  const [error, setError] = useState<string | null>(null)
+  const busy = progress.kind !== 'idle'
+
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  function cancel() {
+    abortRef.current?.abort()
+    abortRef.current = null
+    setProgress({ kind: 'idle' })
+  }
+
+  async function start(endpoint: string, formData: FormData) {
+    if (abortRef.current) return
+    setError(null)
+    setProgress({ kind: 'busy' })
+
+    const abortController = new AbortController()
+    abortRef.current = abortController
+    try {
+      const response = await fetchOAuthInstall(endpoint, {
+        body: formData,
+        method: 'POST',
+        signal: abortController.signal,
+      })
+      const source = await readOAuthInstallStream(response, {
+        onAuthorization: (event) => {
+          setProgress({
+            kind: 'awaiting-oauth',
+            authorizationUrl: event.authorizationUrl,
+            inputKey: event.inputKey,
+            userCode: event.userCode,
+            verificationUri: event.verificationUri,
+            verificationUriComplete: event.verificationUriComplete,
+          })
+          openAuthorization(event.authorizationUrl)
+        },
+        onCallbackReceived: (event) => {
+          setProgress({ kind: 'oauth-callback-received', inputKey: event.inputKey })
+        },
+        onCompleted: (event) => {
+          setProgress({ kind: 'oauth-completed', inputKey: event.inputKey })
+        },
+        onSource: (event) => {
+          setProgress({ kind: 'success', name: event.name })
+        },
+      })
+
+      if (!abortController.signal.aborted) {
+        setProgress({ kind: 'success', name: source.name })
+        await onComplete(source.name)
+      }
+    } catch (cause) {
+      if (abortController.signal.aborted) return
+      setError(cause instanceof Error ? cause.message : String(cause))
+      setProgress({ kind: 'idle' })
+    } finally {
+      if (abortRef.current === abortController) abortRef.current = null
+    }
+  }
+
+  return { busy, cancel, error, progress, start }
+}
+
+export function oauthActionLabel(
+  progress: OAuthInstallProgress,
+  labels: { busy: string; idle: string },
+): string {
+  if (progress.kind === 'busy') return labels.busy
+  if (progress.kind === 'awaiting-oauth') return 'Awaiting OAuth…'
+  if (progress.kind === 'oauth-callback-received') return 'Exchanging token…'
+  if (progress.kind === 'oauth-completed') return 'Finishing…'
+  if (progress.kind === 'success') return 'Configured'
+  return labels.idle
+}

--- a/apps/reef/app/lib/source-oauth-response.server.ts
+++ b/apps/reef/app/lib/source-oauth-response.server.ts
@@ -1,0 +1,102 @@
+import type {
+  CreateBundledSourceWithOAuthResponse,
+  ImportSourceResponse,
+} from '@/generated/coral/v1/sources_pb'
+
+import {
+  oauthInstallEventToNdjson,
+  type OAuthInstallStreamEvent,
+} from './source-oauth-install-stream'
+
+const NDJSON_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Content-Type': 'application/x-ndjson; charset=utf-8',
+} as const
+
+type OAuthSourceResponse = CreateBundledSourceWithOAuthResponse | ImportSourceResponse
+
+export function oauthSourceStreamResponse(
+  responses: AsyncIterable<OAuthSourceResponse>,
+  signal?: AbortSignal,
+): Response {
+  const encoder = new TextEncoder()
+  let closed = false
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (event: OAuthInstallStreamEvent) => {
+        if (closed || signal?.aborted) return
+        controller.enqueue(encoder.encode(oauthInstallEventToNdjson(event)))
+      }
+
+      try {
+        await relayOAuthSourceStreamEvents(responses, send, signal)
+      } catch (error) {
+        if (!signal?.aborted) {
+          send({ type: 'error', message: error instanceof Error ? error.message : String(error) })
+        }
+      } finally {
+        if (!closed) {
+          closed = true
+          if (!signal?.aborted) controller.close()
+        }
+      }
+    },
+    cancel() {
+      closed = true
+    },
+  })
+
+  return new Response(stream, { headers: NDJSON_HEADERS })
+}
+
+export async function relayOAuthSourceStreamEvents(
+  responses: AsyncIterable<OAuthSourceResponse>,
+  send: (event: OAuthInstallStreamEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  for await (const response of responses) {
+    if (signal?.aborted) return
+    const event = response.event
+    switch (event.case) {
+      case 'oauthAuthorization':
+        send({
+          type: 'oauthAuthorization',
+          authorizationUrl: event.value.authorizationUrl,
+          expiresInSeconds: event.value.expiresInSeconds.toString(),
+          inputKey: event.value.inputKey,
+          userCode: event.value.userCode,
+          verificationUri: event.value.verificationUri,
+          verificationUriComplete: event.value.verificationUriComplete,
+        })
+        break
+      case 'oauthCallbackReceived':
+        send({ type: 'oauthCallbackReceived', inputKey: event.value.inputKey })
+        break
+      case 'oauthCompleted':
+        send({
+          type: 'oauthCompleted',
+          inputKey: event.value.inputKey,
+          metadata: event.value.metadata.map((item) => ({ key: item.key, value: item.value })),
+        })
+        break
+      case 'source':
+        send({ type: 'source', name: event.value.name, version: event.value.version })
+        return
+      case undefined:
+        throw new Error('OAuth install stream included an empty event')
+      default: {
+        const exhaustive: never = event
+        return exhaustive
+      }
+    }
+  }
+  throw new Error('OAuth install stream ended without a source event')
+}
+
+export function oauthStreamErrorResponse(message: string, status: number): Response {
+  return new Response(oauthInstallEventToNdjson({ type: 'error', message }), {
+    headers: NDJSON_HEADERS,
+    status,
+  })
+}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -7,6 +7,7 @@ export default [
   // same-origin fetch. It intentionally sits outside the app shell and does not
   // render a page.
   route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
+  route(routePattern('workspaceSourceOAuthImport'), 'routes/source-oauth-import.ts'),
   route('onboarding', 'routes/onboarding.tsx'),
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),

--- a/apps/reef/app/routes/source-install.tsx
+++ b/apps/reef/app/routes/source-install.tsx
@@ -1,5 +1,5 @@
 import type { Route } from './+types/source-install'
-import { redirect, useNavigate } from 'react-router'
+import { redirect, useNavigate, useRevalidator } from 'react-router'
 
 import type { SourcesActionData } from './sources-action'
 import { runSourcesAction } from './sources-action'
@@ -29,12 +29,24 @@ export async function clientAction({
 
 export default function SourceInstallRoute({ actionData, params }: Route.ComponentProps) {
   const navigate = useNavigate()
+  const revalidator = useRevalidator()
   const sourcesPath = routePath('workspaceSources', { workspaceId: params.workspaceId })
 
   return (
     <SourceCreateDialog
       actionData={actionData}
       discoveryPath={routePath('workspaceSourceDiscovery', { workspaceId: params.workspaceId })}
+      oauthImportPath={routePath('workspaceSourceOAuthImport', {
+        workspaceId: params.workspaceId,
+      })}
+      onOAuthImportComplete={async (name) => {
+        addToast('success', {
+          title: `Created ${name}`,
+          description: 'The source was validated and installed.',
+        })
+        await revalidator.revalidate()
+        await navigate(sourcesPath)
+      }}
       open
       onOpenChange={(open) => {
         if (!open) navigate(sourcesPath)

--- a/apps/reef/app/routes/source-oauth-import.server.test.ts
+++ b/apps/reef/app/routes/source-oauth-import.server.test.ts
@@ -1,0 +1,54 @@
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { importSource } = vi.hoisted(() => ({ importSource: vi.fn() }))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  sourceClientForRequest: () => ({ importSource }),
+}))
+
+import { ImportSourceResponseSchema, SourceSchema } from '@/generated/coral/v1/sources_pb'
+
+import { action } from './source-oauth-import'
+
+describe('action', () => {
+  beforeEach(() => importSource.mockReset())
+
+  it('imports the authored manifest with its selected OAuth credential method', async () => {
+    importSource.mockImplementation(async function* () {
+      yield create(ImportSourceResponseSchema, {
+        event: {
+          case: 'source',
+          value: create(SourceSchema, { name: 'github_custom' }),
+        },
+      })
+    })
+    const request = new Request('http://localhost/workspaces/analytics/sources/oauth-import', {
+      body: new URLSearchParams({
+        manifest_yaml: 'name: github_custom\ndsl_version: 4\n',
+        name: 'github_custom',
+        oauth_input_key: 'API_TOKEN',
+        oauth_method_index: '0',
+      }),
+      method: 'POST',
+    })
+
+    const response = await action({
+      params: { workspaceId: 'analytics' },
+      request,
+    } as Parameters<typeof action>[0])
+    expect(response.headers.get('content-type')).toContain('application/x-ndjson')
+    await response.text()
+
+    expect(importSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifestYaml: 'name: github_custom\ndsl_version: 4\n',
+        oauthCredentialRetrievals: [
+          expect.objectContaining({ inputKey: 'API_TOKEN', methodIndex: 0 }),
+        ],
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+      expect.objectContaining({ signal: request.signal }),
+    )
+  })
+})

--- a/apps/reef/app/routes/source-oauth-import.ts
+++ b/apps/reef/app/routes/source-oauth-import.ts
@@ -1,0 +1,50 @@
+import { create } from '@bufbuild/protobuf'
+
+import type { Route } from './+types/source-oauth-import'
+
+import {
+  ImportSourceRequestSchema,
+  OAuthCredentialRetrievalSchema,
+} from '@/generated/coral/v1/sources_pb'
+import { sourceClientForRequest } from '@/lib/coral-request.server'
+import {
+  oauthSourceStreamResponse,
+  oauthStreamErrorResponse,
+} from '@/lib/source-oauth-response.server'
+import { formValue } from '@/lib/source-install-form'
+import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+
+export async function action({ params, request }: Route.ActionArgs): Promise<Response> {
+  const formData = await request.formData()
+  const manifestYaml = formData.get('manifest_yaml')
+  const inputKey = formValue(formData, 'oauth_input_key')
+  const methodIndex = Number(formValue(formData, 'oauth_method_index'))
+
+  if (typeof manifestYaml !== 'string' || !manifestYaml.trim()) {
+    return oauthStreamErrorResponse('Missing source manifest', 400)
+  }
+  if (!inputKey) return oauthStreamErrorResponse('Missing OAuth source input key', 400)
+  if (!Number.isInteger(methodIndex) || methodIndex < 0) {
+    return oauthStreamErrorResponse('Invalid OAuth credential method index', 400)
+  }
+
+  try {
+    const stream = sourceClientForRequest(request).importSource(
+      create(ImportSourceRequestSchema, {
+        manifestYaml,
+        oauthCredentialRetrievals: [
+          create(OAuthCredentialRetrievalSchema, {
+            inputKey,
+            methodIndex,
+          }),
+        ],
+        workspace: workspaceFromParams(params),
+      }),
+      { signal: request.signal },
+    )
+    return oauthSourceStreamResponse(stream, request.signal)
+  } catch (error) {
+    return oauthStreamErrorResponse(errorMessage(error), 500)
+  }
+}

--- a/apps/reef/app/routes/source-oauth-install.server.test.ts
+++ b/apps/reef/app/routes/source-oauth-install.server.test.ts
@@ -24,8 +24,9 @@ import {
   type CreateBundledSourceWithOAuthResponse,
 } from '@/generated/coral/v1/sources_pb'
 import type { OAuthInstallStreamEvent } from '@/lib/source-oauth-install-stream'
+import { relayOAuthSourceStreamEvents } from '@/lib/source-oauth-response.server'
 
-import { action, relayOAuthInstallStreamEvents } from './source-oauth-install'
+import { action } from './source-oauth-install'
 
 async function* responses(
   events: CreateBundledSourceWithOAuthResponse[],
@@ -109,7 +110,7 @@ describe('relayOAuthInstallStreamEvents', () => {
   it('relays callback receipt before the terminal source event', async () => {
     const send = vi.fn<(event: OAuthInstallStreamEvent) => void>()
 
-    await relayOAuthInstallStreamEvents(
+    await relayOAuthSourceStreamEvents(
       responses([
         create(CreateBundledSourceWithOAuthResponseSchema, {
           event: {

--- a/apps/reef/app/routes/source-oauth-install.ts
+++ b/apps/reef/app/routes/source-oauth-install.ts
@@ -5,7 +5,6 @@ import type { Route } from './+types/source-oauth-install'
 import {
   CreateBundledSourceWithOAuthRequestSchema,
   GetSourceInfoRequestSchema,
-  type CreateBundledSourceWithOAuthResponse,
   type SourceInfo,
 } from '@/generated/coral/v1/sources_pb'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
@@ -20,16 +19,11 @@ import {
 } from '@/lib/source-install-form'
 import { originLabel } from '@/lib/sources'
 import {
-  oauthInstallEventToNdjson,
-  type OAuthInstallStreamEvent,
-} from '@/lib/source-oauth-install-stream'
+  oauthSourceStreamResponse,
+  oauthStreamErrorResponse,
+} from '@/lib/source-oauth-response.server'
 import { errorMessage } from '@/lib/utils'
 import { workspaceFromParams } from '@/lib/workspace-routing'
-
-const NDJSON_HEADERS = {
-  'Cache-Control': 'no-store',
-  'Content-Type': 'application/x-ndjson; charset=utf-8',
-} as const
 
 // Resource route: normal source CRUD stays in React Router loaders/actions, but
 // interactive OAuth/device-code installs need browser-visible server-streaming
@@ -40,10 +34,10 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
   let name: string
   try {
     const resolvedName = resolveSourceName(params.sourceName, formData)
-    if (!resolvedName) return ndjsonErrorResponse('Missing source name', 400)
+    if (!resolvedName) return oauthStreamErrorResponse('Missing source name', 400)
     name = resolvedName
   } catch (error) {
-    return ndjsonErrorResponse(errorMessage(error), 400)
+    return oauthStreamErrorResponse(errorMessage(error), 400)
   }
 
   const sourceClient = sourceClientForRequest(request)
@@ -51,22 +45,22 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
     const workspace = workspaceFromParams(params)
     const info = await getSourceInfo(sourceClient, name, workspace)
     if (info.installed && originLabel(info.origin) !== 'bundled') {
-      return ndjsonErrorResponse("Imported sources can't be installed here yet", 400)
+      return oauthStreamErrorResponse("Imported sources can't be installed here yet", 400)
     }
 
     if (!firstOAuthMethodInput(info, formData)) {
-      return ndjsonErrorResponse(
+      return oauthStreamErrorResponse(
         'Selected credential method is not OAuth; use the normal install action.',
         400,
       )
     }
 
     const missing = firstMissingRequiredInput(info, formData)
-    if (missing) return ndjsonErrorResponse(`${missing} is required`, 400)
+    if (missing) return oauthStreamErrorResponse(`${missing} is required`, 400)
 
     const oauthCredentialRetrievals = oauthCredentialRetrievalsFromForm(info, formData)
     if (oauthCredentialRetrievals.length === 0) {
-      return ndjsonErrorResponse(
+      return oauthStreamErrorResponse(
         'No OAuth credential retrieval was selected; use the normal install action.',
         400,
       )
@@ -83,87 +77,10 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
       }),
       { signal: request.signal },
     )
-    return oauthInstallStreamResponse(stream, request.signal)
+    return oauthSourceStreamResponse(stream, request.signal)
   } catch (error) {
-    return ndjsonErrorResponse(errorMessage(error), 500)
+    return oauthStreamErrorResponse(errorMessage(error), 500)
   }
-}
-
-export function oauthInstallStreamResponse(
-  responses: AsyncIterable<CreateBundledSourceWithOAuthResponse>,
-  signal?: AbortSignal,
-): Response {
-  const encoder = new TextEncoder()
-  let closed = false
-
-  const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      const send = (event: OAuthInstallStreamEvent) => {
-        if (closed || signal?.aborted) return
-        controller.enqueue(encoder.encode(oauthInstallEventToNdjson(event)))
-      }
-
-      try {
-        await relayOAuthInstallStreamEvents(responses, send, signal)
-      } catch (error) {
-        if (!signal?.aborted) send({ type: 'error', message: errorMessage(error) })
-      } finally {
-        if (!closed) {
-          closed = true
-          if (!signal?.aborted) controller.close()
-        }
-      }
-    },
-    cancel() {
-      closed = true
-    },
-  })
-
-  return new Response(stream, { headers: NDJSON_HEADERS })
-}
-
-export async function relayOAuthInstallStreamEvents(
-  responses: AsyncIterable<CreateBundledSourceWithOAuthResponse>,
-  send: (event: OAuthInstallStreamEvent) => void,
-  signal?: AbortSignal,
-): Promise<void> {
-  for await (const response of responses) {
-    if (signal?.aborted) return
-    const event = response.event
-    switch (event.case) {
-      case 'oauthAuthorization':
-        send({
-          type: 'oauthAuthorization',
-          authorizationUrl: event.value.authorizationUrl,
-          expiresInSeconds: event.value.expiresInSeconds.toString(),
-          inputKey: event.value.inputKey,
-          userCode: event.value.userCode,
-          verificationUri: event.value.verificationUri,
-          verificationUriComplete: event.value.verificationUriComplete,
-        })
-        break
-      case 'oauthCallbackReceived':
-        send({ type: 'oauthCallbackReceived', inputKey: event.value.inputKey })
-        break
-      case 'oauthCompleted':
-        send({
-          type: 'oauthCompleted',
-          inputKey: event.value.inputKey,
-          metadata: event.value.metadata.map((item) => ({ key: item.key, value: item.value })),
-        })
-        break
-      case 'source':
-        send({ type: 'source', name: event.value.name, version: event.value.version })
-        return
-      case undefined:
-        throw new Error('OAuth install stream included an empty event')
-      default: {
-        const exhaustive: never = event
-        return exhaustive
-      }
-    }
-  }
-  throw new Error('OAuth install stream ended without a source event')
 }
 
 function resolveSourceName(paramName: string | undefined, formData: FormData): string | null {
@@ -185,11 +102,4 @@ async function getSourceInfo(
   )
   if (!response.sourceInfo) throw new Error(`Source info for ${name} was not found`)
   return response.sourceInfo
-}
-
-function ndjsonErrorResponse(message: string, status: number): Response {
-  return new Response(oauthInstallEventToNdjson({ type: 'error', message }), {
-    headers: NDJSON_HEADERS,
-    status,
-  })
 }

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -14,6 +14,7 @@ const CANONICAL_PATTERNS = {
   workspaceSource: '/workspaces/:workspaceId/sources/:sourceName',
   workspaceSourceDiscovery: '/workspaces/:workspaceId/sources/discover',
   workspaceSourceInstall: '/workspaces/:workspaceId/sources/install',
+  workspaceSourceOAuthImport: '/workspaces/:workspaceId/sources/oauth-import',
   workspaceSources: '/workspaces/:workspaceId/sources',
   workspaceTrace: '/workspaces/:workspaceId/traces/:traceId',
   workspaceTraces: '/workspaces/:workspaceId/traces',
@@ -57,6 +58,9 @@ describe('route map', () => {
         workspaceId: 'analytics',
       }),
       workspaceSourceInstall: routePath('workspaceSourceInstall', { workspaceId: 'analytics' }),
+      workspaceSourceOAuthImport: routePath('workspaceSourceOAuthImport', {
+        workspaceId: 'analytics',
+      }),
       workspaceSources: routePath('workspaceSources', { workspaceId: 'analytics' }),
       workspaceTrace: routePath('workspaceTrace', {
         traceId: 'trace_123',
@@ -75,6 +79,7 @@ describe('route map', () => {
       workspaceSource: '/workspaces/analytics/sources/github',
       workspaceSourceDiscovery: '/workspaces/analytics/sources/discover',
       workspaceSourceInstall: '/workspaces/analytics/sources/install',
+      workspaceSourceOAuthImport: '/workspaces/analytics/sources/oauth-import',
       workspaceSources: '/workspaces/analytics/sources',
       workspaceTrace: '/workspaces/analytics/traces/trace_123',
       workspaceTraces: '/workspaces/analytics/traces',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -9,6 +9,7 @@ const WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH =
   '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName'
 const WORKSPACE_SOURCE_DISCOVERY_PATH = '/workspaces/:workspaceId/sources/discover'
 const WORKSPACE_SOURCE_INSTALL_PATH = '/workspaces/:workspaceId/sources/install'
+const WORKSPACE_SOURCE_OAUTH_IMPORT_PATH = '/workspaces/:workspaceId/sources/oauth-import'
 const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
 const WORKSPACE_SOURCE_PATH = '/workspaces/:workspaceId/sources/:sourceName'
 const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
@@ -72,6 +73,13 @@ export const routeDefinitions = {
     path: WORKSPACE_SOURCE_INSTALL_PATH,
     toPath: (params: { workspaceId: string }) =>
       generatePath(WORKSPACE_SOURCE_INSTALL_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSourceOAuthImport: {
+    path: WORKSPACE_SOURCE_OAUTH_IMPORT_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_SOURCE_OAUTH_IMPORT_PATH, {
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/reef/app/views/sources/source-create.css.ts
+++ b/apps/reef/app/views/sources/source-create.css.ts
@@ -42,3 +42,7 @@ export const authPanelHidden = style({
 export const importError = style({
   marginBlockStart: 14,
 })
+
+export const oauthProgress = style({
+  marginBlockStart: 14,
+})

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -19,14 +19,26 @@ const DISCOVERY: SuccessfulDiscovery = {
   url: 'https://weather.example/openapi.yaml',
 }
 
-function RoutedSourceCreateDialog() {
+function RoutedSourceCreateDialog({
+  fetchOAuthImport,
+  onOAuthImportComplete,
+  openAuthorization,
+}: {
+  fetchOAuthImport?: typeof fetch
+  onOAuthImportComplete?: (name: string) => Promise<void> | void
+  openAuthorization?: (url: string) => unknown
+}) {
   const navigate = useNavigate()
   const actionData = useActionData<SourcesActionData>()
   return (
     <SourceCreateDialog
       actionData={actionData}
       discoveryPath="/workspaces/analytics/sources/discover"
+      fetchOAuthImport={fetchOAuthImport}
+      oauthImportPath="/workspaces/analytics/sources/oauth-import"
+      onOAuthImportComplete={onOAuthImportComplete}
       open
+      openAuthorization={openAuthorization}
       onOpenChange={(open) => {
         if (!open) navigate('/workspaces/analytics/sources')
       }}
@@ -37,12 +49,17 @@ function RoutedSourceCreateDialog() {
 async function renderSourceCreate(
   discovery: SuccessfulDiscovery = DISCOVERY,
   action?: () => Promise<SourcesActionData>,
+  options: {
+    fetchOAuthImport?: typeof fetch
+    onOAuthImportComplete?: (name: string) => Promise<void> | void
+    openAuthorization?: (url: string) => unknown
+  } = {},
 ) {
   const router = createMemoryRouter(
     [
       {
         action,
-        element: <RoutedSourceCreateDialog />,
+        element: <RoutedSourceCreateDialog {...options} />,
         path: '/workspaces/:workspaceId/sources/install',
       },
       {
@@ -268,6 +285,104 @@ describe('SourceCreateDialog', () => {
     expect(manifest).toContain('\ninputs:\n  API_TOKEN:\n    kind: secret\n')
     expect(manifest).toContain('\nsurface:\n  type: openapi\n')
     expect(manifest).not.toContain('\nsurfaces:\n')
+  })
+
+  it('creates a device-flow manifest and streams OAuth progress', async () => {
+    const openAuthorization = vi.fn()
+    let submittedForm: FormData | undefined
+    let releaseSource: (() => void) | undefined
+    const sourceReady = new Promise<void>((resolve) => {
+      releaseSource = resolve
+    })
+    const fetchOAuthImport = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      submittedForm = init?.body as FormData
+      const encoder = new TextEncoder()
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                JSON.stringify({
+                  type: 'oauthAuthorization',
+                  authorizationUrl: 'https://github.com/login/device',
+                  expiresInSeconds: '900',
+                  inputKey: 'API_TOKEN',
+                  userCode: 'ABCD-1234',
+                  verificationUri: 'https://github.com/login/device',
+                  verificationUriComplete: '',
+                }) + '\n',
+              ),
+            )
+            await sourceReady
+            controller.enqueue(
+              encoder.encode(
+                JSON.stringify({ type: 'source', name: 'github_custom', version: '' }) + '\n',
+              ),
+            )
+            controller.close()
+          },
+        }),
+      )
+    })
+    const onOAuthImportComplete = vi.fn()
+    const githubUrl =
+      'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml'
+    const { screen } = await renderSourceCreate(
+      {
+        auth: { kind: 'unknown', label: '' },
+        description: '',
+        format: 'unknown',
+        name: 'github_custom',
+        status: 'success',
+        url: githubUrl,
+        warning: 'The source document is larger than 2 MB',
+      },
+      undefined,
+      { fetchOAuthImport, onOAuthImportComplete, openAuthorization },
+    )
+
+    await screen.getByLabelText('Source URL').fill(githubUrl)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await screen.getByRole('radio', { name: 'OAuth device flow' }).click()
+
+    await screen
+      .getByLabelText('Device authorization URL')
+      .fill('https://github.com/login/device/code')
+    await screen.getByLabelText('Token URL').fill('https://github.com/login/oauth/access_token')
+    await screen.getByLabelText('Client ID').fill('Iv23liJHis6Bs8NO1DAI')
+    await screen.getByLabelText('Scopes').fill('repo read:org read:user user:email')
+    await screen.getByRole('button', { name: 'Create source' }).click()
+
+    await expect.element(screen.getByText('ABCD-1234')).toBeVisible()
+    const hint = screen.getByText('Optional, separated by spaces.').element()
+    const progress = screen
+      .getByText('Waiting for Api token authorization in your browser…')
+      .element().parentElement?.parentElement
+    if (!progress) throw new Error('OAuth progress box not found')
+    expect(progress.getBoundingClientRect().top - hint.getBoundingClientRect().bottom).toBe(14)
+    await expect
+      .element(
+        screen
+          .getByRole('dialog', { name: 'Create source Step 3/3' })
+          .getByRole('button', { name: 'Cancel' }),
+      )
+      .toBeEnabled()
+    expect(openAuthorization).toHaveBeenCalledWith('https://github.com/login/device')
+    expect(fetchOAuthImport).toHaveBeenCalledWith(
+      '/workspaces/analytics/sources/oauth-import',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    const manifest = String(submittedForm?.get('manifest_yaml'))
+    expect(manifest).toContain('type: device_code')
+    expect(manifest).toContain('device_authorization_url: "https://github.com/login/device/code"')
+    expect(manifest).toContain('token_url: "https://github.com/login/oauth/access_token"')
+    expect(manifest).toContain('default: "Iv23liJHis6Bs8NO1DAI"')
+    expect(submittedForm?.get('secret_value')).toBeNull()
+
+    releaseSource?.()
+    await expect.poll(() => onOAuthImportComplete.mock.calls.length).toBe(1)
+    expect(onOAuthImportComplete).toHaveBeenCalledWith('github_custom')
   })
 
   it('keeps the credentials dialog height stable across authentication choices', async () => {

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -287,7 +287,7 @@ describe('SourceCreateDialog', () => {
     expect(manifest).not.toContain('\nsurfaces:\n')
   })
 
-  it('creates a device-flow manifest and streams OAuth progress', async () => {
+  it('creates a GitHub device-flow manifest and streams OAuth progress', async () => {
     const openAuthorization = vi.fn()
     let submittedForm: FormData | undefined
     let releaseSource: (() => void) | undefined
@@ -346,12 +346,12 @@ describe('SourceCreateDialog', () => {
     await screen.getByRole('button', { name: 'Next' }).click()
     await screen.getByRole('radio', { name: 'OAuth device flow' }).click()
 
-    await screen
-      .getByLabelText('Device authorization URL')
-      .fill('https://github.com/login/device/code')
-    await screen.getByLabelText('Token URL').fill('https://github.com/login/oauth/access_token')
-    await screen.getByLabelText('Client ID').fill('Iv23liJHis6Bs8NO1DAI')
-    await screen.getByLabelText('Scopes').fill('repo read:org read:user user:email')
+    await expect
+      .element(screen.getByLabelText('Device authorization URL'))
+      .toHaveValue('https://github.com/login/device/code')
+    await expect
+      .element(screen.getByLabelText('Token URL'))
+      .toHaveValue('https://github.com/login/oauth/access_token')
     await screen.getByRole('button', { name: 'Create source' }).click()
 
     await expect.element(screen.getByText('ABCD-1234')).toBeVisible()
@@ -383,6 +383,40 @@ describe('SourceCreateDialog', () => {
     releaseSource?.()
     await expect.poll(() => onOAuthImportComplete.mock.calls.length).toBe(1)
     expect(onOAuthImportComplete).toHaveBeenCalledWith('github_custom')
+  })
+
+  it('prefills the maintained Sentry device-flow settings but requires its client ID', async () => {
+    const sentryUrl =
+      'https://raw.githubusercontent.com/getsentry/sentry-api-schema/refs/heads/main/openapi-derefed.json'
+    const { screen } = await renderSourceCreate({
+      auth: { kind: 'bearer', label: 'Bearer token' },
+      description: 'Sentry Public API',
+      format: 'unknown',
+      name: 'sentry_custom',
+      status: 'success',
+      url: sentryUrl,
+      warning: 'The source document is larger than 2 MB',
+    })
+
+    await screen.getByLabelText('Source URL').fill(sentryUrl)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await screen.getByRole('radio', { name: 'OAuth device flow' }).click()
+
+    await expect
+      .element(screen.getByLabelText('Device authorization URL'))
+      .toHaveValue('https://sentry.io/oauth/device/code/')
+    await expect
+      .element(screen.getByLabelText('Token URL'))
+      .toHaveValue('https://sentry.io/oauth/token/')
+    await expect
+      .element(screen.getByLabelText('Scopes'))
+      .toHaveValue('org:read event:read member:read project:read project:releases team:read')
+    await expect.element(screen.getByLabelText('Client ID')).toHaveValue('')
+    await expect.element(screen.getByRole('button', { name: 'Create source' })).toBeDisabled()
+
+    await screen.getByLabelText('Client ID').fill('sentry-oauth-app-client-id')
+    await expect.element(screen.getByRole('button', { name: 'Create source' })).toBeEnabled()
   })
 
   it('keeps the credentials dialog height stable across authentication choices', async () => {

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -10,6 +10,8 @@ import { TextArea, TextInput } from '@/wax/components/inputs/text'
 import { Pill } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
+import { OAuthInstallStatus } from '@/components/sources/install/oauth-progress'
+import { oauthActionLabel, useOAuthInstallFlow } from '@/lib/source-oauth-install-flow'
 import type { SourcesActionData } from '@/routes/sources-action'
 import type {
   SourceDetectedAuth,
@@ -18,14 +20,14 @@ import type {
 } from '@/routes/source-discovery'
 
 import * as styles from './source-create.css'
-import { SourceError, SourceField, SourceHeader } from './source-presentation'
+import { formatFieldName, SourceError, SourceField, SourceHeader } from './source-presentation'
 
 const SECRET_KEY = 'API_TOKEN'
 const NAME_PATTERN = /^[a-z][a-z0-9_]*$/
 const RESERVED_SOURCE_NAMES = new Set(['coral', 'coral_admin', 'public'])
 
 type SurfaceType = 'openapi' | 'mcp'
-type AuthChoice = 'none' | 'bearer' | 'header'
+type AuthChoice = 'none' | 'bearer' | 'header' | 'oauthDevice'
 
 interface Draft {
   name: string
@@ -34,6 +36,10 @@ interface Draft {
   url: string
   auth: AuthChoice
   headerName: string
+  oauthClientId: string
+  oauthDeviceAuthorizationUrl: string
+  oauthScopes: string
+  oauthTokenUrl: string
   token: string
 }
 
@@ -44,6 +50,10 @@ const EMPTY_DRAFT: Draft = {
   url: '',
   auth: 'bearer',
   headerName: '',
+  oauthClientId: '',
+  oauthDeviceAuthorizationUrl: '',
+  oauthScopes: '',
+  oauthTokenUrl: '',
   token: '',
 }
 
@@ -52,12 +62,20 @@ const STEP_COUNT = 3
 export function SourceCreateDialog({
   actionData,
   discoveryPath,
+  fetchOAuthImport = fetch,
+  oauthImportPath,
+  onOAuthImportComplete,
   open,
+  openAuthorization = (url) => window.open(url, '_blank', 'noopener,noreferrer'),
   onOpenChange,
 }: {
   actionData: SourcesActionData
   discoveryPath: string
+  fetchOAuthImport?: typeof fetch
+  oauthImportPath: string
+  onOAuthImportComplete?: (name: string) => Promise<void> | void
   open: boolean
+  openAuthorization?: (url: string) => unknown
   onOpenChange: (open: boolean) => void
 }) {
   const requestCancelRef = useRef<() => void>(() => onOpenChange(false))
@@ -76,7 +94,11 @@ export function SourceCreateDialog({
             <SourceCreateDialogContent
               actionData={actionData}
               discoveryPath={discoveryPath}
+              fetchOAuthImport={fetchOAuthImport}
+              oauthImportPath={oauthImportPath}
+              onOAuthImportComplete={onOAuthImportComplete}
               onCancel={() => onOpenChange(false)}
+              openAuthorization={openAuthorization}
               requestCancelRef={requestCancelRef}
             />
           ) : null}
@@ -89,12 +111,20 @@ export function SourceCreateDialog({
 function SourceCreateDialogContent({
   actionData,
   discoveryPath,
+  fetchOAuthImport,
+  oauthImportPath,
+  onOAuthImportComplete,
   onCancel,
+  openAuthorization,
   requestCancelRef,
 }: {
   actionData: SourcesActionData
   discoveryPath: string
+  fetchOAuthImport: typeof fetch
+  oauthImportPath: string
+  onOAuthImportComplete?: (name: string) => Promise<void> | void
   onCancel: () => void
+  openAuthorization: (url: string) => unknown
   requestCancelRef: RefObject<() => void>
 }) {
   const [step, setStep] = useState(0)
@@ -102,9 +132,19 @@ function SourceCreateDialogContent({
   const [confirmingCancel, setConfirmingCancel] = useState(false)
   const formId = useId()
   const discovery = useFetcher<SourceDiscoveryData>()
+  const oauth = useOAuthInstallFlow({
+    fetchOAuthInstall: fetchOAuthImport,
+    openAuthorization,
+    onComplete: async (name) => {
+      if (onOAuthImportComplete) await onOAuthImportComplete(name)
+      else onCancel()
+    },
+  })
 
   const navigation = useNavigation()
-  const submitting = navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'import'
+  const navigationSubmitting =
+    navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'import'
+  const submitting = navigationSubmitting || oauth.busy
   const importError =
     actionData?.status === 'error' && actionData.intent === 'import' ? actionData.message : null
   const discovering = discovery.state !== 'idle'
@@ -161,11 +201,24 @@ function SourceCreateDialogContent({
       return true
     }
     if (draft.auth === 'header' && draft.headerName.trim().length === 0) return false
+    if (draft.auth === 'oauthDevice') {
+      return (
+        isHttpsUrl(draft.oauthDeviceAuthorizationUrl) &&
+        isHttpsUrl(draft.oauthTokenUrl) &&
+        draft.oauthClientId.trim().length > 0
+      )
+    }
     return draft.auth === 'none' || draft.token.trim().length > 0
   })()
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    if (step === 2) return
+    if (step === 2) {
+      if (draft.auth !== 'oauthDevice') return
+      event.preventDefault()
+      if (!stepValid || submitting) return
+      void oauth.start(oauthImportPath, new FormData(event.currentTarget))
+      return
+    }
 
     event.preventDefault()
     if (!stepValid || discovering || submitting) return
@@ -181,10 +234,16 @@ function SourceCreateDialogContent({
       <input type="hidden" name="_intent" value="import" />
       <input type="hidden" name="name" value={draft.name.trim()} />
       <input type="hidden" name="manifest_yaml" value={buildManifestYaml(draft)} />
-      {draft.auth !== 'none' ? (
+      {draft.auth === 'bearer' || draft.auth === 'header' ? (
         <>
           <input type="hidden" name="secret_key" value={SECRET_KEY} />
           <input type="hidden" name="secret_value" value={draft.token.trim()} />
+        </>
+      ) : null}
+      {draft.auth === 'oauthDevice' ? (
+        <>
+          <input type="hidden" name="oauth_input_key" value={SECRET_KEY} />
+          <input type="hidden" name="oauth_method_index" value="0" />
         </>
       ) : null}
 
@@ -194,7 +253,12 @@ function SourceCreateDialogContent({
       {discoveryError ? <SourceError>{discoveryError}</SourceError> : null}
 
       <Dialog.Actions>
-        <ButtonContainer disabled={submitting} onClick={requestCancel} size="32" variant="bare">
+        <ButtonContainer
+          disabled={navigationSubmitting}
+          onClick={requestCancel}
+          size="32"
+          variant="bare"
+        >
           <ButtonText>Cancel</ButtonText>
         </ButtonContainer>
         <ButtonContainer
@@ -222,7 +286,7 @@ function SourceCreateDialogContent({
 
               <Dialog.Actions>
                 <ButtonContainer
-                  disabled={submitting}
+                  disabled={navigationSubmitting}
                   onClick={requestCancel}
                   size="32"
                   variant="bare"
@@ -262,10 +326,18 @@ function SourceCreateDialogContent({
                       {importError ? (
                         <SourceError className={styles.importError}>{importError}</SourceError>
                       ) : null}
+                      <OAuthInstallStatus
+                        className={styles.oauthProgress}
+                        inputLabel={formatFieldName}
+                        progress={oauth.progress}
+                      />
+                      {oauth.error ? (
+                        <SourceError className={styles.importError}>{oauth.error}</SourceError>
+                      ) : null}
 
                       <Dialog.Actions>
                         <ButtonContainer
-                          disabled={submitting}
+                          disabled={navigationSubmitting}
                           onClick={requestCancel}
                           size="32"
                           variant="bare"
@@ -288,7 +360,16 @@ function SourceCreateDialogContent({
                           variant="primary"
                         >
                           {submitting ? <SpinningButtonIcon name="Loader" /> : null}
-                          <ButtonText>{submitting ? 'Creating…' : 'Create source'}</ButtonText>
+                          <ButtonText>
+                            {draft.auth === 'oauthDevice'
+                              ? oauthActionLabel(oauth.progress, {
+                                  busy: 'Creating…',
+                                  idle: 'Create source',
+                                })
+                              : navigationSubmitting
+                                ? 'Creating…'
+                                : 'Create source'}
+                          </ButtonText>
                         </ButtonContainer>
                       </Dialog.Actions>
                     </div>
@@ -312,7 +393,14 @@ function SourceCreateDialogContent({
               >
                 <ButtonText>Keep editing</ButtonText>
               </ButtonContainer>
-              <ButtonContainer onClick={onCancel} size="32" variant="destructive">
+              <ButtonContainer
+                onClick={() => {
+                  oauth.cancel()
+                  onCancel()
+                }}
+                size="32"
+                variant="destructive"
+              >
                 <ButtonText>Discard</ButtonText>
               </ButtonContainer>
             </Dialog.Actions>
@@ -457,16 +545,22 @@ function CredentialsStep({
   const idBearerToken = useId()
   const idHeaderName = useId()
   const idHeaderToken = useId()
+  const idOAuthClientId = useId()
+  const idOAuthDeviceAuthorizationUrl = useId()
+  const idOAuthScopes = useId()
+  const idOAuthTokenUrl = useId()
   const authChoices: { key: AuthChoice; label: string }[] =
     draft.surfaceType === 'openapi'
       ? [
           { key: 'none', label: 'None' },
           { key: 'bearer', label: 'Bearer token' },
+          { key: 'oauthDevice', label: 'OAuth device flow' },
           { key: 'header', label: 'Custom header' },
         ]
       : [
           { key: 'none', label: 'None' },
           { key: 'bearer', label: 'Bearer token' },
+          { key: 'oauthDevice', label: 'OAuth device flow' },
         ]
   return (
     <div className={styles.fieldGroup}>
@@ -512,6 +606,63 @@ function CredentialsStep({
               onChange={(value) => update({ token: value })}
               placeholder="Paste token"
               disabled={disabled || draft.auth !== 'bearer'}
+            />
+          </SourceField>
+        </div>
+        <div
+          aria-hidden={draft.auth !== 'oauthDevice'}
+          className={classNames(
+            styles.authPanel,
+            draft.auth !== 'oauthDevice' && styles.authPanelHidden,
+          )}
+        >
+          <SourceField
+            className={styles.fieldItem}
+            htmlFor={idOAuthDeviceAuthorizationUrl}
+            label="Device authorization URL"
+          >
+            <TextInput
+              disabled={disabled || draft.auth !== 'oauthDevice'}
+              id={idOAuthDeviceAuthorizationUrl}
+              onChange={(value) => update({ oauthDeviceAuthorizationUrl: value })}
+              placeholder="https://provider.example/oauth/device/code"
+              value={draft.oauthDeviceAuthorizationUrl}
+            />
+          </SourceField>
+          <SourceField className={styles.fieldItem} htmlFor={idOAuthTokenUrl} label="Token URL">
+            <TextInput
+              disabled={disabled || draft.auth !== 'oauthDevice'}
+              id={idOAuthTokenUrl}
+              onChange={(value) => update({ oauthTokenUrl: value })}
+              placeholder="https://provider.example/oauth/token"
+              value={draft.oauthTokenUrl}
+            />
+          </SourceField>
+          <SourceField className={styles.fieldItem} htmlFor={idOAuthClientId} label="Client ID">
+            <TextInput
+              disabled={disabled || draft.auth !== 'oauthDevice'}
+              id={idOAuthClientId}
+              onChange={(value) => update({ oauthClientId: value })}
+              placeholder="OAuth public client ID"
+              value={draft.oauthClientId}
+            />
+          </SourceField>
+          <SourceField
+            className={styles.fieldItem}
+            hint={
+              <Typography.BodySmall variant="tertiary">
+                Optional, separated by spaces.
+              </Typography.BodySmall>
+            }
+            htmlFor={idOAuthScopes}
+            label="Scopes"
+          >
+            <TextInput
+              disabled={disabled || draft.auth !== 'oauthDevice'}
+              id={idOAuthScopes}
+              onChange={(value) => update({ oauthScopes: value })}
+              placeholder="read profile"
+              value={draft.oauthScopes}
             />
           </SourceField>
         </div>
@@ -567,6 +718,14 @@ function sourceNameIsValid(name: string): boolean {
   return sourceNameValidationError(name) === null
 }
 
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value.trim()).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 function sourceNameValidationError(name: string): string | null {
   if (!name) return 'Enter a source name.'
   if (RESERVED_SOURCE_NAMES.has(name)) {
@@ -594,6 +753,39 @@ function buildManifestYaml(draft: Draft): string {
       '    kind: secret',
       `    hint: ${s(`API token for ${name}`)}`,
     )
+    if (draft.auth === 'oauthDevice') {
+      lines.push(
+        '    credential:',
+        '      methods:',
+        '        - type: oauth',
+        '          label: Connect with OAuth device flow',
+        '          description: Sign in with a device code.',
+        '          oauth:',
+        '            flow:',
+        '              type: device_code',
+        '            endpoints:',
+        `              device_authorization_url: ${s(draft.oauthDeviceAuthorizationUrl.trim())}`,
+        `              token_url: ${s(draft.oauthTokenUrl.trim())}`,
+        '            client:',
+        '              id:',
+        `                default: ${s(draft.oauthClientId.trim())}`,
+      )
+      const scopes = oauthScopes(draft.oauthScopes)
+      if (scopes.length > 0) {
+        lines.push(
+          '            scopes:',
+          '              scope:',
+          '                delimiter: space',
+          '                values:',
+          ...scopes.map((scope) => `                  - ${s(scope)}`),
+        )
+      }
+      lines.push(
+        '        - type: source_config',
+        '          label: Paste token',
+        '          description: Paste an existing access token.',
+      )
+    }
   }
   lines.push('surface:')
 
@@ -619,4 +811,15 @@ function buildManifestYaml(draft: Draft): string {
     }
   }
   return lines.join('\n') + '\n'
+}
+
+function oauthScopes(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(/[\s,]+/)
+        .map((scope) => scope.trim())
+        .filter(Boolean),
+    ),
+  ]
 }

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -23,6 +23,15 @@ import * as styles from './source-create.css'
 import { formatFieldName, SourceError, SourceField, SourceHeader } from './source-presentation'
 
 const SECRET_KEY = 'API_TOKEN'
+const GITHUB_OAUTH_CLIENT_ID = 'Iv23liJHis6Bs8NO1DAI'
+const GITHUB_DEVICE_AUTHORIZATION_URL = 'https://github.com/login/device/code'
+const GITHUB_OAUTH_TOKEN_URL = 'https://github.com/login/oauth/access_token'
+const GITHUB_OAUTH_SCOPES = 'repo read:org read:user user:email'
+const SENTRY_OPENAPI_PATH = '/getsentry/sentry-api-schema/refs/heads/main/openapi-derefed.json'
+const SENTRY_DEVICE_AUTHORIZATION_URL = 'https://sentry.io/oauth/device/code/'
+const SENTRY_OAUTH_TOKEN_URL = 'https://sentry.io/oauth/token/'
+const SENTRY_OAUTH_SCOPES =
+  'org:read event:read member:read project:read project:releases team:read'
 const NAME_PATTERN = /^[a-z][a-z0-9_]*$/
 const RESERVED_SOURCE_NAMES = new Set(['coral', 'coral_admin', 'public'])
 
@@ -573,7 +582,9 @@ function CredentialsStep({
         <Radio.Group
           aria-label="Authentication"
           value={draft.auth}
-          onValueChange={(auth) => update({ auth })}
+          onValueChange={(auth) =>
+            update(auth === 'oauthDevice' ? oauthDeviceDraft(draft) : { auth })
+          }
         >
           {authChoices.map((choice) => (
             <Radio.Item key={choice.key} value={choice.key}>
@@ -700,6 +711,56 @@ function CredentialsStep({
       </div>
     </div>
   )
+}
+
+function oauthDeviceDraft(draft: Draft): Partial<Draft> {
+  const preset = oauthDevicePreset(draft.url)
+  return {
+    auth: 'oauthDevice',
+    oauthClientId: draft.oauthClientId || preset?.clientId || '',
+    oauthDeviceAuthorizationUrl:
+      draft.oauthDeviceAuthorizationUrl || preset?.deviceAuthorizationUrl || '',
+    oauthScopes: draft.oauthScopes || preset?.scopes || '',
+    oauthTokenUrl: draft.oauthTokenUrl || preset?.tokenUrl || '',
+  }
+}
+
+function oauthDevicePreset(url: string):
+  | {
+      clientId: string
+      deviceAuthorizationUrl: string
+      scopes: string
+      tokenUrl: string
+    }
+  | undefined {
+  try {
+    const parsed = new URL(url)
+    if (
+      parsed.hostname === 'raw.githubusercontent.com' &&
+      parsed.pathname.startsWith('/github/rest-api-description/')
+    ) {
+      return {
+        clientId: GITHUB_OAUTH_CLIENT_ID,
+        deviceAuthorizationUrl: GITHUB_DEVICE_AUTHORIZATION_URL,
+        scopes: GITHUB_OAUTH_SCOPES,
+        tokenUrl: GITHUB_OAUTH_TOKEN_URL,
+      }
+    }
+    if (
+      parsed.hostname === 'raw.githubusercontent.com' &&
+      parsed.pathname === SENTRY_OPENAPI_PATH
+    ) {
+      return {
+        clientId: '',
+        deviceAuthorizationUrl: SENTRY_DEVICE_AUTHORIZATION_URL,
+        scopes: SENTRY_OAUTH_SCOPES,
+        tokenUrl: SENTRY_OAUTH_TOKEN_URL,
+      }
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
 }
 
 function authChoiceFromDiscovery(auth: SourceDetectedAuth): AuthChoice | null {

--- a/apps/reef/app/views/sources/source-install.tsx
+++ b/apps/reef/app/views/sources/source-install.tsx
@@ -1,19 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { Form, useNavigate, useRevalidator } from 'react-router'
 
 import { Container as ButtonContainer } from '@/wax/components/button/container'
 import { SpinningButtonIcon } from '@/wax/components/button/icon'
 import { Text as ButtonText } from '@/wax/components/button/text'
 import { Dialog, Tabs } from '@/wax/components'
-import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
-import { Typography } from '@/wax/components/typography'
 
 import { Markdown } from '@/components/markdown'
 import { OAuthFields, type OAuthField } from '@/components/sources/install/oauth-fields'
-import { OAuthProgress } from '@/components/sources/install/oauth-progress'
-import * as oauthStatusStyles from '@/components/sources/install/oauth-status.css'
-import { readOAuthInstallStream } from '@/lib/source-oauth-install-stream'
+import { OAuthInstallStatus } from '@/components/sources/install/oauth-progress'
+import { oauthActionLabel, useOAuthInstallFlow } from '@/lib/source-oauth-install-flow'
 import type {
   CatalogEntry,
   CatalogOAuthCredentialMethod,
@@ -30,21 +27,6 @@ import {
   SourceInputField,
   SourceNoConfiguration,
 } from './source-presentation'
-
-type InstallProgress =
-  | { kind: 'idle' }
-  | { kind: 'busy' }
-  | {
-      kind: 'awaiting-oauth'
-      authorizationUrl: string
-      inputKey: string
-      userCode: string
-      verificationUri: string
-      verificationUriComplete: string
-    }
-  | { kind: 'oauth-callback-received'; inputKey: string }
-  | { kind: 'oauth-completed'; inputKey: string }
-  | { kind: 'success'; name: string }
 
 export function SourceInstallDialog({
   actionError,
@@ -111,15 +93,22 @@ function SourceInstallDialogContent({
 }) {
   const navigate = useNavigate()
   const revalidator = useRevalidator()
-  const abortRef = useRef<AbortController | null>(null)
   const formRef = useRef<HTMLFormElement>(null)
   const [values, setValues] = useState<Record<string, string>>({})
   const [methodChoices, setMethodChoices] = useState<Record<string, number>>({})
-  const [progress, setProgress] = useState<InstallProgress>({ kind: 'idle' })
-  const [streamError, setStreamError] = useState<string | null>(null)
+  const oauth = useOAuthInstallFlow({
+    fetchOAuthInstall,
+    openAuthorization,
+    onComplete: async () => {
+      await revalidator.revalidate()
+      await (onOAuthInstallComplete
+        ? onOAuthInstallComplete()
+        : navigate(routePath('workspaceSources', { workspaceId })))
+    },
+  })
   const inputSpecs = entry.inputSpecs
   const inputs: CatalogSourceInputSpec[] = inputSpecs ?? []
-  const oauthBusy = progress.kind !== 'idle'
+  const oauthBusy = oauth.busy
   const busy = submitting || oauthBusy
 
   const effectiveChoice = (input: CatalogSourceInputSpec): number => methodChoices[input.key] ?? 0
@@ -149,14 +138,8 @@ function SourceInstallDialogContent({
     })
   }, [inputSpecs, values, methodChoices])
 
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort()
-    }
-  }, [])
-
   function cancel() {
-    abortRef.current?.abort()
+    oauth.cancel()
     onCancel()
   }
 
@@ -171,56 +154,7 @@ function SourceInstallDialogContent({
 
   async function submitOAuthInstall() {
     if (!formRef.current || oauthBusy) return
-    setStreamError(null)
-    setProgress({ kind: 'busy' })
-
-    const abortController = new AbortController()
-    abortRef.current = abortController
-    try {
-      const response = await fetchOAuthInstall(oauthInstallEndpoint(workspaceId, entry.name), {
-        body: new FormData(formRef.current),
-        method: 'POST',
-        signal: abortController.signal,
-      })
-      const source = await readOAuthInstallStream(response, {
-        onAuthorization: (event) => {
-          setProgress({
-            kind: 'awaiting-oauth',
-            authorizationUrl: event.authorizationUrl,
-            inputKey: event.inputKey,
-            userCode: event.userCode,
-            verificationUri: event.verificationUri,
-            verificationUriComplete: event.verificationUriComplete,
-          })
-          openAuthorization(event.authorizationUrl)
-        },
-        onCallbackReceived: (event) => {
-          setProgress({ kind: 'oauth-callback-received', inputKey: event.inputKey })
-        },
-        onCompleted: (event) => {
-          setProgress({ kind: 'oauth-completed', inputKey: event.inputKey })
-        },
-        onSource: (event) => {
-          setProgress({ kind: 'success', name: event.name })
-        },
-      })
-
-      if (!abortController.signal.aborted) {
-        setProgress({ kind: 'success', name: source.name })
-        await revalidator.revalidate()
-        if (!abortController.signal.aborted) {
-          await (onOAuthInstallComplete
-            ? onOAuthInstallComplete()
-            : navigate(routePath('workspaceSources', { workspaceId })))
-        }
-      }
-    } catch (error) {
-      if (abortController.signal.aborted) return
-      setStreamError(error instanceof Error ? error.message : String(error))
-      setProgress({ kind: 'idle' })
-    } finally {
-      if (abortRef.current === abortController) abortRef.current = null
-    }
+    await oauth.start(oauthInstallEndpoint(workspaceId, entry.name), new FormData(formRef.current))
   }
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -261,41 +195,9 @@ function SourceInstallDialogContent({
         </div>
       )}
 
-      {progress.kind === 'awaiting-oauth' ? (
-        <OAuthProgress
-          authorizationUrl={progress.authorizationUrl}
-          inputLabel={formatFieldName(progress.inputKey)}
-          userCode={progress.userCode}
-          verificationUri={progress.verificationUri}
-          verificationUriComplete={progress.verificationUriComplete}
-        />
-      ) : null}
-      {progress.kind === 'oauth-completed' ? (
-        <div className={oauthStatusStyles.box}>
-          <Icon name="CircleCheck" size="16" color="success" />
-          <Typography.BodySmall variant="primary">
-            {formatFieldName(progress.inputKey)} authorized. Finishing install…
-          </Typography.BodySmall>
-        </div>
-      ) : null}
-      {progress.kind === 'oauth-callback-received' ? (
-        <div className={oauthStatusStyles.box}>
-          <Icon name="Loader" size="16" color="secondary" />
-          <Typography.BodySmall variant="primary">
-            {formatFieldName(progress.inputKey)} authorization received. Exchanging token…
-          </Typography.BodySmall>
-        </div>
-      ) : null}
-      {progress.kind === 'success' ? (
-        <div className={oauthStatusStyles.box}>
-          <Icon name="CircleCheck" size="16" color="success" />
-          <Typography.BodySmall variant="primary">
-            {formatFieldName(progress.name)} configured.
-          </Typography.BodySmall>
-        </div>
-      ) : null}
+      <OAuthInstallStatus inputLabel={formatFieldName} progress={oauth.progress} />
 
-      {streamError ? <SourceError>{streamError}</SourceError> : null}
+      {oauth.error ? <SourceError>{oauth.error}</SourceError> : null}
 
       {actionError ? <SourceError>{actionError}</SourceError> : null}
 
@@ -311,7 +213,11 @@ function SourceInstallDialogContent({
           variant="primary"
         >
           {busy ? <SpinningButtonIcon name="Loader" /> : null}
-          <ButtonText>{busyLabel(progress, submitting)}</ButtonText>
+          <ButtonText>
+            {submitting
+              ? 'Adding…'
+              : oauthActionLabel(oauth.progress, { busy: 'Adding…', idle: 'Add source' })}
+          </ButtonText>
         </ButtonContainer>
       </Dialog.Actions>
     </Form>
@@ -538,13 +444,4 @@ function clearValues(values: Record<string, string>, keys: string[]): Record<str
 
 function oauthInstallEndpoint(workspaceId: string, name: string): string {
   return `${routePath('workspaceSource', { sourceName: name, workspaceId })}/oauth-install`
-}
-
-function busyLabel(progress: InstallProgress, submitting: boolean): string {
-  if (submitting || progress.kind === 'busy') return 'Adding…'
-  if (progress.kind === 'awaiting-oauth') return 'Awaiting OAuth…'
-  if (progress.kind === 'oauth-callback-received') return 'Exchanging token…'
-  if (progress.kind === 'oauth-completed') return 'Finishing…'
-  if (progress.kind === 'success') return 'Configured'
-  return 'Add source'
 }


### PR DESCRIPTION
That is not a good idea. If we add thos presets, we better add the source itself.  
This branch is just useful for thesting the flow of the parent branch

Constraint: OpenAPI documents do not expose device-flow endpoints or application client IDs.
Rejected: Treat presets as generic discovery | GitHub and Sentry schemas do not contain the required metadata.
Confidence: high
Scope-risk: narrow
Directive: Keep this optional provider knowledge separate from the generic OAuth flow.
Tested: npm exec -- vitest --browser.headless app/views/sources/source-create.test.tsx