### PR TITLE
perf(traces): bound Query Stream operation detail reads

### DIFF
--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -14,7 +14,8 @@ use classification::{
 use super::{
     StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord, TraceListSpanRecord,
     TraceSpanRecord, TraceStore, TraceStoreError, TraceStoreFile, TraceSummaryRecord, attr_string,
-    attr_u64, parse_attributes, read_list_spans_file, status_from_attributes, usize_to_u32,
+    attr_u64, parse_attributes, read_list_spans_file, read_trace_spans_file,
+    status_from_attributes, usize_to_u32,
 };
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
@@ -88,32 +89,26 @@ pub(super) fn get(
     root_span_id: &str,
     workspace_name: Option<&str>,
 ) -> Result<TraceDetailRecord, TraceStoreError> {
-    let trace = store.get_trace_sync(trace_id)?;
-    let spans_by_id = trace
-        .spans
-        .iter()
-        .map(|span| (span.span_id.as_str(), span))
-        .collect::<HashMap<_, _>>();
-    let root = spans_by_id
-        .get(root_span_id)
-        .copied()
-        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
-    if query_stream_metadata(root).is_none() || !query_stream_root_is_visible(root, &spans_by_id) {
+    store.prune_expired()?;
+    let files = store.jsonl_files_by_modified()?;
+    let (root_file_index, root) = find_query_stream_root(&files, trace_id, root_span_id)?;
+    if query_stream_metadata(&root).is_none()
+        || !query_stream_root_is_visible(&files, root_file_index, &root)?
+    {
         return Err(TraceStoreError::NotFound(trace_id.to_string()));
     }
 
-    let mut spans = collect_query_stream_operation_spans(trace.spans, trace_id, root_span_id)?;
-    let span_refs = spans.iter().collect::<Vec<_>>();
-    let summary = query_stream_summaries(&span_refs, workspace_name)
-        .into_iter()
-        .find(|summary| summary.root_span_id == root_span_id)
-        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
+    let mut spans = collect_query_stream_operation_spans(&files, root_file_index, root)?;
     spans.sort_by(|left, right| {
         left.start_time_unix_nanos
             .cmp(&right.start_time_unix_nanos)
             .then_with(|| left.span_id.cmp(&right.span_id))
     });
-    debug_assert_eq!(spans.len(), summary.span_count as usize);
+    let span_refs = spans.iter().collect::<Vec<_>>();
+    let summary = query_stream_summaries(&span_refs, workspace_name)
+        .into_iter()
+        .find(|summary| summary.root_span_id == root_span_id)
+        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
     Ok(TraceDetailRecord { summary, spans })
 }
 
@@ -565,36 +560,95 @@ fn take_indexed_values_after<T>(index: &mut BTreeMap<i64, Vec<T>>, watermark: i6
     index.split_off(&split_at).into_values().flatten().collect()
 }
 
-// Selected-operation DETAIL. This layer applies operation ownership semantics
-// to a complete locally stored trace. A later stack layer narrows the file
-// reads without changing the selection result.
+// Selected-operation DETAIL. This section resolves one visible operation and
+// collects only the descendant spans owned by that operation.
+
+fn find_query_stream_root(
+    files: &[TraceStoreFile],
+    trace_id: &str,
+    root_span_id: &str,
+) -> Result<(usize, TraceSpanRecord), TraceStoreError> {
+    for (file_index, file) in files.iter().enumerate().rev() {
+        if let Some(root) = read_trace_spans_file(&file.path, trace_id)?
+            .into_iter()
+            .find(|span| span.span_id == root_span_id)
+        {
+            return Ok((file_index, root));
+        }
+    }
+    Err(TraceStoreError::NotFound(trace_id.to_string()))
+}
 
 fn query_stream_root_is_visible(
+    files: &[TraceStoreFile],
+    root_file_index: usize,
     root: &TraceSpanRecord,
-    spans_by_id: &HashMap<&str, &TraceSpanRecord>,
-) -> bool {
-    let mut parent_span_id = root.parent_span_id.as_deref();
+) -> Result<bool, TraceStoreError> {
+    let root_file = files
+        .get(root_file_index)
+        .ok_or_else(|| TraceStoreError::NotFound(root.trace_id.clone()))?;
+    let root_bucket = equal_mtime_file_bucket(files, root_file.modified_unix_nanos);
+    let conservative_start = files
+        .partition_point(|file| file.span_end_upper_bound_unix_nanos < root.end_time_unix_nanos);
+    let mut parent_span_id = root.parent_span_id.clone();
     let mut parent_span_is_remote = root.parent_span_is_remote;
     let mut visited = HashSet::new();
-    while let Some(current_parent_span_id) = parent_span_id {
-        if parent_span_is_remote {
-            return true;
-        }
-        if !visited.insert(current_parent_span_id) {
-            return false;
-        }
-        let Some(parent) = spans_by_id.get(current_parent_span_id).copied() else {
-            return false;
-        };
-        if query_stream_metadata(parent).is_some_and(|metadata| metadata.explicit)
-            || is_unmarked_mcp_protocol_span(parent)
-        {
-            return false;
-        }
-        parent_span_id = parent.parent_span_id.as_deref();
-        parent_span_is_remote = parent.parent_span_is_remote;
+
+    if parent_span_id.is_none() || parent_span_is_remote {
+        return Ok(true);
     }
-    true
+
+    // A parent's end cannot precede the selected root's end. Start at the
+    // conservative file bound, but always include the root's complete
+    // equal-mtime bucket because path order is only a deterministic tie-break.
+    let mut bucket_start = conservative_start.min(root_bucket.start);
+    while let Some(bucket_file) = files.get(bucket_start) {
+        let bucket = equal_mtime_file_bucket(files, bucket_file.modified_unix_nanos);
+        let spans_by_id = read_trace_spans_by_id(files, bucket.clone(), &root.trace_id)?;
+        loop {
+            let Some(current_parent_span_id) = parent_span_id.as_deref() else {
+                return Ok(true);
+            };
+            if parent_span_is_remote {
+                return Ok(true);
+            }
+            let Some(parent) = spans_by_id.get(current_parent_span_id) else {
+                break;
+            };
+            if !visited.insert(current_parent_span_id.to_string()) {
+                return Ok(false);
+            }
+            if query_stream_metadata(parent).is_some_and(|metadata| metadata.explicit)
+                || is_unmarked_mcp_protocol_span(parent)
+            {
+                return Ok(false);
+            }
+            parent_span_id.clone_from(&parent.parent_span_id);
+            parent_span_is_remote = parent.parent_span_is_remote;
+        }
+        bucket_start = bucket.end;
+    }
+    Ok(false)
+}
+
+fn read_trace_spans_by_id(
+    files: &[TraceStoreFile],
+    range: std::ops::Range<usize>,
+    trace_id: &str,
+) -> Result<HashMap<String, TraceSpanRecord>, TraceStoreError> {
+    let mut spans_by_id = HashMap::new();
+    for file in files
+        .iter()
+        .skip(range.start)
+        .take(range.end.saturating_sub(range.start))
+    {
+        for span in read_trace_spans_file(&file.path, trace_id)? {
+            // Ascending (mtime, path) order preserves the store's newest-record
+            // precedence when a span is duplicated within the scanned range.
+            spans_by_id.insert(span.span_id.clone(), span);
+        }
+    }
+    Ok(spans_by_id)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -603,74 +657,123 @@ struct SelectedOperationNodeState {
 }
 
 fn collect_query_stream_operation_spans(
-    spans: Vec<TraceSpanRecord>,
-    trace_id: &str,
-    root_span_id: &str,
+    files: &[TraceStoreFile],
+    root_file_index: usize,
+    root: TraceSpanRecord,
 ) -> Result<Vec<TraceSpanRecord>, TraceStoreError> {
-    let mut candidates = spans
-        .into_iter()
-        .map(|span| (span.span_id.clone(), span))
-        .collect::<HashMap<_, _>>();
-    let root = candidates
-        .remove(root_span_id)
-        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
+    let trace_id = root.trace_id.clone();
+    let root_span_id = root.span_id.clone();
+    let root_start_time_unix_nanos = root.start_time_unix_nanos;
+    let root_file = files
+        .get(root_file_index)
+        .ok_or_else(|| TraceStoreError::NotFound(trace_id.clone()))?;
+    let root_bucket = equal_mtime_file_bucket(files, root_file.modified_unix_nanos);
+    let conservative_start = files
+        .partition_point(|file| file.span_end_upper_bound_unix_nanos < root_start_time_unix_nanos);
     let root_metadata = query_stream_metadata(&root)
         .expect("query stream root metadata was validated before collecting descendants");
     let root_state = SelectedOperationNodeState {
         suppresses_entries: root_metadata.explicit || is_unmarked_mcp_protocol_span(&root),
     };
-    let mut node_states = HashMap::from([(root_span_id.to_string(), root_state)]);
-    let mut selected = HashMap::from([(root_span_id.to_string(), root)]);
-    let mut children_by_parent = HashMap::<String, Vec<TraceSpanRecord>>::new();
-    for span in candidates.into_values() {
-        let Some(parent_span_id) = span.parent_span_id.as_deref() else {
-            continue;
-        };
-        children_by_parent
-            .entry(parent_span_id.to_string())
-            .or_default()
-            .push(span);
-    }
-    let mut ready = children_by_parent.remove(root_span_id).unwrap_or_default();
+    let mut node_states = HashMap::from([(root_span_id.clone(), root_state)]);
+    let mut spans_by_id = HashMap::from([(root_span_id, root)]);
 
-    while let Some(span) = ready.pop() {
-        if node_states.contains_key(&span.span_id) {
-            continue;
+    // Descendants cannot start before the selected root. Scan from the end of
+    // its complete equal-mtime bucket back to the conservative file bound,
+    // resolving each bucket atomically because path order is not causal.
+    let candidate_start = conservative_start.min(root_bucket.start);
+    let mut bucket_end = root_bucket.end;
+    while bucket_end > candidate_start {
+        let newest_bucket_file = files
+            .get(bucket_end - 1)
+            .ok_or_else(|| TraceStoreError::NotFound(trace_id.clone()))?;
+        let bucket = equal_mtime_file_bucket(files, newest_bucket_file.modified_unix_nanos);
+        let bucket_start = bucket.start.max(candidate_start);
+        let bucket_spans_by_id =
+            read_trace_spans_by_id(files, bucket_start..bucket_end, &trace_id)?;
+        let mut children_by_parent = HashMap::<String, Vec<TraceSpanRecord>>::new();
+        let mut ready = Vec::new();
+        for span in bucket_spans_by_id.into_values() {
+            if node_states.contains_key(&span.span_id) {
+                continue;
+            }
+            let Some(parent_span_id) = span.parent_span_id.as_deref() else {
+                continue;
+            };
+            if node_states.contains_key(parent_span_id) {
+                ready.push(span);
+            } else {
+                children_by_parent
+                    .entry(parent_span_id.to_string())
+                    .or_default()
+                    .push(span);
+            }
         }
-        let Some(parent) = span
-            .parent_span_id
-            .as_deref()
-            .and_then(|parent_span_id| node_states.get(parent_span_id))
-            .copied()
-        else {
-            continue;
-        };
-        let metadata = query_stream_metadata(&span);
-        let starts_nested_visible_operation = metadata.is_some() && !parent.suppresses_entries;
-        if starts_nested_visible_operation {
-            // This is the root of a separate visible operation. Prune its
-            // branch instead of retaining false ownership state for it.
-            continue;
+
+        while let Some(span) = ready.pop() {
+            if node_states.contains_key(&span.span_id) {
+                continue;
+            }
+            let Some(parent) = span
+                .parent_span_id
+                .as_deref()
+                .and_then(|parent_span_id| node_states.get(parent_span_id))
+                .copied()
+            else {
+                continue;
+            };
+            let metadata = query_stream_metadata(&span);
+            let starts_nested_visible_operation = metadata.is_some() && !parent.suppresses_entries;
+            if starts_nested_visible_operation {
+                // This is the root of a separate visible operation. Prune its
+                // branch instead of retaining false ownership state for it.
+                continue;
+            }
+            let state = SelectedOperationNodeState {
+                suppresses_entries: parent.suppresses_entries
+                    || is_unmarked_mcp_protocol_span(&span)
+                    || metadata.as_ref().is_some_and(|metadata| metadata.explicit),
+            };
+            let span_id = span.span_id.clone();
+            node_states.insert(span_id.clone(), state);
+            spans_by_id.insert(span_id.clone(), span);
+            if let Some(children) = children_by_parent.remove(&span_id) {
+                ready.extend(children);
+            }
         }
-        let state = SelectedOperationNodeState {
-            suppresses_entries: parent.suppresses_entries
-                || is_unmarked_mcp_protocol_span(&span)
-                || metadata.as_ref().is_some_and(|metadata| metadata.explicit),
-        };
-        let span_id = span.span_id.clone();
-        node_states.insert(span_id.clone(), state);
-        selected.insert(span_id.clone(), span);
-        if let Some(children) = children_by_parent.remove(&span_id) {
-            ready.extend(children);
-        }
+
+        debug_assert_eq!(
+            node_states.len(),
+            spans_by_id.len(),
+            "detail projection must not retain state for pruned operation branches"
+        );
+        bucket_end = bucket_start;
     }
 
-    debug_assert_eq!(
-        node_states.len(),
-        selected.len(),
-        "detail projection must not retain state for pruned operation branches"
-    );
-    Ok(selected.into_values().collect())
+    Ok(spans_by_id.into_values().collect())
+}
+
+#[cfg(test)]
+fn assert_query_stream_list_detail_parity(
+    store: &TraceStore,
+    limit: usize,
+    offset: usize,
+    workspace_name: Option<&str>,
+) -> Vec<TraceSummaryRecord> {
+    let summaries = store
+        .list_query_stream_sync(limit, offset, workspace_name)
+        .expect("list query stream fixture");
+    for summary in &summaries {
+        let detail = store
+            .get_query_stream_entry_sync(&summary.trace_id, &summary.root_span_id, workspace_name)
+            .expect("every list row has a matching detail projection");
+        assert_eq!(
+            &detail.summary, summary,
+            "list/detail mismatch for {}/{}",
+            summary.trace_id, summary.root_span_id
+        );
+    }
+    summaries
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
@@ -34,7 +34,7 @@ fn query_stream_projects_outer_operations_and_selects_details_by_span() {
         .build();
 
     let files = TraceFiles::with_records(&[sql_tool, nested_query]);
-    let summaries = files.list(10, 0, None);
+    let summaries = files.list_with_detail(10, 0, None);
     assert_eq!(summaries.len(), 1);
     let sql_summary = summaries.first().expect("SQL summary");
     assert_eq!(sql_summary.root_span_id, "sql-tool");
@@ -90,7 +90,8 @@ fn query_stream_projects_search_text_for_tool_operation() {
         .times(12, 15)
         .build();
 
-    let summaries = project(&[tool, search, internal_query], Some("beta"));
+    let files = TraceFiles::with_records(&[tool, search, internal_query]);
+    let summaries = files.list_with_detail(10, 0, Some("beta"));
     let summary = summaries.first().expect("tool search summary");
     assert_eq!(summaries.len(), 1);
     assert_eq!(summary.root_span_id, "search-tool");
@@ -109,7 +110,8 @@ fn query_stream_projects_search_text_for_direct_operation() {
         .attrs(json!({"coral.local.search.query": "direct search phrase"}))
         .build();
 
-    let summaries = project(&[search], Some("gamma"));
+    let files = TraceFiles::with_records(&[search]);
+    let summaries = files.list_with_detail(10, 0, Some("gamma"));
     let summary = summaries.first().expect("direct search summary");
     assert_eq!(summaries.len(), 1);
     assert_eq!(summary.root_span_id, "direct-search");
@@ -183,7 +185,7 @@ fn query_stream_hides_entries_with_unfinished_local_parents() {
     .to_string();
 
     let files = TraceFiles::with_records(&[unfinished_child, remote_root]);
-    let summaries = files.list(10, 0, Some("alpha"));
+    let summaries = files.list_with_detail(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     assert_eq!(
         summaries.first().expect("remote summary").root_span_id,
@@ -266,7 +268,7 @@ fn query_stream_detail_excludes_nested_visible_operations() {
     nested_child.name = "coral.future.child".to_string();
 
     let files = TraceFiles::with_records(&[outer, nested, nested_child]);
-    let summaries = files.list(10, 0, None);
+    let summaries = files.list_with_detail(10, 0, None);
     assert_eq!(summaries.len(), 2);
 
     let detail = files
@@ -283,6 +285,8 @@ fn query_stream_detail_excludes_nested_visible_operations() {
         vec!["outer-query"]
     );
 }
+
+// LIST projection, pagination, and streaming behavior.
 
 #[test]
 fn query_stream_projects_many_operations_from_one_distributed_trace() {
@@ -357,7 +361,8 @@ fn query_stream_suppresses_protocol_descendants_without_method_enumeration() {
     direct_future.start_time_unix_nanos = 10;
     direct_future.end_time_unix_nanos = 11;
 
-    let summaries = project(&[protocol, protocol_child, direct_future], Some("alpha"));
+    let files = TraceFiles::with_records(&[protocol, protocol_child, direct_future]);
+    let summaries = files.list_with_detail(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     let summary = summaries.first().expect("future summary");
     assert_eq!(summary.root_span_id, "direct-future");
@@ -419,7 +424,7 @@ fn query_stream_supports_legacy_operations_and_protocol_suppression() {
         search,
         search_catalog_query,
     ]);
-    let summaries = files.list(10, 0, Some("alpha"));
+    let summaries = files.list_with_detail(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 2);
     let search_summary = summaries.first().expect("legacy search summary");
     assert_eq!(search_summary.root_span_id, "legacy-search-tool");
@@ -479,7 +484,7 @@ fn query_stream_detail_uses_search_text_without_inheriting_internal_query() {
         .build();
 
     let files = TraceFiles::with_records(&[tool, search, query]);
-    let summaries = files.list(10, 0, Some("alpha"));
+    let summaries = files.list_with_detail(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     let summary = summaries.first().expect("search tool summary");
     assert_eq!(summary.root_span_id, "search-tool");
@@ -531,8 +536,9 @@ fn query_stream_legacy_tool_requires_consistent_descendant_workspace() {
     beta.end_time_unix_nanos = 21;
 
     let records = [tool, alpha, beta];
-    assert!(project(&records, Some("alpha")).is_empty());
-    let global = project(&records, None);
+    let files = TraceFiles::with_records(&records);
+    assert!(files.list(10, 0, Some("alpha")).is_empty());
+    let global = files.list_with_detail(10, 0, None);
     assert_eq!(global.len(), 1);
     assert_eq!(
         global.first().expect("legacy tool").operation_name,

--- a/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
@@ -5,11 +5,91 @@ use std::time::{Duration, SystemTime};
 use serde_json::json;
 
 use super::super::{StoredTraceStatus, TraceListSpanRecord, unix_nanos};
-use super::QueryStreamProjector;
 use super::test_support::{TraceFiles, span};
+use super::{QueryStreamProjector, query_stream_root_is_visible};
 
 #[test]
-fn query_stream_resolves_equal_mtime_files_as_one_bucket() {
+fn query_stream_search_detail_stops_before_unrelated_older_files() {
+    let files = TraceFiles::new();
+    let base_time = SystemTime::now() - Duration::from_secs(20);
+    let root_start = base_time + Duration::from_secs(5);
+    let root_end = base_time + Duration::from_secs(8);
+
+    let root = span("bounded-detail-trace", "selected-tool")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("tool", "search", "alpha")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "search",
+        }))
+        .times(unix_nanos(root_start), unix_nanos(root_end))
+        .build();
+    let child = span("bounded-detail-trace", "selected-search")
+        .named("coral.search")
+        .child_of(&root)
+        .entry("search", "search", "alpha")
+        .attrs(json!({"coral.local.search.query": "bounded search phrase"}))
+        .times(
+            unix_nanos(root_start + Duration::from_secs(1)),
+            unix_nanos(root_start + Duration::from_secs(2)),
+        )
+        .build();
+    files.write_records_at(&[child, root], root_end);
+
+    // This trace-shaped directory fails if opened as JSONL. Its conservative
+    // end bound is before the selected root, so detail must not touch it.
+    files.write_directory_at("spans-unrelated-old.jsonl", base_time);
+
+    let detail = files
+        .get("bounded-detail-trace", "selected-tool", Some("alpha"))
+        .expect("get bounded detail without opening unrelated older file");
+    assert_eq!(detail.summary.root_span_id, "selected-tool");
+    assert_eq!(detail.summary.query, "bounded search phrase");
+    assert!(!detail.summary.row_count_recorded);
+    assert_eq!(detail.spans.len(), 2);
+}
+
+#[test]
+fn query_stream_remote_parent_visibility_stops_before_unrelated_newer_files() {
+    let files = TraceFiles::new();
+    let base_time = SystemTime::now() - Duration::from_secs(20);
+    let root_end = base_time + Duration::from_secs(5);
+    let newer_time = base_time + Duration::from_secs(10);
+
+    let root = span("forward-bounded-trace", "selected-tool")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("tool", "sql", "alpha")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "sql",
+        }))
+        .times(1, unix_nanos(root_end))
+        .build();
+    files.write_at(&root, root_end);
+
+    // Root discovery has already selected `root`; its remote parent must stop
+    // the forward ancestry scan before this unreadable trace-shaped directory.
+    files.write_directory_at("spans-unrelated-new.jsonl", newer_time);
+
+    let store = files.store();
+    let trace_files = store
+        .jsonl_files_by_modified()
+        .expect("list trace store files");
+    let root_path = files.timestamped_path(root_end);
+    let root_file_index = trace_files
+        .iter()
+        .position(|file| file.path == root_path)
+        .expect("root file index");
+    assert!(
+        query_stream_root_is_visible(&trace_files, root_file_index, &root)
+            .expect("check remote-parent visibility")
+    );
+}
+
+#[test]
+fn query_stream_list_and_detail_resolve_equal_mtime_files_as_one_bucket() {
     let files = TraceFiles::new();
     let base_time = SystemTime::now() - Duration::from_secs(10);
     let common_modified = base_time + Duration::from_secs(1);
@@ -52,7 +132,7 @@ fn query_stream_resolves_equal_mtime_files_as_one_bucket() {
         files.write_named_at(name, span, common_modified);
     }
 
-    let summaries = files.list(10, 0, Some("alpha"));
+    let summaries = files.list_with_detail(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     let summary = summaries.first().expect("equal-mtime summary");
     assert_eq!(summary.root_span_id, "selected-tool");
@@ -60,6 +140,19 @@ fn query_stream_resolves_equal_mtime_files_as_one_bucket() {
     assert_eq!(summary.row_count, 1);
     assert!(summary.row_count_recorded);
     assert_eq!(summary.span_count, 2);
+
+    let detail = files
+        .get("equal-mtime-trace", "selected-tool", Some("alpha"))
+        .expect("get equal-mtime operation detail");
+    assert_eq!(detail.summary, *summary);
+    assert_eq!(
+        detail
+            .spans
+            .iter()
+            .map(|span| span.span_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["selected-tool", "nested-query"]
+    );
 }
 
 #[test]
@@ -149,7 +242,7 @@ fn query_stream_offset_page_reads_enough_recent_files_then_stops() {
     files.write_at(&second, second_time);
     files.write_invalid_at(unreadable_time);
 
-    let summaries = files.list(1, 1, Some("alpha"));
+    let summaries = files.list_with_detail(1, 1, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     assert_eq!(
         summaries.first().expect("offset summary").root_span_id,
@@ -187,7 +280,7 @@ fn query_stream_completes_returned_operations_from_older_files() {
     files.write_at(&child, child_end);
     files.write_at(&root, operation_end);
 
-    let summaries = files.list(1, 0, Some("alpha"));
+    let summaries = files.list_with_detail(1, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     let summary = summaries.first().expect("completed operation summary");
     assert_eq!(summary.root_span_id, "tool-root");
@@ -268,7 +361,7 @@ fn query_stream_keeps_newer_duplicate_span_across_files() {
         .build();
     files.write_at(&newer, newer_modified);
 
-    let summaries = files.list(1, 0, Some("alpha"));
+    let summaries = files.list_with_detail(1, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     assert_eq!(
         summaries.first().expect("newer duplicate summary").query,

--- a/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, FileTimes};
+use std::path::PathBuf;
 use std::time::SystemTime;
 
 use serde_json::{Map, Value, json};
@@ -122,7 +123,13 @@ impl TraceFiles {
     }
 
     pub(super) fn write_at(&self, record: &TraceSpanRecord, modified: SystemTime) {
-        self.write_named_at(&timestamped_jsonl_path(modified), record, modified);
+        self.write_records_at(std::slice::from_ref(record), modified);
+    }
+
+    pub(super) fn write_records_at(&self, records: &[TraceSpanRecord], modified: SystemTime) {
+        let path = self.path(&timestamped_jsonl_path(modified));
+        write_record_file_lines(&path, records);
+        set_modified_time(&path, modified);
     }
 
     pub(super) fn write_named_at(
@@ -131,9 +138,18 @@ impl TraceFiles {
         record: &TraceSpanRecord,
         modified: SystemTime,
     ) {
-        let path = self.temp.path().join(name);
+        let path = self.path(name);
         write_record_file(&path, record);
         set_modified_time(&path, modified);
+    }
+
+    pub(super) fn write_directory_at(&self, name: &str, modified: SystemTime) {
+        let path = self.path(name);
+        fs::create_dir(&path).expect("trace-shaped directory");
+        fs::File::open(&path)
+            .expect("open trace-shaped directory")
+            .set_times(FileTimes::new().set_modified(modified))
+            .expect("set trace-shaped directory modified time");
     }
 
     pub(super) fn write_invalid_at(&self, modified: SystemTime) {
@@ -148,9 +164,18 @@ impl TraceFiles {
         offset: usize,
         workspace_name: Option<&str>,
     ) -> Vec<TraceSummaryRecord> {
-        TraceStore::new(self.temp.path().to_path_buf())
+        self.store()
             .list_query_stream_sync(limit, offset, workspace_name)
             .expect("list query stream")
+    }
+
+    pub(super) fn list_with_detail(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: Option<&str>,
+    ) -> Vec<TraceSummaryRecord> {
+        super::assert_query_stream_list_detail_parity(&self.store(), limit, offset, workspace_name)
     }
 
     pub(super) fn get(
@@ -159,10 +184,19 @@ impl TraceFiles {
         root_span_id: &str,
         workspace_name: Option<&str>,
     ) -> Result<TraceDetailRecord, TraceStoreError> {
-        TraceStore::new(self.temp.path().to_path_buf()).get_query_stream_entry_sync(
-            trace_id,
-            root_span_id,
-            workspace_name,
-        )
+        self.store()
+            .get_query_stream_entry_sync(trace_id, root_span_id, workspace_name)
+    }
+
+    pub(super) fn store(&self) -> TraceStore {
+        TraceStore::new(self.temp.path().to_path_buf())
+    }
+
+    pub(super) fn path(&self, name: &str) -> PathBuf {
+        self.temp.path().join(name)
+    }
+
+    pub(super) fn timestamped_path(&self, modified: SystemTime) -> PathBuf {
+        self.path(&timestamped_jsonl_path(modified))
     }
 }


### PR DESCRIPTION
## Summary

- replace #1902's full-trace detail load with target-aware reads from the local trace store
- find the selected operation root, validate only the local ancestry needed for visibility, and collect only the descendant spans owned by that operation
- treat equal-modification-time files as one bucket so ancestry and descendants do not depend on pathname order
- stop ancestry traversal immediately at remote-parent boundaries
- stop descendant reads at the existing conservative span-end watermark
- keep newer duplicate span records and fail closed on malformed parent cycles
- preserve the same LIST/DETAIL summary, including locally retained Search text, without reading unrelated older files
- add LIST/DETAIL parity plus forward- and backward-bounded read regressions

## Stack boundary

- Layer 6 of 8
- Depends on: #1902
- Next: #1903
- This PR is a storage-read optimization and hardening layer; it does not change the API or selected-operation semantics introduced below it.

## Validation

- `make rust-checks`: passed at the final stack tip (format, Clippy, 2,399 tests passed / 6 skipped, rustdoc)
- `cargo test -p coral-app query_stream_ --lib --locked`: 25 passed at the final stack tip
- regressions cover bounded Search detail, equal-mtime traversal, remote-parent shortcuts, nested-operation pruning, forward/backward bounds, malformed cycles, workspace filtering, and internal SQL suppression
- `git diff --check`: passed
