### PR TITLE
fix(desktop): reuse release CLI artifacts for macOS packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,7 @@ jobs:
             "$RUNNER_TEMP/unsigned-macos/macos-unsigned-x86_64-apple-darwin/coral" \
             "$RUNNER_TEMP/unsigned-macos/macos-unsigned-aarch64-apple-darwin/coral" \
             -output "$RUNNER_TEMP/coral-universal"
-          lipo -verify_arch x86_64 arm64 "$RUNNER_TEMP/coral-universal"
+          lipo "$RUNNER_TEMP/coral-universal" -verify_arch x86_64 arm64
 
       - name: Install Rust toolchain
         run: rustup show

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,6 +323,7 @@ jobs:
   build-desktop-macos:
     needs:
       - validate-release-ref
+      - build
     environment: release
     runs-on: blacksmith-6vcpu-macos-26
     env:
@@ -332,6 +333,21 @@ jobs:
         with:
           ref: ${{ needs.validate-release-ref.outputs.commit-sha }}
           persist-credentials: false
+
+      - name: Download unsigned macOS binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: macos-unsigned-*-apple-darwin
+          path: ${{ runner.temp }}/unsigned-macos
+          merge-multiple: false
+
+      - name: Create universal Coral binary
+        run: |
+          lipo -create \
+            "$RUNNER_TEMP/unsigned-macos/macos-unsigned-x86_64-apple-darwin/coral" \
+            "$RUNNER_TEMP/unsigned-macos/macos-unsigned-aarch64-apple-darwin/coral" \
+            -output "$RUNNER_TEMP/coral-universal"
+          lipo -verify_arch x86_64 arm64 "$RUNNER_TEMP/coral-universal"
 
       - name: Install Rust toolchain
         run: rustup show
@@ -348,14 +364,15 @@ jobs:
       - name: Build xtask
         run: cargo build --locked -p xtask
 
-      # Build before Apple credentials enter the environment: the desktop
-      # build installs UI and Reef dependencies and executes Rust build scripts.
+      # Build before Apple credentials enter the environment: dependency
+      # installation and build scripts run here, while the reused CLI artifacts
+      # were also built without credentials.
       # The release flag is compiled into the main process to enable updates;
       # signing and notarization still happen only in the credentialed step.
       - name: Build universal desktop inputs
         env:
+          CORAL_DESKTOP_CLI_PATH: ${{ runner.temp }}/coral-universal
           CORAL_DESKTOP_RELEASE: "1"
-          CORAL_DESKTOP_UNIVERSAL: "1"
         run: npm run build --prefix apps/desktop
 
       - name: Verify release updater bundle

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -8,6 +8,9 @@ const outputDir = resolve(desktopRoot, 'resources', 'coral')
 const binaryName = process.platform === 'win32' ? 'coral.exe' : 'coral'
 const targetBinary = resolve(repoRoot, 'target', 'release', binaryName)
 const universalMacBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
+const prebuiltBinaryPath = process.env.CORAL_DESKTOP_CLI_PATH?.trim()
+const prebuiltBinary = prebuiltBinaryPath ? resolve(repoRoot, prebuiltBinaryPath) : undefined
+const needsCliBuild = prebuiltBinary === undefined
 const universalMac = process.env.CORAL_DESKTOP_UNIVERSAL === '1'
 const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
 
@@ -30,8 +33,11 @@ function run(command, args, options = {}) {
   })
 }
 
-await run('npm', ['ci', '--prefix', 'apps/ui'])
-await run('npm', ['run', 'build', '--prefix', 'apps/ui'])
+// apps/ui is embedded only when this script builds coral-cli locally.
+if (needsCliBuild) {
+  await run('npm', ['ci', '--prefix', 'apps/ui'])
+  await run('npm', ['run', 'build', '--prefix', 'apps/ui'])
+}
 await run('npm', ['ci', '--prefix', 'apps/reef'])
 await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
   env: {
@@ -63,14 +69,14 @@ async function buildCoralCli() {
   return universalMacBinary
 }
 
-const builtBinary = await buildCoralCli()
+const sourceBinary = prebuiltBinary ?? (await buildCoralCli())
 
 await rm(outputDir, { recursive: true, force: true })
 await mkdir(outputDir, { recursive: true })
-await copyFile(builtBinary, join(outputDir, binaryName))
+await copyFile(sourceBinary, join(outputDir, binaryName))
 
 if (process.platform !== 'win32') {
   await chmod(join(outputDir, binaryName), 0o755)
 }
 
-console.log(`[stage-coral] staged ${builtBinary} -> ${join(outputDir, binaryName)}`)
+console.log(`[stage-coral] staged ${sourceBinary} -> ${join(outputDir, binaryName)}`)


### PR DESCRIPTION
## Summary

Tweak the Desktop job. It doesn't need to build the coral cli binary from scratch, since another job we have is already doing that.

## Test plan

Stack a PR on top of this which builds the binaries

<img width="720" height="78" alt="image" src="https://github.com/user-attachments/assets/c4ff3e52-c7c6-48bf-978e-81fc6d19694f" />

Check that the desktop packaging only starts after those are completed

<img width="673" height="47" alt="image" src="https://github.com/user-attachments/assets/89c262a6-4eb0-41d3-92a3-d95932b3142c" />


And [it succeeds ](https://github.com/withcoral/coral/actions/runs/30000540427/job/89184486942?pr=1936)