### PR TITLE
fix(reef): align source discovery limits

### DIFF
--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -141,10 +141,10 @@ components:
       auth: { kind: 'unknown', label: '' },
       description: '',
       format: 'mcp',
+      inspectionError: 'The URL returned HTTP 405',
       name: 'mcp',
       status: 'success',
       url: 'https://tools.example/mcp',
-      warning: 'The URL returned HTTP 405',
     })
   })
 

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -1,6 +1,8 @@
 import type { Route } from './+types/source-discovery'
 
-const MAX_DESCRIPTOR_BYTES = 2 * 1024 * 1024
+const MAX_DESCRIPTOR_SIZE_MB = 64
+// Keep this aligned with coral-app's DSL v4 materialization limit.
+const MAX_DESCRIPTOR_BYTES = MAX_DESCRIPTOR_SIZE_MB * 1024 * 1024
 
 export type SourceDocumentFormat = 'mcp' | 'openapi-json' | 'openapi-yaml' | 'unknown'
 export type SourceDetectedAuth = {
@@ -14,10 +16,10 @@ export type SourceDiscoveryData =
       auth: SourceDetectedAuth
       description: string
       format: SourceDocumentFormat
+      inspectionError?: string
       name: string
       status: 'success'
       url: string
-      warning?: string
     }
   | {
       message: string
@@ -52,8 +54,8 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
         auth: unknownAuth(),
         description: '',
         format: 'unknown',
+        inspectionError: `The URL returned HTTP ${response.status}`,
         title: '',
-        warning: `The URL returned HTTP ${response.status}`,
       })
     }
 
@@ -62,15 +64,15 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
     return discoveredSource(rawUrl, sourceUrl, metadata)
   } catch (error) {
     if (request.signal.aborted) throw error
-    let warning = 'The source URL could not be loaded'
-    if (signal.aborted) warning = 'Source discovery timed out'
-    else if (error instanceof Error) warning = error.message
+    let inspectionError = 'The source URL could not be loaded'
+    if (signal.aborted) inspectionError = 'Source discovery timed out'
+    else if (error instanceof Error) inspectionError = error.message
     return discoveredSource(rawUrl, sourceUrl, {
       auth: unknownAuth(),
       description: '',
       format: 'unknown',
+      inspectionError,
       title: '',
-      warning,
     })
   }
 }
@@ -191,7 +193,7 @@ function objectKeys(value: unknown): string[] {
 async function responseTextWithinLimit(response: Response): Promise<string> {
   const declaredLength = Number(response.headers.get('content-length'))
   if (Number.isFinite(declaredLength) && declaredLength > MAX_DESCRIPTOR_BYTES) {
-    throw new Error('The source document is larger than 2 MB')
+    throw new Error(`The source document is larger than ${MAX_DESCRIPTOR_SIZE_MB} MB`)
   }
   if (!response.body) return ''
 
@@ -205,7 +207,7 @@ async function responseTextWithinLimit(response: Response): Promise<string> {
     bytesRead += value.byteLength
     if (bytesRead > MAX_DESCRIPTOR_BYTES) {
       await reader.cancel()
-      throw new Error('The source document is larger than 2 MB')
+      throw new Error(`The source document is larger than ${MAX_DESCRIPTOR_SIZE_MB} MB`)
     }
     text += decoder.decode(value, { stream: true })
   }
@@ -405,8 +407,8 @@ function discoveredSource(
     auth: SourceDetectedAuth
     description: string
     format: SourceDocumentFormat
+    inspectionError?: string
     title: string
-    warning?: string
   },
 ): SourceDiscoveryData {
   return {
@@ -419,6 +421,6 @@ function discoveredSource(
     name: sourceName(metadata.title || fallbackTitle(sourceUrl)),
     status: 'success',
     url,
-    ...(metadata.warning ? { warning: metadata.warning } : {}),
+    ...(metadata.inspectionError ? { inspectionError: metadata.inspectionError } : {}),
   }
 }

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -381,7 +381,7 @@ function DetailsStep({
     <div className={styles.fieldGroup}>
       {discovery ? (
         <Typography.BodySmall variant="tertiary">
-          {discoverySummary(discovery)} Review the detected details.
+          {discoverySummary(discovery)} Review the source details.
         </Typography.BodySmall>
       ) : null}
       <SourceField
@@ -434,13 +434,21 @@ function DetailsStep({
   )
 }
 
-function discoverySummary(discovery: { format: SourceDocumentFormat; warning?: string }): string {
+function discoverySummary(discovery: {
+  format: SourceDocumentFormat
+  inspectionError?: string
+}): string {
   if (discovery.format === 'mcp') return 'Detected an MCP endpoint from its URL.'
   if (discovery.format === 'openapi-json') return 'Detected an OpenAPI JSON document.'
   if (discovery.format === 'openapi-yaml') return 'Detected an OpenAPI YAML document.'
-  return discovery.warning
-    ? `No OpenAPI document was detected. ${discovery.warning}.`
-    : 'No OpenAPI document was detected.'
+  if (discovery.inspectionError) {
+    return `The source document could not be inspected. ${asSentence(discovery.inspectionError)}`
+  }
+  return 'No OpenAPI document was detected.'
+}
+
+function asSentence(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`
 }
 
 function CredentialsStep({


### PR DESCRIPTION
## Summary

UI had arbitrary 2MB limit, aligning it to BE 64MB.
While at it, improve the error message, so instead of saying "No OpenAPI detected", we'll say "Couldn't parse" or "Exceeded limit" 😄 

## Test plan

Load GitHub openAPI, it's now parsed correctly

<img width="562" height="448" alt="image" src="https://github.com/user-attachments/assets/8c6b6f97-72c0-4780-9bde-b7e602d08f2e" />
