### PR TITLE
fix(spec): restore wrapped-list response handling

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -14,7 +14,7 @@ use coral_spec::v4::{
     V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest, ValidatedSurfacePlan,
     generate_projection_catalog, import_mcp_surface, import_openapi_surface,
     normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
-    sync_projection_inputs, validate_materialized_source, validate_materialized_source_structure,
+    sync_projection_catalog, validate_materialized_source, validate_materialized_source_structure,
     validate_openapi_base_url_template, validate_semantic_ir_structure,
 };
 use coral_spec::{
@@ -868,7 +868,7 @@ fn sync_loaded_projection_inputs(
         V4ProjectionCatalogOrigin::Materialized => ProjectionInputSyncMode::RecomputeInputExposure,
         V4ProjectionCatalogOrigin::Override => ProjectionInputSyncMode::PreserveExistingExposure,
     };
-    sync_projection_inputs(plan, projections, projection_sync_mode).map_err(|error| {
+    sync_projection_catalog(plan, projections, projection_sync_mode).map_err(|error| {
         match projections_file.origin {
             V4ProjectionCatalogOrigin::Materialized => {
                 incompatible_materialization_error(source_name, error.to_string())
@@ -1568,11 +1568,15 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id: {type: integer}
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: integer}
 "
     }
 
@@ -1841,21 +1845,26 @@ surface:
     }
 
     #[test]
-    fn build_v4_materialization_persists_lookup_keys_in_operation_metadata() {
+    fn build_v4_materialization_persists_inferred_operation_metadata() {
         let (_state, _descriptor, layout, _manifest_yaml, _manifest) = setup_materialization();
         let surface_dir = layout.v4_materialized_dir(&workspace_name(), &source_name());
         let metadata: OperationMetadataCatalog =
             read_yaml(&surface_dir.join(OPERATION_METADATA_FILENAME))
                 .expect("read operation metadata");
-        let lookup_keys = match metadata
+        let (row_path, lookup_keys) = match metadata
             .operations
             .values()
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Rest { lookup_keys, .. } => lookup_keys,
+            coral_spec::v4::OperationMetadata::Rest {
+                row_path,
+                lookup_keys,
+                ..
+            } => (row_path, lookup_keys),
             coral_spec::v4::OperationMetadata::Mcp { .. } => panic!("expected REST metadata"),
         };
+        assert_eq!(row_path, &["items"]);
         assert_eq!(lookup_keys, &["state"]);
     }
 
@@ -1899,16 +1908,22 @@ surface:
         let metadata: OperationMetadataCatalog =
             read_yaml(&build.temp_dir.join(OPERATION_METADATA_FILENAME))
                 .expect("read operation metadata");
-        let pagination = match metadata
+        let (row_path, pagination) = match metadata
             .operations
             .values()
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Mcp { pagination } => pagination,
+            coral_spec::v4::OperationMetadata::Mcp {
+                row_path,
+                pagination,
+            } => (row_path, pagination),
             coral_spec::v4::OperationMetadata::Rest { .. } => panic!("expected MCP metadata"),
         };
-        assert!(pagination.cursor.is_none());
+        assert_eq!(row_path, &["items"]);
+        let cursor = pagination.cursor.as_ref().expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
         assert!(pagination.offset.is_none());
 
         let projections: ProjectionCatalog =
@@ -2292,7 +2307,7 @@ surface:
     }
 
     #[test]
-    fn load_v4_materialization_applies_operation_metadata_override_without_rewriting_artifact() {
+    fn load_v4_materialization_applies_metadata_override_without_rewriting_artifacts() {
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let generated_path = layout
             .v4_materialized_dir(&workspace_name(), &source_name())
@@ -2304,9 +2319,15 @@ surface:
             .values_mut()
             .next()
             .expect("operation metadata");
-        let coral_spec::v4::OperationMetadata::Rest { lookup_keys, .. } = operation_metadata else {
+        let coral_spec::v4::OperationMetadata::Rest {
+            row_path,
+            lookup_keys,
+            ..
+        } = operation_metadata
+        else {
             panic!("expected REST metadata");
         };
+        row_path.clear();
         *lookup_keys = vec!["q".to_string()];
         let override_path = layout
             .v4_override_dir(&workspace_name(), &source_name())
@@ -2344,16 +2365,38 @@ surface:
                 .plan
                 .input_is_lookup_key(&operation_id, "state")
         );
+        assert!(
+            materialized
+                .surface
+                .plan
+                .output_row_path(&operation_id)
+                .is_empty()
+        );
+        let column_names = materialized
+            .projections
+            .projections
+            .first()
+            .expect("projection")
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(column_names, ["total_count", "items"]);
 
         let artifact_metadata: OperationMetadataCatalog =
             read_yaml(&generated_path).expect("read persisted operation metadata");
-        let coral_spec::v4::OperationMetadata::Rest { lookup_keys, .. } = artifact_metadata
+        let coral_spec::v4::OperationMetadata::Rest {
+            row_path,
+            lookup_keys,
+            ..
+        } = artifact_metadata
             .operations
             .get(&operation_id)
             .expect("artifact operation metadata")
         else {
             panic!("expected REST metadata");
         };
+        assert_eq!(row_path, &["items"]);
         assert_eq!(lookup_keys, &["state"]);
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -238,6 +238,10 @@ fn http_manifest_for_surface(
             })?;
         let rest = rest_execution_for_operation(operation)?;
         let pagination = materialized_surface.plan.rest_pagination(&operation.id);
+        let response = response_with_row_path(
+            rest.response.response.clone(),
+            materialized_surface.plan.output_row_path(&operation.id),
+        );
         let request = request_spec_for_projection(projection, operation)
             .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
         let columns = projection_column_specs(projection);
@@ -256,7 +260,7 @@ fn http_manifest_for_surface(
                     },
                     request,
                     requests: Vec::new(),
-                    response: rest.response.response.clone(),
+                    response: response.clone(),
                     pagination: pagination.clone(),
                 });
             }
@@ -270,7 +274,7 @@ fn http_manifest_for_surface(
                     detail_hints: projection.detail_hints.clone(),
                     args: projection_arg_specs(projection),
                     request,
-                    response: rest.response.response.clone(),
+                    response,
                     pagination: pagination.clone(),
                     columns,
                 });
@@ -347,11 +351,13 @@ fn mcp_manifest_for_surface(
         };
         let (cursor_pagination, offset_pagination) =
             materialized_surface.plan.mcp_pagination(&operation.id);
+        let row_path = materialized_surface.plan.output_row_path(&operation.id);
         match &projection.kind {
             ProjectionKind::Table => {
                 tables.push(mcp_table_spec(
                     projection,
                     mcp,
+                    row_path,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -361,6 +367,7 @@ fn mcp_manifest_for_surface(
                     projection,
                     *function_kind,
                     mcp,
+                    row_path,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -385,6 +392,7 @@ fn mcp_manifest_for_surface(
 fn mcp_table_spec(
     projection: &Projection,
     mcp: &coral_spec::v4::McpExecutionAttachment,
+    row_path: &[String],
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableSpec {
@@ -405,7 +413,7 @@ fn mcp_table_spec(
         limit_binding: None,
         pagination,
         offset_pagination,
-        response: ResponseSpec::default(),
+        response: response_with_row_path(ResponseSpec::default(), row_path),
     }
 }
 
@@ -413,6 +421,7 @@ fn mcp_table_function_spec(
     projection: &Projection,
     function_kind: SourceTableFunctionKind,
     mcp: &coral_spec::v4::McpExecutionAttachment,
+    row_path: &[String],
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableFunctionSpec {
@@ -429,11 +438,16 @@ fn mcp_table_function_spec(
             detail_hints: projection.detail_hints.clone(),
             args: mcp_projection_arg_specs(projection),
             request: RequestSpec::default(),
-            response: ResponseSpec::default(),
+            response: response_with_row_path(ResponseSpec::default(), row_path),
             pagination: PaginationSpec::default(),
             columns: projection_column_specs(projection),
         },
     }
+}
+
+fn response_with_row_path(mut response: ResponseSpec, row_path: &[String]) -> ResponseSpec {
+    response.rows_path = row_path.to_vec();
+    response
 }
 
 fn mcp_filter_bindings(projection: &Projection) -> Vec<McpTableFilterBinding> {
@@ -513,7 +527,7 @@ mod tests {
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
         AcceptedIdentityRequirement, Fingerprint, FingerprintSurface, HttpMethod,
-        IdentityRequirements, IrExecutionAttachment, IrInputLocation, IrOperation,
+        IdentityRequirements, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
         IrOperationInput, IrOperationOutput, IrScalarType, IrType, IrTypeShape,
         MCP_IMPORTER_VERSION, MaterializedSurface, McpExecutionAttachment, McpOperationPagination,
         McpRuntimeConfig, OPENAPI_IMPORTER_VERSION, OPERATION_METADATA_GENERATOR_VERSION,
@@ -524,7 +538,9 @@ mod tests {
         SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource,
         V4SourceCommon, V4SourceManifest, V4Surface, ValidatedSurfacePlan,
     };
-    use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
+    use coral_spec::{
+        PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec, SourceTableFunctionKind,
+    };
 
     use crate::bootstrap::AppError;
 
@@ -557,6 +573,14 @@ mod tests {
         operation_id: &str,
         pagination: PaginationSpec,
     ) -> MaterializedSurface {
+        rest_materialized_surface(operation_id, pagination, Vec::new())
+    }
+
+    fn rest_materialized_surface(
+        operation_id: &str,
+        pagination: PaginationSpec,
+        row_path: Vec<String>,
+    ) -> MaterializedSurface {
         let mut pagination_inputs = Vec::new();
         for name in [
             pagination.page_param.as_deref(),
@@ -577,6 +601,7 @@ mod tests {
             }
             pagination_inputs.push(test_input(name, IrInputLocation::Query));
         }
+        let (output, types) = rest_test_output(&row_path);
         let semantic_ir = SemanticIr {
             artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
             source_name: "github_v4".to_string(),
@@ -590,10 +615,7 @@ mod tests {
                 read_only: true,
                 naming: None,
                 inputs: pagination_inputs.clone(),
-                output: IrOperationOutput {
-                    cardinality: coral_spec::v4::OutputCardinality::List,
-                    type_ref: "item".to_string(),
-                },
+                output,
                 entity: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                     method: HttpMethod::Get,
@@ -617,7 +639,7 @@ mod tests {
                 })),
                 diagnostics: Vec::new(),
             }],
-            types: vec![test_object_type("item")],
+            types,
             diagnostics: Vec::new(),
         };
         let operation_metadata = OperationMetadataCatalog {
@@ -627,6 +649,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Rest {
+                    row_path,
                     pagination,
                     lookup_keys: Vec::new(),
                 },
@@ -637,6 +660,50 @@ mod tests {
             source_document_sha256: None,
             normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
             raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
+        }
+    }
+
+    fn rest_test_output(row_path: &[String]) -> (IrOperationOutput, Vec<IrType>) {
+        if row_path.is_empty() {
+            (
+                IrOperationOutput {
+                    cardinality: coral_spec::v4::OutputCardinality::List,
+                    type_ref: "item".to_string(),
+                },
+                vec![test_object_type("item")],
+            )
+        } else {
+            (
+                IrOperationOutput {
+                    cardinality: coral_spec::v4::OutputCardinality::Singleton,
+                    type_ref: "envelope".to_string(),
+                },
+                vec![
+                    test_object_type("item"),
+                    IrType {
+                        id: "items".to_string(),
+                        shape: IrTypeShape::List {
+                            item_type_ref: "item".to_string(),
+                        },
+                        nullable: false,
+                        description: String::new(),
+                    },
+                    IrType {
+                        id: "envelope".to_string(),
+                        shape: IrTypeShape::Object {
+                            fields: vec![IrField {
+                                name: "items".to_string(),
+                                type_ref: "items".to_string(),
+                                required: true,
+                                nullable: false,
+                                description: String::new(),
+                            }],
+                        },
+                        nullable: false,
+                        description: String::new(),
+                    },
+                ],
+            )
         }
     }
 
@@ -708,6 +775,15 @@ mod tests {
         pagination: Option<McpPaginationSpec>,
         offset_pagination: Option<McpOffsetPaginationSpec>,
     ) -> MaterializedSurface {
+        mcp_materialized_surface(operation_id, pagination, offset_pagination, Vec::new())
+    }
+
+    fn mcp_materialized_surface(
+        operation_id: &str,
+        pagination: Option<McpPaginationSpec>,
+        offset_pagination: Option<McpOffsetPaginationSpec>,
+        row_path: Vec<String>,
+    ) -> MaterializedSurface {
         let mut inputs = Vec::new();
         if let Some(cursor) = pagination.as_ref() {
             let mut input = test_input(&cursor.cursor_arg, IrInputLocation::ToolArg);
@@ -751,6 +827,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Mcp {
+                    row_path,
                     pagination: McpOperationPagination {
                         cursor: pagination,
                         offset: offset_pagination,
@@ -1080,6 +1157,84 @@ mod tests {
             mcp.tables.first().expect("mcp table").pagination.as_ref(),
             Some(&pagination)
         );
+    }
+
+    #[test]
+    fn http_runtime_component_applies_operation_row_path() {
+        let manifest = manifest_with_surface(openapi_surface());
+        let materialized = V4MaterializedSource {
+            fingerprint: Some(fingerprint(SurfaceType::OpenApi, "github_v4")),
+            surface: rest_materialized_surface(
+                "rest_list_issues",
+                PaginationSpec::default(),
+                vec!["items".to_string()],
+            ),
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                projections: vec![published_projection("rest_list_issues")],
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let component = runtime_component_for_v4_source(&manifest, &materialized)
+            .expect("runtime component")
+            .expect("published component");
+        let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+            panic!("expected HTTP component");
+        };
+        let table = http.tables.first().expect("HTTP table");
+        assert_eq!(table.response.rows_path, ["items"]);
+    }
+
+    #[test]
+    fn mcp_runtime_component_applies_row_path_to_tables_and_functions() {
+        let manifest = manifest_with_surface(mcp_surface());
+        let materialized = |projection| V4MaterializedSource {
+            fingerprint: Some(fingerprint(SurfaceType::Mcp, "github_v4")),
+            surface: mcp_materialized_surface(
+                "mcp_list_issues",
+                None,
+                None,
+                vec!["items".to_string()],
+            ),
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                projections: vec![projection],
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let table_component = runtime_component_for_v4_source(
+            &manifest,
+            &materialized(published_projection("mcp_list_issues")),
+        )
+        .expect("table component")
+        .expect("published table");
+        let coral_engine::RuntimeSourceComponent::Mcp(table_mcp) = table_component else {
+            panic!("expected MCP component");
+        };
+        let table = table_mcp.tables.first().expect("MCP table");
+        assert_eq!(table.response.rows_path, ["items"]);
+
+        let mut function_projection = published_projection("mcp_list_issues");
+        function_projection.kind = ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table,
+        };
+        let function_component =
+            runtime_component_for_v4_source(&manifest, &materialized(function_projection))
+                .expect("function component")
+                .expect("published function");
+        let coral_engine::RuntimeSourceComponent::Mcp(function_mcp) = function_component else {
+            panic!("expected MCP component");
+        };
+        let function = function_mcp.functions.first().expect("MCP function");
+        assert_eq!(function.common.response.rows_path, ["items"]);
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,8 +7,8 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v7";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
-pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v1";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v10";
+pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v2";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v11";
 
 mod artifacts;
 mod diagnostics;
@@ -47,6 +47,7 @@ pub use manifest::{
     V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
+pub(crate) use operation_metadata::resolve_output_row_type_ref;
 pub use operation_metadata::{
     ImportedSurface, McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
     ValidatedSurfacePlan, validate_operation_metadata_structure, validate_semantic_ir_structure,
@@ -55,7 +56,8 @@ pub use projections::{
     Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionInputSyncMode,
     ProjectionKind, ProjectionVisibility, SqlInputExposure, generate_projection_catalog,
     mcp_projection_arg_specs, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection, sync_projection_inputs,
+    projection_filter_specs, request_spec_for_projection, sync_projection_catalog,
+    sync_projection_inputs,
 };
 pub use schema::generated_v4_source_manifest_schema;
 pub use surfaces::{

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -21,6 +21,15 @@ fn imported_rest_pagination<'a>(
     }
 }
 
+fn imported_row_path<'a>(surface: &'a ImportedSurface, operation_id: &str) -> &'a [String] {
+    surface
+        .operation_metadata
+        .operations
+        .get(operation_id)
+        .expect("operation metadata")
+        .row_path()
+}
+
 #[test]
 fn extracts_openapi_document_metadata() {
     let metadata = openapi_document_metadata(
@@ -308,7 +317,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_common_envelope_objects_as_singletons() {
+fn importer_infers_nested_wrapped_list_row_paths_as_metadata() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: statusgator
@@ -341,9 +350,12 @@ paths:
                 type: object
                 properties:
                   success: {type: boolean}
-                  data:
-                    type: array
-                    items: {$ref: '#/components/schemas/Incident'}
+                  results:
+                    type: object
+                    properties:
+                      data:
+                        type: array
+                        items: {$ref: '#/components/schemas/Incident'}
                   pagination:
                     type: object
 components:
@@ -359,6 +371,7 @@ components:
     .expect("import");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(imported_row_path(&ir, "listincidents"), ["results", "data"]);
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -372,9 +385,9 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("success"), Some(&ManifestDataType::Boolean));
-    assert_eq!(columns.get("data"), Some(&ManifestDataType::Json));
-    assert_eq!(columns.get("pagination"), Some(&ManifestDataType::Json));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.get("name"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 2);
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -384,7 +397,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_single_array_payload_objects_as_singletons() {
+fn importer_infers_sole_array_payload_row_path() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -433,6 +446,13 @@ components:
     .expect("import");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(
+        imported_row_path(
+            &ir,
+            "actions_list_selected_repositories_enabled_github_actions_organization"
+        ),
+        ["repositories"]
+    );
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -442,8 +462,9 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("total_count"), Some(&ManifestDataType::Int64));
-    assert_eq!(columns.get("repositories"), Some(&ManifestDataType::Json));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("name"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 2);
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -453,7 +474,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_search_result_objects_as_singletons() {
+fn importer_prefers_named_wrapped_list_when_multiple_arrays_exist() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -512,6 +533,10 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(
+        imported_row_path(&ir, "search_issues_and_pull_requests"),
+        ["items"]
+    );
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -521,21 +546,11 @@ paths:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("total_count"), Some(&ManifestDataType::Int64));
-    assert_eq!(
-        columns.get("incomplete_results"),
-        Some(&ManifestDataType::Boolean)
-    );
-    assert_eq!(columns.get("items"), Some(&ManifestDataType::Json));
-    assert_eq!(columns.get("search_type"), Some(&ManifestDataType::Utf8));
-    assert_eq!(
-        columns.get("lexical_fallback_reason"),
-        Some(&ManifestDataType::Json)
-    );
-    assert!(!columns.contains_key("id"));
-    assert!(!columns.contains_key("number"));
-    assert!(!columns.contains_key("title"));
-    assert!(!columns.contains_key("state"));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("number"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("title"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.get("state"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 4);
 }
 
 #[test]
@@ -543,7 +558,7 @@ paths:
     clippy::too_many_lines,
     reason = "The fixture mirrors the resource object shape that regressed."
 )]
-fn importer_keeps_resource_objects_with_array_fields_as_singletons() {
+fn importer_legacy_sole_array_heuristic_can_select_resource_child_lists() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -636,6 +651,7 @@ components:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(imported_row_path(&ir, "projects_get_org_item"), ["fields"]);
 
     let row_type = ir
         .types
@@ -656,21 +672,12 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(projection.columns.len(), 11);
-    assert_eq!(column_types.get("id"), Some(&ManifestDataType::Float64));
-    assert_eq!(
-        column_types.get("content_type"),
-        Some(&ManifestDataType::Utf8)
-    );
-    assert_eq!(
-        column_types.get("created_at"),
-        Some(&ManifestDataType::Timestamp)
-    );
-    assert_eq!(column_types.get("fields"), Some(&ManifestDataType::Json));
+    assert_eq!(projection.columns.len(), 1);
+    assert_eq!(column_types.get("value"), Some(&ManifestDataType::Json));
 }
 
 #[test]
-fn importer_keeps_named_array_fields_on_resource_objects_as_singletons() {
+fn importer_legacy_preferred_name_can_select_resource_child_lists() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: resources
@@ -716,6 +723,7 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(imported_row_path(&ir, "bundles_get"), ["items"]);
 }
 
 #[test]
@@ -1812,10 +1820,8 @@ paths:
         "iterator_list",
         "start_cursor_list",
         "nested_next_list",
-        "singleton_get",
         "cursor_header_list",
         "cursor_page_list",
-        "numeric_page_list",
     ] {
         let operation = operations.get(operation_id).expect("operation");
         assert_eq!(
@@ -1825,10 +1831,25 @@ paths:
         );
         assert_eq!(
             imported_rest_pagination(&ir, operation_id).mode,
-            PaginationMode::None,
+            PaginationMode::CursorQuery,
             "{operation_id}"
         );
+        assert!(!imported_row_path(&ir, operation_id).is_empty());
     }
+
+    assert_eq!(
+        imported_rest_pagination(&ir, "numeric_page_list").mode,
+        PaginationMode::Page
+    );
+    assert_eq!(imported_row_path(&ir, "numeric_page_list"), ["data"]);
+
+    let singleton = operations.get("singleton_get").expect("singleton");
+    assert_eq!(singleton.output.cardinality, OutputCardinality::Singleton);
+    assert!(imported_row_path(&ir, "singleton_get").is_empty());
+    assert_eq!(
+        imported_rest_pagination(&ir, "singleton_get").mode,
+        PaginationMode::None
+    );
 
     let link = imported_rest_pagination(&ir, "link_list");
     assert_eq!(link.mode, PaginationMode::LinkHeader);

--- a/crates/coral-spec/src/v4/operation_metadata/mod.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/mod.rs
@@ -14,5 +14,6 @@ pub use model::{
     ImportedSurface, McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
 };
 pub use plan::ValidatedSurfacePlan;
+pub(crate) use policy::resolve_output_row_type_ref;
 pub use policy::validate_operation_metadata_structure;
 pub use structural::validate_semantic_ir_structure;

--- a/crates/coral-spec/src/v4/operation_metadata/model.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/model.rs
@@ -43,13 +43,26 @@ pub struct OperationMetadataCatalog {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OperationMetadata {
     Rest {
+        #[serde(default)]
+        row_path: Vec<String>,
         #[serde(serialize_with = "serialize_rest_operation_pagination")]
         pagination: PaginationSpec,
         lookup_keys: Vec<String>,
     },
     Mcp {
+        #[serde(default)]
+        row_path: Vec<String>,
         pagination: McpOperationPagination,
     },
+}
+
+impl OperationMetadata {
+    #[must_use]
+    pub fn row_path(&self) -> &[String] {
+        match self {
+            Self::Rest { row_path, .. } | Self::Mcp { row_path, .. } => row_path,
+        }
+    }
 }
 
 fn serialize_rest_operation_pagination<S>(

--- a/crates/coral-spec/src/v4/operation_metadata/plan.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/plan.rs
@@ -5,7 +5,8 @@ use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 use crate::v4::ir::{IrInputLocation, IrOperation, SemanticIr};
 use crate::v4::operation_metadata::model::{OperationMetadata, OperationMetadataCatalog};
 use crate::v4::operation_metadata::policy::{
-    rest_pagination_owned_inputs, validate_operation_metadata_structure,
+    resolve_output_row_type_ref, rest_pagination_owned_inputs,
+    validate_operation_metadata_structure,
 };
 use crate::v4::operation_metadata::structural::validate_semantic_ir_structure;
 use crate::{PaginationSpec, Result};
@@ -70,6 +71,46 @@ impl ValidatedSurfacePlan {
     }
 
     #[must_use]
+    pub fn output_row_path(&self, operation_id: &str) -> &[String] {
+        self.metadata_for_operation(operation_id).row_path()
+    }
+
+    #[must_use]
+    /// Returns the effective REST row type after applying operation metadata.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the operation is absent, is not a REST operation, or the
+    /// validated plan invariant has been violated.
+    pub fn rest_output_type_ref(&self, operation_id: &str) -> &str {
+        let operation = self
+            .semantic_ir
+            .operations
+            .iter()
+            .find(|operation| operation.id == operation_id)
+            .expect("validated plan contains the requested operation");
+        assert!(
+            matches!(
+                operation.execution,
+                crate::v4::ir::IrExecutionAttachment::Rest(_)
+            ),
+            "MCP operation has no REST output type"
+        );
+        let types = self
+            .semantic_ir
+            .types
+            .iter()
+            .map(|ty| (ty.id.as_str(), ty))
+            .collect();
+        resolve_output_row_type_ref(
+            &operation.output,
+            self.output_row_path(operation_id),
+            &types,
+        )
+        .expect("validated row path resolves to an output type")
+    }
+
+    #[must_use]
     /// Returns effective REST pagination for a REST operation.
     ///
     /// # Panics
@@ -93,7 +134,7 @@ impl ValidatedSurfacePlan {
         operation_id: &str,
     ) -> (Option<&McpPaginationSpec>, Option<&McpOffsetPaginationSpec>) {
         match self.metadata_for_operation(operation_id) {
-            OperationMetadata::Mcp { pagination } => {
+            OperationMetadata::Mcp { pagination, .. } => {
                 (pagination.cursor.as_ref(), pagination.offset.as_ref())
             }
             OperationMetadata::Rest { .. } => panic!("MCP operation has REST metadata"),
@@ -125,7 +166,7 @@ impl ValidatedSurfacePlan {
                     && rest_pagination_owned_inputs(operation, pagination)
                         .is_ok_and(|owned| owned.contains(input_name))
             }
-            OperationMetadata::Mcp { pagination } => {
+            OperationMetadata::Mcp { pagination, .. } => {
                 location == IrInputLocation::ToolArg
                     && (pagination
                         .cursor

--- a/crates/coral-spec/src/v4/operation_metadata/policy.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/policy.rs
@@ -4,7 +4,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::v4::ir::{
-    IrExecutionAttachment, IrInputLocation, IrOperation, IrScalarType, SemanticIr,
+    IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationOutput, IrScalarType, IrType,
+    IrTypeShape, SemanticIr,
 };
 use crate::v4::operation_metadata::model::{
     McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
@@ -22,6 +23,11 @@ pub fn validate_operation_metadata_structure(
         .iter()
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<BTreeMap<_, _>>();
+    let types = semantic_ir
+        .types
+        .iter()
+        .map(|ty| (ty.id.as_str(), ty))
+        .collect::<BTreeMap<_, _>>();
 
     for operation_id in metadata.operations.keys() {
         if !operations.contains_key(operation_id.as_str()) {
@@ -36,7 +42,7 @@ pub fn validate_operation_metadata_structure(
                 "operation metadata is missing operation '{operation_id}'"
             ))
         })?;
-        validate_operation_metadata(operation, effective)?;
+        validate_operation_metadata(operation, effective, &types)?;
     }
     Ok(())
 }
@@ -44,15 +50,24 @@ pub fn validate_operation_metadata_structure(
 fn validate_operation_metadata(
     operation: &IrOperation,
     metadata: &OperationMetadata,
+    types: &BTreeMap<&str, &IrType>,
 ) -> Result<()> {
     match (&operation.execution, metadata) {
         (
             IrExecutionAttachment::Rest(_),
             OperationMetadata::Rest {
+                row_path,
                 pagination,
                 lookup_keys,
             },
         ) => {
+            validate_row_path(operation, row_path)?;
+            resolve_output_row_type_ref(&operation.output, row_path, types).map_err(|error| {
+                ManifestError::validation(format!(
+                    "operation '{}' output row path is invalid: {error}",
+                    operation.id
+                ))
+            })?;
             if pagination.mode == PaginationMode::None
                 && !rest_pagination_is_canonical_none(pagination)
             {
@@ -65,7 +80,14 @@ fn validate_operation_metadata(
             let pagination_inputs = validate_rest_pagination(operation, pagination)?;
             validate_lookup_keys(operation, lookup_keys, &pagination_inputs)
         }
-        (IrExecutionAttachment::Mcp(_), OperationMetadata::Mcp { pagination }) => {
+        (
+            IrExecutionAttachment::Mcp(_),
+            OperationMetadata::Mcp {
+                row_path,
+                pagination,
+            },
+        ) => {
+            validate_row_path(operation, row_path)?;
             validate_mcp_pagination(operation, pagination)
         }
         (IrExecutionAttachment::Rest(_), OperationMetadata::Mcp { .. }) => {
@@ -81,6 +103,57 @@ fn validate_operation_metadata(
             )))
         }
     }
+}
+
+fn validate_row_path(operation: &IrOperation, row_path: &[String]) -> Result<()> {
+    if row_path
+        .iter()
+        .any(|segment| segment.trim().is_empty() || segment != segment.trim())
+    {
+        return Err(ManifestError::validation(format!(
+            "operation '{}' output row path contains a blank or padded segment",
+            operation.id
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn resolve_output_row_type_ref<'a>(
+    output: &'a IrOperationOutput,
+    row_path: &[String],
+    types: &BTreeMap<&str, &'a IrType>,
+) -> std::result::Result<&'a str, String> {
+    if row_path.is_empty() {
+        return Ok(&output.type_ref);
+    }
+
+    let mut type_ref = output.type_ref.as_str();
+    for segment in row_path {
+        let ty = types
+            .get(type_ref)
+            .ok_or_else(|| format!("type '{type_ref}' is missing"))?;
+        let IrTypeShape::Object { fields } = &ty.shape else {
+            return Err(format!(
+                "segment '{segment}' traverses non-object type '{type_ref}'"
+            ));
+        };
+        let field = fields
+            .iter()
+            .find(|field| field.name == *segment)
+            .ok_or_else(|| format!("type '{type_ref}' has no field '{segment}'"))?;
+        type_ref = &field.type_ref;
+    }
+
+    let ty = types
+        .get(type_ref)
+        .ok_or_else(|| format!("type '{type_ref}' is missing"))?;
+    let IrTypeShape::List { item_type_ref } = &ty.shape else {
+        return Err(format!("terminal type '{type_ref}' is not a list"));
+    };
+    if item_type_ref != "json" && !types.contains_key(item_type_ref.as_str()) {
+        return Err(format!("list item type '{item_type_ref}' is missing"));
+    }
+    Ok(item_type_ref)
 }
 
 fn validate_rest_pagination(

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -150,6 +150,7 @@ fn plan_rejects_mcp_offset_pagination_starting_past_first_page() {
     }
     let operation_id = operation.id.clone();
     let metadata_with_offset_start = |offset_start| OperationMetadata::Mcp {
+        row_path: Vec::new(),
         pagination: crate::v4::McpOperationPagination {
             cursor: None,
             offset: Some(crate::backends::mcp::McpOffsetPaginationSpec {
@@ -199,17 +200,82 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
         !yaml.contains("lookup_keys:"),
         "unexpected policy in IR: {yaml}"
     );
+    assert!(
+        !yaml.contains("row_path:"),
+        "unexpected policy in IR: {yaml}"
+    );
     assert!(matches!(
         imported.operation_metadata.operations.values().next(),
-        Some(OperationMetadata::Rest { pagination, lookup_keys })
+        Some(OperationMetadata::Rest {
+            pagination,
+            lookup_keys,
+            ..
+        })
             if pagination.page_param.as_deref() == Some("page")
                 && lookup_keys == &["state"]
     ));
 }
 
 #[test]
+fn plan_rejects_blank_or_unresolvable_rest_row_paths() {
+    let (_manifest, mut imported) = imported();
+    let metadata = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata");
+    let OperationMetadata::Rest { row_path, .. } = metadata else {
+        panic!("expected REST metadata");
+    };
+
+    *row_path = vec![" ".to_string()];
+    let error = imported
+        .validated_plan()
+        .expect_err("blank row path must fail");
+    assert!(
+        error.to_string().contains("blank or padded segment"),
+        "unexpected error: {error}"
+    );
+
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    *row_path = vec!["missing".to_string()];
+    let error = imported
+        .validated_plan()
+        .expect_err("unresolvable row path must fail");
+    assert!(
+        error.to_string().contains("traverses non-object type"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn operation_metadata_without_row_path_defaults_to_root() {
+    let metadata: OperationMetadata = serde_yaml::from_str(
+        r"
+type: rest
+pagination:
+  mode: none
+lookup_keys: []
+",
+    )
+    .expect("legacy metadata");
+
+    assert!(metadata.row_path().is_empty());
+}
+
+#[test]
 fn disabled_rest_pagination_serializes_only_its_mode() {
     let metadata = OperationMetadata::Rest {
+        row_path: Vec::new(),
         pagination: crate::PaginationSpec::default(),
         lookup_keys: Vec::new(),
     };

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1359,7 +1359,7 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
 }
 
 #[test]
-fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
+fn generated_mcp_projection_keeps_inferred_pagination_cursor_internal() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1414,16 +1414,16 @@ fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
         .find(|input| input.wire_name == "cursor")
         .expect("cursor input");
 
-    assert_eq!(cursor.sql_exposure, SqlInputExposure::FunctionArg);
+    assert_eq!(cursor.sql_exposure, SqlInputExposure::Internal);
     assert!(
         mcp_projection_arg_specs(projection)
             .iter()
-            .any(|arg| arg.bind.arg == "cursor")
+            .all(|arg| arg.bind.arg != "cursor")
     );
 }
 
 #[test]
-fn generated_mcp_projection_with_only_cursor_is_table_function_without_pagination_metadata() {
+fn generated_mcp_projection_with_only_inferred_cursor_is_table() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1471,17 +1471,14 @@ fn generated_mcp_projection_with_only_cursor_is_table_function_without_paginatio
         .find(|projection| projection.operation_id == "list_items")
         .expect("mcp projection");
 
-    assert!(matches!(
-        projection.kind,
-        ProjectionKind::TableFunction { .. }
-    ));
+    assert!(matches!(projection.kind, ProjectionKind::Table));
     assert_eq!(
         projection
             .inputs
             .iter()
-            .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
+            .filter(|input| input.sql_exposure != SqlInputExposure::Internal)
             .count(),
-        1
+        0
     );
 }
 
@@ -1582,6 +1579,123 @@ paths:
     )
     .expect("import");
     (manifest, imported)
+}
+
+fn imported_wrapped_items_surface() -> (V4SourceManifest, ImportedSurface) {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  file: /tmp/openapi.yaml
+  base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+",
+    )
+    .expect("import");
+    (manifest, imported)
+}
+
+#[test]
+fn generated_projection_columns_follow_effective_row_path_overrides() {
+    let (manifest, mut imported) = imported_wrapped_items_surface();
+    let generated_plan = imported.validated_plan().expect("generated plan");
+    let mut catalog = generate_projection_catalog(&manifest, &generated_plan).expect("projections");
+    let projection = catalog.projections.first().expect("projection");
+    let column = projection.columns.first().expect("column");
+    assert_eq!(column.name, "id", "generated metadata selects item rows");
+
+    let metadata = imported
+        .operation_metadata
+        .operations
+        .get_mut("items_list")
+        .expect("metadata");
+    let OperationMetadata::Rest { row_path, .. } = metadata else {
+        panic!("expected REST metadata");
+    };
+    row_path.clear();
+    let overridden_plan = imported.validated_plan().expect("overridden plan");
+    sync_projection_catalog(
+        &overridden_plan,
+        &mut catalog,
+        ProjectionInputSyncMode::RecomputeInputExposure,
+    )
+    .expect("sync generated projection");
+
+    let column_names = catalog
+        .projections
+        .first()
+        .expect("projection")
+        .columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(column_names, ["total_count", "items"]);
+}
+
+#[test]
+fn projection_override_columns_survive_effective_row_path_changes() {
+    let (manifest, mut imported) = imported_wrapped_items_surface();
+    let generated_plan = imported.validated_plan().expect("generated plan");
+    let mut catalog = generate_projection_catalog(&manifest, &generated_plan).expect("projections");
+    catalog
+        .projections
+        .first_mut()
+        .expect("projection")
+        .columns
+        .first_mut()
+        .expect("column")
+        .name = "authored_id".to_string();
+
+    let metadata = imported
+        .operation_metadata
+        .operations
+        .get_mut("items_list")
+        .expect("metadata");
+    let OperationMetadata::Rest { row_path, .. } = metadata else {
+        panic!("expected REST metadata");
+    };
+    row_path.clear();
+    let overridden_plan = imported.validated_plan().expect("overridden plan");
+    sync_projection_catalog(
+        &overridden_plan,
+        &mut catalog,
+        ProjectionInputSyncMode::PreserveExistingExposure,
+    )
+    .expect("sync projection override");
+
+    let projection = catalog.projections.first().expect("projection");
+    let column = projection.columns.first().expect("column");
+    assert_eq!(column.name, "authored_id");
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -131,7 +131,7 @@ fn generate_projection(
             }
         })
         .collect::<Vec<_>>();
-    let columns = projection_columns(type_by_id, operation);
+    let columns = projection_columns(plan, type_by_id, operation);
     let name = generated_projection_name(operation, is_search);
     let guide = projection_guide(&kind, &inputs, is_search);
     let projection = Projection {
@@ -300,7 +300,16 @@ fn type_index(ir: &SemanticIr) -> TypeIndex<'_> {
     ir.types.iter().map(|ty| (ty.id.as_str(), ty)).collect()
 }
 
+pub(super) fn derived_projection_columns(
+    plan: &ValidatedSurfacePlan,
+    operation: &IrOperation,
+) -> Vec<ProjectionColumn> {
+    let type_by_id = type_index(plan.semantic_ir());
+    projection_columns(plan, &type_by_id, operation)
+}
+
 fn projection_columns(
+    plan: &ValidatedSurfacePlan,
     type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
 ) -> Vec<ProjectionColumn> {
@@ -327,7 +336,8 @@ fn projection_columns(
             },
         ];
     }
-    let Some(row_type) = type_by_id.get(operation.output.type_ref.as_str()) else {
+    let effective_type_ref = plan.rest_output_type_ref(&operation.id);
+    let Some(row_type) = type_by_id.get(effective_type_ref) else {
         return vec![ProjectionColumn {
             name: "value".to_string(),
             data_type: ManifestDataType::Json,

--- a/crates/coral-spec/src/v4/projections/mod.rs
+++ b/crates/coral-spec/src/v4/projections/mod.rs
@@ -12,4 +12,4 @@ pub use runtime::{
     mcp_projection_arg_specs, projection_arg_specs, projection_column_specs,
     projection_filter_specs, request_spec_for_projection,
 };
-pub use sync::{ProjectionInputSyncMode, sync_projection_inputs};
+pub use sync::{ProjectionInputSyncMode, sync_projection_catalog, sync_projection_inputs};

--- a/crates/coral-spec/src/v4/projections/sync.rs
+++ b/crates/coral-spec/src/v4/projections/sync.rs
@@ -8,6 +8,8 @@ use crate::v4::operation_metadata::ValidatedSurfacePlan;
 use crate::v4::projections::{ProjectionCatalog, ProjectionKind, SqlInputExposure};
 use crate::{ManifestError, Result};
 
+use super::derive::derived_projection_columns;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProjectionInputSyncMode {
     RecomputeInputExposure,
@@ -65,6 +67,34 @@ pub fn sync_projection_inputs(
             input.lookup_key = matches!(operation.execution, IrExecutionAttachment::Rest(_))
                 && input.sql_exposure == SqlInputExposure::Filter
                 && plan.input_is_lookup_key(&operation.id, &input.wire_name);
+        }
+    }
+    Ok(())
+}
+
+/// Synchronizes every projection field derived from effective operation
+/// metadata. Authored projection overrides retain their explicit columns.
+pub fn sync_projection_catalog(
+    plan: &ValidatedSurfacePlan,
+    projections: &mut ProjectionCatalog,
+    mode: ProjectionInputSyncMode,
+) -> Result<()> {
+    sync_projection_inputs(plan, projections, mode)?;
+    if mode != ProjectionInputSyncMode::RecomputeInputExposure {
+        return Ok(());
+    }
+
+    for projection in &mut projections.projections {
+        let Some(operation) = plan
+            .semantic_ir()
+            .operations
+            .iter()
+            .find(|operation| operation.id == projection.operation_id)
+        else {
+            continue;
+        };
+        if matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
+            projection.columns = derived_projection_columns(plan, operation);
         }
     }
     Ok(())

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -5,6 +5,15 @@ use serde_json::Value;
 use crate::v4::ir::IrScalarType;
 
 const ANNOTATION_KEYS: &[&str] = &["$comment", "default", "description", "examples", "title"];
+const WRAPPED_LIST_MAX_DEPTH: usize = 8;
+const WRAPPED_LIST_PREFERRED_PROPERTIES: &[&str] = &["items", "data", "results", "rows"];
+const WRAPPED_LIST_METADATA_PROPERTIES: &[&str] = &[
+    "total_count",
+    "incomplete_results",
+    "has_more",
+    "next",
+    "previous",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RefError<'a> {
@@ -30,6 +39,131 @@ pub(crate) enum JsonSchemaComparisonError {
 pub(crate) struct JsonObjectShape {
     pub(crate) properties: BTreeMap<String, Value>,
     pub(crate) required: BTreeSet<String>,
+}
+
+/// Inputs available to wrapped-list inference.
+///
+/// The operation name is deliberately part of the context even though the
+/// initial heuristic is schema-only. Future inference policy can add naming,
+/// pagination, and other signals without changing every surface importer.
+#[derive(Clone, Copy)]
+pub(crate) struct WrappedListInferenceContext<'a> {
+    pub(crate) operation_name: &'a str,
+    pub(crate) schema_root: &'a Value,
+    pub(crate) response_schema: &'a Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WrappedListInference {
+    pub(crate) row_path: Vec<String>,
+}
+
+pub(crate) fn infer_wrapped_list(
+    context: WrappedListInferenceContext<'_>,
+) -> Option<WrappedListInference> {
+    let _ = context.operation_name;
+    infer_wrapped_list_path(
+        context.schema_root,
+        context.response_schema,
+        &mut BTreeSet::new(),
+        0,
+    )
+    .ok()
+    .flatten()
+    .map(|row_path| WrappedListInference { row_path })
+}
+
+fn infer_wrapped_list_path<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> Result<Option<Vec<String>>, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        WRAPPED_LIST_MAX_DEPTH,
+        |resolved, resolving_refs, next_depth| {
+            if schema_uses_composition(resolved) {
+                return Ok(None);
+            }
+            if !json_schema_type_contains(resolved, "object") {
+                return Ok(None);
+            }
+            let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
+                return Ok(None);
+            };
+
+            // Preserve the legacy preference order for direct payload arrays.
+            for name in WRAPPED_LIST_PREFERRED_PROPERTIES {
+                if let Some(property) = properties.get(*name)
+                    && resolved_schema_has_type(
+                        root,
+                        property,
+                        resolving_refs,
+                        next_depth,
+                        "array",
+                    )?
+                {
+                    return Ok(Some(vec![(*name).to_string()]));
+                }
+            }
+
+            // Recurse only through preferred wrapper names. This adds nested
+            // envelopes such as `results.data` without turning the heuristic
+            // into an unrestricted walk of every resource child.
+            for name in WRAPPED_LIST_PREFERRED_PROPERTIES {
+                if let Some(property) = properties.get(*name)
+                    && let Some(mut path) =
+                        infer_wrapped_list_path(root, property, resolving_refs, next_depth)?
+                {
+                    path.insert(0, (*name).to_string());
+                    return Ok(Some(path));
+                }
+            }
+
+            let mut arrays = Vec::new();
+            for (name, property) in properties {
+                if WRAPPED_LIST_METADATA_PROPERTIES.contains(&name.as_str()) {
+                    continue;
+                }
+                if resolved_schema_has_type(root, property, resolving_refs, next_depth, "array")? {
+                    arrays.push(name);
+                }
+            }
+            match arrays.as_slice() {
+                [name] => Ok(Some(vec![(*name).clone()])),
+                [] | [_, _, ..] => Ok(None),
+            }
+        },
+    )
+}
+
+fn schema_uses_composition(schema: &Value) -> bool {
+    ["allOf", "anyOf", "oneOf", "not"]
+        .iter()
+        .any(|keyword| schema.get(*keyword).is_some())
+}
+
+fn resolved_schema_has_type<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    expected: &str,
+) -> Result<bool, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        WRAPPED_LIST_MAX_DEPTH,
+        |resolved, _, _| {
+            Ok(!schema_uses_composition(resolved) && json_schema_type_contains(resolved, expected))
+        },
+    )
 }
 
 pub(crate) fn resolve_local_ref<'a>(
@@ -588,6 +722,148 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    fn inferred_row_path(root: &Value, response_schema: &Value) -> Option<Vec<String>> {
+        infer_wrapped_list(WrappedListInferenceContext {
+            operation_name: "list_items",
+            schema_root: root,
+            response_schema,
+        })
+        .map(|inference| inference.row_path)
+    }
+
+    #[test]
+    fn wrapped_list_prefers_named_direct_arrays_in_stable_order() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "data": {"type": "array", "items": {"type": "object"}},
+                "items": {"type": "array", "items": {"type": "object"}}
+            }
+        });
+
+        assert_eq!(
+            inferred_row_path(&schema, &schema),
+            Some(vec!["items".into()])
+        );
+    }
+
+    #[test]
+    fn wrapped_list_recurses_through_preferred_wrapper_names() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "results": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {"type": "object"}
+                        }
+                    }
+                }
+            }
+        });
+
+        assert_eq!(
+            inferred_row_path(&schema, &schema),
+            Some(vec!["results".into(), "data".into()])
+        );
+    }
+
+    #[test]
+    fn wrapped_list_falls_back_to_the_sole_non_metadata_array() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "repositories": {"type": "array", "items": {"type": "object"}}
+            }
+        });
+
+        assert_eq!(
+            inferred_row_path(&schema, &schema),
+            Some(vec!["repositories".into()])
+        );
+    }
+
+    #[test]
+    fn wrapped_list_abstains_for_multiple_non_preferred_arrays() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "warnings": {"type": "array", "items": {"type": "string"}},
+                "repositories": {"type": "array", "items": {"type": "object"}}
+            }
+        });
+
+        assert_eq!(inferred_row_path(&schema, &schema), None);
+    }
+
+    #[test]
+    fn wrapped_list_resolves_openapi_component_references_from_document_root() {
+        let document = json!({
+            "components": {
+                "schemas": {
+                    "Envelope": {
+                        "type": "object",
+                        "properties": {
+                            "items": {"$ref": "#/components/schemas/Items"}
+                        }
+                    },
+                    "Items": {
+                        "type": "array",
+                        "items": {"type": "object"}
+                    }
+                }
+            }
+        });
+        let response = json!({"$ref": "#/components/schemas/Envelope"});
+
+        assert_eq!(
+            inferred_row_path(&document, &response),
+            Some(vec!["items".into()])
+        );
+    }
+
+    #[test]
+    fn wrapped_list_resolves_mcp_defs_from_output_schema_root() {
+        let schema = json!({
+            "$defs": {
+                "Items": {
+                    "type": "array",
+                    "items": {"type": "object"}
+                }
+            },
+            "type": "object",
+            "properties": {
+                "items": {"$ref": "#/$defs/Items"}
+            }
+        });
+
+        assert_eq!(
+            inferred_row_path(&schema, &schema),
+            Some(vec!["items".into()])
+        );
+    }
+
+    #[test]
+    fn wrapped_list_abstains_for_unresolvable_or_composed_schemas() {
+        let external = json!({"$ref": "https://example.com/schema.json#/Envelope"});
+        let composed = json!({
+            "type": "object",
+            "properties": {
+                "items": {"type": "array", "items": {"type": "object"}}
+            },
+            "oneOf": [
+                {"type": "object", "properties": {"items": {"type": "array"}}}
+            ]
+        });
+
+        assert_eq!(inferred_row_path(&external, &external), None);
+        assert_eq!(inferred_row_path(&composed, &composed), None);
+    }
 
     #[test]
     fn scalar_type_accepts_nullable_type_arrays() {

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -934,6 +934,14 @@ surface:
             wrapped_items.output.cardinality,
             OutputCardinality::Singleton
         );
+        assert_eq!(
+            ir.operation_metadata
+                .operations
+                .get("wrapped_items")
+                .expect("metadata")
+                .row_path(),
+            ["items"]
+        );
         let wrapped_fields = row_fields(&ir, "wrapped_items_row");
         assert_eq!(field(wrapped_fields, "items").type_ref, "mcp_json");
         assert!(wrapped_fields.iter().any(|field| field.name == "raw"));
@@ -951,7 +959,7 @@ surface:
     }
 
     #[test]
-    fn does_not_infer_cursor_pagination_for_wrapped_list_envelopes() {
+    fn infers_cursor_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-items",
@@ -990,13 +998,16 @@ surface:
         let operation = operation(&ir, "list_items");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
         let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_items"), ["items"]);
         let (cursor, offset) = plan.mcp_pagination("list_items");
-        assert!(cursor.is_none());
+        let cursor = cursor.expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
         assert!(offset.is_none());
     }
 
     #[test]
-    fn does_not_infer_offset_pagination_for_wrapped_list_envelopes() {
+    fn infers_offset_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-catalog",
@@ -1044,9 +1055,15 @@ surface:
         let surface = &v4.surface;
         let ir = import_mcp_surface(v4, surface, &catalog).expect("import");
         let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_catalog"), ["items"]);
         let (cursor, offset) = plan.mcp_pagination("list_catalog");
         assert!(cursor.is_none());
-        assert!(offset.is_none());
+        let offset = offset.expect("offset pagination");
+        assert_eq!(offset.limit_arg, "limit");
+        assert_eq!(offset.default_limit, 50);
+        assert_eq!(offset.max_limit, 200);
+        assert_eq!(offset.offset_arg, "offset");
+        assert_eq!(offset.offset_start, 0);
 
         let projections = generate_projection_catalog(v4, &ir.validated_plan().expect("plan"))
             .expect("projection catalog");
@@ -1055,12 +1072,9 @@ surface:
             .iter()
             .find(|projection| projection.operation_id == "list_catalog")
             .expect("projection");
-        assert!(matches!(
-            projection.kind,
-            crate::v4::ProjectionKind::TableFunction { .. }
-        ));
+        assert!(matches!(projection.kind, crate::v4::ProjectionKind::Table));
         for input in &projection.inputs {
-            assert_eq!(input.sql_exposure, SqlInputExposure::FunctionArg);
+            assert_eq!(input.sql_exposure, SqlInputExposure::Internal);
         }
     }
 
@@ -1124,7 +1138,7 @@ surface:
     }
 
     #[test]
-    fn object_with_sibling_array_without_cursor_stays_singleton() {
+    fn preferred_child_array_is_metadata_while_semantic_output_stays_singleton() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "get-item",
@@ -1151,6 +1165,14 @@ surface:
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "get_item");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+        assert_eq!(
+            ir.operation_metadata
+                .operations
+                .get("get_item")
+                .expect("metadata")
+                .row_path(),
+            ["items"]
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -1,6 +1,7 @@
 use crate::v4::ir::{
     IrEntityCandidate, IrExecutionAttachment, IrOperation, McpExecutionAttachment,
 };
+use crate::v4::surfaces::json_schema::{WrappedListInferenceContext, infer_wrapped_list};
 use crate::v4::{McpOperationPagination, OperationMetadata};
 
 use super::import::McpImporter;
@@ -23,9 +24,22 @@ impl McpImporter<'_> {
 
         let inputs = imported_inputs.inputs;
         let output = self.import_output(operation_id, tool.output_schema.as_ref());
+        let row_path = tool
+            .output_schema
+            .as_ref()
+            .and_then(|schema| {
+                infer_wrapped_list(WrappedListInferenceContext {
+                    operation_name: &tool.name,
+                    schema_root: schema,
+                    response_schema: schema,
+                })
+            })
+            .map(|inference| inference.row_path)
+            .unwrap_or_default();
         let (pagination, offset_pagination) = infer_mcp_pagination_contracts(
             &inputs,
             &output,
+            &row_path,
             tool.output_schema.as_ref(),
             &tool.input_schema,
         );
@@ -55,6 +69,7 @@ impl McpImporter<'_> {
         Some((
             operation,
             OperationMetadata::Mcp {
+                row_path,
                 pagination: McpOperationPagination {
                     cursor: pagination,
                     offset: offset_pagination,

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -7,13 +7,14 @@ use crate::v4::surfaces::json_schema::json_schema_type_contains;
 pub(super) fn infer_mcp_pagination_contracts(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     output_schema: Option<&Value>,
     input_schema: &Value,
 ) -> (Option<McpPaginationSpec>, Option<McpOffsetPaginationSpec>) {
-    let pagination = infer_mcp_pagination(inputs, output, output_schema);
+    let pagination = infer_mcp_pagination(inputs, output, row_path, output_schema);
     let offset_pagination = pagination
         .is_none()
-        .then(|| infer_mcp_offset_pagination(inputs, output, input_schema))
+        .then(|| infer_mcp_offset_pagination(inputs, output, row_path, input_schema))
         .flatten();
     (pagination, offset_pagination)
 }
@@ -21,12 +22,10 @@ pub(super) fn infer_mcp_pagination_contracts(
 fn infer_mcp_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     output_schema: Option<&Value>,
 ) -> Option<McpPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
+    if !is_list_like_output(output, row_path) {
         return None;
     }
     let cursor_arg = cursor_input_name(inputs)?;
@@ -41,12 +40,10 @@ fn infer_mcp_pagination(
 fn infer_mcp_offset_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     input_schema: &Value,
 ) -> Option<McpOffsetPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
+    if !is_list_like_output(output, row_path) {
         return None;
     }
     let properties = input_schema.get("properties").and_then(Value::as_object)?;
@@ -69,6 +66,10 @@ fn infer_mcp_offset_pagination(
         offset_start: offset.default,
         max_pages: None,
     })
+}
+
+fn is_list_like_output(output: &IrOperationOutput, row_path: &[String]) -> bool {
+    output.cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 
 struct OffsetPaginationInput<'a> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -12,10 +12,13 @@ use crate::v4::ir::{
 use crate::v4::lookup_keys::infer_rest_lookup_keys;
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
-    json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
-    json_schema_type_display,
+    WrappedListInferenceContext, infer_wrapped_list, json_schema_default_to_string,
+    json_schema_scalar_type_or_string, json_schema_type_contains, json_schema_type_display,
 };
-use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
+use crate::{
+    ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
+    v4::resolve_output_row_type_ref,
+};
 
 use super::import::OpenApiImporter;
 use super::responses::OpenApiResponsePaginationContext;
@@ -45,7 +48,24 @@ impl OpenApiImporter<'_> {
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
         let (output, response, entity, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
-        let pagination = detect_pagination(&parameters, &pagination_context);
+        let inferred_row_path = infer_wrapped_list(WrappedListInferenceContext {
+            operation_name: raw_operation_id.unwrap_or(&operation_id),
+            schema_root: self.document,
+            response_schema: &pagination_context.schema,
+        })
+        .map(|inference| inference.row_path)
+        .unwrap_or_default();
+        let types = self
+            .types
+            .iter()
+            .map(|(id, ty)| (id.as_str(), ty))
+            .collect::<BTreeMap<_, _>>();
+        let row_path = if resolve_output_row_type_ref(&output, &inferred_row_path, &types).is_ok() {
+            inferred_row_path
+        } else {
+            Vec::new()
+        };
+        let pagination = detect_pagination(&parameters, &pagination_context, &row_path);
         let lookup_keys = infer_rest_lookup_keys(&parameters, &pagination);
         let rest_parameters = parameters
             .iter()
@@ -91,6 +111,7 @@ impl OpenApiImporter<'_> {
         Ok((
             operation,
             OperationMetadata::Rest {
+                row_path,
                 pagination,
                 lookup_keys,
             },
@@ -308,8 +329,9 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
 fn detect_pagination(
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
+    row_path: &[String],
 ) -> PaginationSpec {
-    if !is_paginated_cardinality(context.cardinality) {
+    if !is_list_like_output(context.cardinality, row_path) {
         return PaginationSpec::default();
     }
     detect_link_header_pagination(inputs, context)
@@ -583,11 +605,8 @@ fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
         && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
 }
 
-fn is_paginated_cardinality(cardinality: OutputCardinality) -> bool {
-    matches!(
-        cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    )
+fn is_list_like_output(cardinality: OutputCardinality, row_path: &[String]) -> bool {
+    cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 
 fn page_size_spec(input: &IrOperationInput) -> PageSizeSpec {


### PR DESCRIPTION
## Summary

- restore shared wrapped-list response-envelope detection for OpenAPI and MCP imports
- keep the full envelope as a singleton semantic fact while storing the inferred `row_path` in operation metadata
- use the effective row path for pagination inference, REST projection columns, and HTTP/MCP runtime row extraction
- reconcile generated projection columns after operation-metadata overrides while preserving authored projection override columns

## Why

Response schemas such as `{ results: { data: [...] }, total_count: 53 }` currently become one SQL row containing the envelope rather than a relation over the nested array. Earlier wrapped-list handling encoded that inference as semantic cardinality, which mixed policy with imported facts and created durable false positives.

This change restores the broad legacy heuristic but confines the decision to overridable operation metadata. Semantic IR continues to describe the actual response envelope.

The heuristic prefers direct `items`, `data`, `results`, or `rows` arrays, recursively follows only those wrapper names, and otherwise accepts a sole direct non-metadata array. It is bounded and abstains on ambiguous, unresolved, cyclic, external-reference, and composed schemas.

The broad heuristic deliberately retains known false positives: a resource response with a preferred child array can still be interpreted as a row envelope. Tests document that trade-off.

Closes #1910

## Validation

- `make rust-checks` — passed formatting, Clippy with warnings denied, 2,067 workspace tests, and Rust documentation checks
- focused `coral-spec`, runtime-package, and materialization tests — passed
- `make perf-check` — started, but the cold release build was interrupted before the benchmark ran; performance validation remains outstanding