### PR TITLE
chore: remove modelling of wrapped lists from the IR

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1905,16 +1905,11 @@ surface:
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Mcp { pagination } => {
-                pagination.cursor.as_ref().expect("pagination")
-            }
+            coral_spec::v4::OperationMetadata::Mcp { pagination } => pagination,
             coral_spec::v4::OperationMetadata::Rest { .. } => panic!("expected MCP metadata"),
         };
-        assert_eq!(pagination.cursor_arg, "cursor");
-        assert_eq!(
-            pagination.response_cursor_path,
-            vec!["meta".to_string(), "nextCursor".to_string()]
-        );
+        assert!(pagination.cursor.is_none());
+        assert!(pagination.offset.is_none());
 
         let projections: ProjectionCatalog =
             read_yaml(&build.temp_dir.join(PROJECTIONS_FILENAME)).expect("read projections");

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -352,7 +352,6 @@ fn mcp_manifest_for_surface(
                 tables.push(mcp_table_spec(
                     projection,
                     mcp,
-                    operation,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -362,7 +361,6 @@ fn mcp_manifest_for_surface(
                     projection,
                     *function_kind,
                     mcp,
-                    operation,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -387,7 +385,6 @@ fn mcp_manifest_for_surface(
 fn mcp_table_spec(
     projection: &Projection,
     mcp: &coral_spec::v4::McpExecutionAttachment,
-    operation: &coral_spec::v4::IrOperation,
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableSpec {
@@ -408,7 +405,7 @@ fn mcp_table_spec(
         limit_binding: None,
         pagination,
         offset_pagination,
-        response: mcp_response_for_operation(operation),
+        response: ResponseSpec::default(),
     }
 }
 
@@ -416,7 +413,6 @@ fn mcp_table_function_spec(
     projection: &Projection,
     function_kind: SourceTableFunctionKind,
     mcp: &coral_spec::v4::McpExecutionAttachment,
-    operation: &coral_spec::v4::IrOperation,
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableFunctionSpec {
@@ -433,17 +429,10 @@ fn mcp_table_function_spec(
             detail_hints: projection.detail_hints.clone(),
             args: mcp_projection_arg_specs(projection),
             request: RequestSpec::default(),
-            response: mcp_response_for_operation(operation),
+            response: ResponseSpec::default(),
             pagination: PaginationSpec::default(),
             columns: projection_column_specs(projection),
         },
-    }
-}
-
-fn mcp_response_for_operation(operation: &coral_spec::v4::IrOperation) -> ResponseSpec {
-    ResponseSpec {
-        rows_path: operation.output.row_path.clone(),
-        ..ResponseSpec::default()
     }
 }
 
@@ -604,7 +593,6 @@ mod tests {
                 output: IrOperationOutput {
                     cardinality: coral_spec::v4::OutputCardinality::List,
                     type_ref: "item".to_string(),
-                    row_path: Vec::new(),
                 },
                 entity: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
@@ -746,7 +734,6 @@ mod tests {
                 output: IrOperationOutput {
                     cardinality: coral_spec::v4::OutputCardinality::List,
                     type_ref: "tool_result".to_string(),
-                    row_path: Vec::new(),
                 },
                 entity: None,
                 execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -54,7 +54,6 @@ pub struct IrOperationInput {
 pub struct IrOperationOutput {
     pub cardinality: OutputCardinality,
     pub type_ref: String,
-    pub row_path: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -198,7 +197,6 @@ mod tests {
                 output: IrOperationOutput {
                     cardinality: OutputCardinality::List,
                     type_ref: "issue".to_string(),
-                    row_path: Vec::new(),
                 },
                 entity: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
@@ -268,7 +266,6 @@ mod tests {
                 output: IrOperationOutput {
                     cardinality: OutputCardinality::List,
                     type_ref: "item".to_string(),
-                    row_path: Vec::new(),
                 },
                 entity: None,
                 execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -359,7 +359,6 @@ components:
     .expect("import");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-    assert!(operation.output.row_path.is_empty());
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -434,7 +433,6 @@ components:
     .expect("import");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-    assert!(operation.output.row_path.is_empty());
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -514,7 +512,6 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-    assert!(operation.output.row_path.is_empty());
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -639,7 +636,6 @@ components:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-    assert!(operation.output.row_path.is_empty());
 
     let row_type = ir
         .types
@@ -720,7 +716,6 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-    assert!(operation.output.row_path.is_empty());
 }
 
 #[test]
@@ -769,7 +764,6 @@ components:
     .expect("recursive schema imports");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-    assert!(operation.output.row_path.is_empty());
 
     let types = ir
         .types

--- a/crates/coral-spec/src/v4/operation_metadata/structural.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/structural.rs
@@ -201,16 +201,5 @@ fn validate_ir_operation(
             false,
         )?;
     }
-    if operation
-        .output
-        .row_path
-        .iter()
-        .any(|segment| segment.trim().is_empty())
-    {
-        return Err(ManifestError::validation(format!(
-            "operation '{}' output row path contains an empty segment",
-            operation.id
-        )));
-    }
     Ok(())
 }

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1359,7 +1359,7 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
 }
 
 #[test]
-fn generated_mcp_projection_keeps_pagination_cursor_internal() {
+fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1414,16 +1414,16 @@ fn generated_mcp_projection_keeps_pagination_cursor_internal() {
         .find(|input| input.wire_name == "cursor")
         .expect("cursor input");
 
-    assert_eq!(cursor.sql_exposure, SqlInputExposure::Internal);
+    assert_eq!(cursor.sql_exposure, SqlInputExposure::FunctionArg);
     assert!(
         mcp_projection_arg_specs(projection)
             .iter()
-            .all(|arg| arg.bind.arg != "cursor")
+            .any(|arg| arg.bind.arg == "cursor")
     );
 }
 
 #[test]
-fn generated_mcp_projection_with_only_pagination_cursor_is_table() {
+fn generated_mcp_projection_with_only_cursor_is_table_function_without_pagination_metadata() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1471,14 +1471,17 @@ fn generated_mcp_projection_with_only_pagination_cursor_is_table() {
         .find(|projection| projection.operation_id == "list_items")
         .expect("mcp projection");
 
-    assert!(matches!(projection.kind, ProjectionKind::Table));
+    assert!(matches!(
+        projection.kind,
+        ProjectionKind::TableFunction { .. }
+    ));
     assert_eq!(
         projection
             .inputs
             .iter()
-            .filter(|input| input.sql_exposure != SqlInputExposure::Internal)
+            .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
             .count(),
-        0
+        1
     );
 }
 

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -934,7 +934,6 @@ surface:
             wrapped_items.output.cardinality,
             OutputCardinality::WrappedList
         );
-        assert_eq!(wrapped_items.output.row_path, vec!["items".to_string()]);
         let wrapped_fields = row_fields(&ir, "wrapped_items_row");
         assert_eq!(field(wrapped_fields, "enabled").type_ref, "mcp_boolean");
 
@@ -989,7 +988,6 @@ surface:
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "list_items");
         assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
-        assert_eq!(operation.output.row_path, vec!["items".to_string()]);
         let plan = ir.validated_plan().expect("plan");
         let pagination = plan.mcp_pagination("list_items").0.expect("pagination");
         assert_eq!(pagination.cursor_arg, "cursor");
@@ -1155,7 +1153,6 @@ surface:
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "get_item");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
-        assert!(operation.output.row_path.is_empty());
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -865,7 +865,7 @@ surface:
     }
 
     #[test]
-    fn imports_output_cardinalities_and_row_types() {
+    fn imports_output_cardinalities_and_row_types_without_unwrapping_objects() {
         let catalog = McpToolCatalog {
             tools: vec![
                 tool_with_schemas(
@@ -932,10 +932,11 @@ surface:
         let wrapped_items = operation(&ir, "wrapped_items");
         assert_eq!(
             wrapped_items.output.cardinality,
-            OutputCardinality::WrappedList
+            OutputCardinality::Singleton
         );
         let wrapped_fields = row_fields(&ir, "wrapped_items_row");
-        assert_eq!(field(wrapped_fields, "enabled").type_ref, "mcp_boolean");
+        assert_eq!(field(wrapped_fields, "items").type_ref, "mcp_json");
+        assert!(wrapped_fields.iter().any(|field| field.name == "raw"));
 
         let get_item = operation(&ir, "get_item");
         assert_eq!(get_item.output.cardinality, OutputCardinality::Singleton);
@@ -950,7 +951,7 @@ surface:
     }
 
     #[test]
-    fn infers_cursor_pagination_for_wrapped_list_envelopes() {
+    fn does_not_infer_cursor_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-items",
@@ -987,16 +988,15 @@ surface:
 
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "list_items");
-        assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
+        assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
         let plan = ir.validated_plan().expect("plan");
-        let pagination = plan.mcp_pagination("list_items").0.expect("pagination");
-        assert_eq!(pagination.cursor_arg, "cursor");
-        assert_eq!(pagination.response_cursor_path, ["meta", "nextCursor"]);
-        assert_eq!(pagination.max_pages, None);
+        let (cursor, offset) = plan.mcp_pagination("list_items");
+        assert!(cursor.is_none());
+        assert!(offset.is_none());
     }
 
     #[test]
-    fn infers_offset_pagination_for_mcp_discovery_contract() {
+    fn does_not_infer_offset_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-catalog",
@@ -1046,12 +1046,7 @@ surface:
         let plan = ir.validated_plan().expect("plan");
         let (cursor, offset) = plan.mcp_pagination("list_catalog");
         assert!(cursor.is_none());
-        let pagination = offset.expect("offset pagination");
-        assert_eq!(pagination.limit_arg, "limit");
-        assert_eq!(pagination.default_limit, 50);
-        assert_eq!(pagination.max_limit, 200);
-        assert_eq!(pagination.offset_arg, "offset");
-        assert_eq!(pagination.offset_start, 0);
+        assert!(offset.is_none());
 
         let projections = generate_projection_catalog(v4, &ir.validated_plan().expect("plan"))
             .expect("projection catalog");
@@ -1060,9 +1055,12 @@ surface:
             .iter()
             .find(|projection| projection.operation_id == "list_catalog")
             .expect("projection");
-        assert!(matches!(projection.kind, crate::v4::ProjectionKind::Table));
+        assert!(matches!(
+            projection.kind,
+            crate::v4::ProjectionKind::TableFunction { .. }
+        ));
         for input in &projection.inputs {
-            assert_eq!(input.sql_exposure, SqlInputExposure::Internal);
+            assert_eq!(input.sql_exposure, SqlInputExposure::FunctionArg);
         }
     }
 

--- a/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
@@ -9,7 +9,6 @@ use crate::v4::surfaces::json_schema::{
 
 use super::import::McpImporter;
 use super::input_schema::schema_description;
-use super::pagination::find_response_cursor_path;
 
 impl McpImporter<'_> {
     pub(super) fn import_output(
@@ -23,7 +22,6 @@ impl McpImporter<'_> {
             return IrOperationOutput {
                 cardinality: OutputCardinality::Singleton,
                 type_ref: row_type_id,
-                row_path: Vec::new(),
             };
         };
         if json_schema_type_contains(schema, "array") {
@@ -32,22 +30,12 @@ impl McpImporter<'_> {
             return IrOperationOutput {
                 cardinality: OutputCardinality::List,
                 type_ref: row_type_id,
-                row_path: Vec::new(),
-            };
-        }
-        if let Some((array_property, item_schema)) = wrapped_list_property(schema) {
-            self.insert_row_type_from_schema(&row_type_id, item_schema);
-            return IrOperationOutput {
-                cardinality: OutputCardinality::WrappedList,
-                type_ref: row_type_id,
-                row_path: vec![array_property.to_string()],
             };
         }
         self.insert_row_type_from_schema(&row_type_id, Some(schema));
         IrOperationOutput {
             cardinality: OutputCardinality::Singleton,
             type_ref: row_type_id,
-            row_path: Vec::new(),
         }
     }
 
@@ -127,37 +115,4 @@ impl McpImporter<'_> {
             },
         );
     }
-}
-
-fn wrapped_list_property(schema: &Value) -> Option<(&str, Option<&Value>)> {
-    if !json_schema_type_contains(schema, "object") {
-        return None;
-    }
-    let properties = schema.get("properties").and_then(Value::as_object)?;
-    let mut arrays = properties
-        .iter()
-        .filter(|(_name, property)| json_schema_type_contains(property, "array"));
-    let (name, property) = arrays.next()?;
-    if arrays.next().is_some() {
-        return None;
-    }
-    if properties.len() != 1
-        && find_response_cursor_path(schema).is_none()
-        && !is_offset_pagination_envelope(properties)
-    {
-        return None;
-    }
-    Some((name.as_str(), property.get("items")))
-}
-
-fn is_offset_pagination_envelope(properties: &serde_json::Map<String, Value>) -> bool {
-    properties
-        .get("limit")
-        .is_some_and(|schema| json_schema_type_contains(schema, "integer"))
-        && properties
-            .get("offset")
-            .is_some_and(|schema| json_schema_type_contains(schema, "integer"))
-        && properties
-            .get("has_more")
-            .is_some_and(|schema| json_schema_type_contains(schema, "boolean"))
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -57,7 +57,6 @@ impl OpenApiImporter<'_> {
                 IrOperationOutput {
                     cardinality: OutputCardinality::None,
                     type_ref: "none".to_string(),
-                    row_path: Vec::new(),
                 },
                 RestResponseAttachment {
                     status_code: 204,
@@ -79,7 +78,6 @@ impl OpenApiImporter<'_> {
                 IrOperationOutput {
                     cardinality: OutputCardinality::Unknown,
                     type_ref: "json".to_string(),
-                    row_path: Vec::new(),
                 },
                 RestResponseAttachment {
                     status_code: selected.status_code,
@@ -94,8 +92,7 @@ impl OpenApiImporter<'_> {
                 },
             );
         };
-        let (cardinality, row_path, row_schema, entity_name) =
-            classify_response_schema(path, &resolved);
+        let (cardinality, row_schema, entity_name) = classify_response_schema(path, &resolved);
         let type_ref = self
             .import_schema(
                 &row_schema,
@@ -104,10 +101,7 @@ impl OpenApiImporter<'_> {
                 diagnostics,
             )
             .unwrap_or_else(|| "json".to_string());
-        let response = ResponseSpec {
-            rows_path: row_path.clone(),
-            ..ResponseSpec::default()
-        };
+        let response = ResponseSpec::default();
         let entity = (cardinality != OutputCardinality::None
             && cardinality != OutputCardinality::Unknown)
             .then(|| IrEntityCandidate {
@@ -119,7 +113,6 @@ impl OpenApiImporter<'_> {
             IrOperationOutput {
                 cardinality,
                 type_ref,
-                row_path,
             },
             RestResponseAttachment {
                 status_code: selected.status_code,
@@ -241,15 +234,14 @@ fn response_headers(
 fn classify_response_schema(
     path: &str,
     schema: &Value,
-) -> (OutputCardinality, Vec<String>, Value, Option<String>) {
+) -> (OutputCardinality, Value, Option<String>) {
     if schema == &Value::Null {
-        return (OutputCardinality::None, Vec::new(), Value::Null, None);
+        return (OutputCardinality::None, Value::Null, None);
     }
     if schema.get("type").and_then(Value::as_str) == Some("array") {
         let item = schema.get("items").cloned().unwrap_or(Value::Null);
         return (
             OutputCardinality::List,
-            Vec::new(),
             item.clone(),
             item.get("$ref")
                 .and_then(Value::as_str)
@@ -264,7 +256,6 @@ fn classify_response_schema(
     {
         return (
             OutputCardinality::Singleton,
-            Vec::new(),
             schema.clone(),
             schema
                 .get("$ref")
@@ -273,7 +264,7 @@ fn classify_response_schema(
                 .or_else(|| Some(entity_name_from_path(path))),
         );
     }
-    (OutputCardinality::Unknown, Vec::new(), schema.clone(), None)
+    (OutputCardinality::Unknown, schema.clone(), None)
 }
 
 fn entity_name_from_ref(reference: &str) -> String {


### PR DESCRIPTION
#1494 removed support for detecting "wrapped lists" -- but it only removed it from OpenAPI sources.

The MCP DSL v4 surface type still has wrapped list detection, and it's even more rudimentary than the one that #1494 objected to.

#1910 calls for re-introducing wrapped list detection, but storing it in operation metadata rather than the semantic IR.

So this PR is a cleanup: it removes wrapped lists from the sematic IR model, and removes the MCP-specific detection logic, in preparation for a clean, general detection method to be added in response to #1910.