### PR TITLE
fix(mcp): simplify task lifecycle results

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -82,7 +82,7 @@ fn task_started_value(task: &coral_api::v1::Task) -> Result<TaskStartedValue, to
     Ok(TaskStartedValue {
         task_id,
         message: "Task started.",
-        instructions: "Pass this task_id as task_id on subsequent Coral MCP tool calls for this work, then call end_task when the task is complete.",
+        instructions: "Pass this task_id on subsequent Coral MCP tool calls for this task, then call end_task when it is complete.",
     })
 }
 
@@ -529,7 +529,6 @@ impl CoralMcpServer {
         serialize_tool_value(TaskEndedValue {
             task_id,
             task_status: task_status_from_proto(task_end.task_status)?,
-            success: "Task ended.",
             note: "Task status recorded.",
         })
     }

--- a/crates/coral-mcp/src/surface/task.rs
+++ b/crates/coral-mcp/src/surface/task.rs
@@ -99,7 +99,6 @@ pub(crate) struct TaskStartedValue {
 pub(crate) struct TaskEndedValue {
     pub(crate) task_id: TaskId,
     pub(crate) task_status: TaskStatus,
-    pub(crate) success: &'static str,
     pub(crate) note: &'static str,
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -613,11 +613,9 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     let root_task_id = root["task_id"].as_str().expect("root task id").to_string();
     uuid::Uuid::parse_str(&root_task_id).expect("task id is a UUID");
     assert_eq!(root["message"], "Task started.");
-    assert!(
-        root["instructions"]
-            .as_str()
-            .expect("instructions")
-            .contains("end_task")
+    assert_eq!(
+        root["instructions"],
+        "Pass this task_id on subsequent Coral MCP tool calls for this task, then call end_task when it is complete."
     );
 
     let sql = client
@@ -650,7 +648,11 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     assert_structured_content_only(&end);
     let end = end.structured_content.expect("end structured content");
     assert_matches_output_schema(end_task_tool, &end);
-    assert_eq!(end["success"], "Task ended.");
+    assert!(
+        !end.as_object()
+            .expect("end task object")
+            .contains_key("success")
+    );
     assert_eq!(end["task_status"], "success");
 
     let invalid_task_id = client


### PR DESCRIPTION
## Summary

- remove the redundant fixed `success` field from `end_task` results
- keep the lifecycle result focused on the canonical task identifier and status
- tighten the returned lifecycle instructions around the start/end protocol

This replacement builds on and supersedes #1763 by @jamesaud.

## Breaking change

`end_task` results no longer include the fixed `success` field.

## Validation

- `make rust-checks` at the top of the stack — 2,067 passed, 5 skipped
- focused `coral-mcp` lifecycle coverage
- exact-head independent Standards and Spec reviews — no unresolved findings

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
