### PR TITLE
refactor(spec): simplify v4 diagnostics

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -533,7 +533,6 @@ impl QueryManager {
                         SourceLoadDiagnosticStage::Query,
                         workspace_name,
                         &source.name,
-                        "SOURCE_LOAD_FAILED",
                         &error.to_string(),
                     );
                 }

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use coral_spec::v4::{
-    Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
-    MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION,
-    OPERATION_METADATA_GENERATOR_VERSION, OperationMetadataCatalog, PROJECTION_GENERATOR_VERSION,
-    ProjectionCatalog, ProjectionInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
+    Diagnostic, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION, MaterializedSurface,
+    McpToolCatalog, OPENAPI_IMPORTER_VERSION, OPERATION_METADATA_GENERATOR_VERSION,
+    OperationMetadataCatalog, PROJECTION_GENERATOR_VERSION, ProjectionCatalog,
+    ProjectionInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
     V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest, ValidatedSurfacePlan,
     generate_projection_catalog, import_mcp_surface, import_openapi_surface,
     normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
@@ -43,9 +43,8 @@ pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";
 pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
 pub(crate) const OPERATION_METADATA_FILENAME: &str = "operation-metadata.yaml";
 
-type ReportedDiagnosticKey = (String, String);
 type ReportedDiagnosticStateKey = (String, String, String);
-type ReportedDiagnostics = BTreeMap<ReportedDiagnosticStateKey, BTreeSet<ReportedDiagnosticKey>>;
+type ReportedDiagnostics = BTreeMap<ReportedDiagnosticStateKey, BTreeSet<String>>;
 type RawDocumentValidationKey = (String, String);
 
 #[derive(Debug, Clone)]
@@ -79,10 +78,9 @@ impl SourceDiagnosticReporter {
         stage: SourceLoadDiagnosticStage,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
-        code: &str,
         detail: &str,
     ) {
-        let diagnostic = materialization_warning(code, detail);
+        let diagnostic = materialization_warning(detail);
         self.report_source_diagnostics(
             workspace_name,
             source_name,
@@ -154,20 +152,16 @@ impl SourceDiagnosticReporter {
         let (diagnostic, cacheable) = match std::fs::read(path) {
             Ok(raw_bytes) if sha256_hex(&raw_bytes) != expected_sha256 => (
                 Some(materialization_warning(
-                    "V4_RAW_DOCUMENT_FINGERPRINT_MISMATCH",
                     "raw source document hash does not match",
                 )),
                 true,
             ),
             Ok(_) => (None, true),
             Err(error) => (
-                Some(materialization_warning(
-                    "V4_RAW_DOCUMENT_UNAVAILABLE",
-                    format!(
-                        "could not read raw source document '{}' for provenance validation: {error}",
-                        path.display()
-                    ),
-                )),
+                Some(materialization_warning(format!(
+                    "could not read raw source document '{}' for provenance validation: {error}",
+                    path.display()
+                ))),
                 false,
             ),
         };
@@ -201,7 +195,7 @@ impl SourceDiagnosticReporter {
         let diagnostics = diagnostics.into_iter().collect::<Vec<_>>();
         let current = diagnostics
             .iter()
-            .map(|diagnostic| (diagnostic.code.clone(), diagnostic.message.clone()))
+            .map(|diagnostic| diagnostic.message.clone())
             .collect::<BTreeSet<_>>();
         let mut reported = self
             .reported
@@ -209,12 +203,11 @@ impl SourceDiagnosticReporter {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let previous = reported.get(&state_key).cloned().unwrap_or_default();
         for diagnostic in diagnostics {
-            let key = (diagnostic.code.clone(), diagnostic.message.clone());
+            let key = diagnostic.message.clone();
             if previous.contains(&key) {
                 continue;
             }
             tracing::warn!(
-                diagnostic.code = %diagnostic.code,
                 diagnostic.stage = stage,
                 workspace = %workspace_name,
                 source = %source_name,
@@ -236,7 +229,7 @@ impl SourceDiagnosticReporter {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
         stage: &str,
-        code: &str,
+        message: &str,
     ) -> bool {
         self.reported
             .lock()
@@ -249,7 +242,7 @@ impl SourceDiagnosticReporter {
             .is_some_and(|diagnostics| {
                 diagnostics
                     .iter()
-                    .any(|(diagnostic_code, _message)| diagnostic_code == code)
+                    .any(|diagnostic| diagnostic.contains(message))
             })
     }
 }
@@ -469,10 +462,9 @@ fn report_materialization_failure(
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     load_diagnostics: &mut Vec<Diagnostic>,
-    code: &str,
     error: &AppError,
 ) {
-    load_diagnostics.push(materialization_warning(code, error.to_string()));
+    load_diagnostics.push(materialization_warning(error.to_string()));
     diagnostic_reporter.report_source_diagnostics(
         workspace_name,
         source_name,
@@ -495,7 +487,6 @@ fn validate_semantic_ir_structure_with_reporter(
             workspace_name,
             source_name,
             load_diagnostics,
-            "V4_SEMANTIC_IR_UNAVAILABLE",
             &error,
         );
         error
@@ -518,10 +509,7 @@ fn read_validated_semantic_ir_with_reporter(
         diagnostic_reporter,
     )?;
     if let Err(error) = validate_semantic_ir(manifest, &semantic_ir) {
-        load_diagnostics.push(materialization_warning(
-            "V4_SEMANTIC_IR_PROVENANCE_MISMATCH",
-            error,
-        ));
+        load_diagnostics.push(materialization_warning(error));
     }
     validate_semantic_ir_structure_with_reporter(
         &semantic_ir,
@@ -543,18 +531,14 @@ fn build_validated_plan_with_reporter(
     diagnostic_reporter: &SourceDiagnosticReporter,
 ) -> Result<ValidatedSurfacePlan, AppError> {
     ValidatedSurfacePlan::new(semantic_ir, operation_metadata).map_err(|error| {
-        let (error, code) = match metadata_file.origin {
-            V4OperationMetadataOrigin::Materialized => (
-                incompatible_materialization_error(source_name, error.to_string()),
-                "V4_OPERATION_METADATA_UNAVAILABLE",
-            ),
-            V4OperationMetadataOrigin::Override => (
-                invalid_operation_metadata_override_error(
-                    source_name,
-                    &metadata_file.path,
-                    error.to_string(),
-                ),
-                "V4_OPERATION_METADATA_OVERRIDE_FAILED",
+        let error = match metadata_file.origin {
+            V4OperationMetadataOrigin::Materialized => {
+                incompatible_materialization_error(source_name, error.to_string())
+            }
+            V4OperationMetadataOrigin::Override => invalid_operation_metadata_override_error(
+                source_name,
+                &metadata_file.path,
+                error.to_string(),
             ),
         };
         report_materialization_failure(
@@ -562,7 +546,6 @@ fn build_validated_plan_with_reporter(
             workspace_name,
             source_name,
             load_diagnostics,
-            code,
             &error,
         );
         error
@@ -582,7 +565,6 @@ fn read_semantic_ir_with_reporter(
             workspace_name,
             source_name,
             load_diagnostics,
-            "V4_SEMANTIC_IR_UNAVAILABLE",
             error,
         );
     })
@@ -603,10 +585,6 @@ fn read_operation_metadata_with_reporter(
                 workspace_name,
                 source_name,
                 load_diagnostics,
-                match metadata_file.origin {
-                    V4OperationMetadataOrigin::Materialized => "V4_OPERATION_METADATA_UNAVAILABLE",
-                    V4OperationMetadataOrigin::Override => "V4_OPERATION_METADATA_OVERRIDE_FAILED",
-                },
                 error,
             );
         },
@@ -640,33 +618,23 @@ fn load_optional_fingerprint(
     let fingerprint = match read_yaml::<Fingerprint>(path) {
         Ok(fingerprint) => fingerprint,
         Err(error) => {
-            diagnostics.push(materialization_warning(
-                "V4_FINGERPRINT_UNAVAILABLE",
-                format!(
-                    "could not read optional fingerprint '{}': {error}",
-                    path.display()
-                ),
-            ));
+            diagnostics.push(materialization_warning(format!(
+                "could not read optional fingerprint '{}': {error}",
+                path.display()
+            )));
             return None;
         }
     };
     if let Err(error) = validate_fingerprint_header(manifest, &fingerprint) {
-        diagnostics.push(materialization_warning(
-            "V4_FINGERPRINT_HEADER_MISMATCH",
-            error,
-        ));
+        diagnostics.push(materialization_warning(error));
     }
     if fingerprint.manifest_sha256 != sha256_hex(manifest_yaml.as_bytes()) {
         diagnostics.push(materialization_warning(
-            "V4_MANIFEST_FINGERPRINT_MISMATCH",
             "manifest fingerprint does not match installed manifest",
         ));
     }
     if let Err(error) = validate_fingerprint_surface(manifest, &fingerprint) {
-        diagnostics.push(materialization_warning(
-            "V4_FINGERPRINT_SURFACE_MISMATCH",
-            error,
-        ));
+        diagnostics.push(materialization_warning(error));
     }
     Some(fingerprint)
 }
@@ -728,10 +696,7 @@ fn load_projection_catalog(
     };
     if let Err(error) = validate_projection_catalog_header(manifest, &projections, projections_file)
     {
-        diagnostics.push(materialization_warning(
-            "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH",
-            error,
-        ));
+        diagnostics.push(materialization_warning(error));
     }
     Ok(projections)
 }
@@ -740,25 +705,17 @@ fn load_optional_diagnostics(path: &Path, diagnostics: &mut Vec<Diagnostic>) -> 
     match read_yaml(path) {
         Ok(diagnostics) => diagnostics,
         Err(error) => {
-            diagnostics.push(materialization_warning(
-                "V4_DIAGNOSTICS_UNAVAILABLE",
-                format!(
-                    "could not read optional diagnostics '{}': {error}",
-                    path.display()
-                ),
-            ));
+            diagnostics.push(materialization_warning(format!(
+                "could not read optional diagnostics '{}': {error}",
+                path.display()
+            )));
             Vec::new()
         }
     }
 }
 
-fn materialization_warning(code: &str, message: impl Into<String>) -> Diagnostic {
-    Diagnostic {
-        code: code.to_string(),
-        severity: DiagnosticSeverity::Warning,
-        message: message.into(),
-        operation_id: None,
-    }
+fn materialization_warning(message: impl Into<String>) -> Diagnostic {
+    Diagnostic::new(message, None)
 }
 
 fn validate_projection_catalog_header(
@@ -820,10 +777,7 @@ fn load_operation_metadata(
         }
     };
     if let Err(error) = validate_operation_metadata_header(manifest, &metadata, metadata_file) {
-        diagnostics.push(materialization_warning(
-            "V4_OPERATION_METADATA_PROVENANCE_MISMATCH",
-            error,
-        ));
+        diagnostics.push(materialization_warning(error));
     }
     Ok(metadata)
 }
@@ -1981,7 +1935,11 @@ surface:
             read_yaml(&build.temp_dir.join(DIAGNOSTICS_FILENAME)).expect("read diagnostics");
         let diagnostic = diagnostics
             .iter()
-            .find(|diagnostic| diagnostic.code == "OPENAPI_EXTERNAL_REF_UNSUPPORTED")
+            .find(|diagnostic| {
+                diagnostic
+                    .message
+                    .contains("dereferenced or bundled OpenAPI documents")
+            })
             .expect("unsupported operation ref diagnostic");
         assert!(
             diagnostic
@@ -2057,12 +2015,11 @@ surface:
         )
         .expect("changed manifest hash is advisory");
 
-        assert!(
-            materialized
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "V4_MANIFEST_FINGERPRINT_MISMATCH")
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("manifest fingerprint does not match")
+        }));
     }
 
     #[test]
@@ -2088,11 +2045,11 @@ surface:
         )
         .expect("generated projection catalog provenance is advisory");
 
-        assert!(
-            materialized.diagnostics.iter().any(|diagnostic| {
-                diagnostic.code == "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH"
-            })
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("projection catalog generator version mismatch")
+        }));
     }
 
     #[test]
@@ -2151,11 +2108,11 @@ surface:
         )
         .expect("stale projection generator provenance is advisory");
 
-        assert!(
-            materialized.diagnostics.iter().any(|diagnostic| {
-                diagnostic.code == "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH"
-            })
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("projection override was copied from generator version")
+        }));
     }
 
     #[test]
@@ -2211,12 +2168,11 @@ surface:
         )
         .expect("corrupted optional fingerprint is advisory");
 
-        assert!(
-            materialized
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "V4_FINGERPRINT_UNAVAILABLE")
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("could not read optional fingerprint")
+        }));
     }
 
     #[test]
@@ -2244,13 +2200,13 @@ surface:
             &workspace_name(),
             &source_name(),
             "materialization",
-            "V4_FINGERPRINT_UNAVAILABLE",
+            "could not read optional fingerprint",
         ));
         assert!(reporter.tracks_diagnostic(
             &workspace_name(),
             &source_name(),
             "materialization",
-            "V4_SEMANTIC_IR_UNAVAILABLE",
+            "semantic IR",
         ));
     }
 
@@ -2283,12 +2239,11 @@ surface:
         )
         .expect("old fingerprint provenance is advisory");
 
-        assert!(
-            materialized
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "V4_FINGERPRINT_HEADER_MISMATCH")
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("fingerprint artifact schema version mismatch")
+        }));
     }
 
     #[test]
@@ -2543,13 +2498,13 @@ surface:
             &workspace_name(),
             &source_name(),
             "materialization",
-            "V4_FINGERPRINT_UNAVAILABLE",
+            "could not read optional fingerprint",
         ));
         assert!(reporter.tracks_diagnostic(
             &workspace_name(),
             &source_name(),
             "materialization",
-            "V4_OPERATION_METADATA_OVERRIDE_FAILED",
+            "operation metadata override",
         ));
     }
 
@@ -2580,12 +2535,11 @@ surface:
         )
         .expect("mismatched fingerprint surface type is advisory");
 
-        assert!(
-            materialized
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "V4_FINGERPRINT_SURFACE_MISMATCH")
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("surface type fingerprint does not match")
+        }));
     }
 
     #[test]
@@ -2605,12 +2559,11 @@ surface:
         )
         .expect("raw descriptor hash is advisory provenance");
 
-        assert!(
-            materialized
-                .diagnostics
-                .iter()
-                .any(|diagnostic| { diagnostic.code == "V4_RAW_DOCUMENT_FINGERPRINT_MISMATCH" })
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("raw source document hash does not match")
+        }));
     }
 
     #[cfg(unix)]
@@ -2646,12 +2599,11 @@ surface:
         std::fs::set_permissions(&raw_path, original_permissions)
             .expect("restore raw descriptor permissions");
         let materialized = result.expect("unreadable raw descriptor is advisory provenance");
-        assert!(
-            materialized
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "V4_RAW_DOCUMENT_UNAVAILABLE")
-        );
+        assert!(materialized.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("could not read raw source document")
+        }));
     }
 
     #[test]

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -365,7 +365,6 @@ mod tests {
             SourceLoadDiagnosticStage::Query,
             &workspace_name,
             &source_name,
-            "SOURCE_LOAD_FAILED",
             "test failure",
         );
         credential_manager
@@ -414,7 +413,7 @@ mod tests {
             &workspace_name,
             &source_name,
             "query-source",
-            "SOURCE_LOAD_FAILED",
+            "test failure",
         ));
     }
 
@@ -441,7 +440,6 @@ mod tests {
             SourceLoadDiagnosticStage::Query,
             &workspace_name,
             &source_name,
-            "SOURCE_LOAD_FAILED",
             "test failure",
         );
 
@@ -454,7 +452,7 @@ mod tests {
             &workspace_name,
             &source_name,
             "query-source",
-            "SOURCE_LOAD_FAILED",
+            "test failure",
         ));
     }
 }

--- a/crates/coral-spec/src/v4/diagnostics.rs
+++ b/crates/coral-spec/src/v4/diagnostics.rs
@@ -2,31 +2,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Diagnostic {
-    pub code: String,
-    pub severity: DiagnosticSeverity,
     pub message: String,
     pub operation_id: Option<String>,
 }
 
 impl Diagnostic {
-    pub(crate) fn warning(
-        code: &str,
-        message: impl Into<String>,
-        operation_id: Option<String>,
-    ) -> Self {
+    pub fn new(message: impl Into<String>, operation_id: Option<String>) -> Self {
         Self {
-            code: code.to_string(),
-            severity: DiagnosticSeverity::Warning,
             message: message.into(),
             operation_id,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum DiagnosticSeverity {
-    Info,
-    Warning,
-    Error,
 }

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -226,7 +226,7 @@ mod tests {
                     description: String::new(),
                 },
             ],
-            diagnostics: vec![Diagnostic::warning("TEST", "diagnostic", None)],
+            diagnostics: vec![Diagnostic::new("diagnostic", None)],
         };
 
         let yaml = serde_yaml::to_string(&ir).expect("serialize semantic IR");

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -34,7 +34,7 @@ pub use artifacts::{
     Fingerprint, FingerprintSurface, MaterializedSurface, V4MaterializedSource,
     validate_materialized_source, validate_materialized_source_structure,
 };
-pub use diagnostics::{Diagnostic, DiagnosticSeverity};
+pub use diagnostics::Diagnostic;
 pub use ir::{
     HttpMethod, IrEntityCandidate, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
     IrOperationInput, IrOperationNaming, IrOperationOutput, IrScalarType, IrType, IrTypeShape,

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -68,62 +68,6 @@ paths: {}
 }
 
 #[test]
-fn importer_warns_and_skips_external_openapi_operation_refs() {
-    let manifest = parse_source_manifest_yaml(
-        r"
-name: digitalocean_ref_test
-dsl_version: 4
-surface:
-    type: openapi
-    file: /tmp/openapi.yaml
-    base_url: https://api.example.com
-",
-    )
-    .expect("manifest");
-    let v4 = manifest.as_v4().expect("v4");
-    let surface = &v4.surface;
-    let ir = import_openapi_surface(
-        v4,
-        surface,
-        r"
-openapi: 3.0.3
-paths:
-  /account:
-    get:
-      $ref: resources/account/account_get.yml
-"
-        .as_bytes(),
-    )
-    .expect("operation ref import should emit diagnostics");
-
-    assert!(
-        ir.operations.is_empty(),
-        "unsupported operation refs should not import empty operations: {:?}",
-        ir.operations
-    );
-    let diagnostic = ir
-        .diagnostics
-        .iter()
-        .find(|diagnostic| diagnostic.code == "OPENAPI_EXTERNAL_REF_UNSUPPORTED")
-        .expect("unsupported operation ref diagnostic");
-    assert!(diagnostic.operation_id.is_none());
-    assert!(
-        diagnostic
-            .message
-            .contains("resources/account/account_get.yml"),
-        "{}",
-        diagnostic.message
-    );
-    assert!(
-        diagnostic
-            .message
-            .contains("dereferenced or bundled OpenAPI documents"),
-        "{}",
-        diagnostic.message
-    );
-}
-
-#[test]
 fn importer_resolves_local_openapi_operation_refs() {
     let manifest = parse_source_manifest_yaml(
         r"
@@ -1191,16 +1135,23 @@ paths:
         .as_bytes(),
     )
     .expect("broken response refs import with diagnostics");
-    let codes = ir
+    let messages = ir
         .operations
         .iter()
         .flat_map(|operation| operation.diagnostics.iter())
-        .map(|diagnostic| diagnostic.code.as_str())
+        .map(|diagnostic| diagnostic.message.as_str())
         .collect::<Vec<_>>();
-    assert!(codes.contains(&"OPENAPI_REF_NOT_FOUND"), "{codes:?}");
     assert!(
-        codes.contains(&"OPENAPI_EXTERNAL_REF_UNSUPPORTED"),
-        "{codes:?}"
+        messages
+            .iter()
+            .any(|message| message.contains("was not found")),
+        "{messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("external reference")),
+        "{messages:?}"
     );
     for operation in &ir.operations {
         assert_eq!(operation.output.cardinality, OutputCardinality::None);
@@ -1252,12 +1203,14 @@ components:
     .expect("conflicting allOf imports with diagnostics");
 
     let operation = ir.operations.first().expect("operation");
-    let codes = operation
-        .diagnostics
-        .iter()
-        .map(|diagnostic| diagnostic.code.as_str())
-        .collect::<Vec<_>>();
-    assert!(codes.contains(&"OPENAPI_ALLOF_CONFLICT"), "{codes:?}");
+    assert!(
+        operation
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("allOf property")),
+        "{:?}",
+        operation.diagnostics
+    );
     assert_eq!(operation.output.type_ref, "json");
 }
 
@@ -1997,15 +1950,19 @@ paths:
     )
     .expect("broken schema imports with diagnostics");
     let operation = ir.operations.first().expect("operation");
-    let codes = operation
-        .diagnostics
-        .iter()
-        .map(|diagnostic| diagnostic.code.as_str())
-        .collect::<Vec<_>>();
-    assert!(codes.contains(&"OPENAPI_PARAMETER_INVALID"), "{codes:?}");
     assert!(
-        codes.contains(&"OPENAPI_RESPONSE_SCHEMA_UNRESOLVED"),
-        "{codes:?}"
+        operation.diagnostics.iter().any(|diagnostic| diagnostic
+            .message
+            .contains("parameter without a string name")),
+        "{:?}",
+        operation.diagnostics
+    );
+    assert!(
+        operation.diagnostics.iter().any(|diagnostic| diagnostic
+            .message
+            .contains("response schema could not be resolved")),
+        "{:?}",
+        operation.diagnostics
     );
     assert_eq!(operation.output.cardinality, OutputCardinality::Unknown);
 }

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -419,7 +419,7 @@ components:
         catalog
             .diagnostics
             .iter()
-            .all(|diagnostic| diagnostic.code != "PROJECTION_NAME_COLLISION_RESOLVED"),
+            .all(|diagnostic| !diagnostic.message.contains("projection name collision")),
         "tag-grouped names should not need collision diagnostics: {:?}",
         catalog.diagnostics
     );
@@ -575,13 +575,9 @@ paths:
         .expect("projection");
     assert_eq!(projection.visibility, ProjectionVisibility::Hidden);
     assert!(
-        projection
-            .diagnostics
-            .iter()
-            .any(
-                |diagnostic| diagnostic.code == "PROJECTION_INPUT_UNSUPPORTED"
-                    && diagnostic.message.contains("Header")
-            ),
+        projection.diagnostics.iter().any(|diagnostic| diagnostic
+            .message
+            .contains("required Header input 'page' cannot be exposed in SQL")),
         "required header sharing the pagination param name must stay unsupported: {:?}",
         projection.diagnostics
     );
@@ -627,8 +623,7 @@ paths:
     for dropped in ["Header input 'X-Api-Version'", "Cookie input 'session'"] {
         assert!(
             projection.diagnostics.iter().any(|diagnostic| {
-                diagnostic.code == "PROJECTION_INPUT_UNSUPPORTED"
-                    && diagnostic.message.contains(dropped)
+                diagnostic.message.contains(dropped)
                     && diagnostic
                         .message
                         .contains("not sent by generated requests")
@@ -1201,14 +1196,14 @@ components:
     let catalog_collision_diagnostics = catalog
         .diagnostics
         .iter()
-        .filter(|diagnostic| diagnostic.code == "PROJECTION_NAME_COLLISION_RESOLVED")
+        .filter(|diagnostic| diagnostic.message.contains("projection name collision"))
         .collect::<Vec<_>>();
     assert_eq!(catalog_collision_diagnostics.len(), 3);
     let projection_collision_diagnostics = catalog
         .projections
         .iter()
         .flat_map(|projection| &projection.diagnostics)
-        .filter(|diagnostic| diagnostic.code == "PROJECTION_NAME_COLLISION_RESOLVED")
+        .filter(|diagnostic| diagnostic.message.contains("projection name collision"))
         .count();
     assert_eq!(
         projection_collision_diagnostics,

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -90,8 +90,7 @@ fn generate_projection(
             };
             if exposure == SqlInputExposure::Internal && input.required && !pagination_owned_input {
                 visibility = ProjectionVisibility::Hidden;
-                projection_diagnostics.push(Diagnostic::warning(
-                    "PROJECTION_INPUT_UNSUPPORTED",
+                projection_diagnostics.push(Diagnostic::new(
                     format!(
                         "required {:?} input '{}' cannot be exposed in SQL",
                         input.location, input.name
@@ -105,8 +104,7 @@ fn generate_projection(
                 // Request lowering only renders path and query parameters, so
                 // an optional header or cookie is omitted from every generated
                 // request; the projection stays usable but must say so.
-                projection_diagnostics.push(Diagnostic::warning(
-                    "PROJECTION_INPUT_UNSUPPORTED",
+                projection_diagnostics.push(Diagnostic::new(
                     format!(
                         "optional {:?} input '{}' is not sent by generated requests",
                         input.location, input.name

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use crate::v4::diagnostics::{Diagnostic, DiagnosticSeverity};
+use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrExecutionAttachment, IrOperation, OutputCardinality, SemanticIr};
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, stable_suffix};
@@ -67,12 +67,10 @@ pub(super) fn resolve_projection_name_collisions(
                 .get_mut(*index)
                 .expect("projection index came from projections");
             projection.name.clone_from(&name);
-            let diagnostic = Diagnostic {
-                code: "PROJECTION_NAME_COLLISION_RESOLVED".to_string(),
-                severity: DiagnosticSeverity::Warning,
-                message: format!("projection name collision resolved as '{name}'"),
-                operation_id: Some(projection.operation_id.clone()),
-            };
+            let diagnostic = Diagnostic::new(
+                format!("projection name collision resolved as '{name}'"),
+                Some(projection.operation_id.clone()),
+            );
             projection.diagnostics.push(diagnostic.clone());
             diagnostics.push(diagnostic);
         }

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -520,7 +520,7 @@ surface:
         assert!(
             ir.diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_REF_NOT_FOUND")
+                .any(|diagnostic| diagnostic.message.contains("was not found"))
         );
 
         let projections = generate_projection_catalog(
@@ -563,7 +563,7 @@ surface:
         assert!(
             ir.diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_REF_UNSUPPORTED")
+                .any(|diagnostic| diagnostic.message.contains("reference cycle"))
         );
     }
 
@@ -586,11 +586,11 @@ surface:
 
         let ir = import_catalog(&catalog);
         assert!(ir.operations.is_empty());
-        assert!(
-            ir.diagnostics.iter().any(|diagnostic| {
-                diagnostic.code == "MCP_INPUT_SCHEMA_REQUIRED_PROPERTY_MISSING"
-            })
-        );
+        assert!(ir.diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("required properties that are not defined")
+        }));
     }
 
     #[test]
@@ -817,7 +817,7 @@ surface:
         assert!(
             ir.diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_CONFLICT")
+                .any(|diagnostic| diagnostic.message.contains("conflicting property"))
         );
     }
 
@@ -853,7 +853,7 @@ surface:
         assert!(
             ir.diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED")
+                .any(|diagnostic| diagnostic.message.contains("uses anyOf/oneOf"))
         );
 
         let projections = generate_projection_catalog(

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -178,13 +178,10 @@ fn validate_required_properties(
     if missing.is_empty() {
         return true;
     }
-    context.push_warning(
-        "MCP_INPUT_SCHEMA_REQUIRED_PROPERTY_MISSING",
-        format!(
-            "MCP input schema marks required properties that are not defined: {}",
-            missing.join(", ")
-        ),
-    );
+    context.push_warning(format!(
+        "MCP input schema marks required properties that are not defined: {}",
+        missing.join(", ")
+    ));
     false
 }
 
@@ -198,17 +195,13 @@ fn merge_input_object_shape(
     match merge_json_object_shape_annotation_insensitive(target, source, depth, max_depth) {
         Ok(()) => true,
         Err(JsonSchemaComparisonError::PropertyConflict(property)) => {
-            context.push_warning(
-                "MCP_INPUT_SCHEMA_CONFLICT",
-                format!("MCP input schema defines conflicting property '{property}'"),
-            );
+            context.push_warning(format!(
+                "MCP input schema defines conflicting property '{property}'"
+            ));
             false
         }
         Err(JsonSchemaComparisonError::DepthExceeded) => {
-            context.push_warning(
-                "MCP_INPUT_SCHEMA_DEPTH_EXCEEDED",
-                "MCP input schema exceeds the maximum supported nesting depth",
-            );
+            context.push_warning("MCP input schema exceeds the maximum supported nesting depth");
             false
         }
     }
@@ -223,37 +216,31 @@ struct InputSchemaContext<'a, 'b> {
 impl InputSchemaContext<'_, '_> {
     fn push_unsupported_composition(&mut self) {
         self.push_warning(
-            "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED",
             "MCP input schema uses anyOf/oneOf, which cannot be safely imported as SQL inputs",
         );
     }
 
     fn push_schema_walk_diagnostic(&mut self, error: JsonSchemaWalkError<'_>) {
-        let (code, message) = match error {
-            JsonSchemaWalkError::ExternalRef(reference) => (
-                "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-                format!("MCP input schema external reference '{reference}' is unsupported"),
-            ),
-            JsonSchemaWalkError::RefCycle(reference) => (
-                "MCP_INPUT_SCHEMA_REF_UNSUPPORTED",
-                format!("MCP input schema reference cycle includes '{reference}'"),
-            ),
-            JsonSchemaWalkError::RefNotFound(reference) => (
-                "MCP_INPUT_SCHEMA_REF_NOT_FOUND",
-                format!("MCP input schema reference '{reference}' was not found"),
-            ),
-            JsonSchemaWalkError::DepthExceeded => (
-                "MCP_INPUT_SCHEMA_DEPTH_EXCEEDED",
-                "MCP input schema exceeds the maximum supported nesting depth".to_string(),
-            ),
+        let message = match error {
+            JsonSchemaWalkError::ExternalRef(reference) => {
+                format!("MCP input schema external reference '{reference}' is unsupported")
+            }
+            JsonSchemaWalkError::RefCycle(reference) => {
+                format!("MCP input schema reference cycle includes '{reference}'")
+            }
+            JsonSchemaWalkError::RefNotFound(reference) => {
+                format!("MCP input schema reference '{reference}' was not found")
+            }
+            JsonSchemaWalkError::DepthExceeded => {
+                "MCP input schema exceeds the maximum supported nesting depth".to_string()
+            }
         };
-        self.push_warning(code, message);
+        self.push_warning(message);
     }
 
-    fn push_warning(&mut self, code: &'static str, message: impl Into<String>) {
+    fn push_warning(&mut self, message: impl Into<String>) {
         *self.schema_complete = false;
-        self.diagnostics.push(Diagnostic::warning(
-            code,
+        self.diagnostics.push(Diagnostic::new(
             message,
             Some(self.operation_id.to_string()),
         ));

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -143,17 +143,15 @@ impl<'a> OpenApiImporter<'a> {
     }
 
     fn ref_error_diagnostic(error: RefError<'_>, context: &RefDiagnosticContext<'_>) -> Diagnostic {
-        let (code, message) = match error {
-            RefError::External(reference) => (
-                "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
+        let message = match error {
+            RefError::External(reference) => {
                 format!(
                     "external reference '{reference}' is unsupported; Coral currently requires dereferenced or bundled OpenAPI documents"
-                ),
-            ),
-            RefError::NotFound(reference) => (
-                "OPENAPI_REF_NOT_FOUND",
-                format!("reference '{reference}' was not found"),
-            ),
+                )
+            }
+            RefError::NotFound(reference) => {
+                format!("reference '{reference}' was not found")
+            }
         };
         let (message, operation_id) = match context {
             RefDiagnosticContext::Operation { path, method_name } => (
@@ -164,6 +162,6 @@ impl<'a> OpenApiImporter<'a> {
                 (message, Some(operation_id.to_string()))
             }
         };
-        Diagnostic::warning(code, message, operation_id)
+        Diagnostic::new(message, operation_id)
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -122,16 +122,14 @@ impl OpenApiImporter<'_> {
                 continue;
             };
             let Some(parameter_obj) = resolved.as_object() else {
-                diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_PARAMETER_INVALID",
+                diagnostics.push(Diagnostic::new(
                     format!("operation '{operation_id}' has a parameter that is not an object"),
                     Some(operation_id.to_string()),
                 ));
                 continue;
             };
             let Some(name) = parameter_obj.get("name").and_then(Value::as_str) else {
-                diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_PARAMETER_INVALID",
+                diagnostics.push(Diagnostic::new(
                     format!("operation '{operation_id}' has a parameter without a string name"),
                     Some(operation_id.to_string()),
                 ));
@@ -142,8 +140,7 @@ impl OpenApiImporter<'_> {
                 .and_then(Value::as_str)
                 .and_then(parse_parameter_location)
             else {
-                diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_PARAMETER_SERIALIZATION_UNSUPPORTED",
+                diagnostics.push(Diagnostic::new(
                     format!("operation '{operation_id}' has unsupported parameter location"),
                     Some(operation_id.to_string()),
                 ));
@@ -189,8 +186,7 @@ impl OpenApiImporter<'_> {
     ) -> Option<IrScalarType> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
         let Some(scalar) = json_schema_scalar_type_or_string(&resolved) else {
-            diagnostics.push(Diagnostic::warning(
-                "PROJECTION_INPUT_UNSUPPORTED",
+            diagnostics.push(Diagnostic::new(
                 format!(
                     "parameter '{name}' has unsupported schema type '{}'",
                     json_schema_type_display(&resolved)
@@ -222,8 +218,7 @@ impl OpenApiImporter<'_> {
                 diagnostics,
             )
             .unwrap_or_else(|| "json".to_string());
-        diagnostics.push(Diagnostic::warning(
-            "OPENAPI_REQUEST_BODY_UNPUBLISHED",
+        diagnostics.push(Diagnostic::new(
             format!("operation '{operation_id}' has a request body and will not be published"),
             Some(operation_id.to_string()),
         ));

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -69,8 +69,7 @@ impl OpenApiImporter<'_> {
         };
 
         let Some(resolved) = self.resolve_ref(&selected.schema, operation_id, diagnostics) else {
-            diagnostics.push(Diagnostic::warning(
-                "OPENAPI_RESPONSE_SCHEMA_UNRESOLVED",
+            diagnostics.push(Diagnostic::new(
                 format!("operation '{operation_id}' response schema could not be resolved"),
                 Some(operation_id.to_string()),
             ));

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -58,16 +58,14 @@ impl OpenApiImporter<'_> {
                 match merge_json_schema_properties_exact(&mut merged, properties) {
                     Ok(()) => {}
                     Err(JsonSchemaComparisonError::PropertyConflict(property)) => {
-                        diagnostics.push(Diagnostic::warning(
-                            "OPENAPI_ALLOF_CONFLICT",
+                        diagnostics.push(Diagnostic::new(
                             format!("allOf property '{property}' conflicts in operation '{operation_id}'"),
                             Some(operation_id.to_string()),
                         ));
                         return None;
                     }
                     Err(JsonSchemaComparisonError::DepthExceeded) => {
-                        diagnostics.push(Diagnostic::warning(
-                            "OPENAPI_ALLOF_CONFLICT",
+                        diagnostics.push(Diagnostic::new(
                             format!("allOf schema exceeds maximum comparison depth in operation '{operation_id}'"),
                             Some(operation_id.to_string()),
                         ));


### PR DESCRIPTION
## Summary

- remove the unused `code` field from DSL v4 diagnostics
- remove `severity`, since every diagnostic is a warning
- replace `Diagnostic::warning` with `Diagnostic::new`
- deduplicate and test diagnostics using their message text

## Why

Diagnostic codes existed primarily to make tests convenient, while severity modeled states Coral never emitted. Removing both fields makes the diagnostic artifact match its actual semantics and eliminates dead labels throughout the OpenAPI, MCP, projection, and materialization paths.

Existing diagnostic YAML with `code` and `severity` remains readable because those legacy fields are ignored during deserialization. Newly generated diagnostics contain only `message` and `operation_id`.

## Impact

DSL v4 diagnostic artifacts are smaller and their Rust API is simpler. Tests now verify user-visible diagnostic messages instead of internal codes, and app-level diagnostic reporting deduplicates by message.

## Validation

- `cargo test -p coral-spec`
- `cargo test -p coral-app`
- `make rust-checks` (formatting, Clippy with warnings denied, 2,054 nextest tests, and rustdoc)