### PR TITLE
fix(desktop): allow select all shortcut

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -296,6 +296,8 @@ function installMenu() {
         { role: 'cut' },
         { role: 'copy' },
         { role: 'paste' },
+        { type: 'separator' },
+        { role: 'selectAll' },
       ],
     },
     {


### PR DESCRIPTION
## Summary

Turns out the desktop shell can prevent some actions, in this case cmd+a to select all.
Adding it to the menu restores it.

## Test plan

Before this PR, in desktop app, cmd+a does nothing
After this PR, it selects all