### PR TITLE
feat(spec): add relational database runtime models

### DIFF
--- a/crates/coral-spec/src/backends/database.rs
+++ b/crates/coral-spec/src/backends/database.rs
@@ -1,0 +1,58 @@
+#![allow(
+    missing_docs,
+    reason = "This module defines field-heavy database source manifest types."
+)]
+
+//! Backend-owned manifest model for relational database sources.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{ManifestInputSpec, ParsedTemplate, SourceManifestCommon};
+
+/// Validated database source manifest consumed by the query engine.
+#[derive(Debug, Clone)]
+pub struct DatabaseSourceManifest {
+    pub common: SourceManifestCommon,
+    pub connection: DatabaseConnectionSpec,
+    pub declared_inputs: Vec<ManifestInputSpec>,
+}
+
+/// Provider-specific database connection configuration.
+#[derive(Debug, Clone)]
+pub enum DatabaseConnectionSpec {
+    Postgres(PostgresConnectionSpec),
+    MySql(MySqlConnectionSpec),
+    Sqlite(SqliteConnectionSpec),
+}
+
+/// `PostgreSQL` connection configuration.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresConnectionSpec {
+    pub host: ParsedTemplate,
+    pub port: ParsedTemplate,
+    pub database: ParsedTemplate,
+    pub user: ParsedTemplate,
+    pub password: ParsedTemplate,
+    #[serde(default)]
+    pub sslmode: Option<ParsedTemplate>,
+}
+
+/// `MySQL` connection configuration.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MySqlConnectionSpec {
+    pub host: ParsedTemplate,
+    pub port: ParsedTemplate,
+    pub database: ParsedTemplate,
+    pub user: ParsedTemplate,
+    pub password: ParsedTemplate,
+}
+
+/// `SQLite` connection configuration.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteConnectionSpec {
+    pub path: ParsedTemplate,
+}

--- a/crates/coral-spec/src/backends/mod.rs
+++ b/crates/coral-spec/src/backends/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! These modules define the normalized manifest shapes consumed by the engine:
 //!
+//! - [`database`] for relational database sources
 //! - [`http`] for HTTP-backed sources
 //! - [`mod@file`] for file-backed sources such as `parquet`, `jsonl`, `json`, and `csv`
 //! - [`mcp`] for Model Context Protocol-backed sources
@@ -10,6 +11,7 @@
 //! [`crate::parse_source_manifest_yaml`] or [`crate::parse_source_manifest_value`]
 //! and then inspect the resulting [`crate::ValidatedSourceManifest`].
 
+pub mod database;
 pub mod file;
 pub mod http;
 pub mod mcp;

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -93,6 +93,10 @@ mod udf;
 pub mod v4;
 mod validate;
 
+pub use backends::database::{
+    DatabaseConnectionSpec, DatabaseSourceManifest, MySqlConnectionSpec, PostgresConnectionSpec,
+    SqliteConnectionSpec,
+};
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 pub use backends::mcp::{
     McpEnvSpec, McpHttpAuthSpec, McpLimitBinding, McpServerSpec, McpSourceManifest,


### PR DESCRIPTION
## Summary

- add provider-specific runtime models for PostgreSQL, MySQL, and SQLite sources
- represent database sources as SQL catalogs while preserving remote schema identity
- add generic engine contracts for database runtime registration and column discovery

## Stack

- Depends on: #1894
- Next: #1895

This is PR 3 of 7 in the relational database source MVP stack.