### PR TITLE
feat(app): persist tasks in SQL

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -237,7 +237,7 @@ jobs:
           CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: |
           cargo test --locked -p coral-app --lib \
-            state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+            repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
             --test postgres_database_tests \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ postgres-tests: postgres-start
 	url="postgres://postgres:postgres@127.0.0.1:$$host_port/$$db_name"; \
 	echo "Running Postgres tests against $$url"; \
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
-	  state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+	  repository_round_trips_against_postgres \
 	  -- --ignored; \
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app \
 	  --test postgres_database_tests \

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -51,6 +51,27 @@ root.
   initial DB bootstrap may coexist with filesystem-backed source behavior, but
   repository wiring must keep SQLx pools, transactions, SeaQuery schema
   identifiers, and row structs inside that module.
+- Give an independently identified entity one stable ID as its sole primary
+  key. Use a composite primary key only when the tuple itself is the durable
+  domain identity, not merely because every access is scoped by a parent such
+  as `workspace_id`.
+- Treat `workspace_id` as the confidentiality and access-control boundary for
+  workspace-owned rows. Every externally influenced lookup or mutation must
+  match the workspace and entity ID even when the entity ID is globally unique.
+- Name event timestamps for the fact they record as
+  `<fact>_at_unix_nanos BIGINT`. Name actor attribution
+  `<event>_by_principal_id`; attribution does not imply ownership or
+  authorization.
+- Prefer portable `TEXT` columns plus named `CHECK` constraints for small
+  closed value sets shared by SQLite and Postgres. Couple nullable fields with
+  a named constraint when they represent one state transition.
+- Versioned migrations must fail loudly on schema drift. Do not use
+  `IF NOT EXISTS` unless the migration deliberately adopts a documented legacy
+  object.
+- Design indexes from concrete access paths, including predicate and ordering
+  columns. Put multi-repository transaction choreography in a focused
+  `state/db/*_state.rs` operation; repositories expose the smallest reusable
+  query primitives.
 - DB repository behavior should have shared tests that run against SQLite
   locally and Postgres in CI through the repository harness.
 - Until the RDBMS migration phases replace the relevant stores, persist

--- a/crates/coral-app/migrations/0003_tasks.sql
+++ b/crates/coral-app/migrations/0003_tasks.sql
@@ -1,0 +1,32 @@
+CREATE TABLE tasks (
+    id TEXT NOT NULL PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    created_by_principal_id TEXT NOT NULL,
+    intent TEXT NOT NULL,
+    outcome TEXT,
+    created_at_unix_nanos BIGINT NOT NULL,
+    completed_at_unix_nanos BIGINT,
+
+    CONSTRAINT tasks_workspace_fk
+        FOREIGN KEY (workspace_id)
+        REFERENCES workspaces(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT tasks_outcome_valid
+        CHECK (outcome IS NULL OR outcome IN ('success', 'failure')),
+
+    CONSTRAINT tasks_completion_consistent
+        CHECK (
+            (outcome IS NULL AND completed_at_unix_nanos IS NULL)
+            OR
+            (outcome IS NOT NULL AND completed_at_unix_nanos IS NOT NULL)
+        )
+);
+
+CREATE INDEX idx_tasks_workspace_retention
+    ON tasks (
+        workspace_id,
+        completed_at_unix_nanos,
+        created_at_unix_nanos,
+        id
+    );

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -67,7 +67,7 @@ use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_stat
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
 use crate::task::service::TaskService;
-use crate::task::store::JsonlTaskEventStore;
+use crate::task::store::TaskStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcRequestContextLayer;
@@ -341,7 +341,7 @@ impl ServerBuilder {
             .load_with_overrides(&self.config.feature_overrides)?;
         let coral_db = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
-        run_state_migrations(&coral_db, &config_store).await?;
+        run_state_migrations(&coral_db, &config_store, &layout).await?;
         let coral_db = Arc::new(coral_db);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
@@ -383,7 +383,7 @@ impl ServerBuilder {
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -629,11 +629,11 @@ async fn start_server(
     };
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
-    let catalog_service = CatalogService::new(query.clone());
+    let catalog_service = CatalogService::new(query.clone(), task.clone());
     let function_service = FunctionService::new(query.clone());
-    let query_service = QueryService::new(query);
-    let search_service = SearchService::new(search.clone());
-    let feedback_service = FeedbackService::new(feedback);
+    let query_service = QueryService::new(query, task.clone());
+    let search_service = SearchService::new(search.clone(), task.clone());
+    let feedback_service = FeedbackService::new(feedback, task.clone());
     let task_service = TaskService::new(task);
     let mut application_routes = Routes::default()
         .add_service(
@@ -949,7 +949,7 @@ mod tests {
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
-    use crate::task::store::JsonlTaskEventStore;
+    use crate::task::store::TaskStore;
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
@@ -1027,7 +1027,7 @@ enabled = false
             .await
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
-        run_state_migrations(&db, config_store)
+        run_state_migrations(&db, config_store, layout)
             .await
             .expect("run state migrations");
         Arc::new(db)
@@ -1365,7 +1365,7 @@ backend = "unsupported"
         let config_dir = temp.path().join("coral-config");
         disable_internal_tracing(&config_dir);
         let server = ServerBuilder::new()
-            .with_config_dir(config_dir.clone())
+            .with_config_dir(config_dir)
             .start()
             .await
             .expect("start server");
@@ -1401,20 +1401,6 @@ backend = "unsupported"
             .expect("task end");
         assert_eq!(task_end.task_id, task.task_id);
         assert_eq!(task_end.task_status, TaskStatus::Success as i32);
-
-        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
-        let workspace = WorkspaceName::default();
-        let tasks =
-            std::fs::read_to_string(layout.task_events_file(&workspace)).expect("task events file");
-        assert!(tasks.contains(&task.task_id));
-        assert!(
-            tasks.contains("find the HR onboarding form"),
-            "task events should contain start intent, got: {tasks}"
-        );
-        assert!(
-            tasks.contains("success"),
-            "task events should contain end status, got: {tasks}"
-        );
         server.shutdown().await.expect("shutdown");
     }
 
@@ -1532,7 +1518,6 @@ backend = "unsupported"
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1540,6 +1525,7 @@ backend = "unsupported"
             None,
             Arc::clone(&db),
         );
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
@@ -1981,7 +1967,6 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1989,6 +1974,7 @@ tables:
             None,
             Arc::clone(&db),
         );
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
@@ -2110,7 +2096,6 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -2118,6 +2103,7 @@ tables:
             None,
             Arc::clone(&db),
         );
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
@@ -2236,7 +2222,6 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -2244,6 +2229,7 @@ tables:
             None,
             Arc::clone(&db),
         );
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -16,21 +16,27 @@ use crate::catalog::discovery::{
 };
 use crate::query::QueryAttribution;
 use crate::query::manager::QueryManager;
+use crate::request_context::RequestContext;
+use crate::task::manager::TaskManager;
+use crate::task::service::task_manager_status;
 use crate::transport::{
     catalog_item_to_proto, catalog_search_result_to_proto, column_search_result_to_proto,
     describe_table_response_to_proto, grpc_span, instrument_grpc, pagination_to_proto,
-    query_status, workspace_name_from_proto,
+    query_status, request_context, workspace_name_from_proto,
 };
+use crate::workspaces::WorkspaceName;
 
 #[derive(Clone)]
 pub(crate) struct CatalogService {
     catalog: CatalogDiscovery,
+    tasks: TaskManager,
 }
 
 impl CatalogService {
-    pub(crate) fn new(query_manager: QueryManager) -> Self {
+    pub(crate) fn new(query_manager: QueryManager, task_manager: TaskManager) -> Self {
         Self {
             catalog: CatalogDiscovery::new(query_manager),
+            tasks: task_manager,
         }
     }
 }
@@ -43,11 +49,13 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<ListCatalogResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
-        let attribution = QueryAttribution::from_extensions(request.extensions());
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
             let catalog_page = catalog
@@ -84,10 +92,12 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<SearchCatalogResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
-        let attribution = QueryAttribution::from_extensions(request.extensions());
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
             let pagination = search_pagination(request.pagination.map(pagination_from_proto))
@@ -131,10 +141,12 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<DescribeTableResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
-        let attribution = QueryAttribution::from_extensions(request.extensions());
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
             let table_name = required_trimmed(&request.table_name, "table_name")?;
             let result = catalog
@@ -159,10 +171,12 @@ impl CatalogServiceApi for CatalogService {
     ) -> Result<Response<ListColumnsResponse>, Status> {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
-        let attribution = QueryAttribution::from_extensions(request.extensions());
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
             let table_name = required_trimmed(&request.table_name, "table_name")?;
             let pagination = column_pagination(request.pagination.map(pagination_from_proto))
@@ -202,6 +216,18 @@ impl CatalogServiceApi for CatalogService {
         }))
         .await
     }
+}
+
+async fn query_attribution(
+    tasks: &TaskManager,
+    workspace: &WorkspaceName,
+    request_context: &RequestContext,
+) -> Result<QueryAttribution, Status> {
+    tasks
+        .validate_attribution(workspace, request_context.task_id())
+        .await
+        .map(QueryAttribution::new)
+        .map_err(task_manager_status)
 }
 
 fn pagination_from_proto(pagination: PaginationRequest) -> Pagination {

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -636,7 +636,7 @@ impl FileCredentialBackend {
     fn write_unlocked(path: &Path, material: Option<&[u8]>) -> Result<(), CredentialsError> {
         match material {
             Some(material) => write_file_unlocked(path, material),
-            None => remove_file_if_exists_unlocked(path).map_err(Into::into),
+            None => storage_fs::remove_file_if_exists(path).map_err(Into::into),
         }
     }
 
@@ -1094,7 +1094,7 @@ fn save_values_unlocked(
     values: &BTreeMap<String, String>,
 ) -> Result<(), CredentialsError> {
     if values.is_empty() {
-        remove_file_if_exists_unlocked(path)?;
+        storage_fs::remove_file_if_exists(path)?;
         return Ok(());
     }
 
@@ -1117,14 +1117,6 @@ fn render_env_file(values: &BTreeMap<String, String>) -> String {
         output.push('\n');
     }
     output
-}
-
-fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Error> {
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
 }
 
 fn parse_env_file(raw: &str) -> Result<BTreeMap<String, String>, CredentialsError> {

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -6,17 +6,24 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::feedback::manager::{FeedbackManager, FeedbackReport};
-use crate::task::id::TaskId;
-use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto, workspace_to_proto};
+use crate::task::manager::TaskManager;
+use crate::task::service::task_manager_status;
+use crate::transport::{
+    grpc_span, instrument_grpc, request_context, workspace_name_from_proto, workspace_to_proto,
+};
 
 #[derive(Clone)]
 pub(crate) struct FeedbackService {
     feedback: FeedbackManager,
+    tasks: TaskManager,
 }
 
 impl FeedbackService {
-    pub(crate) fn new(feedback: FeedbackManager) -> Self {
-        Self { feedback }
+    pub(crate) fn new(feedback: FeedbackManager, task_manager: TaskManager) -> Self {
+        Self {
+            feedback,
+            tasks: task_manager,
+        }
     }
 }
 
@@ -27,11 +34,16 @@ impl FeedbackServiceApi for FeedbackService {
         request: Request<SubmitFeedbackRequest>,
     ) -> Result<Response<SubmitFeedbackResponse>, Status> {
         let span = grpc_span(&request);
-        let task_id = request.extensions().get::<TaskId>().copied();
         let feedback = self.feedback.clone();
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let task_id = tasks
+                .validate_attribution(&workspace_name, request_context.task_id())
+                .await
+                .map_err(task_manager_status)?;
             let submission = feedback
                 .submit_feedback(
                     &workspace_name,

--- a/crates/coral-app/src/query/attribution.rs
+++ b/crates/coral-app/src/query/attribution.rs
@@ -1,7 +1,5 @@
 //! Transport-free attribution for a query's originating context.
 
-use tonic::codegen::http;
-
 use crate::task::id::TaskId;
 
 /// Request-scoped attribution threaded from the gRPC service edge into the query
@@ -14,15 +12,13 @@ use crate::task::id::TaskId;
 /// here; only the opaque id is propagated.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct QueryAttribution {
-    /// The task whose intent this query served, when the caller supplied a
-    /// valid `coral-task-id`; `None` for an untagged query.
+    /// The active task whose intent this query served; `None` for an untagged
+    /// query.
     pub(crate) task_id: Option<TaskId>,
 }
 
 impl QueryAttribution {
-    pub(crate) fn from_extensions(extensions: &http::Extensions) -> Self {
-        Self {
-            task_id: extensions.get::<TaskId>().copied(),
-        }
+    pub(crate) fn new(task_id: Option<TaskId>) -> Self {
+        Self { task_id }
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1219,13 +1219,18 @@ mod tests {
 
     use super::*;
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
+    use crate::identity::Principal;
+    use crate::request_context::RequestContext;
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+    use crate::task::manager::TaskManager;
+    use crate::task::store::TaskStore;
 
     struct QueryManagerFixture {
         _temp: TempDir,
         manager: QueryManager,
+        db: Arc<CoralDb>,
     }
 
     async fn query_manager_with(
@@ -1257,6 +1262,7 @@ mod tests {
         QueryManagerFixture {
             _temp: temp,
             manager,
+            db,
         }
     }
 
@@ -1290,6 +1296,7 @@ mod tests {
         QueryManagerFixture {
             _temp: temp,
             manager,
+            db,
         }
     }
 
@@ -1319,10 +1326,26 @@ mod tests {
             .await
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
-        run_state_migrations(&db, config_store)
+        run_state_migrations(&db, config_store, layout)
             .await
             .expect("run state migrations");
         Arc::new(db)
+    }
+
+    async fn active_task_context(db: &Arc<CoralDb>) -> (TaskManager, RequestContext, String) {
+        let task = TaskManager::new(TaskStore::new(Arc::clone(db)));
+        let principal = Principal::local();
+        let started = task
+            .start_task(
+                WorkspaceName::default(),
+                principal.clone(),
+                "Exercise query attribution".to_string(),
+            )
+            .await
+            .expect("start attributed task");
+        let task_id = started.id.to_string();
+        let context = RequestContext::new(principal).with_task_id(Some(started.id));
+        (task, context, task_id)
     }
 
     fn assert_workspace_not_found(error: AppError, workspace_name: &WorkspaceName) {
@@ -1391,7 +1414,8 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
-        let service = QueryService::new(fixture.manager.clone());
+        let (task, request_context, task_id) = active_task_context(&fixture.db).await;
+        let service = QueryService::new(fixture.manager.clone(), task);
 
         let mut request = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
@@ -1399,10 +1423,7 @@ mod tests {
             }),
             sql: "SELECT 1".to_string(),
         });
-        request.extensions_mut().insert(
-            crate::task::id::TaskId::parse("550e8400-e29b-41d4-a716-446655440000")
-                .expect("task id"),
-        );
+        request.extensions_mut().insert(request_context);
 
         // The query may fail (the fixture has no installed sources); the
         // `coral.query` span is created and stamped before execution regardless.
@@ -1419,10 +1440,7 @@ mod tests {
             .iter()
             .find(|attribute| attribute.key.as_str() == "task.id")
             .expect("task.id attribute present");
-        assert_eq!(
-            task_attr.value.as_str(),
-            "550e8400-e29b-41d4-a716-446655440000"
-        );
+        assert_eq!(task_attr.value.as_str(), task_id);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1443,13 +1461,14 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
-        let service = CatalogService::new(fixture.manager.clone());
+        let (task, request_context, task_id) = active_task_context(&fixture.db).await;
+        let service = CatalogService::new(fixture.manager.clone(), task);
 
-        call_catalog_tools_with_task(&service).await;
+        call_catalog_tools_with_task(&service, &request_context).await;
 
         provider.force_flush().expect("flush spans");
         let spans = exporter.get_finished_spans().expect("finished spans");
-        assert_catalog_task_spans(&spans);
+        assert_catalog_task_spans(&spans, &task_id);
     }
 
     #[test]
@@ -1516,7 +1535,10 @@ mod tests {
         );
     }
 
-    async fn call_catalog_tools_with_task(service: &crate::catalog::service::CatalogService) {
+    async fn call_catalog_tools_with_task(
+        service: &crate::catalog::service::CatalogService,
+        request_context: &RequestContext,
+    ) {
         use coral_api::v1::catalog_service_server::CatalogService as CatalogServiceApi;
         use coral_api::v1::{
             DescribeTableRequest, ListCatalogRequest, ListColumnsRequest, PaginationRequest,
@@ -1524,49 +1546,61 @@ mod tests {
         };
 
         let _list_catalog_result = service
-            .list_catalog(tagged_catalog_request(ListCatalogRequest {
-                workspace: Some(default_workspace_proto()),
-                schema_name: String::new(),
-                kind: 0,
-                pagination: Some(PaginationRequest {
-                    limit: 10,
-                    offset: 0,
-                }),
-            }))
+            .list_catalog(tagged_catalog_request(
+                request_context,
+                ListCatalogRequest {
+                    workspace: Some(default_workspace_proto()),
+                    schema_name: String::new(),
+                    kind: 0,
+                    pagination: Some(PaginationRequest {
+                        limit: 10,
+                        offset: 0,
+                    }),
+                },
+            ))
             .await;
         let _search_catalog_result = service
-            .search_catalog(tagged_catalog_request(SearchCatalogRequest {
-                workspace: Some(default_workspace_proto()),
-                pattern: "tables".to_string(),
-                ignore_case: true,
-                schema_name: String::new(),
-                kind: 0,
-                pagination: Some(PaginationRequest {
-                    limit: 10,
-                    offset: 0,
-                }),
-            }))
+            .search_catalog(tagged_catalog_request(
+                request_context,
+                SearchCatalogRequest {
+                    workspace: Some(default_workspace_proto()),
+                    pattern: "tables".to_string(),
+                    ignore_case: true,
+                    schema_name: String::new(),
+                    kind: 0,
+                    pagination: Some(PaginationRequest {
+                        limit: 10,
+                        offset: 0,
+                    }),
+                },
+            ))
             .await;
         let _describe_table_result = service
-            .describe_table(tagged_catalog_request(DescribeTableRequest {
-                workspace: Some(default_workspace_proto()),
-                schema_name: "coral".to_string(),
-                table_name: "tables".to_string(),
-            }))
+            .describe_table(tagged_catalog_request(
+                request_context,
+                DescribeTableRequest {
+                    workspace: Some(default_workspace_proto()),
+                    schema_name: "coral".to_string(),
+                    table_name: "tables".to_string(),
+                },
+            ))
             .await;
         let _list_columns_result = service
-            .list_columns(tagged_catalog_request(ListColumnsRequest {
-                workspace: Some(default_workspace_proto()),
-                schema_name: "coral".to_string(),
-                table_name: "tables".to_string(),
-                pattern: None,
-                ignore_case: true,
-                required_only: false,
-                pagination: Some(PaginationRequest {
-                    limit: 10,
-                    offset: 0,
-                }),
-            }))
+            .list_columns(tagged_catalog_request(
+                request_context,
+                ListColumnsRequest {
+                    workspace: Some(default_workspace_proto()),
+                    schema_name: "coral".to_string(),
+                    table_name: "tables".to_string(),
+                    pattern: None,
+                    ignore_case: true,
+                    required_only: false,
+                    pagination: Some(PaginationRequest {
+                        limit: 10,
+                        offset: 0,
+                    }),
+                },
+            ))
             .await;
     }
 
@@ -1576,23 +1610,22 @@ mod tests {
         }
     }
 
-    fn tagged_catalog_request<T>(message: T) -> tonic::Request<T> {
+    fn tagged_catalog_request<T>(
+        request_context: &RequestContext,
+        message: T,
+    ) -> tonic::Request<T> {
         let mut request = tonic::Request::new(message);
-        request.extensions_mut().insert(
-            crate::task::id::TaskId::parse("650e8400-e29b-41d4-a716-446655440000")
-                .expect("task id"),
-        );
+        request.extensions_mut().insert(request_context.clone());
         request
     }
 
-    fn assert_catalog_task_spans(spans: &[opentelemetry_sdk::trace::SpanData]) {
+    fn assert_catalog_task_spans(spans: &[opentelemetry_sdk::trace::SpanData], task_id: &str) {
         let attributed_query_spans = spans
             .iter()
             .filter(|span| {
                 span.name == "coral.query"
                     && span.attributes.iter().any(|attribute| {
-                        attribute.key.as_str() == "task.id"
-                            && attribute.value.as_str() == "650e8400-e29b-41d4-a716-446655440000"
+                        attribute.key.as_str() == "task.id" && attribute.value.as_str() == task_id
                     })
             })
             .collect::<Vec<_>>();

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -13,17 +13,23 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::core_status;
 use crate::query::QueryAttribution;
 use crate::query::manager::QueryManager;
-use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
+use crate::task::manager::TaskManager;
+use crate::task::service::task_manager_status;
+use crate::transport::{
+    grpc_span, instrument_grpc, query_status, request_context, workspace_name_from_proto,
+};
 
 #[derive(Clone)]
 pub(crate) struct QueryService {
     queries: QueryManager,
+    tasks: TaskManager,
 }
 
 impl QueryService {
-    pub(crate) fn new(query_manager: QueryManager) -> Self {
+    pub(crate) fn new(query_manager: QueryManager, task_manager: TaskManager) -> Self {
         Self {
             queries: query_manager,
+            tasks: task_manager,
         }
     }
 }
@@ -36,10 +42,17 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
-        let attribution = QueryAttribution::from_extensions(request.extensions());
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let attribution = QueryAttribution::new(
+                tasks
+                    .validate_attribution(&workspace_name, request_context.task_id())
+                    .await
+                    .map_err(task_manager_status)?,
+            );
             let execution = queries
                 .execute_sql(&workspace_name, &inner.sql, &attribution)
                 .await
@@ -64,10 +77,17 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExplainSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
-        let attribution = QueryAttribution::from_extensions(request.extensions());
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let attribution = QueryAttribution::new(
+                tasks
+                    .validate_attribution(&workspace_name, request_context.task_id())
+                    .await
+                    .map_err(task_manager_status)?,
+            );
             let plan = queries
                 .explain_sql(&workspace_name, &inner.sql, &attribution)
                 .await

--- a/crates/coral-app/src/request_context.rs
+++ b/crates/coral-app/src/request_context.rs
@@ -1,31 +1,34 @@
 //! Request-scoped app context selected at the transport boundary.
 
 use crate::identity::Principal;
+use crate::task::id::TaskId;
 
 /// Request-scoped data that domain services may need after authentication.
-///
-/// This intentionally starts narrow. Query attribution still flows through its
-/// existing path today, but can move here later without widening every
-/// principal-aware call signature again.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RequestContext {
     principal: Principal,
+    task_id: Option<TaskId>,
 }
 
 impl RequestContext {
     pub(crate) fn new(principal: Principal) -> Self {
-        Self { principal }
+        Self {
+            principal,
+            task_id: None,
+        }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "request principals stay encapsulated for downstream authorization and attribution"
-        )
-    )]
+    pub(crate) fn with_task_id(mut self, task_id: Option<TaskId>) -> Self {
+        self.task_id = task_id;
+        self
+    }
+
     pub(crate) fn principal(&self) -> &Principal {
         &self.principal
+    }
+
+    pub(crate) fn task_id(&self) -> Option<TaskId> {
+        self.task_id
     }
 }
 
@@ -42,5 +45,17 @@ mod tests {
 
         assert_eq!(context.principal(), &principal);
         assert_eq!(context.principal().kind(), PrincipalKind::User);
+        assert_eq!(context.task_id(), None);
+    }
+
+    #[test]
+    fn carries_unvalidated_task_metadata_until_the_service_edge() {
+        let principal = Principal::parse("product:principal:saul", PrincipalKind::User)
+            .expect("valid principal");
+        let task_id = crate::task::id::TaskId::parse("550e8400-e29b-41d4-a716-446655440000")
+            .expect("valid task id");
+        let context = RequestContext::new(principal).with_task_id(Some(task_id));
+
+        assert_eq!(context.task_id(), Some(task_id));
     }
 }

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -51,19 +51,23 @@ use crate::search::result::{
     TableColumnPreview as DomainTableColumnPreview,
 };
 use crate::sources::SourceName;
+use crate::task::manager::TaskManager;
+use crate::task::service::task_manager_status;
 use crate::transport::{
-    catalog_item_to_proto, grpc_span, instrument_grpc, workspace_name_from_proto,
+    catalog_item_to_proto, grpc_span, instrument_grpc, request_context, workspace_name_from_proto,
 };
 
 #[derive(Clone)]
 pub(crate) struct SearchService {
     search: SearchManager,
+    tasks: TaskManager,
 }
 
 impl SearchService {
-    pub(crate) fn new(search_manager: SearchManager) -> Self {
+    pub(crate) fn new(search_manager: SearchManager, task_manager: TaskManager) -> Self {
         Self {
             search: search_manager,
+            tasks: task_manager,
         }
     }
 }
@@ -76,10 +80,17 @@ impl SearchServiceApi for SearchService {
     ) -> Result<Response<ProtoSearchResponse>, Status> {
         let span = grpc_span(&request);
         let search = self.search.clone();
+        let tasks = self.tasks.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
-            let attribution = QueryAttribution::from_extensions(request.extensions());
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let attribution = QueryAttribution::new(
+                tasks
+                    .validate_attribution(&workspace_name, request_context.task_id())
+                    .await
+                    .map_err(task_manager_status)?,
+            );
             let request = SearchRequest::new(workspace_name, &request.query, request.limit)
                 .map_err(search_status)?;
             let response = search

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use super::session::DbRepos;
 use super::{CoralDb, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
-use crate::state::ConfigStore;
+use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceRecord;
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
@@ -17,8 +17,19 @@ pub(crate) struct WorkspaceCatalogCutoverReport {
 pub(crate) async fn run_state_migrations(
     db: &CoralDb,
     config_store: &ConfigStore,
+    layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store).await?;
+    remove_legacy_task_jsonl(config_store, layout)?;
+    Ok(())
+}
+
+fn remove_legacy_task_jsonl(
+    config_store: &ConfigStore,
+    layout: &AppStateLayout,
+) -> Result<(), AppError> {
+    let _state_lock = config_store.state_lock_exclusive()?;
+    layout.remove_legacy_task_event_logs()?;
     Ok(())
 }
 
@@ -35,12 +46,14 @@ async fn cutover_legacy_workspace_catalog_at(
     now_unix_nanos: i64,
 ) -> Result<WorkspaceCatalogCutoverReport, AppError> {
     let _state_lock = config_store.state_lock_exclusive()?;
-    let mut session = db;
-    if session
+    let mut tx = db.begin().await?;
+    if !tx
         .state_migrations()
-        .has_completed(WORKSPACE_CATALOG_CUTOVER_ID)
+        .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, now_unix_nanos)
         .await?
     {
+        tx.rollback().await?;
+        let mut session = db;
         return Ok(WorkspaceCatalogCutoverReport {
             workspace_count: session.workspaces().list().await?.len(),
             cutover_performed: false,
@@ -52,13 +65,9 @@ async fn cutover_legacy_workspace_catalog_at(
         .legacy_workspace_records();
     let workspace_count = workspaces.len();
 
-    let mut tx = db.begin().await?;
     tx.workspaces().delete_all().await?;
     import_legacy_workspaces(&mut tx, &workspaces, now_unix_nanos).await?;
     verify_workspace_parity(&mut tx, &workspaces).await?;
-    tx.state_migrations()
-        .mark_completed(WORKSPACE_CATALOG_CUTOVER_ID, now_unix_nanos)
-        .await?;
     tx.commit().await?;
 
     Ok(WorkspaceCatalogCutoverReport {
@@ -117,6 +126,7 @@ mod tests {
     use super::{
         WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
+        run_state_migrations,
     };
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
@@ -233,6 +243,43 @@ mod tests {
                 cutover_performed: false
             }
         );
+    }
+
+    #[tokio::test]
+    async fn shared_database_does_not_scope_task_cleanup_to_the_first_layout() {
+        let temp = tempdir().expect("temp dir");
+        let first_layout =
+            AppStateLayout::discover(Some(temp.path().join("first"))).expect("first layout");
+        let second_layout =
+            AppStateLayout::discover(Some(temp.path().join("second"))).expect("second layout");
+        first_layout.ensure().expect("ensure first layout");
+        second_layout.ensure().expect("ensure second layout");
+        let first_config_store = ConfigStore::new(first_layout.clone());
+        let second_config_store = ConfigStore::new(second_layout.clone());
+        let first_legacy_file = first_layout
+            .workspace_dir(&WorkspaceName::default())
+            .join("tasks")
+            .join("tasks.jsonl");
+        let second_legacy_file = second_layout
+            .workspace_dir(&WorkspaceName::default())
+            .join("tasks")
+            .join("tasks.jsonl");
+        for path in [&first_legacy_file, &second_legacy_file] {
+            std::fs::create_dir_all(path.parent().expect("legacy task dir"))
+                .expect("create legacy task dir");
+            std::fs::write(path, "sensitive task intent").expect("write legacy task file");
+        }
+        let db = open_sqlite(&first_layout).await;
+
+        run_state_migrations(&db, &first_config_store, &first_layout)
+            .await
+            .expect("run migrations for first layout");
+        run_state_migrations(&db, &second_config_store, &second_layout)
+            .await
+            .expect("run migrations for second layout");
+
+        assert!(!first_legacy_file.exists());
+        assert!(!second_legacy_file.exists());
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -10,12 +10,18 @@ mod migrations;
 mod repositories;
 mod schema;
 mod session;
+mod task_state;
 mod transaction;
+mod workspace_state;
 
 pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
+pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
 pub(crate) use session::{DbRepos, DbSession};
+#[cfg(test)]
+pub(crate) use task_state::TaskMutationBarrier;
+pub(crate) use task_state::{TaskCreation, TaskCreationResult};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod state_migrations;
+pub(crate) mod tasks;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/state_migrations.rs
+++ b/crates/coral-app/src/state/db/repositories/state_migrations.rs
@@ -1,8 +1,11 @@
-use sea_query::{Expr, ExprTrait, Query};
+#[cfg(test)]
+use sea_query::ExprTrait;
+use sea_query::{Expr, OnConflict, Query};
 
 use crate::state::db::schema::AppStateMigrations;
-use crate::state::db::{DbError, DbSession};
+use crate::state::db::{CoralTx, DbError, DbSession};
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub(crate) struct StateMigrationRecord {
     pub(crate) id: String,
@@ -21,29 +24,12 @@ where
         Self { session }
     }
 
+    #[cfg(test)]
     pub(crate) async fn has_completed(&mut self, id: &str) -> Result<bool, DbError> {
         Ok(self.get(id).await?.is_some())
     }
 
-    pub(crate) async fn mark_completed(
-        &mut self,
-        id: &str,
-        completed_at_unix_nanos: i64,
-    ) -> Result<(), DbError> {
-        let statement = Query::insert()
-            .into_table(AppStateMigrations::Table)
-            .columns([
-                AppStateMigrations::Id,
-                AppStateMigrations::CompletedAtUnixNanos,
-            ])
-            .values_panic([
-                Expr::val(id.to_string()),
-                Expr::val(completed_at_unix_nanos),
-            ])
-            .to_owned();
-        self.session.execute(statement).await
-    }
-
+    #[cfg(test)]
     async fn get(&mut self, id: &str) -> Result<Option<StateMigrationRecord>, DbError> {
         let statement = Query::select()
             .columns([
@@ -54,5 +40,182 @@ where
             .and_where(Expr::col(AppStateMigrations::Id).eq(id))
             .to_owned();
         self.session.fetch_optional(statement).await
+    }
+}
+
+impl StateMigrationsRepo<'_, CoralTx<'_>> {
+    /// Claims a one-time migration for the lifetime of the current transaction.
+    ///
+    /// The inserted marker becomes visible only when the transaction commits.
+    /// A rollback releases the claim so another process can retry the migration.
+    pub(crate) async fn try_claim(
+        &mut self,
+        id: &str,
+        completed_at_unix_nanos: i64,
+    ) -> Result<bool, DbError> {
+        let statement = Query::insert()
+            .into_table(AppStateMigrations::Table)
+            .columns([
+                AppStateMigrations::Id,
+                AppStateMigrations::CompletedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(id.to_string()),
+                Expr::val(completed_at_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::column(AppStateMigrations::Id)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .to_owned();
+        Ok(DbSession::execute_rows_affected(self.session, statement).await? == 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::StateMigrationRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+
+    #[tokio::test]
+    async fn state_migration_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        assert_claim_lifecycle(&db, "sqlite_transactional_claim").await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the repository contract against Postgres"]
+    async fn state_migration_repository_round_trips_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres connection");
+        db.migrate().await.expect("migrate postgres");
+        let migration_id = format!("postgres_transactional_claim_{}", uuid::Uuid::new_v4());
+        assert_claim_lifecycle(&db, &migration_id).await;
+    }
+
+    async fn assert_claim_lifecycle(db: &CoralDb, migration_id: &str) {
+        let mut tx = db.begin().await.expect("begin rolled-back claim");
+        assert!(
+            tx.state_migrations()
+                .try_claim(migration_id, 11)
+                .await
+                .expect("claim migration")
+        );
+        tx.rollback().await.expect("roll back claim");
+
+        let mut session = db;
+        assert!(
+            !session
+                .state_migrations()
+                .has_completed(migration_id)
+                .await
+                .expect("read rolled-back claim")
+        );
+
+        let mut tx = db.begin().await.expect("begin committed claim");
+        assert!(
+            tx.state_migrations()
+                .try_claim(migration_id, 12)
+                .await
+                .expect("claim migration after rollback")
+        );
+        tx.commit().await.expect("commit claim");
+
+        let mut tx = db.begin().await.expect("begin duplicate claim");
+        assert!(
+            !tx.state_migrations()
+                .try_claim(migration_id, 13)
+                .await
+                .expect("reject duplicate claim")
+        );
+        tx.rollback().await.expect("roll back duplicate claim");
+
+        assert_eq!(
+            session
+                .state_migrations()
+                .get(migration_id)
+                .await
+                .expect("read completed claim"),
+            Some(StateMigrationRecord {
+                id: migration_id.to_string(),
+                completed_at_unix_nanos: 12,
+            })
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run concurrent claims against Postgres"]
+    async fn state_migration_repository_round_trips_against_postgres_with_one_concurrent_winner() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let first_db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url: url.clone() })
+            .await
+            .expect("open first postgres connection");
+        first_db.migrate().await.expect("migrate postgres");
+        let second_db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open second postgres connection");
+        let migration_id = format!("concurrent_claim_{}", uuid::Uuid::new_v4());
+
+        let mut first_tx = first_db.begin().await.expect("begin first claim");
+        assert!(
+            first_tx
+                .state_migrations()
+                .try_claim(&migration_id, 21)
+                .await
+                .expect("claim migration first")
+        );
+
+        let (first_commit, second_claim) = tokio::join!(
+            async {
+                tokio::task::yield_now().await;
+                first_tx.commit().await
+            },
+            async {
+                let mut second_tx = second_db.begin().await.expect("begin second claim");
+                let claimed = second_tx
+                    .state_migrations()
+                    .try_claim(&migration_id, 22)
+                    .await
+                    .expect("claim migration second");
+                second_tx.rollback().await.expect("roll back second claim");
+                claimed
+            }
+        );
+
+        first_commit.expect("commit first claim");
+        assert!(!second_claim, "the committed claimant must be unique");
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        layout.ensure().expect("ensure layout");
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
     }
 }

--- a/crates/coral-app/src/state/db/repositories/tasks.rs
+++ b/crates/coral-app/src/state/db/repositories/tasks.rs
@@ -1,0 +1,862 @@
+use sea_query::{Expr, ExprTrait, Func, Order, Query};
+
+use crate::state::db::schema::Tasks;
+use crate::state::db::{CoralTx, DbError, DbSession};
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+struct TaskRow {
+    id: String,
+    created_by_principal_id: String,
+    intent: String,
+    outcome: Option<String>,
+    created_at_unix_nanos: i64,
+    completed_at_unix_nanos: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskCompletionUpdate {
+    Completed,
+    AlreadyCompleted,
+    NotFound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskLifecycleState {
+    Active,
+    Completed,
+}
+
+pub(crate) struct TasksRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> TasksRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn find_state(
+        &mut self,
+        workspace_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TaskLifecycleState>, DbError> {
+        let statement = Query::select()
+            .column(Tasks::Outcome)
+            .from(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .to_owned();
+        let row: Option<(Option<String>,)> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(|(outcome,)| {
+            if outcome.is_some() {
+                TaskLifecycleState::Completed
+            } else {
+                TaskLifecycleState::Active
+            }
+        }))
+    }
+
+    pub(in crate::state::db) async fn count(&mut self, workspace_id: &str) -> Result<u64, DbError> {
+        let statement = Query::select()
+            .expr(Func::count(Expr::col(Tasks::Id)))
+            .from(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .to_owned();
+        let (count,): (i64,) = self
+            .session
+            .fetch_optional(statement)
+            .await?
+            .unwrap_or_default();
+        Ok(u64::try_from(count).unwrap_or(0))
+    }
+
+    pub(in crate::state::db) async fn oldest_completed_task_id(
+        &mut self,
+        workspace_id: &str,
+    ) -> Result<Option<String>, DbError> {
+        let statement = Query::select()
+            .column(Tasks::Id)
+            .from(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::CompletedAtUnixNanos).is_not_null())
+            .order_by(Tasks::CompletedAtUnixNanos, Order::Asc)
+            .order_by(Tasks::CreatedAtUnixNanos, Order::Asc)
+            .order_by(Tasks::Id, Order::Asc)
+            .limit(1)
+            .to_owned();
+        let row: Option<(String,)> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(|(task_id,)| task_id))
+    }
+
+    #[cfg(test)]
+    async fn get(&mut self, workspace_id: &str, task_id: &str) -> Result<Option<TaskRow>, DbError> {
+        let statement = Query::select()
+            .columns(task_columns())
+            .from(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+}
+
+impl TasksRepo<'_, CoralTx<'_>> {
+    pub(crate) async fn insert(
+        &mut self,
+        workspace_id: &str,
+        created_by_principal_id: &str,
+        task_id: &str,
+        intent: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = task_insert(
+            workspace_id,
+            created_by_principal_id,
+            task_id,
+            intent,
+            created_at_unix_nanos,
+        );
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn complete(
+        &mut self,
+        workspace_id: &str,
+        task_id: &str,
+        outcome: &str,
+        completed_at_unix_nanos: i64,
+    ) -> Result<TaskCompletionUpdate, DbError> {
+        let statement = Query::update()
+            .table(Tasks::Table)
+            .values([
+                (Tasks::Outcome, Expr::val(outcome.to_string())),
+                (
+                    Tasks::CompletedAtUnixNanos,
+                    Expr::val(Some(completed_at_unix_nanos)),
+                ),
+            ])
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .and_where(Expr::col(Tasks::Outcome).is_null())
+            .to_owned();
+        if self.session.execute_rows_affected(statement).await? > 0 {
+            return Ok(TaskCompletionUpdate::Completed);
+        }
+
+        let statement = Query::select()
+            .column(Tasks::Outcome)
+            .from(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .to_owned();
+        let row: Option<(Option<String>,)> = self.session.fetch_optional(statement).await?;
+        Ok(match row {
+            Some((Some(_),)) => TaskCompletionUpdate::AlreadyCompleted,
+            Some((None,)) | None => TaskCompletionUpdate::NotFound,
+        })
+    }
+
+    pub(in crate::state::db) async fn delete(
+        &mut self,
+        workspace_id: &str,
+        task_id: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .to_owned();
+        self.session.execute(statement).await
+    }
+}
+
+fn task_insert(
+    workspace_id: &str,
+    created_by_principal_id: &str,
+    task_id: &str,
+    intent: &str,
+    created_at_unix_nanos: i64,
+) -> sea_query::InsertStatement {
+    Query::insert()
+        .into_table(Tasks::Table)
+        .columns([
+            Tasks::Id,
+            Tasks::WorkspaceId,
+            Tasks::CreatedByPrincipalId,
+            Tasks::Intent,
+            Tasks::Outcome,
+            Tasks::CreatedAtUnixNanos,
+            Tasks::CompletedAtUnixNanos,
+        ])
+        .values_panic([
+            Expr::val(task_id.to_string()),
+            Expr::val(workspace_id.to_string()),
+            Expr::val(created_by_principal_id.to_string()),
+            Expr::val(intent.to_string()),
+            Expr::val(Option::<String>::None),
+            Expr::val(created_at_unix_nanos),
+            Expr::val(Option::<i64>::None),
+        ])
+        .to_owned()
+}
+
+#[cfg(test)]
+fn task_columns() -> [Tasks; 6] {
+    [
+        Tasks::Id,
+        Tasks::CreatedByPrincipalId,
+        Tasks::Intent,
+        Tasks::Outcome,
+        Tasks::CreatedAtUnixNanos,
+        Tasks::CompletedAtUnixNanos,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use sea_query::{Expr, Query};
+    use tempfile::tempdir;
+
+    use super::{TaskCompletionUpdate, TaskLifecycleState, TaskRow};
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::schema::Tasks;
+    use crate::state::db::session::{DbRepos, DbSession};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, ResolvedDatabaseConfig, TaskCreation, TaskCreationResult,
+        TaskMutationBarrier,
+    };
+
+    #[tokio::test]
+    async fn task_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_task_repository_round_trip(&db, "sqlite_task_round_trip").await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn task_repository_round_trips_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        assert_task_repository_round_trip(&db, &format!("postgres_task_{suffix}")).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The shared SQLite/Postgres harness verifies schema, identity, lifecycle, retention, concurrency, and cascade semantics together."
+    )]
+    async fn assert_task_repository_round_trip(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(workspace_id, 40)
+            .await
+            .expect("workspace");
+        tx.commit().await.expect("commit workspace");
+        assert_task_constraints(db, workspace_id).await;
+
+        let created_by_principal_id = "product:principal:saul";
+        let task = TaskRow {
+            created_by_principal_id: created_by_principal_id.to_string(),
+            id: uuid::Uuid::new_v4().to_string(),
+            intent: "  Find renewal risk  ".to_string(),
+            outcome: None,
+            created_at_unix_nanos: 41,
+            completed_at_unix_nanos: None,
+        };
+        assert_eq!(
+            db.task_state()
+                .create(
+                    TaskCreation {
+                        id: &task.id,
+                        workspace_id,
+                        created_by_principal_id,
+                        intent: &task.intent,
+                        created_at_unix_nanos: task.created_at_unix_nanos,
+                    },
+                    10,
+                )
+                .await
+                .expect("create task"),
+            TaskCreationResult::Created
+        );
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .tasks()
+                .find_state(workspace_id, &task.id)
+                .await
+                .expect("find active state"),
+            Some(TaskLifecycleState::Active)
+        );
+        assert_eq!(
+            session
+                .tasks()
+                .find_state("other-workspace", &task.id)
+                .await
+                .expect("isolate state by workspace"),
+            None
+        );
+        assert_eq!(
+            session
+                .tasks()
+                .get(workspace_id, &task.id)
+                .await
+                .expect("get"),
+            Some(task.clone())
+        );
+
+        let duplicate_workspace_id = format!("{workspace_id}_duplicate");
+        let mut tx = db.begin().await.expect("begin duplicate workspace tx");
+        tx.workspaces()
+            .ensure(&duplicate_workspace_id, 41)
+            .await
+            .expect("duplicate workspace");
+        tx.commit().await.expect("commit duplicate workspace");
+        db.task_state()
+            .create(
+                TaskCreation {
+                    id: &task.id,
+                    workspace_id: &duplicate_workspace_id,
+                    created_by_principal_id: "product:principal:planner",
+                    intent: "Duplicate task id",
+                    created_at_unix_nanos: 42,
+                },
+                10,
+            )
+            .await
+            .expect_err("task UUID must be globally unique");
+
+        assert_eq!(
+            db.task_state()
+                .complete(&duplicate_workspace_id, &task.id, "success", 42)
+                .await
+                .expect("isolate other workspace"),
+            TaskCompletionUpdate::NotFound
+        );
+        assert_eq!(
+            db.task_state()
+                .complete(workspace_id, "missing-task", "success", 42)
+                .await
+                .expect("complete missing task"),
+            TaskCompletionUpdate::NotFound
+        );
+        assert_eq!(
+            db.task_state()
+                .complete(workspace_id, &task.id, "success", 42)
+                .await
+                .expect("complete task"),
+            TaskCompletionUpdate::Completed
+        );
+        assert_eq!(
+            db.task_state()
+                .complete(workspace_id, &task.id, "failure", 43)
+                .await
+                .expect("task is already terminal"),
+            TaskCompletionUpdate::AlreadyCompleted
+        );
+
+        let completed = session
+            .tasks()
+            .get(workspace_id, &task.id)
+            .await
+            .expect("get completed")
+            .expect("task");
+        assert_eq!(completed.outcome.as_deref(), Some("success"));
+        assert_eq!(completed.completed_at_unix_nanos, Some(42));
+        assert_eq!(completed.created_by_principal_id, "product:principal:saul");
+        assert_eq!(
+            session
+                .tasks()
+                .find_state(workspace_id, &task.id)
+                .await
+                .expect("find completed state"),
+            Some(TaskLifecycleState::Completed)
+        );
+
+        let second_id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(
+            db.task_state()
+                .create(
+                    TaskCreation {
+                        id: &second_id,
+                        workspace_id,
+                        created_by_principal_id: "product:principal:planner",
+                        intent: "Second completed task",
+                        created_at_unix_nanos: 43,
+                    },
+                    10,
+                )
+                .await
+                .expect("create second task"),
+            TaskCreationResult::Created
+        );
+        assert_eq!(
+            db.task_state()
+                .complete(workspace_id, &second_id, "failure", 42)
+                .await
+                .expect("complete second task"),
+            TaskCompletionUpdate::Completed
+        );
+        let third_id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(
+            db.task_state()
+                .create(
+                    TaskCreation {
+                        id: &third_id,
+                        workspace_id,
+                        created_by_principal_id,
+                        intent: "Retained active task",
+                        created_at_unix_nanos: 44,
+                    },
+                    2,
+                )
+                .await
+                .expect("create retained task"),
+            TaskCreationResult::Created
+        );
+        assert_eq!(
+            session
+                .tasks()
+                .get(workspace_id, &task.id)
+                .await
+                .expect("get deterministic eviction"),
+            None
+        );
+        assert!(
+            session
+                .tasks()
+                .get(workspace_id, &second_id)
+                .await
+                .expect("get newer completed task")
+                .is_some()
+        );
+        assert!(
+            session
+                .tasks()
+                .get(workspace_id, &third_id)
+                .await
+                .expect("get retained active task")
+                .is_some()
+        );
+
+        assert_capacity_rollback_restores_evicted_tasks(db, workspace_id).await;
+        assert_concurrent_capacity_and_cascade(db, workspace_id).await;
+        assert_create_serializes_with_workspace_delete(db, workspace_id).await;
+        assert_completion_serializes_with_workspace_delete(db, workspace_id).await;
+    }
+
+    async fn assert_capacity_rollback_restores_evicted_tasks(db: &CoralDb, workspace_id: &str) {
+        let rollback_workspace_id = format!("{workspace_id}_capacity_rollback");
+        let mut tx = db.begin().await.expect("begin rollback workspace tx");
+        tx.workspaces()
+            .ensure(&rollback_workspace_id, 45)
+            .await
+            .expect("rollback workspace");
+        tx.commit().await.expect("commit rollback workspace");
+
+        let completed_id = uuid::Uuid::new_v4().to_string();
+        let first_active_id = uuid::Uuid::new_v4().to_string();
+        let second_active_id = uuid::Uuid::new_v4().to_string();
+        for (task_id, intent) in [
+            (&completed_id, "Completed task"),
+            (&first_active_id, "First active task"),
+            (&second_active_id, "Second active task"),
+        ] {
+            assert_eq!(
+                db.task_state()
+                    .create(
+                        TaskCreation {
+                            id: task_id,
+                            workspace_id: &rollback_workspace_id,
+                            created_by_principal_id: "product:principal:saul",
+                            intent,
+                            created_at_unix_nanos: 46,
+                        },
+                        10,
+                    )
+                    .await
+                    .expect("seed task"),
+                TaskCreationResult::Created
+            );
+        }
+        assert_eq!(
+            db.task_state()
+                .complete(&rollback_workspace_id, &completed_id, "success", 47,)
+                .await
+                .expect("complete retained task"),
+            TaskCompletionUpdate::Completed
+        );
+
+        let rejected_id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(
+            db.task_state()
+                .create(
+                    TaskCreation {
+                        id: &rejected_id,
+                        workspace_id: &rollback_workspace_id,
+                        created_by_principal_id: "product:principal:planner",
+                        intent: "Rejected task",
+                        created_at_unix_nanos: 48,
+                    },
+                    2,
+                )
+                .await
+                .expect("reject task at active capacity"),
+            TaskCreationResult::WorkspaceCapacityExceeded
+        );
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .tasks()
+                .count(&rollback_workspace_id)
+                .await
+                .expect("count restored tasks"),
+            3
+        );
+        assert!(
+            session
+                .tasks()
+                .get(&rollback_workspace_id, &completed_id)
+                .await
+                .expect("get restored completed task")
+                .is_some(),
+            "capacity rollback must restore provisional eviction"
+        );
+    }
+
+    async fn assert_concurrent_capacity_and_cascade(db: &CoralDb, workspace_id: &str) {
+        let capacity_workspace_id = format!("{workspace_id}_capacity");
+        let mut tx = db.begin().await.expect("begin capacity workspace tx");
+        tx.workspaces()
+            .ensure(&capacity_workspace_id, 50)
+            .await
+            .expect("capacity workspace");
+        tx.commit().await.expect("commit capacity workspace");
+        let first_id = uuid::Uuid::new_v4().to_string();
+        let second_id = uuid::Uuid::new_v4().to_string();
+        let (first_result, second_result) = tokio::join!(
+            create_task_at_capacity(
+                db,
+                &capacity_workspace_id,
+                "product:principal:saul",
+                &first_id,
+            ),
+            create_task_at_capacity(
+                db,
+                &capacity_workspace_id,
+                "product:principal:planner",
+                &second_id
+            )
+        );
+        assert_ne!(
+            first_result, second_result,
+            "the shared workspace capacity must admit exactly one concurrent task"
+        );
+        assert!([first_result, second_result].contains(&TaskCreationResult::Created));
+        assert!(
+            [first_result, second_result].contains(&TaskCreationResult::WorkspaceCapacityExceeded)
+        );
+        let mut session = db;
+        assert_eq!(
+            session
+                .tasks()
+                .count(&capacity_workspace_id)
+                .await
+                .expect("count retained tasks"),
+            1
+        );
+        let first_exists = session
+            .tasks()
+            .get(&capacity_workspace_id, &first_id)
+            .await
+            .expect("get first concurrent task")
+            .is_some();
+        let second_exists = session
+            .tasks()
+            .get(&capacity_workspace_id, &second_id)
+            .await
+            .expect("get second concurrent task")
+            .is_some();
+        assert_ne!(
+            first_exists, second_exists,
+            "the workspace lock must serialize concurrent retention decisions"
+        );
+
+        let mut tx = db.begin().await.expect("begin cascade tx");
+        assert!(
+            tx.workspaces()
+                .delete(&capacity_workspace_id)
+                .await
+                .expect("delete capacity workspace")
+        );
+        tx.commit().await.expect("commit workspace delete");
+        assert_eq!(
+            session
+                .tasks()
+                .count(&capacity_workspace_id)
+                .await
+                .expect("count cascaded tasks"),
+            0
+        );
+    }
+
+    async fn assert_create_serializes_with_workspace_delete(db: &CoralDb, workspace_id: &str) {
+        let workspace_id = format!("{workspace_id}_create_delete");
+        let mut tx = db.begin().await.expect("begin create/delete workspace tx");
+        tx.workspaces()
+            .ensure(&workspace_id, 52)
+            .await
+            .expect("create create/delete workspace");
+        tx.commit().await.expect("commit create/delete workspace");
+
+        let task_id = uuid::Uuid::new_v4().to_string();
+        let mutation_barrier = TaskMutationBarrier::new();
+        let task_state = db.task_state_with_mutation_barrier(&mutation_barrier);
+        let (creation, ()) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(
+                task_state.create(
+                    TaskCreation {
+                        id: &task_id,
+                        workspace_id: &workspace_id,
+                        created_by_principal_id: "product:principal:saul",
+                        intent: "Task racing workspace deletion",
+                        created_at_unix_nanos: 53,
+                    },
+                    10,
+                ),
+                delete_workspace_after_task_holds(db, &workspace_id, &mutation_barrier),
+            )
+        })
+        .await
+        .expect("create/delete race should finish");
+        assert_eq!(
+            creation.expect("create task racing workspace deletion"),
+            TaskCreationResult::Created
+        );
+        assert_workspace_and_tasks_deleted(db, &workspace_id, &task_id).await;
+    }
+
+    async fn assert_completion_serializes_with_workspace_delete(db: &CoralDb, workspace_id: &str) {
+        let workspace_id = format!("{workspace_id}_complete_delete");
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin completion/delete workspace tx");
+        tx.workspaces()
+            .ensure(&workspace_id, 54)
+            .await
+            .expect("create completion/delete workspace");
+        tx.commit()
+            .await
+            .expect("commit completion/delete workspace");
+
+        let task_id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(
+            db.task_state()
+                .create(
+                    TaskCreation {
+                        id: &task_id,
+                        workspace_id: &workspace_id,
+                        created_by_principal_id: "product:principal:saul",
+                        intent: "Task completion racing workspace deletion",
+                        created_at_unix_nanos: 55,
+                    },
+                    10,
+                )
+                .await
+                .expect("seed task racing workspace deletion"),
+            TaskCreationResult::Created
+        );
+
+        let mutation_barrier = TaskMutationBarrier::new();
+        let task_state = db.task_state_with_mutation_barrier(&mutation_barrier);
+        let (completion, ()) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(
+                task_state.complete(&workspace_id, &task_id, "success", 56),
+                delete_workspace_after_task_holds(db, &workspace_id, &mutation_barrier),
+            )
+        })
+        .await
+        .expect("complete/delete race should finish");
+        assert_eq!(
+            completion.expect("complete task racing workspace deletion"),
+            TaskCompletionUpdate::Completed
+        );
+        assert_workspace_and_tasks_deleted(db, &workspace_id, &task_id).await;
+    }
+
+    async fn delete_workspace_after_task_holds(
+        db: &CoralDb,
+        workspace_id: &str,
+        mutation_barrier: &TaskMutationBarrier,
+    ) {
+        mutation_barrier.wait_until_workspace_held().await;
+        let deletion = async {
+            let deletion = db
+                .begin_workspace_deletion(workspace_id)
+                .await
+                .expect("begin concurrent workspace delete")
+                .expect("workspace must exist before concurrent deletion");
+            deletion
+                .commit()
+                .await
+                .expect("commit concurrent workspace delete");
+        };
+        tokio::pin!(deletion);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), deletion.as_mut())
+                .await
+                .is_err(),
+            "workspace deletion must wait while the task mutation holds the parent lock"
+        );
+        mutation_barrier.release_mutation().await;
+        deletion.await;
+    }
+
+    async fn assert_workspace_and_tasks_deleted(db: &CoralDb, workspace_id: &str, task_id: &str) {
+        let mut session = db;
+        assert_eq!(
+            session
+                .workspaces()
+                .get(workspace_id)
+                .await
+                .expect("get concurrently deleted workspace"),
+            None
+        );
+        assert_eq!(
+            session
+                .tasks()
+                .count(workspace_id)
+                .await
+                .expect("count orphaned tasks"),
+            0
+        );
+        assert_eq!(
+            session
+                .tasks()
+                .get(workspace_id, task_id)
+                .await
+                .expect("get orphaned task"),
+            None
+        );
+    }
+
+    async fn create_task_at_capacity(
+        db: &CoralDb,
+        workspace_id: &str,
+        created_by_principal_id: &str,
+        task_id: &str,
+    ) -> TaskCreationResult {
+        db.task_state()
+            .create(
+                TaskCreation {
+                    id: task_id,
+                    workspace_id,
+                    created_by_principal_id,
+                    intent: "Concurrent task",
+                    created_at_unix_nanos: 51,
+                },
+                1,
+            )
+            .await
+            .expect("create concurrent task")
+    }
+
+    async fn assert_task_constraints(db: &CoralDb, workspace_id: &str) {
+        assert_invalid_task_row(
+            db,
+            workspace_id,
+            Some("cancelled"),
+            Some(41),
+            "reject unsupported outcome",
+        )
+        .await;
+        assert_invalid_task_row(
+            db,
+            workspace_id,
+            Some("success"),
+            None,
+            "reject outcome without completion time",
+        )
+        .await;
+        assert_invalid_task_row(
+            db,
+            workspace_id,
+            None,
+            Some(41),
+            "reject completion time without outcome",
+        )
+        .await;
+    }
+
+    async fn assert_invalid_task_row(
+        db: &CoralDb,
+        workspace_id: &str,
+        outcome: Option<&str>,
+        completed_at_unix_nanos: Option<i64>,
+        expectation: &str,
+    ) {
+        let statement = Query::insert()
+            .into_table(Tasks::Table)
+            .columns([
+                Tasks::Id,
+                Tasks::WorkspaceId,
+                Tasks::CreatedByPrincipalId,
+                Tasks::Intent,
+                Tasks::Outcome,
+                Tasks::CreatedAtUnixNanos,
+                Tasks::CompletedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(uuid::Uuid::new_v4().to_string()),
+                Expr::val(workspace_id.to_string()),
+                Expr::val("product:test:constraint".to_string()),
+                Expr::val("Invalid task row".to_string()),
+                Expr::val(outcome.map(str::to_string)),
+                Expr::val(40_i64),
+                Expr::val(completed_at_unix_nanos),
+            ])
+            .to_owned();
+        let mut tx = db.begin().await.expect("begin constraint tx");
+        DbSession::execute(&mut tx, statement)
+            .await
+            .expect_err(expectation);
+        tx.rollback().await.expect("roll back invalid task row");
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -1,8 +1,8 @@
 use sea_query::{Expr, ExprTrait, OnConflict, Query};
 
-use crate::state::db::DbError;
 use crate::state::db::schema::Workspaces;
 use crate::state::db::session::DbSession;
+use crate::state::db::{CoralTx, DbError};
 
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub(crate) struct WorkspaceRecord {
@@ -67,17 +67,35 @@ where
         self.session.fetch_all(statement).await
     }
 
-    pub(crate) async fn delete(&mut self, id: &str) -> Result<(), DbError> {
+    pub(crate) async fn delete(&mut self, id: &str) -> Result<bool, DbError> {
         let statement = Query::delete()
             .from_table(Workspaces::Table)
             .and_where(Expr::col(Workspaces::Id).eq(id))
             .to_owned();
-        self.session.execute(statement).await
+        Ok(self.session.execute_rows_affected(statement).await? == 1)
     }
 
     pub(crate) async fn delete_all(&mut self) -> Result<(), DbError> {
         let statement = Query::delete().from_table(Workspaces::Table).to_owned();
         self.session.execute(statement).await
+    }
+}
+
+impl WorkspacesRepo<'_, CoralTx<'_>> {
+    /// Holds an existing workspace parent for a child-table mutation.
+    ///
+    /// The no-op update is portable across `SQLite` and Postgres and establishes
+    /// one parent-before-child serialization point for workspace-scoped writes.
+    pub(crate) async fn hold_for_child_mutation(&mut self, id: &str) -> Result<bool, DbError> {
+        let statement = Query::update()
+            .table(Workspaces::Table)
+            .value(
+                Workspaces::CreatedAtUnixNanos,
+                Expr::col(Workspaces::CreatedAtUnixNanos),
+            )
+            .and_where(Expr::col(Workspaces::Id).eq(id))
+            .to_owned();
+        Ok(DbSession::execute_rows_affected(self.session, statement).await? == 1)
     }
 }
 
@@ -176,6 +194,21 @@ mod tests {
             "workspace list did not contain expected record: {workspaces:?}"
         );
 
+        let mut tx = db.begin().await.expect("begin hold tx");
+        assert!(
+            tx.workspaces()
+                .hold_for_child_mutation(&workspace_id)
+                .await
+                .expect("hold existing workspace")
+        );
+        assert!(
+            !tx.workspaces()
+                .hold_for_child_mutation(&missing_workspace_id)
+                .await
+                .expect("hold missing workspace")
+        );
+        tx.rollback().await.expect("roll back hold tx");
+
         let mut tx = db.begin().await.expect("begin rollback tx");
         tx.workspaces()
             .ensure(&rolled_back_workspace_id, 77)
@@ -192,10 +225,12 @@ mod tests {
         );
 
         let mut tx = db.begin().await.expect("begin delete tx");
-        tx.workspaces()
-            .delete(&workspace_id)
-            .await
-            .expect("delete workspace");
+        assert!(
+            tx.workspaces()
+                .delete(&workspace_id)
+                .await
+                .expect("delete workspace")
+        );
         tx.commit().await.expect("commit delete tx");
         assert_eq!(
             session
@@ -205,6 +240,15 @@ mod tests {
                 .expect("get deleted workspace"),
             None
         );
+
+        let mut tx = db.begin().await.expect("begin missing delete tx");
+        assert!(
+            !tx.workspaces()
+                .delete(&missing_workspace_id)
+                .await
+                .expect("delete missing workspace")
+        );
+        tx.rollback().await.expect("roll back missing delete tx");
     }
 
     fn unique_workspace_id() -> String {

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -13,3 +13,15 @@ pub(in crate::state::db) enum AppStateMigrations {
     Id,
     CompletedAtUnixNanos,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum Tasks {
+    Table,
+    Id,
+    WorkspaceId,
+    CreatedByPrincipalId,
+    Intent,
+    Outcome,
+    CreatedAtUnixNanos,
+    CompletedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,10 +7,15 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
+use crate::state::db::repositories::tasks::TasksRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
     async fn execute<S>(&mut self, statement: S) -> Result<(), DbError>
+    where
+        S: SqlxBinder;
+
+    async fn execute_rows_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
     where
         S: SqlxBinder;
 
@@ -35,12 +40,24 @@ pub(crate) trait DbRepos: DbSession + Sized {
     fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
         WorkspacesRepo::new(self)
     }
+
+    fn tasks(&mut self) -> TasksRepo<'_, Self> {
+        TasksRepo::new(self)
+    }
 }
 
 impl<T> DbRepos for T where T: DbSession + Sized {}
 
 impl DbSession for &CoralDb {
     async fn execute<S>(&mut self, statement: S) -> Result<(), DbError>
+    where
+        S: SqlxBinder,
+    {
+        execute_statement(&self.backend, statement).await?;
+        Ok(())
+    }
+
+    async fn execute_rows_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
     where
         S: SqlxBinder,
     {
@@ -74,6 +91,13 @@ impl DbSession for CoralTx<'_> {
         self.execute(statement).await
     }
 
+    async fn execute_rows_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
+    where
+        S: SqlxBinder,
+    {
+        self.execute_rows_affected(statement).await
+    }
+
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
     where
         T: Send + Unpin,
@@ -96,25 +120,26 @@ impl DbSession for CoralTx<'_> {
 pub(super) async fn execute_statement<S>(
     backend: &CoralDbBackend,
     statement: S,
-) -> Result<(), DbError>
+) -> Result<u64, DbError>
 where
     S: SqlxBinder,
 {
     match backend {
         CoralDbBackend::Sqlite(db) => {
             let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
-            sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+            let result = sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
                 .execute(&db.pool)
                 .await?;
+            Ok(result.rows_affected())
         }
         CoralDbBackend::Postgres(db) => {
             let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
-            sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+            let result = sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
                 .execute(&db.pool)
                 .await?;
+            Ok(result.rows_affected())
         }
     }
-    Ok(())
 }
 
 pub(super) async fn fetch_optional_statement<T>(

--- a/crates/coral-app/src/state/db/task_state.rs
+++ b/crates/coral-app/src/state/db/task_state.rs
@@ -1,0 +1,163 @@
+//! Transactional persistence for workspace-scoped Task lifecycle changes.
+
+use super::{CoralDb, DbError, DbRepos, TaskCompletionUpdate, TaskLifecycleState};
+
+pub(crate) struct TaskState<'a> {
+    db: &'a CoralDb,
+    #[cfg(test)]
+    mutation_barrier: Option<&'a TaskMutationBarrier>,
+}
+
+#[cfg(test)]
+pub(crate) struct TaskMutationBarrier {
+    workspace_held: tokio::sync::Barrier,
+    release_mutation: tokio::sync::Barrier,
+}
+
+#[cfg(test)]
+impl TaskMutationBarrier {
+    pub(crate) fn new() -> Self {
+        Self {
+            workspace_held: tokio::sync::Barrier::new(2),
+            release_mutation: tokio::sync::Barrier::new(2),
+        }
+    }
+
+    async fn pause_after_workspace_hold(&self) {
+        self.workspace_held.wait().await;
+        self.release_mutation.wait().await;
+    }
+
+    pub(crate) async fn wait_until_workspace_held(&self) {
+        self.workspace_held.wait().await;
+    }
+
+    pub(crate) async fn release_mutation(&self) {
+        self.release_mutation.wait().await;
+    }
+}
+
+pub(crate) struct TaskCreation<'a> {
+    pub(crate) id: &'a str,
+    pub(crate) workspace_id: &'a str,
+    pub(crate) created_by_principal_id: &'a str,
+    pub(crate) intent: &'a str,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskCreationResult {
+    Created,
+    WorkspaceNotFound,
+    WorkspaceCapacityExceeded,
+}
+
+impl CoralDb {
+    pub(crate) fn task_state(&self) -> TaskState<'_> {
+        TaskState {
+            db: self,
+            #[cfg(test)]
+            mutation_barrier: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_state_with_mutation_barrier<'a>(
+        &'a self,
+        mutation_barrier: &'a TaskMutationBarrier,
+    ) -> TaskState<'a> {
+        TaskState {
+            db: self,
+            mutation_barrier: Some(mutation_barrier),
+        }
+    }
+}
+
+impl TaskState<'_> {
+    pub(crate) async fn create(
+        &self,
+        task: TaskCreation<'_>,
+        max_retained_tasks: u64,
+    ) -> Result<TaskCreationResult, DbError> {
+        let mut tx = self.db.begin().await?;
+        if !tx
+            .workspaces()
+            .hold_for_child_mutation(task.workspace_id)
+            .await?
+        {
+            tx.rollback().await?;
+            return Ok(TaskCreationResult::WorkspaceNotFound);
+        }
+        #[cfg(test)]
+        if let Some(mutation_barrier) = self.mutation_barrier {
+            mutation_barrier.pause_after_workspace_hold().await;
+        }
+        assert!(
+            max_retained_tasks > 0,
+            "task retention limit must be positive"
+        );
+        while tx.tasks().count(task.workspace_id).await? >= max_retained_tasks {
+            let Some(task_id) = tx
+                .tasks()
+                .oldest_completed_task_id(task.workspace_id)
+                .await?
+            else {
+                tx.rollback().await?;
+                return Ok(TaskCreationResult::WorkspaceCapacityExceeded);
+            };
+            tx.tasks().delete(task.workspace_id, &task_id).await?;
+        }
+        tx.tasks()
+            .insert(
+                task.workspace_id,
+                task.created_by_principal_id,
+                task.id,
+                task.intent,
+                task.created_at_unix_nanos,
+            )
+            .await?;
+        tx.commit().await?;
+        Ok(TaskCreationResult::Created)
+    }
+
+    pub(crate) async fn complete(
+        &self,
+        workspace_id: &str,
+        task_id: &str,
+        outcome: &str,
+        completed_at_unix_nanos: i64,
+    ) -> Result<TaskCompletionUpdate, DbError> {
+        let mut tx = self.db.begin().await?;
+        if !tx
+            .workspaces()
+            .hold_for_child_mutation(workspace_id)
+            .await?
+        {
+            tx.rollback().await?;
+            return Ok(TaskCompletionUpdate::NotFound);
+        }
+        #[cfg(test)]
+        if let Some(mutation_barrier) = self.mutation_barrier {
+            mutation_barrier.pause_after_workspace_hold().await;
+        }
+        let result = tx
+            .tasks()
+            .complete(workspace_id, task_id, outcome, completed_at_unix_nanos)
+            .await?;
+        if result == TaskCompletionUpdate::Completed {
+            tx.commit().await?;
+        } else {
+            tx.rollback().await?;
+        }
+        Ok(result)
+    }
+
+    pub(crate) async fn lifecycle(
+        &self,
+        workspace_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TaskLifecycleState>, DbError> {
+        let mut session = self.db;
+        session.tasks().find_state(workspace_id, task_id).await
+    }
+}

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -45,21 +45,30 @@ impl<'a> CoralTx<'a> {
     where
         S: SqlxBinder,
     {
+        self.execute_rows_affected(statement).await?;
+        Ok(())
+    }
+
+    pub(super) async fn execute_rows_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
+    where
+        S: SqlxBinder,
+    {
         match &mut self.backend {
             CoralTxBackend::Sqlite(tx) => {
                 let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
-                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                let result = sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
                     .execute(&mut **tx)
                     .await?;
+                Ok(result.rows_affected())
             }
             CoralTxBackend::Postgres(tx) => {
                 let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
-                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                let result = sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
                     .execute(&mut **tx)
                     .await?;
+                Ok(result.rows_affected())
             }
         }
-        Ok(())
     }
 
     pub(super) async fn fetch_optional<T>(

--- a/crates/coral-app/src/state/db/workspace_state.rs
+++ b/crates/coral-app/src/state/db/workspace_state.rs
@@ -1,0 +1,32 @@
+//! Transactional persistence for workspace deletion.
+
+use super::{CoralDb, CoralTx, DbError, DbRepos};
+
+pub(crate) struct WorkspaceDeletion<'a> {
+    tx: CoralTx<'a>,
+}
+
+impl CoralDb {
+    pub(crate) async fn begin_workspace_deletion(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<WorkspaceDeletion<'_>>, DbError> {
+        let mut tx = self.begin().await?;
+        if tx.workspaces().delete(workspace_id).await? {
+            Ok(Some(WorkspaceDeletion { tx }))
+        } else {
+            tx.rollback().await?;
+            Ok(None)
+        }
+    }
+}
+
+impl WorkspaceDeletion<'_> {
+    pub(crate) async fn commit(self) -> Result<(), DbError> {
+        self.tx.commit().await
+    }
+
+    pub(crate) async fn rollback(self) -> Result<(), DbError> {
+        self.tx.rollback().await
+    }
+}

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -10,7 +10,7 @@ use crate::sources::SourceName;
 use crate::sources::materialization::{
     DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, OPERATION_METADATA_FILENAME, PROJECTIONS_FILENAME,
 };
-use crate::storage::fs::ensure_dir;
+use crate::storage::fs::{ensure_dir, remove_file_if_exists};
 use crate::workspaces::{WorkspaceName, WorkspacePaths};
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
@@ -103,6 +103,22 @@ impl AppStateLayout {
         self.config_dir.join("workspaces")
     }
 
+    pub(crate) fn remove_legacy_task_event_logs(&self) -> Result<(), std::io::Error> {
+        let workspace_entries = match std::fs::read_dir(self.workspaces_root()) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        for entry in workspace_entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            remove_file_if_exists(&entry.path().join("tasks").join("tasks.jsonl"))?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspaces_root().join(workspace_name.as_str())
     }
@@ -151,13 +167,6 @@ impl AppStateLayout {
 
     pub(crate) fn search_sqlite_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.search_dir(workspace_name).join("search.sqlite3")
-    }
-
-    /// Per-workspace task lifecycle event log (JSONL).
-    pub(crate) fn task_events_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
-        self.workspace_dir(workspace_name)
-            .join("tasks")
-            .join("tasks.jsonl")
     }
 
     pub(crate) fn source_dir(
@@ -367,17 +376,46 @@ mod tests {
                 .join("search.sqlite3")
         );
         assert_eq!(
-            layout.task_events_file(&workspace_name),
-            config_dir
-                .join("workspaces")
-                .join("default")
-                .join("tasks")
-                .join("tasks.jsonl")
-        );
-        assert_eq!(
             layout.local_trace_store_dir(),
             config_dir.join("telemetry").join("traces")
         );
+    }
+
+    #[test]
+    fn removes_legacy_task_event_logs_for_each_workspace() {
+        let temp = tempdir().expect("tempdir");
+        let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        layout
+            .remove_legacy_task_event_logs()
+            .expect("missing workspace root is already clean");
+
+        let default_task_log = config_dir.join("workspaces/default/tasks/tasks.jsonl");
+        let analytics_task_log = config_dir.join("workspaces/analytics/tasks/tasks.jsonl");
+        for path in [&default_task_log, &analytics_task_log] {
+            fs::create_dir_all(path.parent().expect("task directory"))
+                .expect("create task directory");
+            fs::write(path, "sensitive task intent").expect("write legacy task log");
+        }
+        let unrelated = config_dir.join("workspaces/default/tasks/notes.jsonl");
+        fs::write(&unrelated, "keep").expect("write unrelated file");
+        let non_workspace_entry = config_dir.join("workspaces/README");
+        fs::write(&non_workspace_entry, "keep").expect("write non-workspace entry");
+
+        layout
+            .remove_legacy_task_event_logs()
+            .expect("remove legacy task logs");
+
+        assert!(!default_task_log.exists());
+        assert!(!analytics_task_log.exists());
+        assert!(unrelated.exists());
+        assert!(non_workspace_entry.exists());
+
+        fs::write(&default_task_log, "reappeared").expect("recreate legacy task log");
+        layout
+            .remove_legacy_task_event_logs()
+            .expect("remove recreated legacy task log");
+        assert!(!default_task_log.exists());
     }
 
     #[test]

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -88,6 +88,14 @@ pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+pub(crate) fn remove_file_if_exists(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
     rename_with_fallback(from, to)?;
 
@@ -288,7 +296,7 @@ fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DirectoryBackup, ensure_file_private};
+    use super::{DirectoryBackup, ensure_file_private, remove_file_if_exists};
 
     #[test]
     fn ensure_file_private_rejects_existing_directory() {
@@ -385,5 +393,17 @@ mod tests {
 
         assert!(!missing_dir.exists());
         assert!(!backup.backup_path().exists());
+    }
+
+    #[test]
+    fn remove_file_if_exists_is_idempotent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("legacy.jsonl");
+        std::fs::write(&path, "legacy").expect("write legacy file");
+
+        remove_file_if_exists(&path).expect("remove existing file");
+        remove_file_if_exists(&path).expect("ignore missing file");
+
+        assert!(!path.exists());
     }
 }

--- a/crates/coral-app/src/task/manager.rs
+++ b/crates/coral-app/src/task/manager.rs
@@ -1,54 +1,82 @@
 //! App-domain task lifecycle orchestration.
 
-use std::sync::Arc;
-
 use super::id::TaskId;
-use super::store::{TaskEnd, TaskEventStore, TaskStart, TaskStatus, TaskStoreError};
+use super::store::{
+    TaskCompletion, TaskCompletionResult, TaskOutcome, TaskStart, TaskStore, TaskStoreError,
+};
+use crate::bootstrap::AppError;
+use crate::identity::Principal;
+use crate::state::db::{TaskLifecycleState, now_unix_nanos_i64};
 use crate::workspaces::WorkspaceName;
 
 /// Coordinates task lifecycle persistence and validation.
 #[derive(Clone)]
 pub(crate) struct TaskManager {
-    store: Arc<dyn TaskEventStore>,
+    store: TaskStore,
 }
 
 impl TaskManager {
-    pub(crate) fn new(store: Arc<dyn TaskEventStore>) -> Self {
+    pub(crate) fn new(store: TaskStore) -> Self {
         Self { store }
     }
 
-    pub(crate) fn start_task(
+    pub(crate) async fn start_task(
         &self,
         workspace: WorkspaceName,
+        created_by: Principal,
         intent: String,
     ) -> Result<TaskStart, TaskManagerError> {
         let start = TaskStart {
             id: TaskId::new(),
             workspace,
+            created_by,
             intent,
+            created_at_unix_nanos: now_unix_nanos_i64()?,
         };
-        self.store.start_task(&start)?;
+        self.store.start_task(&start).await?;
         Ok(start)
     }
 
-    pub(crate) fn end_task(
+    pub(crate) async fn complete_task(
         &self,
         workspace: WorkspaceName,
         task_id: TaskId,
-        status: TaskStatus,
-    ) -> Result<TaskEnd, TaskManagerError> {
-        if !self.store.contains_started_task(&workspace, &task_id)? {
-            return Err(TaskManagerError::TaskNotFound {
-                task_id: task_id.to_string(),
-            });
-        }
-        let end = TaskEnd {
+        outcome: TaskOutcome,
+    ) -> Result<TaskCompletion, TaskManagerError> {
+        let completion = TaskCompletion {
             id: task_id,
             workspace,
-            status,
+            outcome,
+            completed_at_unix_nanos: now_unix_nanos_i64()?,
         };
-        self.store.end_task(&end)?;
-        Ok(end)
+        match self.store.complete_task(&completion).await? {
+            TaskCompletionResult::Completed => Ok(completion),
+            TaskCompletionResult::AlreadyCompleted => Err(TaskManagerError::TaskAlreadyCompleted {
+                task_id: task_id.to_string(),
+            }),
+            TaskCompletionResult::NotFound => Err(TaskManagerError::TaskNotFound {
+                task_id: task_id.to_string(),
+            }),
+        }
+    }
+
+    pub(crate) async fn validate_attribution(
+        &self,
+        workspace: &WorkspaceName,
+        task_id: Option<TaskId>,
+    ) -> Result<Option<TaskId>, TaskManagerError> {
+        let Some(task_id) = task_id else {
+            return Ok(None);
+        };
+        match self.store.task_state(workspace, task_id).await? {
+            Some(TaskLifecycleState::Active) => Ok(Some(task_id)),
+            Some(TaskLifecycleState::Completed) => Err(TaskManagerError::TaskAlreadyCompleted {
+                task_id: task_id.to_string(),
+            }),
+            None => Err(TaskManagerError::TaskNotFound {
+                task_id: task_id.to_string(),
+            }),
+        }
     }
 }
 
@@ -56,6 +84,104 @@ impl TaskManager {
 pub(crate) enum TaskManagerError {
     #[error("task '{task_id}' was not found")]
     TaskNotFound { task_id: String },
+    #[error("task '{task_id}' has already completed")]
+    TaskAlreadyCompleted { task_id: String },
+    #[error(transparent)]
+    App(#[from] AppError),
     #[error(transparent)]
     Store(#[from] TaskStoreError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use super::{TaskManager, TaskManagerError};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
+    use crate::task::id::TaskId;
+    use crate::task::store::{TaskOutcome, TaskStore};
+    use crate::workspaces::WorkspaceName;
+
+    async fn manager() -> (TempDir, TaskManager) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default test database must be SQLite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(WorkspaceName::default().as_str(), 1)
+            .await
+            .expect("seed default workspace");
+        tx.commit().await.expect("commit workspace");
+        (temp, TaskManager::new(TaskStore::new(db)))
+    }
+
+    #[tokio::test]
+    async fn validates_only_active_tasks_in_the_exact_workspace() {
+        let (_temp, manager) = manager().await;
+        let workspace = WorkspaceName::default();
+        let created_by =
+            Principal::parse("product:principal:saul", PrincipalKind::User).expect("creator");
+        let task = manager
+            .start_task(
+                workspace.clone(),
+                created_by,
+                "Investigate renewal risk".to_string(),
+            )
+            .await
+            .expect("start task");
+
+        assert_eq!(
+            manager
+                .validate_attribution(&workspace, Some(task.id))
+                .await
+                .expect("validate active task"),
+            Some(task.id)
+        );
+        assert_eq!(
+            manager
+                .validate_attribution(&workspace, None)
+                .await
+                .expect("allow untagged non-MCP request"),
+            None
+        );
+        assert!(matches!(
+            manager
+                .validate_attribution(
+                    &WorkspaceName::parse("other").expect("workspace"),
+                    Some(task.id),
+                )
+                .await,
+            Err(TaskManagerError::TaskNotFound { .. })
+        ));
+        assert!(matches!(
+            manager
+                .validate_attribution(&workspace, Some(TaskId::new()))
+                .await,
+            Err(TaskManagerError::TaskNotFound { .. })
+        ));
+
+        manager
+            .complete_task(workspace.clone(), task.id, TaskOutcome::Success)
+            .await
+            .expect("end task");
+        assert!(matches!(
+            manager
+                .validate_attribution(&workspace, Some(task.id))
+                .await,
+            Err(TaskManagerError::TaskAlreadyCompleted { .. })
+        ));
+    }
 }

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -10,9 +10,9 @@ use tracing::warn;
 
 use super::id::TaskId;
 use super::manager::{TaskManager, TaskManagerError};
-use super::store::{TaskEnd, TaskStart, TaskStatus as DomainTaskStatus, TaskStoreError};
+use super::store::{TaskCompletion, TaskOutcome as DomainTaskOutcome, TaskStart, TaskStoreError};
 use crate::bootstrap::app_status;
-use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+use crate::transport::{grpc_span, instrument_grpc, request_context, workspace_name_from_proto};
 
 #[derive(Clone)]
 pub(crate) struct TaskService {
@@ -32,13 +32,15 @@ impl TaskServiceApi for TaskService {
         request: Request<StartTaskRequest>,
     ) -> Result<Response<StartTaskResponse>, Status> {
         let span = grpc_span(&request);
+        let created_by = request_context(&request)?.principal().clone();
         let task = self.task.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
             let start = task
-                .start_task(workspace, request.intent)
-                .map_err(|error| task_manager_status(&error))?;
+                .start_task(workspace, created_by, request.intent)
+                .await
+                .map_err(task_manager_status)?;
             Ok(Response::new(StartTaskResponse {
                 task: Some(task_start_to_proto(&start)),
             }))
@@ -56,12 +58,13 @@ impl TaskServiceApi for TaskService {
             let request = request.into_inner();
             let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
             let task_id = TaskId::parse(&request.task_id).map_err(app_status)?;
-            let task_status = task_status_from_proto(request.task_status).map_err(app_status)?;
-            let end = task
-                .end_task(workspace, task_id, task_status)
-                .map_err(|error| task_manager_status(&error))?;
+            let outcome = task_outcome_from_proto(request.task_status).map_err(app_status)?;
+            let completion = task
+                .complete_task(workspace, task_id, outcome)
+                .await
+                .map_err(task_manager_status)?;
             Ok(Response::new(EndTaskResponse {
-                task_end: Some(task_end_to_proto(&end)),
+                task_end: Some(task_completion_to_proto(&completion)),
             }))
         })
         .await
@@ -74,17 +77,17 @@ pub(crate) fn task_start_to_proto(start: &TaskStart) -> ProtoTask {
     }
 }
 
-pub(crate) fn task_end_to_proto(end: &TaskEnd) -> ProtoTaskEnd {
+pub(crate) fn task_completion_to_proto(completion: &TaskCompletion) -> ProtoTaskEnd {
     ProtoTaskEnd {
-        task_id: end.id.to_string(),
-        task_status: task_status_to_proto(end.status) as i32,
+        task_id: completion.id.to_string(),
+        task_status: task_outcome_to_proto(completion.outcome) as i32,
     }
 }
 
-fn task_status_from_proto(status: i32) -> Result<DomainTaskStatus, crate::bootstrap::AppError> {
+fn task_outcome_from_proto(status: i32) -> Result<DomainTaskOutcome, crate::bootstrap::AppError> {
     match ProtoTaskStatus::try_from(status) {
-        Ok(ProtoTaskStatus::Success) => Ok(DomainTaskStatus::Success),
-        Ok(ProtoTaskStatus::Failure) => Ok(DomainTaskStatus::Failure),
+        Ok(ProtoTaskStatus::Success) => Ok(DomainTaskOutcome::Success),
+        Ok(ProtoTaskStatus::Failure) => Ok(DomainTaskOutcome::Failure),
         Ok(ProtoTaskStatus::Unspecified) => Err(crate::bootstrap::AppError::InvalidInput(
             "task status must be success or failure".to_string(),
         )),
@@ -94,20 +97,32 @@ fn task_status_from_proto(status: i32) -> Result<DomainTaskStatus, crate::bootst
     }
 }
 
-fn task_status_to_proto(status: DomainTaskStatus) -> ProtoTaskStatus {
-    match status {
-        DomainTaskStatus::Success => ProtoTaskStatus::Success,
-        DomainTaskStatus::Failure => ProtoTaskStatus::Failure,
+fn task_outcome_to_proto(outcome: DomainTaskOutcome) -> ProtoTaskStatus {
+    match outcome {
+        DomainTaskOutcome::Success => ProtoTaskStatus::Success,
+        DomainTaskOutcome::Failure => ProtoTaskStatus::Failure,
     }
 }
 
-fn task_manager_status(error: &TaskManagerError) -> Status {
+pub(crate) fn task_manager_status(error: TaskManagerError) -> Status {
     match error {
-        TaskManagerError::TaskNotFound { .. } => Status::not_found(error.to_string()),
+        TaskManagerError::TaskNotFound { task_id } => {
+            Status::not_found(format!("task '{task_id}' was not found"))
+        }
+        TaskManagerError::TaskAlreadyCompleted { task_id } => {
+            Status::failed_precondition(format!("task '{task_id}' has already ended"))
+        }
+        TaskManagerError::App(error) => app_status(error),
         TaskManagerError::Store(TaskStoreError::InvalidIntent { .. }) => {
             Status::invalid_argument(error.to_string())
         }
-        TaskManagerError::Store(TaskStoreError::Io(_) | TaskStoreError::Serde(_)) => {
+        TaskManagerError::Store(TaskStoreError::WorkspaceNotFound { workspace }) => {
+            app_status(crate::bootstrap::AppError::WorkspaceNotFound(workspace))
+        }
+        TaskManagerError::Store(TaskStoreError::WorkspaceCapacityExceeded { .. }) => {
+            Status::resource_exhausted(error.to_string())
+        }
+        TaskManagerError::Store(TaskStoreError::Database(_)) => {
             warn!(%error, "failed to persist task lifecycle event");
             Status::internal("failed to persist task lifecycle event")
         }
@@ -116,7 +131,6 @@ fn task_manager_status(error: &TaskManagerError) -> Status {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::sync::Arc;
 
     use coral_api::v1::{EndTaskRequest, StartTaskRequest, TaskStatus, Workspace};
@@ -124,20 +138,36 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{TaskService, TaskServiceApi};
-    use crate::state::AppStateLayout;
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::request_context::RequestContext;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+    use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
-    use crate::task::store::JsonlTaskEventStore;
-    use crate::workspaces::WorkspaceName;
+    use crate::task::store::TaskStore;
 
     const UNKNOWN_TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
-    fn service() -> (TempDir, AppStateLayout, TaskService) {
+    async fn service() -> (TempDir, TaskService) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        let task = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default database is sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let config_store = ConfigStore::new(layout.clone());
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("import default workspace");
+        let task = TaskManager::new(TaskStore::new(db));
         let service = TaskService::new(task);
-        (dir, layout, service)
+        (dir, service)
     }
 
     fn workspace(name: &str) -> Workspace {
@@ -146,13 +176,25 @@ mod tests {
         }
     }
 
+    fn request<T>(message: T) -> Request<T> {
+        request_for_principal(message, Principal::local())
+    }
+
+    fn request_for_principal<T>(message: T, principal: Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal));
+        request
+    }
+
     #[tokio::test]
-    async fn start_task_persists_task() {
-        let (_dir, layout, service) = service();
+    async fn start_task_returns_uuid() {
+        let (_dir, service) = service().await;
 
         let response = service
-            .start_task(Request::new(StartTaskRequest {
-                workspace: Some(workspace("acme")),
+            .start_task(request(StartTaskRequest {
+                workspace: Some(workspace("default")),
                 intent: "Find renewal risk".to_string(),
             }))
             .await
@@ -161,33 +203,36 @@ mod tests {
 
         let task = response.task.expect("task");
         uuid::Uuid::parse_str(&task.task_id).expect("task id is a UUID");
-        let raw =
-            fs::read_to_string(layout.task_events_file(&WorkspaceName::parse("acme").unwrap()))
-                .expect("task file");
-        assert!(raw.contains(&task.task_id));
-        assert!(raw.contains("Find renewal risk"));
     }
 
     #[tokio::test]
-    async fn end_task_persists_success_status() {
-        let (_dir, layout, service) = service();
+    async fn end_task_returns_success_status() {
+        let (_dir, service) = service().await;
+        let principal = Principal::parse("product:principal:saul", PrincipalKind::User)
+            .expect("user principal");
 
         let task = service
-            .start_task(Request::new(StartTaskRequest {
-                workspace: Some(workspace("default")),
-                intent: "Find renewal risk".to_string(),
-            }))
+            .start_task(request_for_principal(
+                StartTaskRequest {
+                    workspace: Some(workspace("default")),
+                    intent: "Find renewal risk".to_string(),
+                },
+                principal.clone(),
+            ))
             .await
             .expect("start task")
             .into_inner()
             .task
             .expect("task");
         let response = service
-            .end_task(Request::new(EndTaskRequest {
-                workspace: Some(workspace("default")),
-                task_id: task.task_id.clone(),
-                task_status: TaskStatus::Success as i32,
-            }))
+            .end_task(request_for_principal(
+                EndTaskRequest {
+                    workspace: Some(workspace("default")),
+                    task_id: task.task_id.clone(),
+                    task_status: TaskStatus::Success as i32,
+                },
+                principal,
+            ))
             .await
             .expect("end task")
             .into_inner();
@@ -195,17 +240,39 @@ mod tests {
         let task_end = response.task_end.expect("task end");
         assert_eq!(task_end.task_id, task.task_id);
         assert_eq!(task_end.task_status, TaskStatus::Success as i32);
-        let raw = fs::read_to_string(layout.task_events_file(&WorkspaceName::default()))
-            .expect("task file");
-        assert!(raw.contains("success"), "got: {raw}");
+
+        let status = service
+            .end_task(request(EndTaskRequest {
+                workspace: Some(workspace("default")),
+                task_id: task.task_id,
+                task_status: TaskStatus::Failure as i32,
+            }))
+            .await
+            .expect_err("terminal task must not change status");
+        assert_eq!(status.code(), Code::FailedPrecondition);
+    }
+
+    #[tokio::test]
+    async fn start_task_rejects_unknown_workspace() {
+        let (_dir, service) = service().await;
+
+        let status = service
+            .start_task(request(StartTaskRequest {
+                workspace: Some(workspace("missing")),
+                intent: "Find renewal risk".to_string(),
+            }))
+            .await
+            .expect_err("workspace must already exist");
+
+        assert_eq!(status.code(), Code::NotFound);
     }
 
     #[tokio::test]
     async fn start_task_rejects_blank_intent() {
-        let (_dir, _layout, service) = service();
+        let (_dir, service) = service().await;
 
         let status = service
-            .start_task(Request::new(StartTaskRequest {
+            .start_task(request(StartTaskRequest {
                 workspace: Some(workspace("default")),
                 intent: " ".to_string(),
             }))
@@ -217,10 +284,10 @@ mod tests {
 
     #[tokio::test]
     async fn end_task_rejects_unknown_task() {
-        let (_dir, _layout, service) = service();
+        let (_dir, service) = service().await;
 
         let status = service
-            .end_task(Request::new(EndTaskRequest {
+            .end_task(request(EndTaskRequest {
                 workspace: Some(workspace("default")),
                 task_id: UNKNOWN_TASK_ID.to_string(),
                 task_status: TaskStatus::Success as i32,
@@ -233,10 +300,10 @@ mod tests {
 
     #[tokio::test]
     async fn end_task_rejects_malformed_task_id() {
-        let (_dir, _layout, service) = service();
+        let (_dir, service) = service().await;
 
         let status = service
-            .end_task(Request::new(EndTaskRequest {
+            .end_task(request(EndTaskRequest {
                 workspace: Some(workspace("default")),
                 task_id: "not-a-uuid".to_string(),
                 task_status: TaskStatus::Success as i32,
@@ -249,9 +316,9 @@ mod tests {
 
     #[tokio::test]
     async fn end_task_rejects_unspecified_status() {
-        let (_dir, _layout, service) = service();
+        let (_dir, service) = service().await;
         let task = service
-            .start_task(Request::new(StartTaskRequest {
+            .start_task(request(StartTaskRequest {
                 workspace: Some(workspace("default")),
                 intent: "Find renewal risk".to_string(),
             }))
@@ -262,7 +329,7 @@ mod tests {
             .expect("task");
 
         let status = service
-            .end_task(Request::new(EndTaskRequest {
+            .end_task(request(EndTaskRequest {
                 workspace: Some(workspace("default")),
                 task_id: task.task_id,
                 task_status: TaskStatus::Unspecified as i32,

--- a/crates/coral-app/src/task/store.rs
+++ b/crates/coral-app/src/task/store.rs
@@ -1,25 +1,34 @@
-//! Per-workspace, append-only task lifecycle store.
+//! Database-backed task lifecycle store.
 
-use std::path::Path;
+use std::sync::Arc;
 
 use coral_api::CORAL_TASK_INTENT_MAX_CHARS;
-use serde::{Deserialize, Serialize};
 
 use super::id::TaskId;
-use crate::state::AppStateLayout;
-use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::identity::Principal;
+use crate::state::db::{
+    CoralDb, DbError, TaskCompletionUpdate, TaskCreation, TaskCreationResult, TaskLifecycleState,
+};
 use crate::workspaces::WorkspaceName;
 
-const MAX_TASK_BYTES_PER_WORKSPACE: u64 = 256 * 1024 * 1024;
+const MAX_RETAINED_TASKS_PER_WORKSPACE: u64 = 10_000;
 
-/// Final task status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum TaskStatus {
+/// Final task outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskOutcome {
     /// Task succeeded.
     Success,
     /// Task failed.
     Failure,
+}
+
+impl TaskOutcome {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
 }
 
 /// A task start event.
@@ -27,365 +36,355 @@ pub(crate) enum TaskStatus {
 pub(crate) struct TaskStart {
     pub(crate) id: TaskId,
     pub(crate) workspace: WorkspaceName,
+    pub(crate) created_by: Principal,
     pub(crate) intent: String,
+    pub(crate) created_at_unix_nanos: i64,
 }
 
-/// A task end event.
+/// A terminal task completion.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TaskEnd {
+pub(crate) struct TaskCompletion {
     pub(crate) id: TaskId,
     pub(crate) workspace: WorkspaceName,
-    pub(crate) status: TaskStatus,
+    pub(crate) outcome: TaskOutcome,
+    pub(crate) completed_at_unix_nanos: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-enum PersistedTaskEvent {
-    Start {
-        task_id: String,
-        workspace: String,
-        intent: String,
-    },
-    End {
-        task_id: String,
-        workspace: String,
-        task_status: TaskStatus,
-    },
-}
-
-impl PersistedTaskEvent {
-    fn from_start(start: &TaskStart, intent: &str) -> Self {
-        Self::Start {
-            task_id: start.id.to_string(),
-            workspace: start.workspace.as_str().to_string(),
-            intent: intent.to_string(),
-        }
-    }
-
-    fn from_end(end: &TaskEnd) -> Self {
-        Self::End {
-            task_id: end.id.to_string(),
-            workspace: end.workspace.as_str().to_string(),
-            task_status: end.status,
-        }
-    }
+/// Result of attempting the one-way transition to a terminal task outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskCompletionResult {
+    /// The active task was completed.
+    Completed,
+    /// The task exists but was already terminal.
+    AlreadyCompleted,
+    /// No task with this id exists in the workspace.
+    NotFound,
 }
 
 /// Errors from the task lifecycle store.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TaskStoreError {
-    /// Filesystem error reading or writing the store.
-    #[error("task store io: {0}")]
-    Io(#[from] std::io::Error),
-    /// JSON serialization error.
-    #[error("task store serialization: {0}")]
-    Serde(#[from] serde_json::Error),
+    /// Database error reading or writing the store.
+    #[error(transparent)]
+    Database(#[from] DbError),
     /// The task intent is empty or exceeds the maximum length.
     #[error("task intent must be non-empty and at most {max} characters")]
     InvalidIntent {
         /// The configured maximum intent length, in characters.
         max: usize,
     },
+    /// The task's workspace was removed before persistence began.
+    #[error("workspace '{workspace}' was not found")]
+    WorkspaceNotFound {
+        /// Missing workspace identifier.
+        workspace: String,
+    },
+    /// The workspace has reached its retained active-task limit.
+    #[error("workspace '{workspace}' already has {max} active tasks")]
+    WorkspaceCapacityExceeded {
+        /// Full workspace identifier.
+        workspace: String,
+        /// Maximum retained tasks.
+        max: u64,
+    },
 }
 
-/// Storage boundary for task lifecycle events.
-pub(crate) trait TaskEventStore: Send + Sync {
-    /// Persists a task start event.
-    fn start_task(&self, start: &TaskStart) -> Result<(), TaskStoreError>;
-
-    /// Persists a task end event.
-    fn end_task(&self, end: &TaskEnd) -> Result<(), TaskStoreError>;
-
-    /// Returns whether a task has been started for this workspace.
-    fn contains_started_task(
-        &self,
-        workspace: &WorkspaceName,
-        task_id: &TaskId,
-    ) -> Result<bool, TaskStoreError>;
-}
-
-/// Append-only, per-workspace JSONL task lifecycle store, bounded by a byte
-/// ceiling with oldest-out eviction.
+/// Database-backed task lifecycle persistence.
 #[derive(Clone)]
-pub(crate) struct JsonlTaskEventStore {
-    layout: AppStateLayout,
-    max_bytes: u64,
+pub(crate) struct TaskStore {
+    db: Arc<CoralDb>,
+    max_retained_tasks: u64,
 }
 
-impl JsonlTaskEventStore {
-    /// Creates a store that persists under `layout`.
-    pub(crate) fn new(layout: AppStateLayout) -> Self {
+impl TaskStore {
+    pub(crate) fn new(db: Arc<CoralDb>) -> Self {
         Self {
-            layout,
-            max_bytes: MAX_TASK_BYTES_PER_WORKSPACE,
+            db,
+            max_retained_tasks: MAX_RETAINED_TASKS_PER_WORKSPACE,
         }
     }
 
-    /// Overrides the per-workspace byte ceiling for tests.
     #[cfg(test)]
-    pub(crate) fn with_max_bytes(mut self, max_bytes: u64) -> Self {
-        self.max_bytes = max_bytes;
+    fn with_max_retained_tasks(mut self, max_retained_tasks: u64) -> Self {
+        self.max_retained_tasks = max_retained_tasks;
         self
     }
 
-    fn append_event(
-        &self,
-        workspace: &WorkspaceName,
-        event: PersistedTaskEvent,
-    ) -> Result<(), TaskStoreError> {
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        let path = self.layout.task_events_file(workspace);
-        let records = read_all_records(&path)?;
-        append_within_budget(&path, records, event, self.max_bytes)
-    }
-}
-
-impl TaskEventStore for JsonlTaskEventStore {
-    fn start_task(&self, start: &TaskStart) -> Result<(), TaskStoreError> {
-        let intent = start.intent.trim();
-        if intent.is_empty() || intent.chars().count() > CORAL_TASK_INTENT_MAX_CHARS {
-            return Err(TaskStoreError::InvalidIntent {
-                max: CORAL_TASK_INTENT_MAX_CHARS,
-            });
+    pub(crate) async fn start_task(&self, start: &TaskStart) -> Result<(), TaskStoreError> {
+        let intent = validate_intent(&start.intent)?;
+        let task_id = start.id.to_string();
+        let result = self
+            .db
+            .task_state()
+            .create(
+                TaskCreation {
+                    id: &task_id,
+                    workspace_id: start.workspace.as_str(),
+                    created_by_principal_id: start.created_by.id().as_str(),
+                    intent,
+                    created_at_unix_nanos: start.created_at_unix_nanos,
+                },
+                self.max_retained_tasks,
+            )
+            .await?;
+        match result {
+            TaskCreationResult::Created => Ok(()),
+            TaskCreationResult::WorkspaceNotFound => Err(TaskStoreError::WorkspaceNotFound {
+                workspace: start.workspace.to_string(),
+            }),
+            TaskCreationResult::WorkspaceCapacityExceeded => {
+                Err(TaskStoreError::WorkspaceCapacityExceeded {
+                    workspace: start.workspace.to_string(),
+                    max: self.max_retained_tasks,
+                })
+            }
         }
-        self.append_event(
-            &start.workspace,
-            PersistedTaskEvent::from_start(start, intent),
-        )
     }
 
-    fn end_task(&self, end: &TaskEnd) -> Result<(), TaskStoreError> {
-        self.append_event(&end.workspace, PersistedTaskEvent::from_end(end))
-    }
-
-    fn contains_started_task(
+    pub(crate) async fn complete_task(
         &self,
-        workspace: &WorkspaceName,
-        task_id: &TaskId,
-    ) -> Result<bool, TaskStoreError> {
-        let _lock = FileLock::shared(self.layout.state_lock())?;
-        let path = self.layout.task_events_file(workspace);
-        let records = read_all_records(&path)?;
-        let task_id = task_id.to_string();
-        Ok(records.iter().any(|record| match record {
-            PersistedTaskEvent::Start {
-                task_id: started_task_id,
-                ..
-            } => started_task_id == &task_id,
-            PersistedTaskEvent::End { .. } => false,
-        }))
-    }
-}
-
-fn read_all_records(path: &Path) -> Result<Vec<PersistedTaskEvent>, TaskStoreError> {
-    let contents = match std::fs::read(path) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => return Err(error.into()),
-    };
-    Ok(contents
-        .split(|&byte| byte == b'\n')
-        .filter_map(|raw_line| {
-            let Ok(line) = std::str::from_utf8(raw_line) else {
-                tracing::warn!("skipping task record with invalid UTF-8");
-                return None;
-            };
-            if line.trim().is_empty() {
-                return None;
-            }
-            match serde_json::from_str::<PersistedTaskEvent>(line) {
-                Ok(record) => Some(record),
-                Err(error) => {
-                    tracing::warn!(%error, "skipping unparsable task record");
-                    None
-                }
-            }
+        completion: &TaskCompletion,
+    ) -> Result<TaskCompletionResult, TaskStoreError> {
+        let update = self
+            .db
+            .task_state()
+            .complete(
+                completion.workspace.as_str(),
+                &completion.id.to_string(),
+                completion.outcome.as_str(),
+                completion.completed_at_unix_nanos,
+            )
+            .await?;
+        Ok(match update {
+            TaskCompletionUpdate::Completed => TaskCompletionResult::Completed,
+            TaskCompletionUpdate::AlreadyCompleted => TaskCompletionResult::AlreadyCompleted,
+            TaskCompletionUpdate::NotFound => TaskCompletionResult::NotFound,
         })
-        .collect())
+    }
+
+    pub(crate) async fn task_state(
+        &self,
+        workspace: &WorkspaceName,
+        task_id: TaskId,
+    ) -> Result<Option<TaskLifecycleState>, TaskStoreError> {
+        let task_id = task_id.to_string();
+        self.db
+            .task_state()
+            .lifecycle(workspace.as_str(), &task_id)
+            .await
+            .map_err(Into::into)
+    }
 }
 
-fn append_within_budget(
-    path: &Path,
-    existing: Vec<PersistedTaskEvent>,
-    record: PersistedTaskEvent,
-    max_bytes: u64,
-) -> Result<(), TaskStoreError> {
-    let mut kept = existing;
-    kept.push(record);
-    let encoded: Vec<Vec<u8>> = kept
-        .iter()
-        .map(serde_json::to_vec)
-        .collect::<Result<_, _>>()?;
-    let record_count = encoded.len();
-    let mut total: u64 = encoded.iter().map(|line| line.len() as u64 + 1).sum();
-    let mut dropped = 0;
-    for line in &encoded {
-        if total <= max_bytes || dropped + 1 >= record_count {
-            break;
-        }
-        total -= line.len() as u64 + 1;
-        dropped += 1;
+fn validate_intent(intent: &str) -> Result<&str, TaskStoreError> {
+    if intent.trim().is_empty() || intent.chars().count() > CORAL_TASK_INTENT_MAX_CHARS {
+        return Err(TaskStoreError::InvalidIntent {
+            max: CORAL_TASK_INTENT_MAX_CHARS,
+        });
     }
-    let mut bytes = Vec::new();
-    for line in encoded.iter().skip(dropped) {
-        bytes.extend_from_slice(line);
-        bytes.push(b'\n');
-    }
-    if let Some(parent) = path.parent() {
-        storage_fs::ensure_dir(parent)?;
-    }
-    storage_fs::write_atomic(path, &bytes)?;
-    Ok(())
+    Ok(intent)
 }
 
 #[cfg(test)]
 mod tests {
-    #![expect(
-        clippy::indexing_slicing,
-        reason = "JSON record assertions intentionally fail loudly in tests"
-    )]
+    use std::sync::Arc;
 
-    use std::fs;
-
-    use serde_json::Value;
     use tempfile::TempDir;
 
     use super::{
-        JsonlTaskEventStore, PersistedTaskEvent, TaskEnd, TaskEventStore, TaskStart, TaskStatus,
-        TaskStoreError,
+        TaskCompletion, TaskCompletionResult, TaskOutcome, TaskStart, TaskStore, TaskStoreError,
+        validate_intent,
     };
+    use crate::identity::{Principal, PrincipalKind};
     use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
 
     const TASK_ID_1: &str = "550e8400-e29b-41d4-a716-446655440000";
     const TASK_ID_2: &str = "650e8400-e29b-41d4-a716-446655440000";
 
-    fn layout() -> (TempDir, AppStateLayout) {
+    async fn store() -> (TempDir, TaskStore) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        (dir, layout)
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default database is sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(WorkspaceName::default().as_str(), 1)
+            .await
+            .expect("seed default workspace");
+        tx.commit().await.expect("commit workspace");
+        (dir, TaskStore::new(db))
     }
 
-    fn start(workspace: &WorkspaceName, id: &str, intent: &str) -> TaskStart {
+    fn start(workspace: &WorkspaceName, task_id: &str, intent: &str) -> TaskStart {
+        start_for_principal(workspace, task_id, intent, Principal::local())
+    }
+
+    fn start_for_principal(
+        workspace: &WorkspaceName,
+        task_id: &str,
+        intent: &str,
+        created_by: Principal,
+    ) -> TaskStart {
         TaskStart {
-            id: TaskId::parse(id).expect("valid task id"),
+            id: TaskId::parse(task_id).expect("valid task id"),
             workspace: workspace.clone(),
+            created_by,
             intent: intent.to_string(),
+            created_at_unix_nanos: 2,
         }
     }
 
-    fn end(workspace: &WorkspaceName, id: &str, status: TaskStatus) -> TaskEnd {
-        TaskEnd {
-            id: TaskId::parse(id).expect("valid task id"),
-            workspace: workspace.clone(),
-            status,
+    fn completion(start: &TaskStart) -> TaskCompletion {
+        TaskCompletion {
+            id: start.id,
+            workspace: start.workspace.clone(),
+            outcome: TaskOutcome::Success,
+            completed_at_unix_nanos: 3,
         }
     }
 
-    #[test]
-    fn start_task_persists_task() {
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let store = JsonlTaskEventStore::new(layout.clone());
-
-        store
-            .start_task(&start(&workspace, TASK_ID_1, "Find renewal risk"))
-            .expect("start task");
-
-        let raw = fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        let record: Value = serde_json::from_str(raw.trim()).expect("task JSONL should parse");
-        assert_eq!(record["event"], "start");
-        assert_eq!(record["task_id"], TASK_ID_1);
-        assert_eq!(record["workspace"], "acme");
-        assert_eq!(record["intent"], "Find renewal risk");
-    }
-
-    #[test]
-    fn contains_started_task_matches_start_events_only() {
-        let (_dir, layout) = layout();
+    #[tokio::test]
+    async fn stores_task_lifecycle_in_database() {
+        let (_dir, store) = store().await;
         let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout);
+        let start = start(&workspace, TASK_ID_1, "  Find renewal risk  ");
 
-        store
-            .end_task(&end(&workspace, TASK_ID_1, TaskStatus::Failure))
-            .expect("end task");
-        assert!(
-            !store
-                .contains_started_task(
-                    &workspace,
-                    &TaskId::parse(TASK_ID_1).expect("valid task id")
-                )
-                .expect("contains task")
-        );
-
-        store
-            .start_task(&start(&workspace, TASK_ID_1, "Find renewal risk"))
-            .expect("start task");
-        assert!(
+        assert_eq!(
             store
-                .contains_started_task(
-                    &workspace,
-                    &TaskId::parse(TASK_ID_1).expect("valid task id")
-                )
-                .expect("contains task")
+                .complete_task(&completion(&start))
+                .await
+                .expect("end missing task"),
+            TaskCompletionResult::NotFound
+        );
+        store.start_task(&start).await.expect("start task");
+        assert_eq!(
+            store
+                .complete_task(&completion(&start))
+                .await
+                .expect("complete stored task"),
+            TaskCompletionResult::Completed
+        );
+        assert_eq!(
+            store
+                .complete_task(&completion(&start))
+                .await
+                .expect("end already terminal task"),
+            TaskCompletionResult::AlreadyCompleted
         );
     }
 
-    #[test]
-    fn end_task_preserves_existing_start_event() {
-        let (_dir, layout) = layout();
+    #[tokio::test]
+    async fn task_lifecycle_uses_workspace_and_id() {
+        let (_dir, store) = store().await;
         let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout.clone());
+        let start = start(&workspace, TASK_ID_1, "Find renewal risk");
+        store.start_task(&start).await.expect("start task");
 
-        store
-            .start_task(&start(&workspace, TASK_ID_1, "Find renewal risk"))
-            .expect("start task");
-        let raw_after_start =
-            fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        assert!(
-            raw_after_start.contains("Find renewal risk"),
-            "got after start: {raw_after_start}"
+        assert_eq!(
+            store
+                .complete_task(&completion(&start))
+                .await
+                .expect("end task by workspace and id"),
+            TaskCompletionResult::Completed
         );
-        let _parsed: PersistedTaskEvent =
-            serde_json::from_str(raw_after_start.trim()).expect("start event should parse");
-        store
-            .end_task(&end(&workspace, TASK_ID_1, TaskStatus::Success))
-            .expect("end task");
-
-        let raw = fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        assert!(raw.contains("Find renewal risk"), "got: {raw}");
-        assert!(raw.contains("success"), "got: {raw}");
+        assert_eq!(
+            store
+                .complete_task(&completion(&start))
+                .await
+                .expect("task is already terminal"),
+            TaskCompletionResult::AlreadyCompleted
+        );
     }
 
-    #[test]
-    fn validates_intent() {
-        let (_dir, layout) = layout();
+    #[tokio::test]
+    async fn evicts_oldest_completed_task_at_retention_limit() {
+        let (_dir, store) = store().await;
+        let store = store.with_max_retained_tasks(1);
         let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout);
+        let first = start(&workspace, TASK_ID_1, "First task");
+        store.start_task(&first).await.expect("start first task");
+        assert_eq!(
+            store
+                .complete_task(&completion(&first))
+                .await
+                .expect("complete first task"),
+            TaskCompletionResult::Completed
+        );
 
-        let blank_start = store
-            .start_task(&start(&workspace, TASK_ID_1, " "))
+        let second = start(&workspace, TASK_ID_2, "Second task");
+        store.start_task(&second).await.expect("start second task");
+        assert_eq!(
+            store
+                .complete_task(&completion(&first))
+                .await
+                .expect("oldest completed task was evicted"),
+            TaskCompletionResult::NotFound
+        );
+        assert_eq!(
+            store
+                .complete_task(&completion(&second))
+                .await
+                .expect("new task remains"),
+            TaskCompletionResult::Completed
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_new_task_instead_of_evicting_an_active_task() {
+        let (_dir, store) = store().await;
+        let store = store.with_max_retained_tasks(1);
+        let workspace = WorkspaceName::default();
+        let first = start(&workspace, TASK_ID_1, "First task");
+        store.start_task(&first).await.expect("start first task");
+
+        let second = start_for_principal(
+            &workspace,
+            TASK_ID_2,
+            "Second task",
+            Principal::parse("product:principal:other", PrincipalKind::Agent)
+                .expect("other principal"),
+        );
+        assert!(matches!(
+            store.start_task(&second).await,
+            Err(TaskStoreError::WorkspaceCapacityExceeded { .. })
+        ));
+        assert_eq!(
+            store
+                .complete_task(&completion(&first))
+                .await
+                .expect("existing active task remains"),
+            TaskCompletionResult::Completed
+        );
+    }
+
+    #[tokio::test]
+    async fn validates_intent_before_writing() {
+        let (_dir, store) = store().await;
+        let error = store
+            .start_task(&start(&WorkspaceName::default(), TASK_ID_1, " "))
+            .await
             .expect_err("blank intent");
-        assert!(matches!(blank_start, TaskStoreError::InvalidIntent { .. }));
+        assert!(matches!(error, TaskStoreError::InvalidIntent { .. }));
     }
 
     #[test]
-    fn task_events_evict_oldest_records_within_budget() {
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout.clone()).with_max_bytes(1);
-
-        store
-            .end_task(&end(&workspace, TASK_ID_1, TaskStatus::Success))
-            .expect("first event");
-        store
-            .end_task(&end(&workspace, TASK_ID_2, TaskStatus::Failure))
-            .expect("second event");
-
-        let raw = fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        assert!(!raw.contains(TASK_ID_1));
-        assert!(raw.contains(TASK_ID_2));
+    fn intent_validation_preserves_authored_text() {
+        let authored = "  Find renewal risk  ";
+        assert_eq!(
+            validate_intent(authored).expect("authored intent should be valid"),
+            authored
+        );
     }
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -122,7 +122,7 @@ where
     }
 
     fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
-        annotate_request_context(&mut request);
+        let task_id = annotate_request_context(&mut request);
         let method_metadata = request.extensions().get::<GrpcServerMethod>().map_or_else(
             || GrpcMethodMetadata::new("coral.v1.UnknownService", "Unknown"),
             |method| GrpcMethodMetadata::new(method.service.as_str(), method.method.as_str()),
@@ -148,9 +148,16 @@ where
                 .await
                 {
                     Ok(principal) => {
+                        let task_id = match task_id {
+                            Ok(task_id) => task_id,
+                            Err(status) => {
+                                record_grpc_status(&span, status.code(), Some(&status));
+                                return Ok(status.into_http());
+                            }
+                        };
                         request
                             .extensions_mut()
-                            .insert(RequestContext::new(principal));
+                            .insert(RequestContext::new(principal).with_task_id(task_id));
                         inner.call(request).await
                     }
                     Err(error) => {
@@ -274,28 +281,34 @@ fn grpc_method<T>(request: &Request<T>) -> GrpcMethodMetadata {
     )
 }
 
-fn annotate_request_context<B>(request: &mut http::Request<B>) {
+fn annotate_request_context<B>(request: &mut http::Request<B>) -> Result<Option<TaskId>, Status> {
     if let Some(method) = GrpcServerMethod::from_path(request.uri().path()) {
         request.extensions_mut().insert(method);
     }
-    if let Some(task_id) = request
-        .headers()
-        .get(CORAL_TASK_ID_METADATA_KEY)
-        .and_then(task_id_from_header_value)
-    {
-        request.extensions_mut().insert(task_id);
+    let mut task_ids = request.headers().get_all(CORAL_TASK_ID_METADATA_KEY).iter();
+    let Some(task_id) = task_ids.next() else {
+        return Ok(None);
+    };
+    if task_ids.next().is_some() {
+        return Err(Status::invalid_argument(
+            "coral-task-id metadata must contain exactly one value",
+        ));
     }
+    task_id_from_header_value(task_id).map(Some)
 }
 
-fn task_id_from_header_value(value: &http::HeaderValue) -> Option<TaskId> {
-    let value = value.to_str().ok()?;
-    match TaskId::parse(value) {
-        Ok(task_id) => Some(task_id),
-        Err(error) => {
-            tracing::debug!(%error, "ignoring malformed coral-task-id metadata");
-            None
-        }
-    }
+fn task_id_from_header_value(value: &http::HeaderValue) -> Result<TaskId, Status> {
+    let value = value
+        .to_str()
+        .map_err(|_error| Status::invalid_argument("coral-task-id metadata must be ASCII"))?;
+    TaskId::parse(value).map_err(app_status)
+}
+
+pub(crate) fn request_context<T>(request: &Request<T>) -> Result<&RequestContext, Status> {
+    request
+        .extensions()
+        .get::<RequestContext>()
+        .ok_or_else(|| Status::internal("request context is unavailable"))
 }
 
 pub(crate) async fn instrument_grpc<T, F>(span: tracing::Span, future: F) -> Result<T, Status>
@@ -615,7 +628,6 @@ mod tests {
     use crate::bootstrap::AppError;
     use crate::identity::PrincipalProviderError;
     use crate::query::manager::QueryManagerError;
-    use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
@@ -822,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn annotate_request_context_extracts_valid_task_id() {
+    fn annotate_request_context_parses_valid_task_id() {
         let mut request = tonic::codegen::http::Request::builder()
             .uri("/coral.v1.QueryService/ExecuteSql")
             .header(
@@ -832,25 +844,21 @@ mod tests {
             .body(())
             .expect("request");
 
-        annotate_request_context(&mut request);
-
-        let task_id = request
-            .extensions()
-            .get::<TaskId>()
-            .expect("task id extension");
+        let task_id = annotate_request_context(&mut request)
+            .expect("valid metadata")
+            .expect("task id");
         assert_eq!(task_id.to_string(), "750e8400-e29b-41d4-a716-446655440000");
     }
 
     #[test]
-    fn annotate_request_context_ignores_absent_and_malformed_task_id() {
+    fn annotate_request_context_accepts_absent_and_rejects_malformed_task_id() {
         let mut absent = tonic::codegen::http::Request::builder()
             .uri("/coral.v1.QueryService/ExecuteSql")
             .body(())
             .expect("request");
-        annotate_request_context(&mut absent);
-        assert!(
-            absent.extensions().get::<TaskId>().is_none(),
-            "a missing coral-task-id yields no attribution"
+        assert_eq!(
+            annotate_request_context(&mut absent).expect("absent metadata"),
+            None
         );
 
         let mut malformed = tonic::codegen::http::Request::builder()
@@ -858,10 +866,37 @@ mod tests {
             .header(CORAL_TASK_ID_METADATA_KEY, "has space")
             .body(())
             .expect("request");
-        annotate_request_context(&mut malformed);
-        assert!(
-            malformed.extensions().get::<TaskId>().is_none(),
-            "a malformed id is ignored, not surfaced"
+        let status =
+            annotate_request_context(&mut malformed).expect_err("reject malformed metadata");
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn annotate_request_context_rejects_repeated_task_id_metadata() {
+        assert_repeated_task_id_metadata_rejected("750e8400-e29b-41d4-a716-446655440001");
+    }
+
+    #[test]
+    fn annotate_request_context_rejects_valid_and_malformed_repeated_task_id_metadata() {
+        assert_repeated_task_id_metadata_rejected("not-a-task-id");
+    }
+
+    fn assert_repeated_task_id_metadata_rejected(second_value: &str) {
+        let mut request = tonic::codegen::http::Request::builder()
+            .uri("/coral.v1.QueryService/ExecuteSql")
+            .header(
+                CORAL_TASK_ID_METADATA_KEY,
+                "750e8400-e29b-41d4-a716-446655440000",
+            )
+            .header(CORAL_TASK_ID_METADATA_KEY, second_value)
+            .body(())
+            .expect("request");
+
+        let status = annotate_request_context(&mut request).expect_err("reject repeated metadata");
+        assert_eq!(status.code(), Code::InvalidArgument);
+        assert_eq!(
+            status.message(),
+            "coral-task-id metadata must contain exactly one value"
         );
     }
 

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -152,16 +152,13 @@ impl WorkspaceManager {
             })?;
 
         let (deleted, workspace_dir_backup) = {
-            let mut tx = self.db.begin().await?;
-            if tx
-                .workspaces()
-                .get(workspace_name.as_str())
+            let Some(deletion) = self
+                .db
+                .begin_workspace_deletion(workspace_name.as_str())
                 .await?
-                .is_none()
-            {
+            else {
                 return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
-            }
-            tx.workspaces().delete(workspace_name.as_str()).await?;
+            };
             let deleted = {
                 let _lifecycle_guard = self.lifecycle_lock.lock();
                 self.config_store
@@ -175,7 +172,7 @@ impl WorkspaceManager {
                     sources: Vec::new(),
                 }),
                 Err(error) => {
-                    if let Err(rollback_error) = tx.rollback().await {
+                    if let Err(rollback_error) = deletion.rollback().await {
                         warn!(
                             workspace = %workspace_name,
                             "workspace config cleanup failed, and database rollback also failed: {rollback_error}"
@@ -184,7 +181,7 @@ impl WorkspaceManager {
                     return Err(error);
                 }
             };
-            tx.commit().await?;
+            deletion.commit().await?;
             self.remove_deleted_workspace_credentials(&deleted);
             let workspace_dir_backup = self.stage_deleted_workspace_dir(&deleted.workspace.name);
             (deleted, workspace_dir_backup)

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -655,6 +655,19 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     );
     assert_eq!(end["task_status"], "success");
 
+    let after_end = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["SELECT 1"],
+                "intent": "Reject attribution to an ended task",
+                "task_id": root_task_id
+            }))),
+        )
+        .await
+        .expect("ended task rejection should be a tool result");
+    assert_eq!(after_end.is_error, Some(true));
+    assert_tool_error_text_contains(&after_end, "has already ended");
+
     let invalid_task_id = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
@@ -716,27 +729,6 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .contains("unknown argument 'initialize_session'")
     );
 
-    let tasks_path = temp
-        .path()
-        .join("coral-config/workspaces/default/tasks/tasks.jsonl");
-    let raw = fs::read_to_string(&tasks_path).expect("task file should exist");
-    let records = raw
-        .lines()
-        .map(|line| serde_json::from_str::<Value>(line).expect("task JSONL should parse"))
-        .collect::<Vec<_>>();
-    assert_eq!(records.len(), 2);
-    let root_record = records
-        .iter()
-        .find(|record| record["task_id"] == root_task_id.as_str())
-        .expect("root task record");
-    assert_eq!(root_record["workspace"], "default");
-    assert_eq!(root_record["intent"], "Investigate customer renewal risk");
-    let end_record = records
-        .iter()
-        .find(|record| record["task_id"] == root_task_id.as_str() && record["event"] == "end")
-        .expect("task end record");
-    assert_eq!(end_record["task_status"], "success");
-
     let blank_intent = client
         .call_tool(
             CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
@@ -750,14 +742,12 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .to_string()
             .contains("missing string argument 'intent'")
     );
-    let raw_after_error = fs::read_to_string(&tasks_path).expect("task file should exist");
-    assert_eq!(raw_after_error.lines().count(), 2);
 
     session.shutdown().await;
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn task_intent_is_persisted_but_not_exported_to_telemetry() {
+async fn task_intent_is_not_exported_to_telemetry() {
     let exporter = InMemorySpanExporter::default();
     let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
@@ -801,17 +791,6 @@ async fn task_intent_is_persisted_but_not_exported_to_telemetry() {
         .expect("task id")
         .to_string();
     uuid::Uuid::parse_str(&task_id).expect("task id is a UUID");
-
-    let tasks_path = temp
-        .path()
-        .join("coral-config/workspaces/default/tasks/tasks.jsonl");
-    let persisted = fs::read_to_string(tasks_path).expect("task file should exist");
-    let start_record = persisted
-        .lines()
-        .map(|line| serde_json::from_str::<Value>(line).expect("task JSONL should parse"))
-        .find(|record| record["task_id"] == task_id && record["event"] == "start")
-        .expect("task start record");
-    assert_eq!(start_record["intent"], sentinel);
 
     session.shutdown().await;
     provider.force_flush().expect("flush spans");
@@ -900,13 +879,6 @@ async fn mcp_task_tools_are_disabled_by_default() {
             .to_string()
             .contains("tool 'open_episode' not found")
     );
-    assert!(
-        !temp
-            .path()
-            .join("coral-config/workspaces/default/tasks/tasks.jsonl")
-            .exists()
-    );
-
     session.shutdown().await;
 }
 
@@ -1737,6 +1709,21 @@ async fn mcp_feedback_tool_accepts_task_id_when_tasks_enabled() {
     let tools = client.list_all_tools().await.expect("tools");
     assert_tool_advertises_task_context(tool_by_name(&tools, "feedback"));
 
+    let started = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+                "intent": "Exercise task-attributed feedback"
+            }))),
+        )
+        .await
+        .expect("start feedback task")
+        .structured_content
+        .expect("start task structured content");
+    let task_id = started["task_id"]
+        .as_str()
+        .expect("started task id")
+        .to_string();
+
     let feedback = client
         .call_tool(
             CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
@@ -1744,7 +1731,7 @@ async fn mcp_feedback_tool_accepts_task_id_when_tasks_enabled() {
                 "tried": "Started a task and inspected failing output",
                 "stuck": "The final step still needs user judgment",
                 "intent": "Record blocked final task step",
-                "task_id": "550e8400-e29b-41d4-a716-446655440000"
+                "task_id": task_id
             }))),
         )
         .await
@@ -1763,7 +1750,7 @@ async fn mcp_feedback_tool_accepts_task_id_when_tasks_enabled() {
     let records = raw.lines().collect::<Vec<_>>();
     assert_eq!(records.len(), 1);
     let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
-    assert_eq!(record["task_id"], "550e8400-e29b-41d4-a716-446655440000");
+    assert_eq!(record["task_id"], task_id);
 
     let invalid_task_id = client
         .call_tool(


### PR DESCRIPTION
## Summary

- move Task lifecycle state into the Unified DB used by app state
- use the Task UUID as the sole primary key while keeping every lookup and mutation workspace-scoped
- treat the Workspace as the confidentiality boundary and retain the creator principal ID for attribution
- model completion with `ended_at_unix_nanos` and `outcome`, with database constraints that keep status and completion fields consistent
- add workspace/status indexes for active-task and retention queries
- keep parent-transaction ownership, retention decisions, eviction, mutation, and commit/rollback in `TaskState` while repositories expose narrow query primitives
- serialize workspace deletion with Task creation and completion by making the parent deletion the transaction's first statement
- add barrier-controlled create/delete and complete/delete races that assert clean serialization and no orphaned rows on SQLite and Postgres
- claim the one-time legacy cutover marker as the first operation in the same transaction, so only one process imports and rollback releases the claim
- reject repeated `coral-task-id` metadata before parsing either value
- keep legacy JSONL cleanup per app-state layout behind layout/filesystem seams
- establish the Task schema conventions in contributor guidance
- exercise the same repository contracts against SQLite and Postgres

## Identity and source scope

A Task stores `created_by_principal_id` for attribution. The authenticated `PrincipalKind` remains on the live request context for future authorization decisions and is deliberately not duplicated into Task rows.

Tasks are shared within a Workspace, so source scope is not part of Task identity or retrieval. This differs from observed values, whose credential- and runtime-scoped identity prevents stale values from crossing a live source boundary.

## Validation

- `make rust-checks` at the restacked top — 2,066 passed, 5 skipped
- SQLite Task and state-migration repository coverage, including forced create/delete and complete/delete races
- `make postgres-tests` at the restacked top — four repository contracts and Postgres server startup passed
- GitHub performance regression checks — passed on both restacked heads
- independent Standards and Spec reviews — no unresolved findings
