### PR TITLE
feat(search)!: return catalog surfaces with supporting fields

### DIFF
--- a/apps/docs/guides/search-with-coral.mdx
+++ b/apps/docs/guides/search-with-coral.mdx
@@ -21,12 +21,17 @@ Among the ranked results, you might see:
 Results
 1. [catalog_metadata] table github.issues
    SQL: github.issues
+   fields: owner (Utf8), repo (Utf8), state (Utf8)
+   required filters: owner, repo
 2. [catalog_metadata] table function github.search_issues
    SQL reference: github.search_issues
    Call: github.search_issues(q => '<value>')
+   arguments: q
+   required arguments: q
+   returns: title (Utf8), url (Utf8)
 ```
 
-The `SQL` line gives you the table reference. For a table function, `SQL reference` identifies the function and `Call` shows its required arguments.
+The `SQL` line gives you the table reference. For tables, `fields` contains required and query-relevant columns, and `required filters` identifies the constraints you must supply. For table functions, `arguments` and `returns` keep inputs separate from result columns, while `required arguments` identifies the inputs you must supply. When present, `omitted_matching_field_count` tells you that additional query-matching fields were left out.
 
 Use a catalog result's `SQL` reference or `Call` example in a query with `coral sql` to fetch rows. See [Query your data](/getting-started/quickstart#3-query-your-data) for a complete example.
 

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -75,7 +75,7 @@ Search prepares the current workspace query runtime and catalog, then searches a
 local index. Runtime preparation can read stored credentials, initialize source
 providers, and inspect file metadata in local or object storage, but it does not
 execute your data query or return source rows. Catalog results provide a
-`sql_reference` or `sql_call_example`. When the `observed_values_search` feature
+`sql_reference`. When the `observed_values_search` feature
 is enabled, search also reads observed-value memory; those results identify the
 value and the surface and column where Coral saw it. Use those clues with
 `coral sql` to fetch current rows.
@@ -94,10 +94,13 @@ Enable them persistently using Coral [runtime features](/reference/configuration
 
 With `--json`, the response separates `results`, `provider_statuses`, and
 `truncation`. Each result identifies its provider and typed result kind.
-Catalog table results include `sql_reference`; table-function results include
-`sql_reference` and `sql_call_example`. Catalog field-level results include
-`surface_sql_reference`, identifying the table or table function that owns the
-matching column, filter, argument, or result column.
+Catalog metadata results identify one table or table function in `item`.
+Table results use `fields` for required and query-relevant columns and
+`required_filters` for required constraints. Table-function results use
+`arguments`, `required_arguments`, sparse `argument_values`, and `returns` to
+keep inputs separate from result columns. When more query-matching fields exist
+than fit in the response, `omitted_matching_field_count` reports how many were
+left out.
 
 Observed-value results include the value, its `schema_name`, surface, column,
 field path, observation count, and when it was last observed. `schema_name` is

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -300,14 +300,15 @@ enum SearchProviderState {
 
 // One typed Universal Search result.
 message SearchResult {
+  reserved 11;
+  reserved "column_hint";
+
   // Provider that produced this result.
   SearchProvider provider = 1;
   // Typed result payload.
   oneof payload {
     // Table or table-function metadata hit with search context.
     CatalogMetadata catalog_metadata = 10;
-    // Column, filter, argument, or result-column hint.
-    ColumnHint column_hint = 11;
     // Local observed-value hit. Reserved for the observed-value provider.
     ObservedValue observed_value = 12;
   }
@@ -315,36 +316,30 @@ message SearchResult {
 
 // Table or table-function metadata hit with search-specific context.
 message CatalogMetadata {
+  reserved 2, 3;
+  reserved "matched_fields", "table_column_preview";
+
   // Matched catalog item.
   CatalogItem item = 1;
-  // Metadata fields that matched the query.
-  repeated string matched_fields = 2;
-  // Compact table column hints for ordinary table hits.
-  SearchTableColumnPreview table_column_preview = 3;
+  // Required inputs plus bounded query-matching fields for this surface.
+  repeated SearchSurfaceField surface_fields = 4;
+  // Number of additional query-matching fields omitted from this result.
+  uint32 omitted_matching_field_count = 5;
 }
 
-// Compact column hints for an ordinary table metadata hit.
-message SearchTableColumnPreview {
-  // Total column count for the table before preview capping.
-  uint32 column_count = 1;
-  // Capped columns selected for query-writing orientation.
-  repeated SearchTableColumnPreviewColumn columns = 2;
-  // Number of table columns not included in the capped preview.
-  uint32 omitted_column_count = 3;
-}
+// One required or query-matching field on a catalog surface.
+message SearchSurfaceField {
+  reserved 4;
+  reserved "description";
 
-// One compact column hint in a table metadata hit preview.
-message SearchTableColumnPreviewColumn {
-  // Column name as exposed by the query engine.
+  // Column, filter, argument, or result-column name.
   string name = 1;
-  // The DataFusion/Arrow data type rendered as text.
+  // Data type when known.
   string data_type = 2;
-  // Whether the column must be constrained before querying the table.
-  bool is_required_filter = 3;
-  // Human-readable column description.
-  string description = 4;
-  // Column metadata fields that matched the query.
-  repeated string matched_fields = 5;
+  // Whether this field must be supplied or constrained.
+  bool required = 3;
+  // How the field should be used when querying the owning surface.
+  SearchFieldRole role = 5;
 }
 
 // Surface kind for a column-style hint.
@@ -369,28 +364,6 @@ enum SearchFieldRole {
   SEARCH_FIELD_ROLE_TABLE_FUNCTION_ARGUMENT = 3;
   // Table-function result column.
   SEARCH_FIELD_ROLE_TABLE_FUNCTION_RESULT_COLUMN = 4;
-}
-
-// A field-level hint that may hold or accept the query clue.
-message ColumnHint {
-  // Source schema that owns the surface.
-  string schema_name = 1;
-  // Table or table-function name.
-  string surface_name = 2;
-  // Whether the owning surface is a table or table function.
-  SearchSurfaceKind surface_kind = 3;
-  // Column, required filter, argument, or result-column name.
-  string name = 4;
-  // Data type when known.
-  string data_type = 5;
-  // Whether this field must be supplied or constrained.
-  bool required = 6;
-  // Human-readable field description.
-  string description = 7;
-  // Metadata fields that matched the query.
-  repeated string matched_fields = 8;
-  // How the field should be used when querying the owning surface.
-  SearchFieldRole field_role = 9;
 }
 
 // Local observed-value result.

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -1,19 +1,16 @@
 //! Catalog metadata Universal Search provider.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use coral_engine::{CatalogInfo, TableFunctionInfo, TableInfo};
 
 use crate::bootstrap::AppError;
-use crate::catalog::discovery::CatalogItem;
 use crate::catalog::model::CatalogResolution;
 use crate::query::manager::QueryManagerError;
-use crate::search::catalog::ranking::{RankedCatalogHit, rank_catalog_hits};
-use crate::search::catalog::snapshot::{
-    CatalogSearchSnapshot, field_role_from_str, surface_kind_from_str,
-};
+use crate::search::catalog::ranking::{RankedCatalogHit, rank_catalog_surfaces};
+use crate::search::catalog::snapshot::{CatalogSearchSnapshot, field_role_from_str};
 use crate::search::catalog::sqlite_index::{
-    CatalogIndexDocumentKind, CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
+    CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
 };
 use crate::search::maintenance::{
     CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult, SearchClearTarget,
@@ -22,9 +19,10 @@ use crate::search::maintenance::{
 };
 use crate::search::provider::ProviderSearchOutcome;
 use crate::search::result::{
-    CatalogMetadataResult, ColumnHintResult, ProviderCoverage, ProviderStatus, SearchCandidate,
-    SearchFieldRole, SearchManagerError, SearchPayload, SearchProviderKind, SearchProviderState,
-    SearchRequest, SearchSurfaceKind, TableColumnPreview, TableColumnPreviewColumn,
+    CatalogMetadataResult, ProviderCoverage, ProviderStatus, SearchCandidate, SearchFieldRole,
+    SearchManagerError, SearchPayload, SearchProviderKind, SearchProviderState, SearchRequest,
+    SearchSurfaceKind, SurfaceField, TableCatalogMetadataResult,
+    TableFunctionCatalogMetadataResult,
 };
 use crate::search::sqlite_store::{
     SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
@@ -33,8 +31,7 @@ use crate::state::AppStateLayout;
 
 const CATALOG_PROVIDER_RETRIEVAL_MULTIPLIER: usize = 5;
 const CATALOG_PROVIDER_MIN_RETRIEVAL_LIMIT: usize = 25;
-const MAX_COLUMN_HINTS_PER_SURFACE: usize = 3;
-const TABLE_COLUMN_PREVIEW_LIMIT: usize = 5;
+const OPTIONAL_MATCHING_FIELD_LIMIT: usize = 5;
 
 struct CatalogProjection {
     store: SqliteSearchStore,
@@ -373,23 +370,29 @@ fn catalog_search_outcome(
     projection: &CatalogProjection,
 ) -> ProviderSearchOutcome {
     let retrieved_hit_count = search_hits.hits.len();
-    let ranked_hits = rank_catalog_hits(search_hits.hits, &request.terms);
-    let candidate_set = catalog_candidates_from_hits(catalog, ranked_hits);
-    let candidate_count = candidate_set.candidates.len();
+    let ranked_surfaces = rank_catalog_surfaces(search_hits.hits, &request.terms);
+    let candidates = catalog_candidates_from_surfaces(catalog, ranked_surfaces);
+    let candidate_count = candidates.len();
+    let surface_count = u32::try_from(
+        catalog
+            .tables
+            .len()
+            .saturating_add(catalog.table_functions.len()),
+    )
+    .unwrap_or(u32::MAX);
     if retrieved_hit_count != candidate_count {
         tracing::debug!(
             workspace = %request.workspace_name,
             retrieved_hit_count,
             candidate_count,
-            omitted_column_hint_count = candidate_set.omitted_column_hint_count,
-            "mapped SQLite catalog hits into provider candidates"
+            "grouped SQLite catalog hits into surface candidates"
         );
     }
-    let has_more = search_hits.retrieval_limited || candidate_set.omitted_column_hint_count > 0;
+    let has_more = search_hits.retrieval_limited;
     let has_failures = !failed_source_names.is_empty();
     let state = if has_more || has_failures {
         SearchProviderState::Partial
-    } else if candidate_set.candidates.is_empty() {
+    } else if candidates.is_empty() {
         SearchProviderState::Empty
     } else {
         SearchProviderState::ResultsFound
@@ -400,18 +403,17 @@ fn catalog_search_outcome(
         projection.refresh.refreshed,
         projection.stale_index,
         search_hits.retrieval_limited,
-        candidate_set.omitted_column_hint_count,
         failed_source_names,
     );
     ProviderSearchOutcome {
-        candidates: candidate_set.candidates,
+        candidates,
         status: ProviderStatus {
             provider: SearchProviderKind::CatalogMetadata,
             state,
             note,
             coverage: Some(ProviderCoverage {
-                eligible_units: search_hits.document_count,
-                searched_units: search_hits.document_count,
+                eligible_units: surface_count,
+                searched_units: surface_count,
                 failed_units: u32::try_from(failed_source_names.len()).unwrap_or(u32::MAX),
                 returned_count: u32::try_from(candidate_count).unwrap_or(u32::MAX),
                 has_more,
@@ -441,131 +443,202 @@ fn missing_cached_projection_outcome(
     )))
 }
 
-fn catalog_candidates_from_hits(
+fn catalog_candidates_from_surfaces(
     catalog: &CatalogInfo,
-    hits: Vec<RankedCatalogHit>,
-) -> CatalogCandidateSet {
+    surfaces: Vec<crate::search::catalog::ranking::RankedCatalogSurface>,
+) -> Vec<SearchCandidate> {
     let mut candidates = Vec::new();
-    let mut column_hints_by_surface = BTreeMap::<(SearchSurfaceKind, String, String), usize>::new();
-    let mut omitted_column_hint_count = 0;
-
-    for ranked_hit in hits {
-        let hit = ranked_hit.hit;
-        match hit.doc_kind {
-            CatalogIndexDocumentKind::CatalogTable => {
-                if let Some(table) = find_table(catalog, &hit.source_name, &hit.surface_name) {
-                    candidates.push(table_candidate(table, &hit, ranked_hit.score));
-                }
+    for surface in surfaces {
+        let surface_fields = surface_fields(
+            catalog,
+            surface.key.kind,
+            &surface.key.source_name,
+            &surface.key.surface_name,
+            &surface.fields,
+        );
+        let surface_candidate = match surface.key.kind {
+            SearchSurfaceKind::Table => {
+                find_table(catalog, &surface.key.source_name, &surface.key.surface_name).map(
+                    |table| table_candidate(table, surface.best_evidence_score, surface_fields),
+                )
             }
-            CatalogIndexDocumentKind::CatalogTableFunction => {
-                if let Some(function) = find_function(catalog, &hit.source_name, &hit.surface_name)
-                {
-                    candidates.push(table_function_candidate(function, &hit, ranked_hit.score));
-                }
-            }
-            CatalogIndexDocumentKind::ColumnHint => {
-                let Some(surface_kind) = surface_kind_from_str(&hit.surface_kind) else {
-                    continue;
-                };
-                let count_key = (
-                    surface_kind,
-                    hit.source_name.clone(),
-                    hit.surface_name.clone(),
-                );
-                let count = column_hints_by_surface.entry(count_key).or_default();
-                if *count >= MAX_COLUMN_HINTS_PER_SURFACE {
-                    omitted_column_hint_count += 1;
-                    continue;
-                }
-                candidates.push(column_hint_candidate(
-                    catalog,
-                    &hit,
-                    surface_kind,
-                    ranked_hit.score,
-                ));
-                *count += 1;
-            }
+            SearchSurfaceKind::TableFunction => find_function(
+                catalog,
+                &surface.key.source_name,
+                &surface.key.surface_name,
+            )
+            .map(|function| {
+                table_function_candidate(function, surface.best_evidence_score, surface_fields)
+            }),
+        };
+        if let Some(candidate) = surface_candidate {
+            candidates.push(candidate);
         }
     }
 
-    CatalogCandidateSet {
-        candidates,
-        omitted_column_hint_count,
-    }
+    candidates
 }
 
-struct CatalogCandidateSet {
-    candidates: Vec<SearchCandidate>,
-    omitted_column_hint_count: usize,
-}
-
-fn table_candidate(table: &TableInfo, hit: &CatalogSearchHit, score: u32) -> SearchCandidate {
+fn table_candidate(
+    table: &TableInfo,
+    score: u32,
+    surface_fields: SurfaceFieldSelection,
+) -> SearchCandidate {
     SearchCandidate {
-        key: hit.doc_id.clone(),
+        key: format!("catalog:table:{}.{}", table.schema_name, table.table_name),
         score,
         provider: SearchProviderKind::CatalogMetadata,
-        payload: SearchPayload::CatalogMetadata(CatalogMetadataResult {
-            item: CatalogItem::Table(table_summary(table)),
-            matched_fields: hit.matched_fields.clone(),
-            table_column_preview: Some(table_column_preview(table)),
-        }),
+        payload: SearchPayload::CatalogMetadata(CatalogMetadataResult::Table(
+            TableCatalogMetadataResult {
+                item: table_summary(table),
+                fields: surface_fields.included_fields,
+                omitted_matching_field_count: surface_fields.omitted_matching_field_count,
+            },
+        )),
     }
 }
 
 fn table_function_candidate(
     function: &TableFunctionInfo,
-    hit: &CatalogSearchHit,
     score: u32,
+    surface_fields: SurfaceFieldSelection,
 ) -> SearchCandidate {
     SearchCandidate {
-        key: hit.doc_id.clone(),
+        key: format!(
+            "catalog:function:{}.{}",
+            function.schema_name, function.function_name
+        ),
         score,
         provider: SearchProviderKind::CatalogMetadata,
-        payload: SearchPayload::CatalogMetadata(CatalogMetadataResult {
-            item: CatalogItem::TableFunction(function.clone()),
-            matched_fields: hit.matched_fields.clone(),
-            table_column_preview: None,
-        }),
+        payload: SearchPayload::CatalogMetadata(CatalogMetadataResult::TableFunction(
+            TableFunctionCatalogMetadataResult {
+                item: function.clone(),
+                arguments: surface_fields
+                    .included_fields
+                    .iter()
+                    .filter(|field| field.role == SearchFieldRole::TableFunctionArgument)
+                    .cloned()
+                    .collect(),
+                returns: surface_fields
+                    .included_fields
+                    .into_iter()
+                    .filter(|field| field.role == SearchFieldRole::TableFunctionResultColumn)
+                    .collect(),
+                omitted_matching_field_count: surface_fields.omitted_matching_field_count,
+            },
+        )),
     }
 }
 
-fn column_hint_candidate(
+struct SurfaceFieldSelection {
+    included_fields: Vec<SurfaceField>,
+    omitted_matching_field_count: u32,
+}
+
+fn surface_fields(
     catalog: &CatalogInfo,
-    hit: &CatalogSearchHit,
     surface_kind: SearchSurfaceKind,
-    score: u32,
-) -> SearchCandidate {
-    let metadata = column_hint_metadata(catalog, hit, surface_kind);
-    SearchCandidate {
-        key: hit.doc_id.clone(),
-        score,
-        provider: SearchProviderKind::CatalogMetadata,
-        payload: SearchPayload::ColumnHint(ColumnHintResult {
-            schema_name: hit.source_name.clone(),
-            surface_name: hit.surface_name.clone(),
+    source_name: &str,
+    surface_name: &str,
+    hits: &[RankedCatalogHit],
+) -> SurfaceFieldSelection {
+    let mut fields = required_fields(catalog, surface_kind, source_name, surface_name);
+    let mut seen = fields
+        .iter()
+        .map(|field| surface_field_identity(surface_kind, field.role, &field.name))
+        .collect::<BTreeSet<_>>();
+    let mut optional_count = 0;
+    let mut omitted_count = 0;
+    for hit in hits {
+        let metadata = surface_field_metadata(catalog, &hit.hit, surface_kind);
+        if !seen.insert(surface_field_identity(
             surface_kind,
-            name: hit.field_name.clone(),
+            metadata.field_role,
+            &hit.hit.field_name,
+        )) {
+            continue;
+        }
+        if !metadata.required && optional_count == OPTIONAL_MATCHING_FIELD_LIMIT {
+            omitted_count += 1;
+            continue;
+        }
+        optional_count += usize::from(!metadata.required);
+        fields.push(SurfaceField {
+            name: hit.hit.field_name.clone(),
             data_type: metadata.data_type,
             required: metadata.required,
-            description: metadata.description,
-            matched_fields: hit.matched_fields.clone(),
-            field_role: metadata.field_role,
-        }),
+            role: metadata.field_role,
+        });
+    }
+    SurfaceFieldSelection {
+        included_fields: fields,
+        omitted_matching_field_count: u32::try_from(omitted_count).unwrap_or(u32::MAX),
     }
 }
 
-struct ColumnHintMetadata {
+fn surface_field_identity(
+    surface_kind: SearchSurfaceKind,
+    role: SearchFieldRole,
+    name: &str,
+) -> (Option<SearchFieldRole>, String) {
+    let role = match surface_kind {
+        SearchSurfaceKind::Table => None,
+        SearchSurfaceKind::TableFunction => Some(role),
+    };
+    (role, name.to_string())
+}
+
+fn required_fields(
+    catalog: &CatalogInfo,
+    surface_kind: SearchSurfaceKind,
+    source_name: &str,
+    surface_name: &str,
+) -> Vec<SurfaceField> {
+    match surface_kind {
+        SearchSurfaceKind::Table => find_table(catalog, source_name, surface_name)
+            .into_iter()
+            .flat_map(|table| {
+                table.required_filters.iter().map(|name| {
+                    let column = table.columns.iter().find(|column| column.name == *name);
+                    SurfaceField {
+                        name: name.clone(),
+                        data_type: column
+                            .map_or_else(String::new, |column| column.data_type.clone()),
+                        required: true,
+                        role: SearchFieldRole::TableFilter,
+                    }
+                })
+            })
+            .collect(),
+        SearchSurfaceKind::TableFunction => find_function(catalog, source_name, surface_name)
+            .into_iter()
+            .flat_map(|function| {
+                function
+                    .arguments
+                    .iter()
+                    .filter(|argument| argument.required)
+                    .map(|argument| SurfaceField {
+                        name: argument.name.clone(),
+                        data_type: String::new(),
+                        required: true,
+                        role: SearchFieldRole::TableFunctionArgument,
+                    })
+            })
+            .collect(),
+    }
+}
+
+struct SurfaceFieldMetadata {
     data_type: String,
     required: bool,
-    description: String,
     field_role: SearchFieldRole,
 }
 
-fn column_hint_metadata(
+fn surface_field_metadata(
     catalog: &CatalogInfo,
     hit: &CatalogSearchHit,
     surface_kind: SearchSurfaceKind,
-) -> ColumnHintMetadata {
+) -> SurfaceFieldMetadata {
     let fallback_role = match surface_kind {
         SearchSurfaceKind::Table => SearchFieldRole::TableColumn,
         SearchSurfaceKind::TableFunction => SearchFieldRole::TableFunctionResultColumn,
@@ -581,11 +654,10 @@ fn column_hint_metadata(
                         .find(|column| column.name == hit.field_name)
                 })
                 .map_or_else(
-                    || fallback_column_hint_metadata(hit, field_role),
-                    |column| ColumnHintMetadata {
+                    || fallback_surface_field_metadata(field_role),
+                    |column| SurfaceFieldMetadata {
                         data_type: column.data_type.clone(),
                         required: column.is_required_filter,
-                        description: column.description.clone(),
                         field_role,
                     },
                 )
@@ -598,13 +670,9 @@ fn column_hint_metadata(
                         .iter()
                         .find(|column| column.name == hit.field_name)
                 });
-            ColumnHintMetadata {
+            SurfaceFieldMetadata {
                 data_type: column.map_or_else(String::new, |column| column.data_type.clone()),
                 required: true,
-                description: column.map_or_else(
-                    || "Required table filter".to_string(),
-                    |column| column.description.clone(),
-                ),
                 field_role,
             }
         }
@@ -617,11 +685,10 @@ fn column_hint_metadata(
                         .find(|argument| argument.name == hit.field_name)
                 })
                 .map_or_else(
-                    || fallback_column_hint_metadata(hit, field_role),
-                    |argument| ColumnHintMetadata {
+                    || fallback_surface_field_metadata(field_role),
+                    |argument| SurfaceFieldMetadata {
                         data_type: String::new(),
                         required: argument.required,
-                        description: "Table function argument".to_string(),
                         field_role,
                     },
                 )
@@ -635,27 +702,22 @@ fn column_hint_metadata(
                         .find(|column| column.name == hit.field_name)
                 })
                 .map_or_else(
-                    || fallback_column_hint_metadata(hit, field_role),
-                    |column| ColumnHintMetadata {
+                    || fallback_surface_field_metadata(field_role),
+                    |column| SurfaceFieldMetadata {
                         data_type: column.data_type.clone(),
                         required: false,
-                        description: column.description.clone(),
                         field_role,
                     },
                 )
         }
-        _ => fallback_column_hint_metadata(hit, field_role),
+        _ => fallback_surface_field_metadata(field_role),
     }
 }
 
-fn fallback_column_hint_metadata(
-    hit: &CatalogSearchHit,
-    field_role: SearchFieldRole,
-) -> ColumnHintMetadata {
-    ColumnHintMetadata {
+fn fallback_surface_field_metadata(field_role: SearchFieldRole) -> SurfaceFieldMetadata {
+    SurfaceFieldMetadata {
         data_type: String::new(),
         required: matches!(field_role, SearchFieldRole::TableFilter),
-        description: hit.description.clone(),
         field_role,
     }
 }
@@ -664,26 +726,6 @@ fn table_summary(table: &TableInfo) -> TableInfo {
     let mut table = table.clone();
     table.columns.clear();
     table
-}
-
-fn table_column_preview(table: &TableInfo) -> TableColumnPreview {
-    let columns = table
-        .columns
-        .iter()
-        .take(TABLE_COLUMN_PREVIEW_LIMIT)
-        .cloned()
-        .map(|column| TableColumnPreviewColumn {
-            column,
-            matched_fields: Vec::new(),
-        })
-        .collect::<Vec<_>>();
-    let column_count = u32::try_from(table.columns.len()).unwrap_or(u32::MAX);
-    let omitted_column_count = table.columns.len().saturating_sub(columns.len());
-    TableColumnPreview {
-        column_count,
-        columns,
-        omitted_column_count: u32::try_from(omitted_column_count).unwrap_or(u32::MAX),
-    }
 }
 
 fn find_table<'a>(
@@ -747,7 +789,6 @@ fn catalog_provider_note(
     refreshed: bool,
     stale_index: bool,
     retrieval_limited: bool,
-    omitted_column_hint_count: usize,
     failed_source_names: &BTreeSet<String>,
 ) -> String {
     let refresh_note = if stale_index {
@@ -762,11 +803,7 @@ fn catalog_provider_note(
             format!("Catalog metadata returned {total_count} search hints{refresh_note}")
         }
         SearchProviderState::Partial => {
-            let reason = partial_catalog_provider_reason(
-                retrieval_limited,
-                omitted_column_hint_count,
-                failed_source_names,
-            );
+            let reason = partial_catalog_provider_reason(retrieval_limited, failed_source_names);
             format!("Catalog metadata returned {total_count} search hints; {reason}{refresh_note}")
         }
         SearchProviderState::Empty => {
@@ -780,7 +817,6 @@ fn catalog_provider_note(
 
 fn partial_catalog_provider_reason(
     retrieval_limited: bool,
-    omitted_column_hint_count: usize,
     failed_source_names: &BTreeSet<String>,
 ) -> String {
     const MAX_FAILED_SOURCE_NAMES_IN_NOTE: usize = 3;
@@ -788,11 +824,6 @@ fn partial_catalog_provider_reason(
     let mut reasons = Vec::new();
     if retrieval_limited {
         reasons.push("local retrieval cap was reached".to_string());
-    }
-    if omitted_column_hint_count > 0 {
-        reasons.push(format!(
-            "{omitted_column_hint_count} matching column hint(s) exceeded the per-surface cap"
-        ));
     }
     if !failed_source_names.is_empty() {
         let displayed_names = failed_source_names
@@ -829,18 +860,25 @@ fn partial_catalog_provider_reason(
 mod tests {
     use std::collections::BTreeSet;
 
-    use coral_engine::{CatalogInfo, ColumnInfo, TableInfo};
+    use coral_engine::{
+        CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
+        TableFunctionResultColumnInfo, TableInfo,
+    };
+    use coral_spec::SourceTableFunctionKind;
     use tempfile::tempdir;
 
     use super::{
-        CatalogProjection, MAX_COLUMN_HINTS_PER_SURFACE, catalog_provider_note,
-        catalog_search_outcome, search_sqlite_app_error,
+        CatalogProjection, OPTIONAL_MATCHING_FIELD_LIMIT, catalog_provider_note,
+        catalog_search_outcome, search_sqlite_app_error, surface_fields,
     };
     use crate::bootstrap::AppError;
+    use crate::search::catalog::ranking::RankedCatalogHit;
     use crate::search::catalog::sqlite_index::{
         CatalogIndexDocumentKind, CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
     };
-    use crate::search::result::{SearchProviderState, SearchRequest};
+    use crate::search::result::{
+        CatalogMetadataResult, SearchPayload, SearchProviderState, SearchRequest, SearchSurfaceKind,
+    };
     use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
     use crate::workspaces::WorkspaceName;
 
@@ -852,7 +890,6 @@ mod tests {
             false,
             true,
             false,
-            0,
             &BTreeSet::new(),
         );
 
@@ -899,7 +936,7 @@ mod tests {
     }
 
     #[test]
-    fn column_hint_cap_reports_partial_provider_coverage() {
+    fn surface_envelope_keeps_required_fields_and_caps_optional_matches() {
         let temp = tempdir().expect("tempdir");
         let workspace_name = WorkspaceName::default();
         let projection = CatalogProjection {
@@ -910,34 +947,139 @@ mod tests {
             .expect("search store"),
             refresh: CatalogRefreshResult {
                 refreshed: false,
-                document_count: 5,
+                document_count: 8,
             },
             stale_index: false,
             refresh_lock_error: None,
-            expected_document_count: 5,
+            expected_document_count: 8,
         };
-        let request = SearchRequest::new(workspace_name, "alpha", 10).expect("search request");
-        let catalog = column_cap_catalog(5);
+        let request =
+            SearchRequest::new(workspace_name, "alpha alpha_5", 10).expect("search request");
+        let catalog = column_cap_catalog(7);
+        let mut hits = column_cap_hits(7);
+        hits.push(CatalogSearchHit {
+            doc_id: "catalog:table:fixture.payments".to_string(),
+            doc_kind: CatalogIndexDocumentKind::CatalogTable,
+            source_name: "fixture".to_string(),
+            surface_kind: "table".to_string(),
+            surface_name: "payments".to_string(),
+            field_name: String::new(),
+            field_role: String::new(),
+            description: "Payments".to_string(),
+            matched_fields: vec!["searchable_text".to_string()],
+            retrieval_score: 1,
+        });
         let outcome = catalog_search_outcome(
             &request,
             &catalog,
             &BTreeSet::new(),
             CatalogSearchHits {
-                hits: column_cap_hits(5),
-                document_count: 5,
+                hits,
+                document_count: 8,
                 retrieval_limited: false,
             },
             &projection,
         );
 
-        assert_eq!(outcome.candidates.len(), MAX_COLUMN_HINTS_PER_SURFACE);
-        assert_eq!(outcome.status.state, SearchProviderState::Partial);
-        assert!(outcome.status.coverage.as_ref().expect("coverage").has_more);
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(outcome.status.state, SearchProviderState::ResultsFound);
+        assert!(!outcome.status.coverage.as_ref().expect("coverage").has_more);
+        let metadata = outcome
+            .candidates
+            .iter()
+            .find_map(|candidate| match &candidate.payload {
+                SearchPayload::CatalogMetadata(CatalogMetadataResult::Table(result)) => {
+                    Some(result)
+                }
+                _ => None,
+            })
+            .expect("surface metadata");
+        assert_eq!(
+            metadata
+                .fields
+                .iter()
+                .filter(|field| !field.required)
+                .count(),
+            OPTIONAL_MATCHING_FIELD_LIMIT
+        );
+        let required_field = metadata.fields.first().expect("required field");
+        assert_eq!(required_field.name, "alpha_0");
+        assert!(required_field.required);
+        assert_eq!(
+            metadata
+                .fields
+                .iter()
+                .filter(|field| field.name == "alpha_0")
+                .count(),
+            1,
+            "a required filter should not also appear as a table column"
+        );
         assert!(
-            outcome
-                .status
-                .note
-                .contains("2 matching column hint(s) exceeded the per-surface cap")
+            metadata.fields.iter().any(|field| field.name == "alpha_5"),
+            "strong optional matches should remain visible"
+        );
+        assert_eq!(metadata.omitted_matching_field_count, 1);
+    }
+
+    #[test]
+    fn function_argument_and_return_can_share_a_name() {
+        let catalog = CatalogInfo {
+            tables: Vec::new(),
+            table_functions: vec![TableFunctionInfo {
+                schema_name: "notion".to_string(),
+                function_name: "search_templates".to_string(),
+                description: String::new(),
+                arguments: vec![TableFunctionArgumentInfo {
+                    name: "name".to_string(),
+                    required: true,
+                    values: Vec::new(),
+                }],
+                result_columns: vec![TableFunctionResultColumnInfo {
+                    name: "name".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: false,
+                    description: "Template name".to_string(),
+                }],
+                kind: SourceTableFunctionKind::Search,
+                search_limits: None,
+            }],
+        };
+        let hits = vec![RankedCatalogHit {
+            hit: CatalogSearchHit {
+                doc_id: "column:function:notion.search_templates:name".to_string(),
+                doc_kind: CatalogIndexDocumentKind::ColumnHint,
+                source_name: "notion".to_string(),
+                surface_kind: "table_function".to_string(),
+                surface_name: "search_templates".to_string(),
+                field_name: "name".to_string(),
+                field_role: "table_function_result_column".to_string(),
+                description: "Template name".to_string(),
+                matched_fields: vec!["field_name".to_string()],
+                retrieval_score: 1,
+            },
+            score: 1,
+        }];
+
+        let selection = surface_fields(
+            &catalog,
+            SearchSurfaceKind::TableFunction,
+            "notion",
+            "search_templates",
+            &hits,
+        );
+
+        assert_eq!(selection.included_fields.len(), 2);
+        let roles = selection
+            .included_fields
+            .iter()
+            .map(|field| field.role)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            roles,
+            [
+                crate::search::result::SearchFieldRole::TableFunctionArgument,
+                crate::search::result::SearchFieldRole::TableFunctionResultColumn,
+            ]
         );
     }
 
@@ -1018,7 +1160,6 @@ mod tests {
             false,
             false,
             false,
-            0,
             &failed_source_names,
         );
 
@@ -1048,12 +1189,12 @@ mod tests {
                         data_type: "Utf8".to_string(),
                         nullable: true,
                         is_virtual: false,
-                        is_required_filter: false,
+                        is_required_filter: index == 0,
                         description: format!("Alpha {index}"),
                         ordinal_position: u32::try_from(index).unwrap_or(u32::MAX),
                     })
                     .collect(),
-                required_filters: Vec::new(),
+                required_filters: vec!["alpha_0".to_string()],
             }],
             table_functions: Vec::new(),
         }

--- a/crates/coral-app/src/search/catalog/ranking.rs
+++ b/crates/coral-app/src/search/catalog/ranking.rs
@@ -1,8 +1,11 @@
 //! Catalog provider relevance ranking.
 
 use std::cmp::Reverse;
+use std::collections::BTreeMap;
 
+use crate::search::catalog::snapshot::surface_kind_from_str;
 use crate::search::catalog::sqlite_index::{CatalogIndexDocumentKind, CatalogSearchHit};
+use crate::search::result::SearchSurfaceKind;
 
 const PARENT_CATALOG_SURFACE_RELEVANCE_BOOST: u32 = 20_000;
 const COLUMN_HINT_RELEVANCE_BOOST: u32 = 0;
@@ -26,6 +29,78 @@ const COLUMN_HINT_RANK_ORDER: u8 = 1;
 pub(crate) struct RankedCatalogHit {
     pub(crate) hit: CatalogSearchHit,
     pub(crate) score: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct CatalogSurfaceKey {
+    pub(crate) source_name: String,
+    pub(crate) kind: SearchSurfaceKind,
+    pub(crate) surface_name: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct RankedCatalogSurface {
+    pub(crate) key: CatalogSurfaceKey,
+    pub(crate) best_evidence_score: u32,
+    pub(crate) fields: Vec<RankedCatalogHit>,
+}
+
+pub(crate) fn rank_catalog_surfaces(
+    hits: Vec<CatalogSearchHit>,
+    terms: &[String],
+) -> Vec<RankedCatalogSurface> {
+    let mut grouped = BTreeMap::<CatalogSurfaceKey, Vec<RankedCatalogHit>>::new();
+    for hit in rank_catalog_hits(hits, terms) {
+        let Some(kind) = surface_kind_from_str(&hit.hit.surface_kind) else {
+            continue;
+        };
+        grouped
+            .entry(CatalogSurfaceKey {
+                source_name: hit.hit.source_name.clone(),
+                kind,
+                surface_name: hit.hit.surface_name.clone(),
+            })
+            .or_default()
+            .push(hit);
+    }
+
+    let mut surfaces = grouped
+        .into_iter()
+        .map(|(key, hits)| rank_surface(key, hits))
+        .collect::<Vec<_>>();
+    surfaces.sort_by(|left, right| {
+        (
+            Reverse(left.best_evidence_score),
+            left.key.source_name.as_str(),
+            left.key.surface_name.as_str(),
+        )
+            .cmp(&(
+                Reverse(right.best_evidence_score),
+                right.key.source_name.as_str(),
+                right.key.surface_name.as_str(),
+            ))
+    });
+    surfaces
+}
+
+fn rank_surface(key: CatalogSurfaceKey, hits: Vec<RankedCatalogHit>) -> RankedCatalogSurface {
+    let mut best_evidence_score = 0;
+    let mut fields = Vec::new();
+    for hit in hits {
+        best_evidence_score = best_evidence_score.max(hit.score);
+        if matches!(hit.hit.doc_kind, CatalogIndexDocumentKind::ColumnHint) {
+            fields.push(hit);
+        }
+    }
+    fields.sort_by(|left, right| {
+        (Reverse(left.score), left.hit.doc_id.as_str())
+            .cmp(&(Reverse(right.score), right.hit.doc_id.as_str()))
+    });
+    RankedCatalogSurface {
+        key,
+        best_evidence_score,
+        fields,
+    }
 }
 
 pub(crate) fn rank_catalog_hits(

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -2,10 +2,9 @@
 
 use std::cmp::Reverse;
 
-use coral_engine::ColumnInfo;
+use coral_engine::{TableFunctionInfo, TableInfo};
 
 use crate::bootstrap::AppError;
-use crate::catalog::discovery::CatalogItem;
 use crate::workspaces::WorkspaceName;
 
 pub(crate) const DEFAULT_UNIVERSAL_SEARCH_LIMIT: u32 = 10;
@@ -131,8 +130,7 @@ impl SearchCandidate {
     pub(crate) fn type_order(&self) -> u8 {
         match &self.payload {
             SearchPayload::CatalogMetadata(_) => 0,
-            SearchPayload::ColumnHint(_) => 1,
-            SearchPayload::ObservedValue(_) => 2,
+            SearchPayload::ObservedValue(_) => 1,
         }
     }
 }
@@ -172,41 +170,36 @@ pub(crate) struct SearchResult {
 #[derive(Debug, Clone)]
 pub(crate) enum SearchPayload {
     CatalogMetadata(CatalogMetadataResult),
-    ColumnHint(ColumnHintResult),
     ObservedValue(ObservedValueResult),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct CatalogMetadataResult {
-    pub(crate) item: CatalogItem,
-    pub(crate) matched_fields: Vec<String>,
-    pub(crate) table_column_preview: Option<TableColumnPreview>,
+pub(crate) enum CatalogMetadataResult {
+    Table(TableCatalogMetadataResult),
+    TableFunction(TableFunctionCatalogMetadataResult),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct TableColumnPreview {
-    pub(crate) column_count: u32,
-    pub(crate) columns: Vec<TableColumnPreviewColumn>,
-    pub(crate) omitted_column_count: u32,
+pub(crate) struct TableCatalogMetadataResult {
+    pub(crate) item: TableInfo,
+    pub(crate) fields: Vec<SurfaceField>,
+    pub(crate) omitted_matching_field_count: u32,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct TableColumnPreviewColumn {
-    pub(crate) column: ColumnInfo,
-    pub(crate) matched_fields: Vec<String>,
+pub(crate) struct TableFunctionCatalogMetadataResult {
+    pub(crate) item: TableFunctionInfo,
+    pub(crate) arguments: Vec<SurfaceField>,
+    pub(crate) returns: Vec<SurfaceField>,
+    pub(crate) omitted_matching_field_count: u32,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ColumnHintResult {
-    pub(crate) schema_name: String,
-    pub(crate) surface_name: String,
-    pub(crate) surface_kind: SearchSurfaceKind,
+pub(crate) struct SurfaceField {
     pub(crate) name: String,
     pub(crate) data_type: String,
     pub(crate) required: bool,
-    pub(crate) description: String,
-    pub(crate) matched_fields: Vec<String>,
-    pub(crate) field_role: SearchFieldRole,
+    pub(crate) role: SearchFieldRole,
 }
 
 #[derive(Debug, Clone)]
@@ -227,7 +220,7 @@ pub(crate) enum SearchSurfaceKind {
     TableFunction,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[expect(
     clippy::enum_variant_names,
     reason = "field roles intentionally mirror the protobuf role names"

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -8,7 +8,7 @@ use coral_api::v1::{
     CatalogClearResult as ProtoCatalogClearResult, CatalogMetadata,
     CatalogRebuildResult as ProtoCatalogRebuildResult,
     ClearSearchDataRequest as ProtoClearSearchDataRequest,
-    ClearSearchDataResponse as ProtoClearSearchDataResponse, ColumnHint,
+    ClearSearchDataResponse as ProtoClearSearchDataResponse,
     DrainSearchQueueRequest as ProtoDrainSearchQueueRequest,
     DrainSearchQueueResponse as ProtoDrainSearchQueueResponse,
     ObservedClearResult as ProtoObservedClearResult,
@@ -23,13 +23,13 @@ use coral_api::v1::{
     SearchProviderCoverage, SearchProviderState, SearchProviderStatus,
     SearchRequest as ProtoSearchRequest, SearchResponse as ProtoSearchResponse,
     SearchResult as ProtoSearchResult, SearchResultTruncation,
-    SearchStorageCleanupResult as ProtoSearchStorageCleanupResult,
-    SearchSurfaceKind as ProtoSearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn,
+    SearchStorageCleanupResult as ProtoSearchStorageCleanupResult, SearchSurfaceField,
+    SearchSurfaceKind as ProtoSearchSurfaceKind,
 };
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
+use crate::catalog::discovery::CatalogItem;
 use crate::query::QueryAttribution;
 use crate::search::maintenance::{
     CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult,
@@ -45,10 +45,9 @@ use crate::search::maintenance::{
 };
 use crate::search::manager::SearchManager;
 use crate::search::result::{
-    CatalogMetadataResult, ColumnHintResult, ObservedValueResult, ProviderCoverage, ProviderStatus,
-    SearchFieldRole, SearchManagerError, SearchPayload, SearchProviderKind,
+    CatalogMetadataResult, ObservedValueResult, ProviderCoverage, ProviderStatus, SearchFieldRole,
+    SearchManagerError, SearchPayload, SearchProviderKind,
     SearchProviderState as DomainProviderState, SearchRequest, SearchResponse, SearchSurfaceKind,
-    TableColumnPreview as DomainTableColumnPreview,
 };
 use crate::sources::SourceName;
 use crate::transport::{
@@ -393,7 +392,6 @@ fn search_payload_to_proto(
         SearchPayload::CatalogMetadata(result) => {
             Payload::CatalogMetadata(catalog_metadata_to_proto(workspace_name, result))
         }
-        SearchPayload::ColumnHint(result) => Payload::ColumnHint(column_hint_to_proto(result)),
         SearchPayload::ObservedValue(result) => {
             Payload::ObservedValue(observed_value_to_proto(result))
         }
@@ -404,44 +402,34 @@ fn catalog_metadata_to_proto(
     workspace_name: &crate::workspaces::WorkspaceName,
     result: CatalogMetadataResult,
 ) -> CatalogMetadata {
+    let (item, surface_fields, omitted_matching_field_count) = match result {
+        CatalogMetadataResult::Table(result) => (
+            CatalogItem::Table(result.item),
+            result.fields,
+            result.omitted_matching_field_count,
+        ),
+        CatalogMetadataResult::TableFunction(result) => {
+            let mut fields = result.arguments;
+            fields.extend(result.returns);
+            (
+                CatalogItem::TableFunction(result.item),
+                fields,
+                result.omitted_matching_field_count,
+            )
+        }
+    };
     CatalogMetadata {
-        item: Some(catalog_item_to_proto(workspace_name, result.item)),
-        matched_fields: result.matched_fields,
-        table_column_preview: result
-            .table_column_preview
-            .map(table_column_preview_to_proto),
-    }
-}
-
-fn table_column_preview_to_proto(preview: DomainTableColumnPreview) -> SearchTableColumnPreview {
-    SearchTableColumnPreview {
-        column_count: preview.column_count,
-        columns: preview
-            .columns
+        item: Some(catalog_item_to_proto(workspace_name, item)),
+        surface_fields: surface_fields
             .into_iter()
-            .map(|column| SearchTableColumnPreviewColumn {
-                name: column.column.name,
-                data_type: column.column.data_type,
-                is_required_filter: column.column.is_required_filter,
-                description: column.column.description,
-                matched_fields: column.matched_fields,
+            .map(|field| SearchSurfaceField {
+                name: field.name,
+                data_type: field.data_type,
+                required: field.required,
+                role: field_role_to_proto(field.role) as i32,
             })
             .collect(),
-        omitted_column_count: preview.omitted_column_count,
-    }
-}
-
-fn column_hint_to_proto(result: ColumnHintResult) -> ColumnHint {
-    ColumnHint {
-        schema_name: result.schema_name,
-        surface_name: result.surface_name,
-        surface_kind: surface_kind_to_proto(result.surface_kind) as i32,
-        name: result.name,
-        data_type: result.data_type,
-        required: result.required,
-        description: result.description,
-        matched_fields: result.matched_fields,
-        field_role: field_role_to_proto(result.field_role) as i32,
+        omitted_matching_field_count,
     }
 }
 

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -12,9 +12,8 @@ use coral_api::v1::{
     CreateWorkspaceRequest, DeleteWorkspaceRequest, DrainSearchQueueRequest, ListCatalogRequest,
     PaginationRequest, RebuildSearchIndexRequest, SearchClearTarget, SearchDataScope,
     SearchFieldRole, SearchIndexProvider, SearchMaintenanceState, SearchProvider,
-    SearchProviderState, SearchRequest, SearchSurfaceKind, TableFunctionKind,
-    ValidateSourceRequest, Workspace, catalog_item, search_clear_target, search_maintenance_result,
-    search_result,
+    SearchProviderState, SearchRequest, TableFunctionKind, ValidateSourceRequest, Workspace,
+    catalog_item, search_clear_target, search_maintenance_result, search_result,
 };
 use coral_app::EngineExtensionsProvider;
 use coral_client::default_workspace;
@@ -570,7 +569,7 @@ async fn table_function_proto_exposes_search_metadata() {
 }
 
 #[tokio::test]
-async fn search_returns_catalog_metadata_for_search_functions_and_column_hints() {
+async fn search_returns_function_fields_in_one_surface_envelope() {
     let harness = GrpcHarness::new().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
@@ -632,21 +631,19 @@ async fn search_returns_catalog_metadata_for_search_functions_and_column_hints()
                                 limits.default_top_k == 5
                                     && limits.max_top_k == 20
                                     && limits.max_calls_per_query == 2
+                            })
+                            && function.result_columns.iter().any(|column| {
+                                column.name == "title" && column.data_type == "Utf8"
                             }),
                     catalog_item::Item::Table(_) => false,
                 }
+            }) && metadata.surface_fields.iter().any(|field| {
+                field.name == "title"
+                    && field.data_type == "Utf8"
+                    && SearchFieldRole::try_from(field.role).is_ok_and(|role| {
+                        role == SearchFieldRole::TableFunctionResultColumn
+                    })
             })
-    )));
-    assert!(response.results.iter().any(|result| matches!(
-        result.payload.as_ref(),
-        Some(search_result::Payload::ColumnHint(hint))
-            if hint.surface_name == "search_messages"
-                && hint.name == "title"
-                && SearchSurfaceKind::try_from(hint.surface_kind)
-                    .is_ok_and(|kind| kind == SearchSurfaceKind::TableFunction)
-                && SearchFieldRole::try_from(hint.field_role)
-                    .is_ok_and(|role| role == SearchFieldRole::TableFunctionResultColumn)
-                && hint.data_type == "Utf8"
     )));
 }
 
@@ -1284,63 +1281,6 @@ async fn source_scoped_all_clear_does_not_load_manifest_and_bumps_generation() {
 }
 
 #[tokio::test]
-async fn search_table_preview_columns_do_not_inherit_table_matched_fields() {
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
-        .await;
-
-    let response = harness
-        .search_client()
-        .search(Request::new(SearchRequest {
-            workspace: Some(default_workspace()),
-            query: "conversation archive".to_string(),
-            limit: 10,
-        }))
-        .await
-        .expect("search")
-        .into_inner();
-
-    let metadata = response
-        .results
-        .iter()
-        .find_map(|result| {
-            let Some(search_result::Payload::CatalogMetadata(metadata)) = result.payload.as_ref()
-            else {
-                return None;
-            };
-            metadata
-                .item
-                .as_ref()
-                .and_then(|item| item.item.as_ref())
-                .is_some_and(|item| {
-                    matches!(item, catalog_item::Item::Table(table) if table.name == "messages")
-                })
-                .then_some(metadata)
-        })
-        .expect("messages table metadata");
-    assert!(
-        metadata
-            .matched_fields
-            .iter()
-            .any(|field| field == "description"),
-        "table metadata should explain that the table description matched"
-    );
-    let preview = metadata
-        .table_column_preview
-        .as_ref()
-        .expect("table column preview");
-    assert_eq!(preview.column_count, 2);
-    assert!(
-        preview
-            .columns
-            .iter()
-            .all(|column| column.matched_fields.is_empty()),
-        "preview columns should not inherit table-level matched fields"
-    );
-}
-
-#[tokio::test]
 async fn search_provider_coverage_counts_mapped_candidates() {
     let harness = GrpcHarness::new().await;
     harness
@@ -1365,7 +1305,7 @@ async fn search_provider_coverage_counts_mapped_candidates() {
     let catalog_status = assert_provider_state(
         &response,
         SearchProvider::CatalogMetadata,
-        SearchProviderState::Partial,
+        SearchProviderState::ResultsFound,
     );
     let coverage = catalog_status.coverage.as_ref().expect("coverage");
     assert_eq!(
@@ -1373,7 +1313,7 @@ async fn search_provider_coverage_counts_mapped_candidates() {
         u32::try_from(response.results.len()).expect("result count"),
         "coverage should count mapped provider candidates, not raw SQLite hits"
     );
-    assert_eq!(coverage.returned_count, 4);
+    assert_eq!(coverage.returned_count, 1);
 }
 
 #[tokio::test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -962,6 +962,18 @@ async fn search_command_renders_text_output_and_provider_statuses() {
         "expected SQL reference: {stdout}"
     );
     assert!(
+        stdout.contains("text (Utf8)"),
+        "expected field evidence: {stdout}"
+    );
+    assert!(
+        stdout.contains("required filters: owner"),
+        "expected required field: {stdout}"
+    );
+    assert!(
+        stdout.contains("omitted matching fields: 1"),
+        "expected omitted matching field count: {stdout}"
+    );
+    assert!(
         stdout.contains("Provider statuses"),
         "expected provider statuses section: {stdout}"
     );
@@ -1004,8 +1016,31 @@ async fn search_json_output_preserves_typed_payloads_and_statuses() {
         "local_messages.messages"
     );
     assert_eq!(
-        response["results"][1]["column_hint"]["field_role"],
-        "table_column"
+        response["results"][0]["catalog_metadata"]["fields"]["text"],
+        "Utf8"
+    );
+    assert_eq!(
+        response["results"][0]["catalog_metadata"]["required_filters"],
+        serde_json::json!(["owner"])
+    );
+    assert_eq!(
+        response["results"][0]["catalog_metadata"]["omitted_matching_field_count"],
+        1
+    );
+    assert!(
+        response["results"][0]["catalog_metadata"]
+            .get("table_column_preview")
+            .is_none()
+    );
+    assert!(
+        response["results"][0]["catalog_metadata"]
+            .get("surface_fields")
+            .is_none()
+    );
+    assert!(
+        response["results"][0]["catalog_metadata"]["item"]
+            .get("table")
+            .is_none()
     );
     assert_eq!(
         response["provider_statuses"][0]["coverage"]["searched_units"],
@@ -1018,7 +1053,7 @@ async fn search_json_output_preserves_typed_payloads_and_statuses() {
     assert!(response["provider_statuses"][1]["coverage"].is_null());
     assert_eq!(response["provider_statuses"][2]["state"], "skipped");
     assert!(response["provider_statuses"][2]["coverage"].is_null());
-    assert_eq!(response["truncation"]["returned_count"], 2);
+    assert_eq!(response["truncation"]["returned_count"], 1);
 
     let requests = server.search_requests();
     assert_eq!(requests.len(), 1, "expected one search call");

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -22,7 +22,7 @@ use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceService
 use coral_api::v1::{
     AddFunctionRequest, AddFunctionResponse, CatalogClearResult, CatalogCounts, CatalogItem,
     CatalogMetadata, CatalogRebuildResult, CatalogSearchResult, ClearSearchDataRequest,
-    ClearSearchDataResponse, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
+    ClearSearchDataResponse, Column, ColumnSearchResult, CreateBundledSourceRequest,
     CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
     DeleteFunctionRequest, DeleteFunctionResponse, DeleteSourceRequest, DeleteSourceResponse,
@@ -38,12 +38,11 @@ use coral_api::v1::{
     SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult,
     SearchMaintenanceState, SearchProvider, SearchProviderCoverage, SearchProviderState,
     SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
-    SearchStorageCleanupResult, SearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
-    SourceOrigin, SourceSecretInput, Table, TableFunction, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    import_source_response, search_maintenance_result, search_result,
-    source_input_spec::Input as ProtoSourceInput,
+    SearchStorageCleanupResult, SearchSurfaceField, Source, SourceCredentialStorage, SourceInfo,
+    SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableFunction, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    create_bundled_source_with_o_auth_response, import_source_response, search_maintenance_result,
+    search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -373,61 +372,39 @@ fn mock_validate_response() -> ValidateSourceResponse {
 fn mock_search_response() -> SearchResponse {
     let table = mock_visible_table();
     SearchResponse {
-        results: vec![
-            SearchResult {
-                provider: SearchProvider::CatalogMetadata as i32,
-                payload: Some(search_result::Payload::CatalogMetadata(CatalogMetadata {
-                    item: Some(CatalogItem {
-                        item: Some(catalog_item::Item::Table(table_summary(&table))),
-                    }),
-                    matched_fields: vec!["description".to_string()],
-                    table_column_preview: Some(SearchTableColumnPreview {
-                        column_count: 3,
-                        columns: vec![
-                            SearchTableColumnPreviewColumn {
-                                name: "owner".to_string(),
-                                data_type: "Utf8".to_string(),
-                                is_required_filter: true,
-                                description: "Repository owner filter".to_string(),
-                                matched_fields: Vec::new(),
-                            },
-                            SearchTableColumnPreviewColumn {
-                                name: "text".to_string(),
-                                data_type: "Utf8".to_string(),
-                                is_required_filter: false,
-                                description: "Message text".to_string(),
-                                matched_fields: vec!["description".to_string()],
-                            },
-                        ],
-                        omitted_column_count: 1,
-                    }),
-                })),
-            },
-            SearchResult {
-                provider: SearchProvider::CatalogMetadata as i32,
-                payload: Some(search_result::Payload::ColumnHint(ColumnHint {
-                    schema_name: "local_messages".to_string(),
-                    surface_name: "messages".to_string(),
-                    surface_kind: SearchSurfaceKind::Table as i32,
-                    name: "text".to_string(),
-                    data_type: "Utf8".to_string(),
-                    required: false,
-                    description: "Message text".to_string(),
-                    matched_fields: vec!["column_name".to_string()],
-                    field_role: SearchFieldRole::TableColumn as i32,
-                })),
-            },
-        ],
+        results: vec![SearchResult {
+            provider: SearchProvider::CatalogMetadata as i32,
+            payload: Some(search_result::Payload::CatalogMetadata(CatalogMetadata {
+                item: Some(CatalogItem {
+                    item: Some(catalog_item::Item::Table(table_summary(&table))),
+                }),
+                surface_fields: vec![
+                    SearchSurfaceField {
+                        name: "owner".to_string(),
+                        data_type: "Utf8".to_string(),
+                        required: true,
+                        role: SearchFieldRole::TableFilter as i32,
+                    },
+                    SearchSurfaceField {
+                        name: "text".to_string(),
+                        data_type: "Utf8".to_string(),
+                        required: false,
+                        role: SearchFieldRole::TableColumn as i32,
+                    },
+                ],
+                omitted_matching_field_count: 1,
+            })),
+        }],
         provider_statuses: vec![
             mock_provider_status(
                 SearchProvider::CatalogMetadata,
                 SearchProviderState::ResultsFound,
-                "Catalog metadata returned 2 search hints",
+                "Catalog metadata returned 1 search result",
                 Some(SearchProviderCoverage {
                     eligible_units: 3,
                     searched_units: 3,
                     failed_units: 0,
-                    returned_count: 2,
+                    returned_count: 1,
                     has_more: false,
                     budget_exhausted: false,
                     timed_out: false,
@@ -449,7 +426,7 @@ fn mock_search_response() -> SearchResponse {
         ],
         truncation: Some(SearchResultTruncation {
             truncated: false,
-            returned_count: 2,
+            returned_count: 1,
             max_results: 10,
             note: String::new(),
         }),

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -1,13 +1,12 @@
 //! Shared Universal Search response rendering for thin clients.
 
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use coral_api::v1::{
-    CatalogItem, CatalogMetadata, ColumnHint, ObservedValue, SearchFieldRole, SearchLimits,
-    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchResponse, SearchResult,
-    SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn, TableFunction, TableFunctionArgument, TableFunctionKind,
-    TableFunctionResultColumn, TableSummary, catalog_item, search_result,
+    CatalogMetadata, ObservedValue, SearchFieldRole, SearchProvider, SearchProviderCoverage,
+    SearchProviderState, SearchResponse, SearchResult, SearchResultTruncation, SearchSurfaceKind,
+    TableFunction, catalog_item, search_result,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -52,11 +51,6 @@ enum SearchResultValue<'a> {
         kind: &'static str,
         catalog_metadata: CatalogMetadataValue<'a>,
     },
-    ColumnHint {
-        provider: &'static str,
-        kind: &'static str,
-        column_hint: ColumnHintValue<'a>,
-    },
     ObservedValue {
         provider: &'static str,
         kind: &'static str,
@@ -77,11 +71,6 @@ impl<'a> From<&'a SearchResult> for SearchResultValue<'a> {
                 kind: "catalog_metadata",
                 catalog_metadata: CatalogMetadataValue::from(metadata),
             },
-            Some(search_result::Payload::ColumnHint(hint)) => Self::ColumnHint {
-                provider,
-                kind: "column_hint",
-                column_hint: ColumnHintValue::from(hint),
-            },
             Some(search_result::Payload::ObservedValue(observed)) => Self::ObservedValue {
                 provider,
                 kind: "observed_value",
@@ -96,276 +85,178 @@ impl<'a> From<&'a SearchResult> for SearchResultValue<'a> {
 }
 
 #[derive(Serialize, JsonSchema)]
+#[serde(untagged)]
+enum CatalogMetadataValue<'a> {
+    Table(TableCatalogMetadataValue<'a>),
+    TableFunction(TableFunctionCatalogMetadataValue<'a>),
+    Unknown(UnknownCatalogMetadataValue<'a>),
+}
+
+#[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
-struct CatalogMetadataValue<'a> {
+struct TableCatalogMetadataValue<'a> {
+    item: CatalogItemValue<'a>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    fields: BTreeMap<&'a str, Option<&'a str>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    required_filters: Vec<&'a str>,
+    #[serde(skip_serializing_if = "is_default")]
+    omitted_matching_field_count: u32,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct TableFunctionCatalogMetadataValue<'a> {
+    item: CatalogItemValue<'a>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    arguments: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    required_arguments: Vec<&'a str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    argument_values: BTreeMap<&'a str, Vec<&'a str>>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    returns: BTreeMap<&'a str, Option<&'a str>>,
+    #[serde(skip_serializing_if = "is_default")]
+    omitted_matching_field_count: u32,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct UnknownCatalogMetadataValue<'a> {
     item: Option<CatalogItemValue<'a>>,
-    matched_fields: &'a [String],
-    table_column_preview: Option<TableColumnPreviewValue<'a>>,
 }
 
 impl<'a> From<&'a CatalogMetadata> for CatalogMetadataValue<'a> {
     fn from(metadata: &'a CatalogMetadata) -> Self {
-        Self {
-            item: metadata
-                .item
-                .as_ref()
-                .and_then(CatalogItemValue::from_catalog_item),
-            matched_fields: &metadata.matched_fields,
-            table_column_preview: metadata
-                .table_column_preview
-                .as_ref()
-                .map(TableColumnPreviewValue::from),
+        match metadata.item.as_ref().and_then(|item| item.item.as_ref()) {
+            Some(catalog_item::Item::Table(table)) => Self::Table(TableCatalogMetadataValue {
+                item: CatalogItemValue::from_table(table),
+                fields: surface_field_map(
+                    metadata,
+                    &[SearchFieldRole::TableColumn, SearchFieldRole::TableFilter],
+                ),
+                required_filters: required_surface_field_names(
+                    metadata,
+                    SearchFieldRole::TableFilter,
+                ),
+                omitted_matching_field_count: metadata.omitted_matching_field_count,
+            }),
+            Some(catalog_item::Item::TableFunction(function)) => {
+                let arguments =
+                    surface_field_names(metadata, SearchFieldRole::TableFunctionArgument);
+                Self::TableFunction(TableFunctionCatalogMetadataValue {
+                    item: CatalogItemValue::from_table_function(function),
+                    argument_values: argument_values(function, &arguments),
+                    arguments,
+                    required_arguments: required_surface_field_names(
+                        metadata,
+                        SearchFieldRole::TableFunctionArgument,
+                    ),
+                    returns: surface_field_map(
+                        metadata,
+                        &[SearchFieldRole::TableFunctionResultColumn],
+                    ),
+                    omitted_matching_field_count: metadata.omitted_matching_field_count,
+                })
+            }
+            None => Self::Unknown(UnknownCatalogMetadataValue { item: None }),
         }
     }
 }
 
+fn surface_field_names(metadata: &CatalogMetadata, role: SearchFieldRole) -> Vec<&str> {
+    let mut names = metadata
+        .surface_fields
+        .iter()
+        .filter(|field| SearchFieldRole::try_from(field.role) == Ok(role))
+        .map(|field| field.name.as_str())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+fn argument_values<'a>(
+    function: &'a TableFunction,
+    included_arguments: &[&str],
+) -> BTreeMap<&'a str, Vec<&'a str>> {
+    function
+        .arguments
+        .iter()
+        .filter(|argument| {
+            !argument.values.is_empty() && included_arguments.contains(&argument.name.as_str())
+        })
+        .map(|argument| {
+            (
+                argument.name.as_str(),
+                argument.values.iter().map(String::as_str).collect(),
+            )
+        })
+        .collect()
+}
+
+fn surface_field_map<'a>(
+    metadata: &'a CatalogMetadata,
+    roles: &[SearchFieldRole],
+) -> BTreeMap<&'a str, Option<&'a str>> {
+    metadata
+        .surface_fields
+        .iter()
+        .filter(|field| {
+            SearchFieldRole::try_from(field.role).is_ok_and(|role| roles.contains(&role))
+        })
+        .map(|field| {
+            (
+                field.name.as_str(),
+                (!field.data_type.is_empty()).then_some(field.data_type.as_str()),
+            )
+        })
+        .collect()
+}
+
+fn required_surface_field_names(metadata: &CatalogMetadata, role: SearchFieldRole) -> Vec<&str> {
+    let mut names = metadata
+        .surface_fields
+        .iter()
+        .filter(|field| {
+            field.required && SearchFieldRole::try_from(field.role).is_ok_and(|value| value == role)
+        })
+        .map(|field| field.name.as_str())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+fn is_default<T: Default + PartialEq>(value: &T) -> bool {
+    value == &T::default()
+}
+
 #[derive(Serialize, JsonSchema)]
-#[serde(untagged)]
-enum CatalogItemValue<'a> {
-    Table(TableSummaryValue<'a>),
-    TableFunction(TableFunctionValue<'a>),
+#[schemars(deny_unknown_fields)]
+struct CatalogItemValue<'a> {
+    kind: &'static str,
+    name: String,
+    sql_reference: String,
+    description: &'a str,
 }
 
 impl<'a> CatalogItemValue<'a> {
-    fn from_catalog_item(item: &'a CatalogItem) -> Option<Self> {
-        match item.item.as_ref()? {
-            catalog_item::Item::Table(table) => Some(Self::Table(TableSummaryValue::from(table))),
-            catalog_item::Item::TableFunction(function) => {
-                Some(Self::TableFunction(TableFunctionValue::from(function)))
-            }
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableSummaryValue<'a> {
-    kind: &'static str,
-    schema_name: &'a str,
-    name: String,
-    sql_reference: String,
-    description: &'a str,
-    table: TableSummaryDetailsValue<'a>,
-}
-
-impl<'a> From<&'a TableSummary> for TableSummaryValue<'a> {
-    fn from(table: &'a TableSummary) -> Self {
+    fn from_table(table: &'a coral_api::v1::TableSummary) -> Self {
         Self {
             kind: "table",
-            schema_name: &table.schema_name,
             name: format!("{}.{}", table.schema_name, table.name),
             sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
             description: &table.description,
-            table: TableSummaryDetailsValue::from(table),
         }
     }
-}
 
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableSummaryDetailsValue<'a> {
-    table_name: &'a str,
-    guide: &'a str,
-    required_filters: &'a [String],
-}
-
-impl<'a> From<&'a TableSummary> for TableSummaryDetailsValue<'a> {
-    fn from(table: &'a TableSummary) -> Self {
-        Self {
-            table_name: &table.name,
-            guide: &table.guide,
-            required_filters: &table.required_filters,
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableFunctionValue<'a> {
-    kind: &'static str,
-    schema_name: &'a str,
-    name: String,
-    sql_reference: String,
-    sql_call_example: String,
-    description: &'a str,
-    table_function: TableFunctionDetailsValue<'a>,
-}
-
-impl<'a> From<&'a TableFunction> for TableFunctionValue<'a> {
-    fn from(function: &'a TableFunction) -> Self {
+    fn from_table_function(function: &'a TableFunction) -> Self {
         Self {
             kind: "table_function",
-            schema_name: &function.schema_name,
             name: format!("{}.{}", function.schema_name, function.name),
             sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
-            sql_call_example: minimal_table_function_call_example(function),
             description: &function.description,
-            table_function: TableFunctionDetailsValue::from(function),
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableFunctionDetailsValue<'a> {
-    function_name: &'a str,
-    function_kind: &'static str,
-    arguments: Vec<TableFunctionArgumentValue<'a>>,
-    result_columns: Vec<TableFunctionResultColumnValue<'a>>,
-    search_limits: Option<SearchLimitsValue>,
-}
-
-impl<'a> From<&'a TableFunction> for TableFunctionDetailsValue<'a> {
-    fn from(function: &'a TableFunction) -> Self {
-        Self {
-            function_name: &function.name,
-            function_kind: table_function_kind_name(function.kind),
-            arguments: function
-                .arguments
-                .iter()
-                .map(TableFunctionArgumentValue::from)
-                .collect(),
-            result_columns: function
-                .result_columns
-                .iter()
-                .map(TableFunctionResultColumnValue::from)
-                .collect(),
-            search_limits: function.search_limits.as_ref().map(SearchLimitsValue::from),
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableFunctionArgumentValue<'a> {
-    name: &'a str,
-    required: bool,
-    values: &'a [String],
-}
-
-impl<'a> From<&'a TableFunctionArgument> for TableFunctionArgumentValue<'a> {
-    fn from(argument: &'a TableFunctionArgument) -> Self {
-        Self {
-            name: &argument.name,
-            required: argument.required,
-            values: &argument.values,
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableFunctionResultColumnValue<'a> {
-    column_name: &'a str,
-    data_type: &'a str,
-    is_nullable: bool,
-    description: &'a str,
-}
-
-impl<'a> From<&'a TableFunctionResultColumn> for TableFunctionResultColumnValue<'a> {
-    fn from(column: &'a TableFunctionResultColumn) -> Self {
-        Self {
-            column_name: &column.name,
-            data_type: &column.data_type,
-            is_nullable: column.nullable,
-            description: &column.description,
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct SearchLimitsValue {
-    default_top_k: u32,
-    max_top_k: u32,
-    max_calls_per_query: u32,
-}
-
-impl From<&SearchLimits> for SearchLimitsValue {
-    fn from(limits: &SearchLimits) -> Self {
-        Self {
-            default_top_k: limits.default_top_k,
-            max_top_k: limits.max_top_k,
-            max_calls_per_query: limits.max_calls_per_query,
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableColumnPreviewValue<'a> {
-    column_count: u32,
-    columns: Vec<TableColumnPreviewColumnValue<'a>>,
-    omitted_column_count: u32,
-}
-
-impl<'a> From<&'a SearchTableColumnPreview> for TableColumnPreviewValue<'a> {
-    fn from(preview: &'a SearchTableColumnPreview) -> Self {
-        Self {
-            column_count: preview.column_count,
-            columns: preview
-                .columns
-                .iter()
-                .map(TableColumnPreviewColumnValue::from)
-                .collect(),
-            omitted_column_count: preview.omitted_column_count,
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct TableColumnPreviewColumnValue<'a> {
-    column_name: &'a str,
-    data_type: &'a str,
-    is_required_filter: bool,
-    description: &'a str,
-    matched_fields: &'a [String],
-}
-
-impl<'a> From<&'a SearchTableColumnPreviewColumn> for TableColumnPreviewColumnValue<'a> {
-    fn from(column: &'a SearchTableColumnPreviewColumn) -> Self {
-        Self {
-            column_name: &column.name,
-            data_type: &column.data_type,
-            is_required_filter: column.is_required_filter,
-            description: &column.description,
-            matched_fields: &column.matched_fields,
-        }
-    }
-}
-
-#[derive(Serialize, JsonSchema)]
-#[schemars(deny_unknown_fields)]
-struct ColumnHintValue<'a> {
-    schema_name: &'a str,
-    surface_name: &'a str,
-    surface_kind: &'static str,
-    surface_sql_reference: String,
-    column_name: &'a str,
-    data_type: &'a str,
-    required: bool,
-    description: &'a str,
-    matched_fields: &'a [String],
-    field_role: &'static str,
-}
-
-impl<'a> From<&'a ColumnHint> for ColumnHintValue<'a> {
-    fn from(hint: &'a ColumnHint) -> Self {
-        Self {
-            schema_name: &hint.schema_name,
-            surface_name: &hint.surface_name,
-            surface_kind: surface_kind_name(hint.surface_kind),
-            surface_sql_reference: format_schema_table_equivalent(
-                &hint.schema_name,
-                &hint.surface_name,
-            ),
-            column_name: &hint.name,
-            data_type: &hint.data_type,
-            required: hint.required,
-            description: &hint.description,
-            matched_fields: &hint.matched_fields,
-            field_role: field_role_name(hint.field_role),
         }
     }
 }
@@ -549,9 +440,6 @@ fn result_text_lines(index: usize, result: &SearchResult) -> Vec<String> {
         Some(search_result::Payload::CatalogMetadata(metadata)) => {
             catalog_metadata_text_lines(index, provider, metadata)
         }
-        Some(search_result::Payload::ColumnHint(hint)) => {
-            column_hint_text_lines(index, provider, hint)
-        }
         Some(search_result::Payload::ObservedValue(observed)) => {
             observed_value_text_lines(index, provider, observed)
         }
@@ -565,63 +453,101 @@ fn catalog_metadata_text_lines(
     metadata: &CatalogMetadata,
 ) -> Vec<String> {
     let mut lines = match metadata.item.as_ref().and_then(|item| item.item.as_ref()) {
-        Some(catalog_item::Item::Table(table)) => vec![
-            format!(
-                "{index}. [{provider}] table {}.{}",
-                table.schema_name, table.name
-            ),
-            format!(
-                "   SQL: {}",
-                format_schema_table_equivalent(&table.schema_name, &table.name)
-            ),
-        ],
-        Some(catalog_item::Item::TableFunction(function)) => vec![
-            format!(
-                "{index}. [{provider}] table function {}.{}",
-                function.schema_name, function.name
-            ),
-            format!(
-                "   SQL reference: {}",
-                format_schema_table_equivalent(&function.schema_name, &function.name)
-            ),
-            format!("   Call: {}", minimal_table_function_call_example(function)),
-        ],
+        Some(catalog_item::Item::Table(table)) => {
+            let mut lines = vec![
+                format!(
+                    "{index}. [{provider}] table {}.{}",
+                    table.schema_name, table.name
+                ),
+                format!(
+                    "   SQL: {}",
+                    format_schema_table_equivalent(&table.schema_name, &table.name)
+                ),
+            ];
+            push_surface_fields_line(
+                &mut lines,
+                "fields",
+                metadata,
+                &[SearchFieldRole::TableColumn, SearchFieldRole::TableFilter],
+            );
+            push_surface_field_names_line(
+                &mut lines,
+                "required filters",
+                &required_surface_field_names(metadata, SearchFieldRole::TableFilter),
+            );
+            lines
+        }
+        Some(catalog_item::Item::TableFunction(function)) => {
+            let mut lines = vec![
+                format!(
+                    "{index}. [{provider}] table function {}.{}",
+                    function.schema_name, function.name
+                ),
+                format!(
+                    "   SQL reference: {}",
+                    format_schema_table_equivalent(&function.schema_name, &function.name)
+                ),
+                format!("   Call: {}", minimal_table_function_call_example(function)),
+            ];
+            push_surface_fields_line(
+                &mut lines,
+                "arguments",
+                metadata,
+                &[SearchFieldRole::TableFunctionArgument],
+            );
+            push_surface_field_names_line(
+                &mut lines,
+                "required arguments",
+                &required_surface_field_names(metadata, SearchFieldRole::TableFunctionArgument),
+            );
+            push_surface_fields_line(
+                &mut lines,
+                "returns",
+                metadata,
+                &[SearchFieldRole::TableFunctionResultColumn],
+            );
+            lines
+        }
         None => vec![format!("{index}. [{provider}] catalog metadata")],
     };
-    push_optional_fields_line(&mut lines, "   matched", &metadata.matched_fields);
-    if let Some(preview) = metadata
-        .table_column_preview
-        .as_ref()
-        .and_then(preview_text)
-    {
-        lines.push(format!("   columns: {preview}"));
+    if metadata.omitted_matching_field_count > 0 {
+        lines.push(format!(
+            "   omitted matching fields: {}",
+            metadata.omitted_matching_field_count
+        ));
     }
     lines
 }
 
-fn column_hint_text_lines(index: usize, provider: &str, hint: &ColumnHint) -> Vec<String> {
-    let mut lines = vec![
-        format!(
-            "{index}. [{provider}] {} {}.{}.{}",
-            field_role_name(hint.field_role),
-            hint.schema_name,
-            hint.surface_name,
-            hint.name
-        ),
-        format!(
-            "   Surface: {} {}",
-            surface_kind_name(hint.surface_kind),
-            format_schema_table_equivalent(&hint.schema_name, &hint.surface_name)
-        ),
-    ];
-    if !hint.data_type.is_empty() {
-        lines.push(format!("   Type: {}", hint.data_type));
+fn push_surface_fields_line(
+    lines: &mut Vec<String>,
+    label: &str,
+    metadata: &CatalogMetadata,
+    roles: &[SearchFieldRole],
+) {
+    let fields = metadata
+        .surface_fields
+        .iter()
+        .filter(|field| {
+            SearchFieldRole::try_from(field.role).is_ok_and(|role| roles.contains(&role))
+        })
+        .map(|field| {
+            if field.data_type.is_empty() {
+                field.name.clone()
+            } else {
+                format!("{} ({})", field.name, field.data_type)
+            }
+        })
+        .collect::<Vec<_>>();
+    if !fields.is_empty() {
+        lines.push(format!("   {label}: {}", fields.join(", ")));
     }
-    if hint.required {
-        lines.push("   Required: true".to_string());
+}
+
+fn push_surface_field_names_line(lines: &mut Vec<String>, label: &str, fields: &[&str]) {
+    if !fields.is_empty() {
+        lines.push(format!("   {label}: {}", fields.join(", ")));
     }
-    push_optional_fields_line(&mut lines, "   matched", &hint.matched_fields);
-    lines
 }
 
 fn observed_value_text_lines(
@@ -668,33 +594,6 @@ fn provider_status_text(status: &coral_api::v1::SearchProviderStatus) -> String 
         line.push_str(&status.note);
     }
     line
-}
-
-fn push_optional_fields_line(lines: &mut Vec<String>, label: &str, fields: &[String]) {
-    if !fields.is_empty() {
-        lines.push(format!("{label}: {}", fields.join(", ")));
-    }
-}
-
-fn preview_text(preview: &SearchTableColumnPreview) -> Option<String> {
-    if preview.columns.is_empty() {
-        return None;
-    }
-    let mut parts = preview
-        .columns
-        .iter()
-        .map(|column| {
-            if column.data_type.is_empty() {
-                column.name.clone()
-            } else {
-                format!("{} ({})", column.name, column.data_type)
-            }
-        })
-        .collect::<Vec<_>>();
-    if preview.omitted_column_count > 0 {
-        parts.push(format!("+{} more", preview.omitted_column_count));
-    }
-    Some(parts.join(", "))
 }
 
 /// Formats the shortest SQL call example for a table function.
@@ -771,27 +670,72 @@ fn surface_kind_name(kind: i32) -> &'static str {
     }
 }
 
-fn field_role_name(role: i32) -> &'static str {
-    match SearchFieldRole::try_from(role) {
-        Ok(SearchFieldRole::TableColumn) => "table_column",
-        Ok(SearchFieldRole::TableFilter) => "table_filter",
-        Ok(SearchFieldRole::TableFunctionArgument) => "table_function_argument",
-        Ok(SearchFieldRole::TableFunctionResultColumn) => "table_function_result_column",
-        Ok(SearchFieldRole::Unspecified) | Err(_) => "unspecified",
-    }
-}
-
-fn table_function_kind_name(kind: i32) -> &'static str {
-    match TableFunctionKind::try_from(kind) {
-        Ok(TableFunctionKind::Table) => "table",
-        Ok(TableFunctionKind::Search) => "search",
-        Ok(TableFunctionKind::Unspecified) | Err(_) => "unspecified",
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use coral_api::v1::{
+        CatalogItem, SearchSurfaceField, TableFunctionArgument, TableFunctionResultColumn,
+    };
+
     use super::*;
+
+    #[test]
+    fn table_function_json_keeps_arguments_and_returns_separate() {
+        let metadata = CatalogMetadata {
+            item: Some(CatalogItem {
+                item: Some(catalog_item::Item::TableFunction(TableFunction {
+                    workspace: None,
+                    schema_name: "notion".to_string(),
+                    name: "search_data_source_templates".to_string(),
+                    description: "Search data source templates".to_string(),
+                    arguments: vec![TableFunctionArgument {
+                        name: "name".to_string(),
+                        required: true,
+                        values: vec!["project".to_string(), "meeting".to_string()],
+                    }],
+                    result_columns: vec![TableFunctionResultColumn {
+                        name: "name".to_string(),
+                        data_type: "Utf8".to_string(),
+                        nullable: false,
+                        description: "Template name".to_string(),
+                    }],
+                    kind: 0,
+                    search_limits: None,
+                })),
+            }),
+            surface_fields: vec![
+                SearchSurfaceField {
+                    name: "name".to_string(),
+                    data_type: String::new(),
+                    required: true,
+                    role: SearchFieldRole::TableFunctionArgument as i32,
+                },
+                SearchSurfaceField {
+                    name: "name".to_string(),
+                    data_type: "Utf8".to_string(),
+                    required: false,
+                    role: SearchFieldRole::TableFunctionResultColumn as i32,
+                },
+            ],
+            omitted_matching_field_count: 0,
+        };
+
+        let value = serde_json::to_value(CatalogMetadataValue::from(&metadata)).expect("serialize");
+
+        assert_eq!(value.get("arguments"), Some(&serde_json::json!(["name"])));
+        assert_eq!(
+            value.get("required_arguments"),
+            Some(&serde_json::json!(["name"]))
+        );
+        assert_eq!(
+            value.pointer("/argument_values/name"),
+            Some(&serde_json::json!(["project", "meeting"]))
+        );
+        assert_eq!(
+            value.pointer("/returns/name").and_then(Value::as_str),
+            Some("Utf8")
+        );
+        assert!(value.get("fields").is_none());
+    }
 
     #[test]
     fn text_output_renders_observed_field_path() {


### PR DESCRIPTION
## Intent

Return a catalog surface as the native search result and treat its columns, filters, arguments, and return columns as supporting evidence. A field cannot be queried without its owning table or table function, and flat child results previously competed with and displaced that parent.

## What changed

- group retrieved catalog documents by owning surface
- score each surface from its strongest existing evidence document
- rank and limit surfaces rather than individual field hints
- always include required filters and arguments
- attach up to five optional matching fields using their existing scores
- keep table-function arguments and return columns role-distinct
- emit compact typed payloads:
  - tables use `fields` plus `required_filters`
  - table functions use `arguments`, `required_arguments`, sparse `argument_values`, and typed `returns`
- deduplicate same-name table filters and columns

Provider fusion, the global result limit, retrieval scoring, and non-catalog providers are unchanged.

## Contract change

This changes the structured Universal Search catalog payload. Standalone field hints become supporting fields on their owning surface. The protobuf field description slot is reserved rather than reused.

### Before and after

Development corpus case `s0086-q3` uses the frozen query:

> Datadog spans checkout-service error unique span identifier

The example uses `datadog.spans` catalog data captured by the replay. The after excerpt renders the same surface evidence with the current PR serializer. Ellipses omit other fields and results.

**Before:** the parent includes the full table-function schema, while matching return columns consume separate result slots.

```jsonc
[
  {
    "provider": "catalog_metadata",
    "kind": "catalog_metadata",
    "catalog_metadata": {
      "item": {
        "kind": "table_function",
        "schema_name": "datadog",
        "name": "datadog.spans",
        "sql_reference": "datadog.spans",
        "sql_call_example": "datadog.spans(start => '<value>', end => '<value>')",
        "description": "Datadog APM distributed tracing spans within a time range.",
        "table_function": {
          "function_name": "spans",
          "function_kind": "table",
          "arguments": [
            { "name": "start", "required": true, "values": [] },
            { "name": "end", "required": true, "values": [] },
            { "name": "query", "required": false, "values": [] }
          ],
          "result_columns": [
            {
              "column_name": "span_id",
              "data_type": "Utf8",
              "is_nullable": true,
              "description": "Span ID"
            },
            // ...
          ],
          "search_limits": null
        }
      },
      "matched_fields": [
        "description",
        "qualified_name",
        "searchable_text",
        "surface_name",
        "title"
      ],
      "table_column_preview": null
    }
  },
  {
    "provider": "catalog_metadata",
    "kind": "column_hint",
    "column_hint": {
      "schema_name": "datadog",
      "surface_name": "spans",
      "surface_kind": "table_function",
      "surface_sql_reference": "datadog.spans",
      "column_name": "span_id",
      "data_type": "Utf8",
      "required": false,
      "description": "Span ID",
      "matched_fields": [
        "description",
        "field_name",
        "qualified_name",
        "searchable_text",
        "surface_name",
        "title"
      ],
      "field_role": "table_function_result_column"
    }
  },
  // separate column_hint results for resource and duration
  // ...
]
```

**After:** one surface result carries the arguments required to call it and the matching return fields.

```jsonc
{
  "provider": "catalog_metadata",
  "kind": "catalog_metadata",
  "catalog_metadata": {
    "item": {
      "kind": "table_function",
      "name": "datadog.spans",
      "sql_reference": "datadog.spans",
      "description": "Datadog APM distributed tracing spans within a time range."
    },
    "arguments": ["end", "query", "start"],
    "required_arguments": ["end", "start"],
    "returns": {
      "duration": "Int64",
      "resource": "Utf8",
      "span_id": "Utf8",
      "start": "Utf8"
    },
    "omitted_matching_field_count": 4
  }
}
```

## Development benchmark

Frozen 300-case corpus, limit 10:

| Metric | Benchmark PR | This PR |
| --- | ---: | ---: |
| Target Hit@10 | 198/300 | 251/300 |
| MRR@10 | 0.3935 | 0.6724 |
| Parent Hit@10 | 248/300 | 268/300 |
| Child Hit@10 | 64/138 | 109/138 |
| Mean response tokens | 1,953.7 | 960.0 |

All 300 cases completed without an operational error. These are relative development results, not a sealed final evaluation.

## Validation

- catalog surface grouping and role-specific field tests
- compact table and table-function JSON tests
- feature-gated CLI structured-payload test
- `make rust-checks` on the fully restacked search stack — 2,078 tests passed; workspace formatting, Clippy, and rustdoc passed
