### PR TITLE
feat(mcp): require task lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,28 @@
+# Coral
+
+Coral exposes connected data to agents and attributes their work without
+conflating current product concepts with retired experimental terminology.
+
+## Language
+
+**Workspace**:
+The confidentiality boundary for Coral data and agent work. Tasks are shared by
+Principals within a Workspace and are never shared across Workspaces.
+
+**Principal**:
+An authenticated actor, stably classified as a User or Agent, whose participation
+in a Task is attributed. Kind informs authorization but does not itself grant
+permission; a Principal does not privately own a Task.
+
+**Task**:
+A Workspace-shared unit of agent work with a declared intent and a terminal
+success or failure outcome. It records the Principal that started it, and Coral
+interactions within it are attributed to its task identifier.
+
+_Avoid_: Using Episode or session as aliases for Task
+
+**Episode**:
+A retired predecessor to Task that is not part of Coral's current product
+model.
+
+_Avoid_: Using episode as an alias for Task

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -18,9 +18,6 @@ pub enum Feature {
     /// Enable observed-value collection, storage, retrieval, and maintenance
     /// for Universal Search.
     ObservedValuesSearch,
-    /// Expose MCP task lifecycle tools and task attribution for follow-up Coral
-    /// MCP tool calls via the `coral-task-id` metadata key.
-    Tasks,
 }
 
 impl Feature {
@@ -87,14 +84,6 @@ const FEATURE_SPECS: &[FeatureSpec] = &[
         description: "Enables collecting, indexing, retrieving, and maintaining values observed during earlier queries. Off by default.",
         enable_flag: "enable-observed-values-search",
         disable_flag: "disable-observed-values-search",
-    },
-    FeatureSpec {
-        feature: Feature::Tasks,
-        key: "tasks",
-        default_enabled: false,
-        description: "Exposes MCP task lifecycle tools and tags follow-up Coral tool calls with task ids. Off by default.",
-        enable_flag: "enable-tasks",
-        disable_flag: "disable-tasks",
     },
 ];
 
@@ -481,5 +470,24 @@ observed_values_search = true
         assert!(error.to_string().contains("unknown feature 'nope'"));
         assert!(error.to_string().contains("feedback"));
         assert!(error.to_string().contains("observed_values_search"));
+    }
+
+    #[test]
+    fn retired_tasks_feature_key_is_unknown() {
+        let temp = TempDir::new().expect("temp dir");
+        let store =
+            FeatureStore::discover(Some(temp.path().join("coral-config"))).expect("feature store");
+        let raw = raw([("tasks", RawFeatureValue::Bool(false))]);
+        let features = Features::from_raw_overrides(&raw);
+        let keys = Feature::all().map(Feature::key).collect::<Vec<_>>();
+        let error = unknown_feature_error("tasks");
+
+        assert_eq!(keys, vec!["feedback", "observed_values_search"]);
+        assert!(!features.enabled(Feature::Feedback));
+        assert!(!features.enabled(Feature::ObservedValuesSearch));
+        assert!(error.to_string().contains("unknown feature 'tasks'"));
+        assert!(!error.to_string().contains("enable-tasks"));
+        assert!(store.enable("tasks").is_err());
+        assert!(store.disable("tasks").is_err());
     }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -920,7 +920,6 @@ async fn run_app_command(
                     feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
                     observed_values_search_enabled: features
                         .enabled(coral_app::features::Feature::ObservedValuesSearch),
-                    tasks_enabled: features.enabled(coral_app::features::Feature::Tasks),
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                     source_names,
                     query_examples,
@@ -2061,6 +2060,16 @@ mod tests {
         .expect_err("conflicting feature overrides should fail");
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn retired_task_feature_flags_are_rejected() {
+        for flag in ["--enable-tasks", "--disable-tasks"] {
+            let error = Cli::try_parse_from(["coral", flag, "mcp-stdio"])
+                .expect_err("retired task feature flag should be rejected");
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+        }
     }
 
     #[test]

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -3,6 +3,7 @@
     reason = "Integration test crates share this harness, but each target only uses a subset of the helpers."
 )]
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -18,6 +19,7 @@ use coral_api::v1::function_service_server::{FunctionService, FunctionServiceSer
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
+use coral_api::v1::task_service_server::{TaskService, TaskServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
     AddFunctionRequest, AddFunctionResponse, CatalogClearResult, CatalogCounts, CatalogItem,
@@ -28,22 +30,23 @@ use coral_api::v1::{
     DeleteFunctionRequest, DeleteFunctionResponse, DeleteSourceRequest, DeleteSourceResponse,
     DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse,
     DiscoverSourcesRequest, DiscoverSourcesResponse, DrainSearchQueueRequest,
-    DrainSearchQueueResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest,
-    ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
-    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest,
-    ListFunctionsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
-    ListWorkspacesResponse, ObservedDrainResult, ObservedRebuildResult, PaginationRequest,
-    PaginationResponse, QueryPlan, RebuildSearchIndexRequest, RebuildSearchIndexResponse,
-    SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult,
-    SearchMaintenanceState, SearchProvider, SearchProviderCoverage, SearchProviderState,
-    SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
-    SearchStorageCleanupResult, SearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
-    SourceOrigin, SourceSecretInput, Table, TableFunction, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    import_source_response, search_maintenance_result, search_result,
-    source_input_spec::Input as ProtoSourceInput,
+    DrainSearchQueueResponse, EndTaskRequest, EndTaskResponse, ExecuteSqlRequest,
+    ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
+    ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse, ListSourcesRequest,
+    ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse, ObservedDrainResult,
+    ObservedRebuildResult, PaginationRequest, PaginationResponse, QueryPlan,
+    RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
+    SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult, SearchMaintenanceState,
+    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
+    SearchResult, SearchResultTruncation, SearchStorageCleanupResult, SearchSurfaceKind,
+    SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
+    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, StartTaskRequest,
+    StartTaskResponse, Table, TableFunction, TableSummary, Task as ProtoTask,
+    TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    catalog_item, create_bundled_source_with_o_auth_response, import_source_response,
+    search_maintenance_result, search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -885,6 +888,8 @@ struct Captured {
     list_workspaces: Mutex<Vec<ListWorkspacesRequest>>,
     create_workspace: Mutex<Vec<CreateWorkspaceRequest>>,
     delete_workspace: Mutex<Vec<DeleteWorkspaceRequest>>,
+    start_task: Mutex<Vec<StartTaskRequest>>,
+    end_task: Mutex<Vec<EndTaskRequest>>,
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -1455,6 +1460,90 @@ impl WorkspaceService for MockWorkspaceService {
     }
 }
 
+#[derive(Default)]
+struct MockTaskState {
+    next_id: u64,
+    tasks: HashMap<(String, String), Option<TaskStatus>>,
+}
+
+#[derive(Clone, Default)]
+struct MockTaskService {
+    state: Arc<Mutex<MockTaskState>>,
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl TaskService for MockTaskService {
+    async fn start_task(
+        &self,
+        request: Request<StartTaskRequest>,
+    ) -> Result<Response<StartTaskResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .start_task
+            .lock()
+            .expect("start_task capture")
+            .push(request.clone());
+        let workspace = request
+            .workspace
+            .ok_or_else(|| Status::invalid_argument("workspace is required"))?;
+        if workspace.name.trim().is_empty() {
+            return Err(Status::invalid_argument("workspace name is required"));
+        }
+        if request.intent.trim().is_empty() {
+            return Err(Status::invalid_argument("task intent is required"));
+        }
+
+        let mut state = self.state.lock().expect("task state");
+        state.next_id = state.next_id.checked_add(1).expect("task id counter");
+        let task_id = format!("00000000-0000-4000-8000-{:012x}", state.next_id);
+        state.tasks.insert((workspace.name, task_id.clone()), None);
+
+        Ok(Response::new(StartTaskResponse {
+            task: Some(ProtoTask { task_id }),
+        }))
+    }
+
+    async fn end_task(
+        &self,
+        request: Request<EndTaskRequest>,
+    ) -> Result<Response<EndTaskResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .end_task
+            .lock()
+            .expect("end_task capture")
+            .push(request.clone());
+        let workspace = request
+            .workspace
+            .ok_or_else(|| Status::invalid_argument("workspace is required"))?;
+        let task_status = TaskStatus::try_from(request.task_status)
+            .map_err(|_error| Status::invalid_argument("unknown task status"))?;
+        if task_status == TaskStatus::Unspecified {
+            return Err(Status::invalid_argument(
+                "task status must be success or failure",
+            ));
+        }
+
+        let mut state = self.state.lock().expect("task state");
+        let status = state
+            .tasks
+            .get_mut(&(workspace.name, request.task_id.clone()))
+            .ok_or_else(|| Status::not_found("task was not found"))?;
+        if status.is_some() {
+            return Err(Status::failed_precondition("task has already ended"));
+        }
+        *status = Some(task_status);
+
+        Ok(Response::new(EndTaskResponse {
+            task_end: Some(ProtoTaskEnd {
+                task_id: request.task_id,
+                task_status: task_status as i32,
+            }),
+        }))
+    }
+}
+
 pub(crate) struct MockServer {
     endpoint_uri: String,
     config_dir: TempDir,
@@ -1482,6 +1571,7 @@ impl MockServer {
         let source_captured = Arc::clone(&captured);
         let function_captured = Arc::clone(&captured);
         let workspace_captured = Arc::clone(&captured);
+        let task_captured = Arc::clone(&captured);
         let query_config = Arc::clone(&config);
         let search_config = Arc::clone(&config);
         let source_config = Arc::clone(&config);
@@ -1510,6 +1600,10 @@ impl MockServer {
                 .add_service(FunctionServiceServer::new(MockFunctionService {
                     config: Arc::clone(&config),
                     captured: function_captured,
+                }))
+                .add_service(TaskServiceServer::new(MockTaskService {
+                    captured: task_captured,
+                    ..MockTaskService::default()
                 }))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     drop(shutdown_rx.await);
@@ -1714,6 +1808,22 @@ impl MockServer {
             .delete_workspace
             .lock()
             .expect("delete_workspace capture")
+            .clone()
+    }
+
+    pub(crate) fn start_task_requests(&self) -> Vec<StartTaskRequest> {
+        self.captured
+            .start_task
+            .lock()
+            .expect("start_task capture")
+            .clone()
+    }
+
+    pub(crate) fn end_task_requests(&self) -> Vec<EndTaskRequest> {
+        self.captured
+            .end_task
+            .lock()
+            .expect("end_task capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -38,8 +38,38 @@ use tonic::Request;
 
 const RAW_JSONRPC_RESPONSE_TIMEOUT: Duration = Duration::from_secs(15);
 
-fn json_object(value: &Value) -> Map<String, Value> {
+fn task_arguments(task_id: &str, value: &Value) -> Map<String, Value> {
+    let mut arguments = raw_json_object(value);
+    assert!(
+        arguments
+            .insert("task_id".to_string(), json!(task_id))
+            .is_none(),
+        "task arguments should not provide their own task_id"
+    );
+    arguments
+        .entry("intent".to_string())
+        .or_insert_with(|| json!("Exercise the MCP CLI test contract"));
+    arguments
+}
+
+fn raw_json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
+}
+
+async fn start_test_task(
+    client: &RunningService<RoleClient, ()>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let started = structured_tool_content(
+        client,
+        CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
+            "intent": "Exercise the MCP CLI test contract"
+        }))),
+    )
+    .await?;
+    Ok(started["task_id"]
+        .as_str()
+        .expect("start task id")
+        .to_string())
 }
 
 fn write_config(server: &MockServer, raw: &str) -> Result<(), io::Error> {
@@ -707,29 +737,31 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
         vec![
+            "start_task",
             "sql",
             "search",
             "list_catalog",
             "describe_table",
-            "list_columns"
+            "list_columns",
+            "end_task"
         ]
     );
     assert!(
-        tools[0]
+        tools[1]
             .description
             .as_deref()
             .expect("sql description")
             .contains("3 table(s) are currently visible")
     );
     assert!(
-        tools[1]
+        tools[2]
             .description
             .as_deref()
             .expect("search description")
             .contains("Returns typed results plus provider statuses")
     );
     assert!(
-        tools[2]
+        tools[3]
             .description
             .as_deref()
             .expect("list_catalog description")
@@ -790,11 +822,13 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
         vec![
+            "start_task",
             "sql",
             "search",
             "list_catalog",
             "describe_table",
             "list_columns",
+            "end_task",
             "feedback"
         ]
     );
@@ -870,9 +904,9 @@ async fn assert_observed_value_discovery_surface(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_enable_tasks_flag_lists_task_tools() -> Result<(), Box<dyn std::error::Error>> {
+async fn mcp_stdio_always_lists_task_tools() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
-    let client = start_mcp_client_with_args(&server, &["--enable-tasks"]).await?;
+    let client = start_mcp_client(&server).await?;
 
     let tools = client.list_all_tools().await?;
     assert_eq!(
@@ -881,12 +915,12 @@ async fn mcp_stdio_enable_tasks_flag_lists_task_tools() -> Result<(), Box<dyn st
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
         vec![
+            "start_task",
             "sql",
             "search",
             "list_catalog",
             "describe_table",
             "list_columns",
-            "start_task",
             "end_task"
         ]
     );
@@ -954,6 +988,45 @@ async fn mcp_stdio_enable_tasks_flag_lists_task_tools() -> Result<(), Box<dyn st
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_task_tools_send_lifecycle_requests() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    let task_id = start_test_task(&client).await?;
+    let start_requests = server.start_task_requests();
+    assert_eq!(start_requests.len(), 1);
+    assert_default_workspace(start_requests[0].workspace.as_ref());
+    assert_eq!(
+        start_requests[0].intent,
+        "Exercise the MCP CLI test contract"
+    );
+
+    let ended = structured_tool_content(
+        &client,
+        CallToolRequestParams::new("end_task").with_arguments(raw_json_object(&json!({
+            "task_id": task_id,
+            "task_status": "success"
+        }))),
+    )
+    .await?;
+    assert_eq!(ended["task_id"], task_id);
+    assert_eq!(ended["task_status"], "success");
+
+    let end_requests = server.end_task_requests();
+    assert_eq!(end_requests.len(), 1);
+    assert_default_workspace(end_requests[0].workspace.as_ref());
+    assert_eq!(end_requests[0].task_id, task_id);
+    assert_eq!(
+        end_requests[0].task_status,
+        coral_api::v1::TaskStatus::Success as i32
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_feature_config_enables_feedback_tool() -> Result<(), Box<dyn std::error::Error>>
 {
     let server = MockServer::start().await;
@@ -978,13 +1051,14 @@ feedback = true
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_feature_config_enables_task_tools() -> Result<(), Box<dyn std::error::Error>> {
+async fn stale_tasks_feature_config_cannot_disable_task_tools()
+-> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     write_config(
         &server,
         r"
 [features]
-tasks = true
+tasks = false
 ",
     )?;
     let client = start_mcp_client(&server).await?;
@@ -992,11 +1066,11 @@ tasks = true
     let tools = client.list_all_tools().await?;
     assert!(
         tools.iter().any(|tool| tool.name.as_ref() == "start_task"),
-        "start_task tool should be listed when [features].tasks is true"
+        "stale [features].tasks must not disable start_task"
     );
     assert!(
         tools.iter().any(|tool| tool.name.as_ref() == "end_task"),
-        "end_task tool should be listed when [features].tasks is true"
+        "stale [features].tasks must not disable end_task"
     );
 
     client.cancel().await?;
@@ -1207,16 +1281,17 @@ async fn mcp_stdio_sql_and_catalog_tools_return_structured_content()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
+    let task_id = start_test_task(&client).await?;
 
-    assert_list_catalog_tool(&client, &server).await?;
+    assert_list_catalog_tool(&client, &server, &task_id).await?;
     client
         .call_tool(CallToolRequestParams::new("search_catalog"))
         .await
         .expect_err("removed search_catalog tool should not be callable");
-    assert_search_tool(&client, &server).await?;
-    assert_describe_table_tool(&client, &server).await?;
-    assert_list_columns_tool(&client).await?;
-    assert_sql_tool(&client).await?;
+    assert_search_tool(&client, &server, &task_id).await?;
+    assert_describe_table_tool(&client, &server, &task_id).await?;
+    assert_list_columns_tool(&client, &task_id).await?;
+    assert_sql_tool(&client, &task_id).await?;
 
     client.cancel().await?;
     server.shutdown().await;
@@ -1226,9 +1301,14 @@ async fn mcp_stdio_sql_and_catalog_tools_return_structured_content()
 async fn assert_list_catalog_tool(
     client: &RunningService<RoleClient, ()>,
     server: &MockServer,
+    task_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let structured_catalog =
-        structured_tool_content(client, CallToolRequestParams::new("list_catalog")).await?;
+    let structured_catalog = structured_tool_content(
+        client,
+        CallToolRequestParams::new("list_catalog")
+            .with_arguments(task_arguments(task_id, &json!({}))),
+    )
+    .await?;
     assert_eq!(structured_catalog["total"], 3);
     assert_eq!(structured_catalog["limit"], 50);
     assert_eq!(structured_catalog["offset"], 0);
@@ -1248,10 +1328,13 @@ async fn assert_list_catalog_tool(
 
     let all_kinds = structured_tool_content(
         client,
-        CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-            "schema": "local_messages",
-            "kind": null
-        }))),
+        CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "schema": "local_messages",
+                "kind": null
+            }),
+        )),
     )
     .await?;
     assert_eq!(all_kinds["total"], 3);
@@ -1259,12 +1342,15 @@ async fn assert_list_catalog_tool(
 
     let paginated = structured_tool_content(
         client,
-        CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-            "schema": "local_messages",
-            "kind": "table",
-            "limit": 2,
-            "offset": 0
-        }))),
+        CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "schema": "local_messages",
+                "kind": "table",
+                "limit": 2,
+                "offset": 0
+            }),
+        )),
     )
     .await?;
     assert_eq!(paginated["total"], 3);
@@ -1274,9 +1360,12 @@ async fn assert_list_catalog_tool(
 
     let functions = structured_tool_content(
         client,
-        CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-            "kind": "table_function"
-        }))),
+        CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "kind": "table_function"
+            }),
+        )),
     )
     .await?;
     assert_eq!(functions["total"], 0);
@@ -1284,8 +1373,10 @@ async fn assert_list_catalog_tool(
 
     client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "invalid"
+            CallToolRequestParams::new("list_catalog").with_arguments(raw_json_object(&json!({
+                "kind": "invalid",
+                "task_id": task_id,
+                "intent": "Validate invalid catalog kind handling"
             }))),
         )
         .await
@@ -1296,13 +1387,17 @@ async fn assert_list_catalog_tool(
 async fn assert_search_tool(
     client: &RunningService<RoleClient, ()>,
     server: &MockServer,
+    task_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let search = structured_tool_content(
         client,
-        CallToolRequestParams::new("search").with_arguments(json_object(&json!({
-            "query": "messages",
-            "limit": 5
-        }))),
+        CallToolRequestParams::new("search").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "query": "messages",
+                "limit": 5
+            }),
+        )),
     )
     .await?;
     assert_eq!(search["results"][0]["kind"], "catalog_metadata");
@@ -1328,15 +1423,19 @@ async fn assert_search_tool(
 async fn assert_describe_table_tool(
     client: &RunningService<RoleClient, ()>,
     server: &MockServer,
+    task_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let describe_before = server.describe_table_requests().len();
     let execute_sql_before = server.execute_sql_requests().len();
     let described = structured_tool_content(
         client,
-        CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
-            "schema": "local_messages",
-            "table": "messages"
-        }))),
+        CallToolRequestParams::new("describe_table").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "schema": "local_messages",
+                "table": "messages"
+            }),
+        )),
     )
     .await?;
     assert_eq!(described["found"], true);
@@ -1354,14 +1453,18 @@ async fn assert_describe_table_tool(
 
 async fn assert_list_columns_tool(
     client: &RunningService<RoleClient, ()>,
+    task_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let columns = structured_tool_content(
         client,
-        CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-            "schema": "local_messages",
-            "table": "messages",
-            "required_only": true
-        }))),
+        CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "schema": "local_messages",
+                "table": "messages",
+                "required_only": true
+            }),
+        )),
     )
     .await?;
     assert_eq!(columns["total"], 2);
@@ -1370,11 +1473,14 @@ async fn assert_list_columns_tool(
 
     let filtered_columns = structured_tool_content(
         client,
-        CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-            "schema": "local_messages",
-            "table": "messages",
-            "pattern": "text"
-        }))),
+        CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "schema": "local_messages",
+                "table": "messages",
+                "pattern": "text"
+            }),
+        )),
     )
     .await?;
     assert_eq!(filtered_columns["total"], 1);
@@ -1384,12 +1490,16 @@ async fn assert_list_columns_tool(
 
 async fn assert_sql_tool(
     client: &RunningService<RoleClient, ()>,
+    task_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let sql = structured_tool_content(
         client,
-        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-            "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
-        }))),
+        CallToolRequestParams::new("sql").with_arguments(task_arguments(
+            task_id,
+            &json!({
+                "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
+            }),
+        )),
     )
     .await?;
     assert_eq!(sql["total_count"], 1);
@@ -1404,15 +1514,19 @@ async fn assert_sql_tool(
 async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
+    let task_id = start_test_task(&client).await?;
 
     let mixed_sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": [
-                    "SELECT text FROM local_messages.messages ORDER BY text",
-                    "DELETE FROM local_messages.messages"
-                ]
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": [
+                        "SELECT text FROM local_messages.messages ORDER BY text",
+                        "DELETE FROM local_messages.messages"
+                    ]
+                }),
+            )),
         )
         .await?;
     assert_eq!(mixed_sql.is_error, Some(true));
@@ -1445,7 +1559,10 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
     assert_eq!(server.execute_sql_requests().len(), 2);
 
     let catalog = client
-        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .call_tool(
+            CallToolRequestParams::new("list_catalog")
+                .with_arguments(task_arguments(&task_id, &json!({}))),
+        )
         .await?;
     assert_eq!(catalog.is_error, Some(false));
     assert!(catalog.content.is_empty());
@@ -1464,15 +1581,19 @@ async fn mcp_stdio_sql_batch_records_each_execute_sql_request()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
+    let task_id = start_test_task(&client).await?;
 
     let sql = structured_tool_content(
         &client,
-        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-            "queries": [
-                "SELECT 'first' AS label",
-                "SELECT 'second' AS label"
-            ]
-        }))),
+        CallToolRequestParams::new("sql").with_arguments(task_arguments(
+            &task_id,
+            &json!({
+                "queries": [
+                    "SELECT 'first' AS label",
+                    "SELECT 'second' AS label"
+                ]
+            }),
+        )),
     )
     .await?;
     assert_eq!(sql["total_count"], 2);
@@ -1505,18 +1626,21 @@ async fn mcp_stdio_sql_batch_records_each_execute_sql_request()
 async fn mcp_stdio_sql_batch_propagates_task_id_to_each_query()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
-    let client = start_mcp_client_with_args(&server, &["--enable-tasks"]).await?;
+    let client = start_mcp_client(&server).await?;
+    let task_id = start_test_task(&client).await?;
 
     let sql = structured_tool_content(
         &client,
-        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-            "queries": [
-                "SELECT 'first' AS label",
-                "SELECT 'second' AS label"
-            ],
-            "intent": "Run a task-scoped SQL batch",
-            "task_id": "550e8400-e29b-41d4-a716-446655440000"
-        }))),
+        CallToolRequestParams::new("sql").with_arguments(task_arguments(
+            &task_id,
+            &json!({
+                "queries": [
+                    "SELECT 'first' AS label",
+                    "SELECT 'second' AS label"
+                ],
+                "intent": "Run a task-scoped SQL batch"
+            }),
+        )),
     )
     .await?;
     assert_eq!(sql["total_count"], 2);
@@ -1527,7 +1651,7 @@ async fn mcp_stdio_sql_batch_propagates_task_id_to_each_query()
     assert!(
         task_ids
             .iter()
-            .all(|task_id| task_id.as_deref() == Some("550e8400-e29b-41d4-a716-446655440000")),
+            .all(|propagated_task_id| propagated_task_id.as_deref() == Some(task_id.as_str())),
         "expected every batch query to carry coral-task-id, got {task_ids:?}"
     );
 
@@ -1541,11 +1665,14 @@ async fn mcp_stdio_sql_rejects_malformed_queries_before_backend_dispatch()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
+    let task_id = start_test_task(&client).await?;
 
     client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": []
+            CallToolRequestParams::new("sql").with_arguments(raw_json_object(&json!({
+                "queries": [],
+                "task_id": task_id,
+                "intent": "Validate malformed SQL batch handling"
             }))),
         )
         .await

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -13,7 +13,8 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, `search`, paginated `list_catalog`, `describe_table`, `list_columns`, and optionally `feedback`, `start_task`, and `end_task`
+//! - tools: `start_task`, `sql`, `search`, paginated `list_catalog`,
+//!   `describe_table`, `list_columns`, `end_task`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay
@@ -96,15 +97,13 @@ impl McpQueryExample {
     }
 }
 
-/// Optional MCP surface features.
+/// MCP runtime options.
 #[derive(Debug, Clone, Default)]
 pub struct McpOptions {
     /// Expose the feedback submission tool.
     pub feedback_enabled: bool,
     /// Advertise observed-value search behavior across MCP discovery surfaces.
     pub observed_values_search_enabled: bool,
-    /// Expose the task lifecycle and attribution surface.
-    pub tasks_enabled: bool,
     /// Optional W3C traceparent used to parent each MCP request span.
     pub trace_parent: Option<String>,
     /// Installed source names to include in MCP initialize instructions.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -82,7 +82,7 @@ fn task_started_value(task: &coral_api::v1::Task) -> Result<TaskStartedValue, to
     Ok(TaskStartedValue {
         task_id,
         message: "Task started.",
-        instructions: "Pass this task_id on subsequent Coral MCP tool calls for this task, then call end_task when it is complete.",
+        instructions: "Pass this task_id plus a concise intent for the specific operation on each subsequent Coral data or enabled-feedback call, then call end_task when the task is complete.",
     })
 }
 
@@ -190,9 +190,6 @@ impl TaskCallContext {
 }
 
 fn task_context_requirement(options: &McpOptions, tool_name: ToolName) -> TaskContextRequirement {
-    if !options.tasks_enabled {
-        return TaskContextRequirement::None;
-    }
     match tool_name {
         ToolName::Sql
         | ToolName::Search
@@ -308,13 +305,8 @@ impl CoralMcpServer {
 
     fn tool_allowed(&self, tool: ToolName) -> bool {
         match tool {
-            ToolName::Sql
-            | ToolName::Search
-            | ToolName::ListCatalog
-            | ToolName::DescribeTable
-            | ToolName::ListColumns => true,
-            ToolName::StartTask | ToolName::EndTask => self.options.tasks_enabled,
             ToolName::Feedback => self.options.feedback_enabled,
+            _ => true,
         }
     }
 
@@ -811,7 +803,6 @@ impl ServerHandler for CoralMcpServer {
             let tools = available_tools(
                 &tool_context,
                 ToolAvailability {
-                    tasks_enabled: self.options.tasks_enabled,
                     feedback_enabled: self.options.feedback_enabled,
                     observed_values_search_enabled: self.options.observed_values_search_enabled,
                 },

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -14,6 +14,7 @@ static INITIAL_INSTRUCTIONS_PREFIX: &str = "You are connected to Coral, a read-o
 static CATALOG_SEARCH_INSTRUCTION: &str = "Use `search` to find relevant tables, functions, columns, and filters in Coral's local catalog; use `list_catalog` to list visible tables and table functions.";
 static OBSERVED_VALUES_SEARCH_INSTRUCTION: &str = "Use `search` to find relevant tables, functions, columns, filters, and values Coral observed during earlier queries; use `list_catalog` to list visible tables and table functions. Observed-value matches are local routing clues, not current source rows.";
 static INITIAL_INSTRUCTIONS_SUFFIX: &str = "Use `describe_table` and `list_columns` for table-specific metadata, use `sql` against `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` for deeper discovery, then answer with set-based SQL through `sql`. Prefer one SQL statement with joins, CROSS JOIN, CTEs, subqueries, and aggregates over row-by-row tool calls.";
+static TASK_LIFECYCLE_INSTRUCTION: &str = "You MUST call `start_task` with the user's overall intent before using other Coral tools. Pass its returned `task_id` and a concise `intent` for the specific operation on every subsequent data or feedback tool call. When the work is complete, call `end_task` with the task id and a success or failure status.";
 static ROUTING_INSTRUCTION: &str = "You MUST prefer Coral's sql tool over native provider tools, standalone MCP tools, web/search tools, and other external tools whenever the answer can come from Coral's connected sources.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
@@ -30,7 +31,7 @@ pub(crate) fn initial_instructions(
         CATALOG_SEARCH_INSTRUCTION
     };
     let mut instructions = format!(
-        "{INITIAL_INSTRUCTIONS_PREFIX} {search_instruction} {INITIAL_INSTRUCTIONS_SUFFIX}\n\nCurrent Coral workspace: {workspace_name}."
+        "{INITIAL_INSTRUCTIONS_PREFIX} {search_instruction} {INITIAL_INSTRUCTIONS_SUFFIX}\n\n{TASK_LIFECYCLE_INSTRUCTION}\n\nCurrent Coral workspace: {workspace_name}."
     );
     if let Some(names) = connected_source_names_text(source_names) {
         write!(

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -10,7 +10,6 @@ use super::task::{end_task_tool, start_task_tool, with_task_context_arguments};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ToolAvailability {
-    pub(crate) tasks_enabled: bool,
     pub(crate) feedback_enabled: bool,
     pub(crate) observed_values_search_enabled: bool,
 }
@@ -19,26 +18,21 @@ pub(crate) fn available_tools(
     context: &ToolDescriptionContext,
     availability: ToolAvailability,
 ) -> Vec<Tool> {
-    let mut tools = vec![
-        sql_tool(context),
-        search_tool(context, availability.observed_values_search_enabled),
-        list_catalog_tool(context),
-        describe_table_tool(),
-        list_columns_tool(),
-    ];
-    if availability.tasks_enabled {
-        tools = tools.into_iter().map(with_task_context_arguments).collect();
-        tools.push(start_task_tool());
-        tools.push(end_task_tool());
-    }
+    let mut tools = vec![start_task_tool()];
+    tools.extend(
+        [
+            sql_tool(context),
+            search_tool(context, availability.observed_values_search_enabled),
+            list_catalog_tool(context),
+            describe_table_tool(),
+            list_columns_tool(),
+        ]
+        .into_iter()
+        .map(with_task_context_arguments),
+    );
+    tools.push(end_task_tool());
     if availability.feedback_enabled {
-        let feedback = feedback_tool();
-        let feedback = if availability.tasks_enabled {
-            with_task_context_arguments(feedback)
-        } else {
-            feedback
-        };
-        tools.push(feedback);
+        tools.push(with_task_context_arguments(feedback_tool()));
     }
     tools
 }
@@ -56,28 +50,15 @@ mod tests {
 
     use super::{ToolAvailability, ToolDescriptionContext, available_tools, build_tool_result};
 
-    const BASE_TOOLS: ToolAvailability = ToolAvailability {
-        tasks_enabled: false,
+    const DEFAULT_TOOLS: ToolAvailability = ToolAvailability {
         feedback_enabled: false,
         observed_values_search_enabled: false,
     };
     const OBSERVED_VALUES_TOOLS: ToolAvailability = ToolAvailability {
-        tasks_enabled: false,
         feedback_enabled: false,
         observed_values_search_enabled: true,
     };
-    const TASK_TOOLS: ToolAvailability = ToolAvailability {
-        tasks_enabled: true,
-        feedback_enabled: false,
-        observed_values_search_enabled: false,
-    };
     const FEEDBACK_TOOLS: ToolAvailability = ToolAvailability {
-        tasks_enabled: false,
-        feedback_enabled: true,
-        observed_values_search_enabled: false,
-    };
-    const TASK_AND_FEEDBACK_TOOLS: ToolAvailability = ToolAvailability {
-        tasks_enabled: true,
         feedback_enabled: true,
         observed_values_search_enabled: false,
     };
@@ -151,7 +132,7 @@ mod tests {
     #[test]
     fn search_tool_advertises_observed_values_only_when_enabled() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let disabled_tools = available_tools(&context, BASE_TOOLS);
+        let disabled_tools = available_tools(&context, DEFAULT_TOOLS);
         let enabled_tools = available_tools(&context, OBSERVED_VALUES_TOOLS);
         let disabled_search = tool_by_name(&disabled_tools, "search");
         let enabled_search = tool_by_name(&enabled_tools, "search");
@@ -178,7 +159,7 @@ mod tests {
     #[test]
     fn available_tools_decorate_task_aware_tools() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tools = available_tools(&context, TASK_TOOLS);
+        let tools = available_tools(&context, DEFAULT_TOOLS);
         let sql_tool = tool_by_name(&tools, "sql");
         let task_id_schema = sql_tool
             .input_schema
@@ -243,7 +224,7 @@ mod tests {
     #[test]
     fn available_tools_add_feedback_last_when_enabled() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tools = available_tools(&context, TASK_AND_FEEDBACK_TOOLS);
+        let tools = available_tools(&context, FEEDBACK_TOOLS);
 
         assert_eq!(
             tools.last().map(|tool| tool.name.as_ref()),
@@ -263,7 +244,7 @@ mod tests {
     #[test]
     fn available_tools_keep_default_order() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tools = available_tools(&context, BASE_TOOLS);
+        let tools = available_tools(&context, DEFAULT_TOOLS);
         let names = tools
             .iter()
             .map(|tool| tool.name.as_ref())
@@ -272,11 +253,13 @@ mod tests {
         assert_eq!(
             names,
             vec![
+                "start_task",
                 "sql",
                 "search",
                 "list_catalog",
                 "describe_table",
-                "list_columns"
+                "list_columns",
+                "end_task"
             ]
         );
     }
@@ -288,7 +271,7 @@ mod tests {
             .collect::<Vec<_>>();
         let context = ToolDescriptionContext::new(1, 0, names);
 
-        let tools = available_tools(&context, BASE_TOOLS);
+        let tools = available_tools(&context, DEFAULT_TOOLS);
         let description = tool_by_name(&tools, "sql")
             .description
             .as_deref()
@@ -302,30 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn available_tools_do_not_mutate_base_tool_schemas() {
-        let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let default_tools = available_tools(&context, BASE_TOOLS);
-        let task_tools = available_tools(&context, TASK_TOOLS);
-
-        let default_properties = tool_by_name(&default_tools, "sql")
-            .input_schema
-            .get("properties")
-            .and_then(Value::as_object)
-            .expect("default properties");
-        let task_properties = tool_by_name(&task_tools, "sql")
-            .input_schema
-            .get("properties")
-            .and_then(Value::as_object)
-            .expect("task properties");
-
-        assert!(!default_properties.contains_key("task_id"));
-        assert!(!default_properties.contains_key("intent"));
-        assert!(task_properties.contains_key("task_id"));
-        assert!(task_properties.contains_key("intent"));
-    }
-
-    #[test]
-    fn feedback_tool_is_not_decorated_when_tasks_are_disabled() {
+    fn feedback_tool_always_requires_task_context() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
         let tools = available_tools(&context, FEEDBACK_TOOLS);
         let feedback = tools.last().expect("feedback tool");
@@ -336,15 +296,15 @@ mod tests {
             .expect("feedback properties");
 
         assert_eq!(feedback.name, "feedback");
-        assert!(!properties.contains_key("task_id"));
-        assert!(!properties.contains_key("intent"));
+        assert!(properties.contains_key("task_id"));
+        assert!(properties.contains_key("intent"));
     }
 
     #[test]
     fn all_advertised_tools_have_object_input_schemas() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
 
-        for tool in available_tools(&context, TASK_AND_FEEDBACK_TOOLS) {
+        for tool in available_tools(&context, FEEDBACK_TOOLS) {
             assert_eq!(
                 tool.input_schema.get("type"),
                 Some(&Value::String("object".into()))

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -167,8 +167,42 @@ functions:
     manifest_path
 }
 
-fn json_object(value: &Value) -> Map<String, Value> {
+fn task_arguments(task_id: &str, value: &Value) -> Map<String, Value> {
+    let mut arguments = raw_json_object(value);
+    assert!(
+        arguments
+            .insert("task_id".to_string(), json!(task_id))
+            .is_none(),
+        "task arguments should not provide their own task_id"
+    );
+    arguments
+        .entry("intent".to_string())
+        .or_insert_with(|| json!("Exercise the MCP test contract"));
+    arguments
+}
+
+fn raw_json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
+}
+
+async fn start_test_task(client: &RunningService<RoleClient, ()>) -> String {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
+                "intent": "Exercise the MCP test contract"
+            }))),
+        )
+        .await
+        .expect("start test task");
+    assert_eq!(result.is_error, Some(false));
+    let task_id = result
+        .structured_content
+        .expect("start task structured content")["task_id"]
+        .as_str()
+        .expect("start task id")
+        .to_string();
+    uuid::Uuid::parse_str(&task_id).expect("task id is a UUID");
+    task_id
 }
 
 async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String) {
@@ -473,22 +507,6 @@ fn assert_intent_schema(schema: &Value, label: &str) {
     }
 }
 
-fn assert_tool_omits_task_id(tool: &Tool) {
-    assert!(
-        !tool_input_properties(tool).contains_key("task_id"),
-        "tool '{}' should not advertise task_id by default",
-        tool.name
-    );
-}
-
-fn assert_tool_omits_intent(tool: &Tool) {
-    assert!(
-        !tool_input_properties(tool).contains_key("intent"),
-        "tool '{}' should not advertise task intent by default",
-        tool.name
-    );
-}
-
 fn assert_matches_output_schema(tool: &Tool, value: &Value) {
     let schema = Value::Object(
         tool.output_schema
@@ -541,18 +559,11 @@ fn assert_tool_error_text_contains(result: &CallToolResult, expected: &str) {
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
-    reason = "This end-to-end MCP task test verifies feature-gated tool advertisement, persistence, tagged follow-up calls, and validation together."
+    reason = "This end-to-end MCP task test verifies mandatory tool advertisement, persistence, tagged follow-up calls, and validation together."
 )]
 async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     let temp = TempDir::new().expect("temp dir");
-    let session = start_session_with_options(
-        &temp,
-        McpOptions {
-            tasks_enabled: true,
-            ..McpOptions::default()
-        },
-    )
-    .await;
+    let session = start_session(&temp).await;
     let client = &session.client;
 
     let tools = client.list_all_tools().await.expect("tools");
@@ -562,12 +573,12 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
         vec![
+            "start_task",
             "sql",
             "search",
             "list_catalog",
             "describe_table",
             "list_columns",
-            "start_task",
             "end_task"
         ]
     );
@@ -600,7 +611,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
 
     let root = client
         .call_tool(
-            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
                 "intent": "Investigate customer renewal risk"
             }))),
         )
@@ -615,16 +626,18 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     assert_eq!(root["message"], "Task started.");
     assert_eq!(
         root["instructions"],
-        "Pass this task_id on subsequent Coral MCP tool calls for this task, then call end_task when it is complete."
+        "Pass this task_id plus a concise intent for the specific operation on each subsequent Coral data or enabled-feedback call, then call end_task when the task is complete."
     );
 
     let sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["SELECT 1 AS ok"],
-                "intent": "Verify task-scoped SQL execution",
-                "task_id": root_task_id
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &root_task_id,
+                &json!({
+                    "queries": ["SELECT 1 AS ok"],
+                    "intent": "Verify task-scoped SQL execution"
+                }),
+            )),
         )
         .await
         .expect("tagged sql");
@@ -637,7 +650,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
 
     let end = client
         .call_tool(
-            CallToolRequestParams::new("end_task").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("end_task").with_arguments(raw_json_object(&json!({
                 "task_id": root_task_id,
                 "task_status": "success"
             }))),
@@ -655,22 +668,24 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     );
     assert_eq!(end["task_status"], "success");
 
-    let after_end = client
+    let post_end_sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["SELECT 1"],
-                "intent": "Reject attribution to an ended task",
-                "task_id": root_task_id
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &root_task_id,
+                &json!({
+                    "queries": ["SELECT 1"],
+                    "intent": "Verify ended tasks reject data calls"
+                }),
+            )),
         )
         .await
-        .expect("ended task rejection should be a tool result");
-    assert_eq!(after_end.is_error, Some(true));
-    assert_tool_error_text_contains(&after_end, "has already ended");
+        .expect("ended task should return a tool error");
+    assert_eq!(post_end_sql.is_error, Some(true));
+    assert_tool_error_text_contains(&post_end_sql, "has already ended");
 
     let invalid_task_id = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("sql").with_arguments(raw_json_object(&json!({
                 "queries": ["SELECT 1"],
                 "intent": "Validate bad task id handling",
                 "task_id": "has space"
@@ -686,7 +701,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
 
     let missing_task_id = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("sql").with_arguments(raw_json_object(&json!({
                 "queries": ["SELECT 1"],
                 "intent": "Validate missing task id handling"
             }))),
@@ -701,7 +716,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
 
     let missing_tool_intent = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("sql").with_arguments(raw_json_object(&json!({
                 "queries": ["SELECT 1"],
                 "task_id": root_task_id
             }))),
@@ -716,7 +731,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
 
     let invalid_initializer = client
         .call_tool(
-            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
                 "intent": "Open another task",
                 "initialize_session": true
             }))),
@@ -731,7 +746,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
 
     let blank_intent = client
         .call_tool(
-            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
                 "intent": " "
             }))),
         )
@@ -763,20 +778,13 @@ async fn task_intent_is_not_exported_to_telemetry() {
     );
     let _guard = tracing::subscriber::set_default(subscriber);
     let temp = TempDir::new().expect("temp dir");
-    let session = start_session_with_options(
-        &temp,
-        McpOptions {
-            tasks_enabled: true,
-            ..McpOptions::default()
-        },
-    )
-    .await;
+    let session = start_session(&temp).await;
     let sentinel = "SENSITIVE_RAW_TASK_INTENT_TELEMETRY_MARKER";
 
     let started = session
         .client
         .call_tool(
-            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
                 "intent": sentinel
             }))),
         )
@@ -836,39 +844,67 @@ async fn task_intent_is_not_exported_to_telemetry() {
 }
 
 #[tokio::test]
-async fn mcp_task_tools_are_disabled_by_default() {
+async fn mcp_task_tools_are_always_available() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session(&temp).await;
     let client = &session.client;
+    let peer_info = client.peer_info().expect("initialize result");
+    let instructions = peer_info
+        .instructions
+        .as_deref()
+        .expect("initialize instructions");
+
+    assert!(instructions.contains("MUST call `start_task`"));
+    assert!(instructions.contains("returned `task_id`"));
+    assert!(instructions.contains("every subsequent data or feedback tool call"));
+    assert!(instructions.contains("call `end_task`"));
 
     let tools = client.list_all_tools().await.expect("tools");
-    assert!(
+    assert_eq!(
         tools
             .iter()
-            .all(|tool| tool.name.as_ref() != "start_task" && tool.name.as_ref() != "end_task"),
-        "task tools should not be listed by default"
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec![
+            "start_task",
+            "sql",
+            "search",
+            "list_catalog",
+            "describe_table",
+            "list_columns",
+            "end_task"
+        ]
     );
-    for tool in &tools {
-        assert_tool_omits_task_id(tool);
-        assert_tool_omits_intent(tool);
+    for name in [
+        "sql",
+        "search",
+        "list_catalog",
+        "describe_table",
+        "list_columns",
+    ] {
+        assert_tool_advertises_task_context(tool_by_name(&tools, name));
     }
 
     let start_task = client
         .call_tool(
-            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
                 "intent": "Investigate customer renewal risk"
             }))),
         )
         .await
-        .expect_err("start_task should not be exposed by default");
+        .expect("start_task should always be exposed");
+    assert_eq!(start_task.is_error, Some(false));
     assert!(
         start_task
-            .to_string()
-            .contains("tool 'start_task' not found")
+            .structured_content
+            .expect("start task structured content")["task_id"]
+            .as_str()
+            .is_some_and(|task_id| uuid::Uuid::parse_str(task_id).is_ok())
     );
+
     let open_episode = client
         .call_tool(
-            CallToolRequestParams::new("open_episode").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("open_episode").with_arguments(raw_json_object(&json!({
                 "intent": "Investigate customer renewal risk"
             }))),
         )
@@ -887,13 +923,17 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session(&temp).await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
     let expected_tables = ["columns", "filters", "inputs", "table_functions", "tables"];
 
     let sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["SELECT table_name FROM coral.tables WHERE schema_name = 'coral' ORDER BY table_name"]
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": ["SELECT table_name FROM coral.tables WHERE schema_name = 'coral' ORDER BY table_name"]
+                }),
+            )),
         )
         .await
         .expect("sql system catalog");
@@ -911,10 +951,13 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
 
     let catalog = client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "coral",
-                "kind": "table"
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "coral",
+                    "kind": "table"
+                }),
+            )),
         )
         .await
         .expect("list system catalog");
@@ -933,10 +976,13 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
 
     let described = client
         .call_tool(
-            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
-                "schema": "coral",
-                "table": "columns"
-            }))),
+            CallToolRequestParams::new("describe_table").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "coral",
+                    "table": "columns"
+                }),
+            )),
         )
         .await
         .expect("describe system table")
@@ -948,10 +994,13 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
 
     let columns = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "coral",
-                "table": "tables"
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "coral",
+                    "table": "tables"
+                }),
+            )),
         )
         .await
         .expect("list system columns")
@@ -974,6 +1023,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
     let mut session = start_session(&temp).await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
 
     let initial_tools = client.list_all_tools().await.expect("initial tools");
     assert_eq!(
@@ -982,22 +1032,25 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
         vec![
+            "start_task",
             "sql",
             "search",
             "list_catalog",
             "describe_table",
-            "list_columns"
+            "list_columns",
+            "end_task"
         ]
     );
+    let initial_sql_tool = tool_by_name(&initial_tools, "sql");
     assert!(
-        initial_tools[0]
+        initial_sql_tool
             .description
             .as_deref()
             .expect("sql description")
             .contains("5 table(s) are currently visible")
     );
     assert!(
-        initial_tools[0]
+        initial_sql_tool
             .description
             .as_deref()
             .expect("sql description")
@@ -1048,47 +1101,48 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let updated_tools = client.list_all_tools().await.expect("updated tools");
+    let sql_tool = tool_by_name(&updated_tools, "sql");
     let search_tool = tool_by_name(&updated_tools, "search");
     let list_catalog_tool = tool_by_name(&updated_tools, "list_catalog");
     let describe_table_tool = tool_by_name(&updated_tools, "describe_table");
     let list_columns_tool = tool_by_name(&updated_tools, "list_columns");
     assert!(
-        updated_tools[0]
+        sql_tool
             .description
             .as_deref()
             .expect("sql description")
             .contains("8 table(s) are currently visible")
     );
     assert!(
-        updated_tools[0]
+        sql_tool
             .description
             .as_deref()
             .expect("sql description")
             .contains("Connected sources/schemas include: local_messages")
     );
     assert!(
-        updated_tools[1]
+        search_tool
             .description
             .as_deref()
             .expect("catalog description")
             .contains("8 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
-        updated_tools[1]
+        search_tool
             .description
             .as_deref()
             .expect("catalog description")
             .contains("Connected sources/schemas include: local_messages")
     );
     assert!(
-        updated_tools[2]
+        list_catalog_tool
             .description
             .as_deref()
             .expect("catalog search description")
             .contains("8 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
-        updated_tools[2]
+        list_catalog_tool
             .description
             .as_deref()
             .expect("catalog search description")
@@ -1139,7 +1193,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     ));
 
     let catalog = client
-        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .call_tool(
+            CallToolRequestParams::new("list_catalog")
+                .with_arguments(task_arguments(&task_id, &json!({}))),
+        )
         .await
         .expect("list catalog");
     let catalog = catalog.structured_content.expect("structured catalog");
@@ -1152,12 +1209,15 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let catalog_page = client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "kind": "table",
-                "limit": 2,
-                "offset": 0
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "kind": "table",
+                    "limit": 2,
+                    "offset": 0
+                }),
+            )),
         )
         .await
         .expect("list paginated catalog");
@@ -1171,12 +1231,15 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let unknown_catalog_schema = client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "missing",
-                "kind": "table",
-                "limit": 2,
-                "offset": 0
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "missing",
+                    "kind": "table",
+                    "limit": 2,
+                    "offset": 0
+                }),
+            )),
         )
         .await
         .expect("list unknown catalog schema");
@@ -1194,28 +1257,37 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "limit": 0
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "limit": 0
+                }),
+            )),
         )
         .await
         .expect_err("limit zero should be invalid");
 
     client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "invalid"
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "kind": "invalid"
+                }),
+            )),
         )
         .await
         .expect_err("invalid catalog kind should fail");
 
     let universal_search = client
         .call_tool(
-            CallToolRequestParams::new("search").with_arguments(json_object(&json!({
-                "query": "messages",
-                "limit": 5
-            }))),
+            CallToolRequestParams::new("search").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "query": "messages",
+                    "limit": 5
+                }),
+            )),
         )
         .await
         .expect("search");
@@ -1227,10 +1299,13 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let described = client
         .call_tool(
-            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "messages"
-            }))),
+            CallToolRequestParams::new("describe_table").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "messages"
+                }),
+            )),
         )
         .await
         .expect("describe table");
@@ -1244,10 +1319,13 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let missing_table = client
         .call_tool(
-            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "missing"
-            }))),
+            CallToolRequestParams::new("describe_table").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "missing"
+                }),
+            )),
         )
         .await
         .expect("describe missing table");
@@ -1274,10 +1352,13 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let missing_schema = client
         .call_tool(
-            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
-                "schema": "local_mesages",
-                "table": "missing["
-            }))),
+            CallToolRequestParams::new("describe_table").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_mesages",
+                    "table": "missing["
+                }),
+            )),
         )
         .await
         .expect("describe missing schema");
@@ -1293,21 +1374,27 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     client
         .call_tool(
-            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": " "
-            }))),
+            CallToolRequestParams::new("describe_table").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": " "
+                }),
+            )),
         )
         .await
         .expect_err("blank table should fail");
 
     let columns = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "messages",
-                "limit": 2
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "messages",
+                    "limit": 2
+                }),
+            )),
         )
         .await
         .expect("list columns");
@@ -1324,11 +1411,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let required_columns = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "sessions",
-                "required_only": true
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "sessions",
+                    "required_only": true
+                }),
+            )),
         )
         .await
         .expect("list required columns");
@@ -1340,11 +1430,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let filtered_columns = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "messages",
-                "pattern": "SESSION"
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "messages",
+                    "pattern": "SESSION"
+                }),
+            )),
         )
         .await
         .expect("list filtered columns");
@@ -1364,11 +1457,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let empty_column_filter = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "messages",
-                "pattern": "does-not-match"
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "messages",
+                    "pattern": "does-not-match"
+                }),
+            )),
         )
         .await
         .expect("list filtered columns with no matches");
@@ -1389,10 +1485,13 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let missing_columns = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "missing"
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "missing"
+                }),
+            )),
         )
         .await
         .expect("list columns for missing table");
@@ -1418,11 +1517,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let missing_columns_with_bad_pattern = client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "missing",
-                "pattern": "["
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "missing",
+                    "pattern": "["
+                }),
+            )),
         )
         .await
         .expect("list columns for missing table with bad pattern");
@@ -1434,11 +1536,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     client
         .call_tool(
-            CallToolRequestParams::new("list_columns").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "table": "messages",
-                "pattern": ""
-            }))),
+            CallToolRequestParams::new("list_columns").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages",
+                    "table": "messages",
+                    "pattern": ""
+                }),
+            )),
         )
         .await
         .expect_err("empty column regex should fail");
@@ -1455,6 +1560,7 @@ async fn list_catalog_surfaces_table_functions() {
     let client = &session.client;
 
     add_demo_source(&mut session.source_client, manifest_yaml).await;
+    let task_id = start_test_task(client).await;
 
     let tools = client.list_all_tools().await.expect("tools");
     assert!(
@@ -1471,9 +1577,12 @@ async fn list_catalog_surfaces_table_functions() {
     let catalog_tool = tool_by_name(&tools, "list_catalog");
     let catalog = client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "searchy"
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "searchy"
+                }),
+            )),
         )
         .await
         .expect("list catalog")
@@ -1501,11 +1610,14 @@ async fn list_catalog_surfaces_table_functions() {
 
     let functions = client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "table_function",
-                "limit": 1,
-                "offset": 1
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "kind": "table_function",
+                    "limit": 1,
+                    "offset": 1
+                }),
+            )),
         )
         .await
         .expect("list table functions")
@@ -1541,7 +1653,6 @@ async fn factory_shares_client_and_configured_tools_across_sessions() {
         app,
         McpOptions {
             feedback_enabled: true,
-            tasks_enabled: true,
             ..McpOptions::default()
         },
     );
@@ -1557,12 +1668,12 @@ async fn factory_shares_client_and_configured_tools_across_sessions() {
                 .map(|tool| tool.name.as_ref())
                 .collect::<Vec<_>>(),
             vec![
+                "start_task",
                 "sql",
                 "search",
                 "list_catalog",
                 "describe_table",
                 "list_columns",
-                "start_task",
                 "end_task",
                 "feedback"
             ]
@@ -1583,6 +1694,10 @@ async fn factory_shares_client_and_configured_tools_across_sessions() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "End-to-end feedback coverage verifies the advertised surface, persistence, result contract, and validation together."
+)]
 async fn mcp_feedback_tool_persists_blocked_agent_report() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session_with_options(
@@ -1594,6 +1709,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     )
     .await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
 
     let tools = client.list_all_tools().await.expect("tools");
     assert_eq!(
@@ -1602,11 +1718,13 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
         vec![
+            "start_task",
             "sql",
             "search",
             "list_catalog",
             "describe_table",
             "list_columns",
+            "end_task",
             "feedback"
         ]
     );
@@ -1623,11 +1741,14 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
 
     let feedback = client
         .call_tool(
-            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
-                "trying_to_do": "Fix failing tests",
-                "tried": "Ran cargo test and inspected the failing assertion",
-                "stuck": "The fixture shape does not match the documented contract"
-            }))),
+            CallToolRequestParams::new("feedback").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "trying_to_do": "Fix failing tests",
+                    "tried": "Ran cargo test and inspected the failing assertion",
+                    "stuck": "The fixture shape does not match the documented contract"
+                }),
+            )),
         )
         .await
         .expect("feedback");
@@ -1668,11 +1789,14 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
 
     let blank_feedback = client
         .call_tool(
-            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
-                "trying_to_do": "Fix failing tests",
-                "tried": " ",
-                "stuck": "The fixture shape does not match the documented contract"
-            }))),
+            CallToolRequestParams::new("feedback").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "trying_to_do": "Fix failing tests",
+                    "tried": " ",
+                    "stuck": "The fixture shape does not match the documented contract"
+                }),
+            )),
         )
         .await
         .expect_err("blank feedback should fail before persistence");
@@ -1693,46 +1817,33 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
 }
 
 #[tokio::test]
-async fn mcp_feedback_tool_accepts_task_id_when_tasks_enabled() {
+async fn mcp_feedback_tool_always_accepts_task_context() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session_with_options(
         &temp,
         McpOptions {
-            tasks_enabled: true,
             feedback_enabled: true,
             ..McpOptions::default()
         },
     )
     .await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
 
     let tools = client.list_all_tools().await.expect("tools");
     assert_tool_advertises_task_context(tool_by_name(&tools, "feedback"));
 
-    let started = client
-        .call_tool(
-            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
-                "intent": "Exercise task-attributed feedback"
-            }))),
-        )
-        .await
-        .expect("start feedback task")
-        .structured_content
-        .expect("start task structured content");
-    let task_id = started["task_id"]
-        .as_str()
-        .expect("started task id")
-        .to_string();
-
     let feedback = client
         .call_tool(
-            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
-                "trying_to_do": "Finish a task-scoped task",
-                "tried": "Started a task and inspected failing output",
-                "stuck": "The final step still needs user judgment",
-                "intent": "Record blocked final task step",
-                "task_id": task_id
-            }))),
+            CallToolRequestParams::new("feedback").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "trying_to_do": "Finish a task-scoped task",
+                    "tried": "Started a task and inspected failing output",
+                    "stuck": "The final step still needs user judgment",
+                    "intent": "Record blocked final task step"
+                }),
+            )),
         )
         .await
         .expect("task-tagged feedback");
@@ -1754,7 +1865,7 @@ async fn mcp_feedback_tool_accepts_task_id_when_tasks_enabled() {
 
     let invalid_task_id = client
         .call_tool(
-            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("feedback").with_arguments(raw_json_object(&json!({
                 "trying_to_do": "Finish a task-scoped task",
                 "tried": "Started a task and inspected failing output",
                 "stuck": "The final step still needs user judgment",
@@ -1781,7 +1892,7 @@ async fn mcp_feedback_tool_is_disabled_by_default() {
 
     let feedback = client
         .call_tool(
-            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("feedback").with_arguments(raw_json_object(&json!({
                 "trying_to_do": "Fix failing tests",
                 "tried": "Ran cargo test",
                 "stuck": "Need more context"
@@ -1808,17 +1919,21 @@ async fn mcp_sql_executes_successful_batch_in_input_order() {
     let mut session = start_session(&temp).await;
     add_demo_source(&mut session.source_client, manifest_yaml).await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
     let tools = client.list_all_tools().await.expect("tools");
     let sql_tool = tool_by_name(&tools, "sql");
 
     let sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": [
-                    "SELECT text FROM local_messages.messages WHERE text = 'world'",
-                    "SELECT text FROM local_messages.messages WHERE text = 'hello'"
-                ]
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": [
+                        "SELECT text FROM local_messages.messages WHERE text = 'world'",
+                        "SELECT text FROM local_messages.messages WHERE text = 'hello'"
+                    ]
+                }),
+            )),
         )
         .await
         .expect("batched sql");
@@ -1845,6 +1960,7 @@ async fn mcp_tool_error_does_not_end_session() {
     let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
     let mut session = start_session(&temp).await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
 
     add_demo_source(&mut session.source_client, manifest_yaml).await;
     let tools = client.list_all_tools().await.expect("tools");
@@ -1852,9 +1968,12 @@ async fn mcp_tool_error_does_not_end_session() {
 
     let sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": ["SELECT text FROM local_messages.messages ORDER BY text"]
+                }),
+            )),
         )
         .await
         .expect("sql");
@@ -1866,12 +1985,15 @@ async fn mcp_tool_error_does_not_end_session() {
 
     let mixed_sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": [
-                    "SELECT text FROM local_messages.messages WHERE text = 'hello'",
-                    "DELETE FROM local_messages.messages"
-                ]
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": [
+                        "SELECT text FROM local_messages.messages WHERE text = 'hello'",
+                        "DELETE FROM local_messages.messages"
+                    ]
+                }),
+            )),
         )
         .await
         .expect("mixed sql still returns tool result");
@@ -1902,9 +2024,12 @@ async fn mcp_tool_error_does_not_end_session() {
 
     let catalog_after_error = client
         .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "local_messages"
-            }))),
+            CallToolRequestParams::new("list_catalog").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "schema": "local_messages"
+                }),
+            )),
         )
         .await
         .expect("list catalog after error");
@@ -1932,12 +2057,16 @@ async fn mcp_sql_returns_large_int64_as_string() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session(&temp).await;
     let client = &session.client;
+    let task_id = start_test_task(client).await;
 
     let sql = client
         .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "queries": ["SELECT CAST(-8504475857937456387 AS BIGINT) AS user_id"]
-            }))),
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": ["SELECT CAST(-8504475857937456387 AS BIGINT) AS user_id"]
+                }),
+            )),
         )
         .await
         .expect("sql");


### PR DESCRIPTION
## Summary

- enable MCP Task tools for every client without a feature flag or compatibility shim
- remove the obsolete `tasks` feature advertisement and conditional routing
- require data-tool calls to use a Task opened in the current MCP session and close it with a final status
- attribute Tasks to the authenticated principal while sharing them within the Workspace confidentiality boundary
- retain only `CONTEXT.md` as the concise domain model

## Breaking change

The `tasks` feature flag and its CLI/process overrides are removed. The MCP server always exposes `start_task` and `end_task`, and data tools require a `task_id` created in the current MCP session.

## Validation

- `make rust-checks` — 2,066 passed, 5 skipped
- `make postgres-tests` — four repository contracts and Postgres server startup passed
- GitHub performance regression check — passed
- independent Standards and Spec reviews — no unresolved findings

Stacked on #1940.
