### PR TITLE
refactor(app): generalize request principals

### DIFF
--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -37,6 +37,13 @@ root.
 - Keep process environment access in `src/bootstrap/env.rs` or other clearly
   app-owned bootstrap seams. Do not read ambient process environment from
   managers, services, state helpers, or credential helpers.
+- Treat `PrincipalId` as an opaque, stable identifier from one collision-free
+  namespace spanning every actor kind and identity authority. Principal
+  providers own canonicalization and supply the authenticated `PrincipalKind`;
+  downstream code must not infer actor kind, ownership, or authorization from
+  the identifier. Kind is an input to authorization policy, not a permission or
+  role by itself, and providers must not classify the same `PrincipalId` as
+  different kinds across requests.
 - Keep `state/`, `credentials/`, `workspaces/`, `sources/`, `query/`, and
   `catalog/` as the main internal boundaries. Do not create new sub-boundaries
   unless they own durable, independent behavior.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -54,7 +54,7 @@ use crate::feedback::publisher::{
 };
 use crate::feedback::service::FeedbackService;
 use crate::functions::service::FunctionService;
-use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
+use crate::identity::{LocalPrincipalProvider, PrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
@@ -104,7 +104,7 @@ pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
     mode: ServerModeSelection,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    principal_provider: Arc<dyn PrincipalProvider>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     feature_overrides: FeatureOverrides,
     enable_stderr_logs: bool,
@@ -122,7 +122,7 @@ impl ServerConfig {
             config_dir: None,
             mode: ServerModeSelection::Explicit(ServerMode::EphemeralGrpc),
             engine_extensions_providers: Vec::new(),
-            user_principal_provider: Arc::new(SingleUserPrincipalProvider),
+            principal_provider: Arc::new(LocalPrincipalProvider),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             feature_overrides: FeatureOverrides::default(),
             enable_stderr_logs: false,
@@ -283,16 +283,16 @@ impl ServerBuilder {
     }
 
     #[must_use]
-    /// Sets the server-side user principal provider.
+    /// Sets the server-side principal provider.
     ///
-    /// The default provider returns the local single-user principal for every
-    /// request. Product runtimes can authenticate inbound metadata and select a
-    /// user by installing their own provider.
-    pub fn with_user_principal_provider(
+    /// The default provider returns the local principal for every
+    /// request. Product runtimes can authenticate inbound metadata and select
+    /// any canonical principal by installing their own provider.
+    pub fn with_principal_provider(
         mut self,
-        user_principal_provider: Arc<dyn UserPrincipalProvider>,
+        principal_provider: Arc<dyn PrincipalProvider>,
     ) -> Self {
-        self.config.user_principal_provider = user_principal_provider;
+        self.config.principal_provider = principal_provider;
         self
     }
 
@@ -425,7 +425,7 @@ impl ServerBuilder {
                 task: task_manager,
             },
             trace_components,
-            self.config.user_principal_provider,
+            self.config.principal_provider,
             mode,
         )
         .await
@@ -604,7 +604,7 @@ struct ServerDependencies {
 async fn start_server(
     dependencies: ServerDependencies,
     trace_components: TraceServerComponents,
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    principal_provider: Arc<dyn PrincipalProvider>,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
     let TraceServerComponents {
@@ -665,7 +665,7 @@ async fn start_server(
     let routes = Routes::from(
         application_routes
             .into_axum_router()
-            .layer(GrpcRequestContextLayer::new(user_principal_provider)),
+            .layer(GrpcRequestContextLayer::new(principal_provider)),
     )
     // Process liveness must not depend on principal selection.
     .add_service(tonic_health::pb::health_server::HealthServer::new(
@@ -954,8 +954,8 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
     use crate::{
-        AwsEngineExtensionsProvider, NoopEngineExtensionsProvider, SingleUserPrincipalProvider,
-        UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError,
+        AwsEngineExtensionsProvider, LocalPrincipalProvider, NoopEngineExtensionsProvider,
+        Principal, PrincipalProvider, PrincipalProviderError,
     };
 
     fn default_workspace() -> Workspace {
@@ -1004,16 +1004,16 @@ enabled = false
     }
 
     #[derive(Debug)]
-    struct RejectingUserPrincipalProvider;
+    struct RejectingPrincipalProvider;
 
     #[tonic::async_trait]
-    impl UserPrincipalProvider for RejectingUserPrincipalProvider {
+    impl PrincipalProvider for RejectingPrincipalProvider {
         async fn principal_for_metadata(
             &self,
             _metadata: &tonic::metadata::MetadataMap,
-        ) -> Result<UserPrincipal, UserPrincipalProviderError> {
-            Err(UserPrincipalProviderError::unauthenticated(
-                "rejected user principal",
+        ) -> Result<Principal, PrincipalProviderError> {
+            Err(PrincipalProviderError::unauthenticated(
+                "rejected principal",
             ))
         }
     }
@@ -1574,7 +1574,7 @@ backend = "unsupported"
                 service: Some(trace_service),
                 local_trace_store_dir: None,
             },
-            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
         )
         .await
@@ -1648,7 +1648,7 @@ backend = "unsupported"
         let temp = TempDir::new().expect("temp dir");
         let server = ServerBuilder::new()
             .with_config_dir(temp.path().join("coral-config"))
-            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
+            .with_principal_provider(Arc::new(RejectingPrincipalProvider))
             .start()
             .await
             .expect("start server");
@@ -1847,7 +1847,7 @@ tables:
         let temp = TempDir::new().expect("temp dir");
         let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
             .with_config_dir(temp.path().join("coral-config"))
-            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
+            .with_principal_provider(Arc::new(RejectingPrincipalProvider))
             .start()
             .await
             .expect("start embedded UI server");
@@ -2021,7 +2021,7 @@ tables:
                 task: task_manager,
             },
             TraceServerComponents::default(),
-            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
         )
         .await
@@ -2147,7 +2147,7 @@ tables:
                 task: task_manager,
             },
             TraceServerComponents::default(),
-            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
         )
         .await
@@ -2273,7 +2273,7 @@ tables:
                 task: task_manager,
             },
             TraceServerComponents::default(),
-            Arc::new(SingleUserPrincipalProvider),
+            Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
         )
         .await

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -4,55 +4,115 @@ use std::fmt;
 
 use crate::bootstrap::AppError;
 
-/// Stable local user used by single-user local mode.
-pub(crate) const LOCAL_MEMBER_ID: &str = "local";
+/// Stable local principal used by single-user local mode.
+pub(crate) const LOCAL_PRINCIPAL_ID: &str = "coral:local";
 
-/// Request-scoped user principal selected by the app transport layer.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UserPrincipal {
-    user_id: String,
-}
+/// Stable, opaque identity shared by every principal kind and authority.
+///
+/// Providers must supply identifiers from one collision-free namespace. The
+/// identifier deliberately does not expose whether the principal is a user,
+/// agent, service, or another future actor kind.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrincipalId(String);
 
-impl UserPrincipal {
-    /// Builds the default single-user local principal.
-    #[must_use]
-    pub fn local() -> Self {
-        Self {
-            user_id: LOCAL_MEMBER_ID.to_string(),
-        }
-    }
-
-    /// Builds a principal for a validated user id.
+impl PrincipalId {
+    /// Parses a canonical principal identifier.
     ///
     /// # Errors
     ///
-    /// Returns [`AppError`] if the user id is empty, contains whitespace,
-    /// contains path separators, or aliases the reserved local single-user
-    /// sentinel.
-    pub fn for_user(user_id: &str) -> Result<Self, AppError> {
-        if user_id.chars().any(char::is_whitespace) {
+    /// Returns [`AppError`] when the identifier is empty or contains
+    /// whitespace or control characters.
+    pub fn parse(value: &str) -> Result<Self, AppError> {
+        if value.is_empty()
+            || value
+                .chars()
+                .any(|character| character.is_whitespace() || character.is_control())
+        {
             return Err(AppError::InvalidInput(
-                "user id must not contain whitespace".to_string(),
+                "principal id must be non-empty and contain no whitespace or control characters"
+                    .to_string(),
             ));
         }
-        let user_id = parse_path_segment("user", user_id)?;
-        if user_id == LOCAL_MEMBER_ID {
+        if value == LOCAL_PRINCIPAL_ID {
             return Err(AppError::InvalidInput(format!(
-                "user id '{LOCAL_MEMBER_ID}' is reserved for single-user local mode"
+                "principal id '{LOCAL_PRINCIPAL_ID}' is reserved for local mode"
             )));
         }
-        Ok(Self { user_id })
+        Ok(Self(value.to_string()))
     }
 
-    /// Returns the validated user id.
+    /// Returns the canonical principal identifier.
     #[must_use]
-    pub fn user_id(&self) -> &str {
-        &self.user_id
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PrincipalId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Authenticated category of actor represented by a [`Principal`].
+///
+/// Kind is available to authorization policy, but does not itself grant a
+/// permission or imply a role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PrincipalKind {
+    /// A human user.
+    User,
+    /// An autonomous or delegated agent.
+    Agent,
+}
+
+/// Request-scoped principal selected by the app transport layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Principal {
+    id: PrincipalId,
+    kind: PrincipalKind,
+}
+
+impl Principal {
+    /// Builds a principal from its canonical identity and authenticated kind.
+    #[must_use]
+    pub const fn new(id: PrincipalId, kind: PrincipalKind) -> Self {
+        Self { id, kind }
+    }
+
+    /// Parses and builds a principal with an authenticated kind.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when `id` is not a valid [`PrincipalId`].
+    pub fn parse(id: &str, kind: PrincipalKind) -> Result<Self, AppError> {
+        PrincipalId::parse(id).map(|id| Self::new(id, kind))
+    }
+
+    /// Builds the default local user principal.
+    #[must_use]
+    pub fn local() -> Self {
+        Self {
+            id: PrincipalId(LOCAL_PRINCIPAL_ID.to_string()),
+            kind: PrincipalKind::User,
+        }
+    }
+
+    /// Returns the stable principal identity.
+    #[must_use]
+    pub const fn id(&self) -> &PrincipalId {
+        &self.id
+    }
+
+    /// Returns the authenticated actor kind.
+    #[must_use]
+    pub const fn kind(&self) -> PrincipalKind {
+        self.kind
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum UserPrincipalProviderErrorKind {
+pub(crate) enum PrincipalProviderErrorKind {
     Unauthenticated,
     Unavailable,
     Internal,
@@ -60,14 +120,14 @@ pub(crate) enum UserPrincipalProviderErrorKind {
 
 /// Client-safe failure reported by a request principal provider.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UserPrincipalProviderError {
-    kind: UserPrincipalProviderErrorKind,
+pub struct PrincipalProviderError {
+    kind: PrincipalProviderErrorKind,
     client_message: String,
 }
 
-impl UserPrincipalProviderError {
+impl PrincipalProviderError {
     fn new(
-        kind: UserPrincipalProviderErrorKind,
+        kind: PrincipalProviderErrorKind,
         client_message: impl Into<String>,
         default_message: &str,
     ) -> Self {
@@ -87,7 +147,7 @@ impl UserPrincipalProviderError {
     #[must_use]
     pub fn unauthenticated(client_message: impl Into<String>) -> Self {
         Self::new(
-            UserPrincipalProviderErrorKind::Unauthenticated,
+            PrincipalProviderErrorKind::Unauthenticated,
             client_message,
             "unauthenticated request",
         )
@@ -97,9 +157,9 @@ impl UserPrincipalProviderError {
     #[must_use]
     pub fn unavailable(client_message: impl Into<String>) -> Self {
         Self::new(
-            UserPrincipalProviderErrorKind::Unavailable,
+            PrincipalProviderErrorKind::Unavailable,
             client_message,
-            "user principal provider unavailable",
+            "principal provider unavailable",
         )
     }
 
@@ -107,13 +167,13 @@ impl UserPrincipalProviderError {
     #[must_use]
     pub fn internal(client_message: impl Into<String>) -> Self {
         Self::new(
-            UserPrincipalProviderErrorKind::Internal,
+            PrincipalProviderErrorKind::Internal,
             client_message,
-            "user principal provider failed",
+            "principal provider failed",
         )
     }
 
-    pub(crate) fn kind(&self) -> UserPrincipalProviderErrorKind {
+    pub(crate) fn kind(&self) -> PrincipalProviderErrorKind {
         self.kind
     }
 
@@ -124,45 +184,46 @@ impl UserPrincipalProviderError {
     }
 }
 
-impl fmt::Display for UserPrincipalProviderError {
+impl fmt::Display for PrincipalProviderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.client_message)
     }
 }
 
-impl std::error::Error for UserPrincipalProviderError {}
+impl std::error::Error for PrincipalProviderError {}
 
-/// Server-side provider for request user principals.
+/// Server-side provider for request principals.
 ///
-/// The OSS provider always returns [`UserPrincipal::local`]. Product runtimes
-/// can install a provider that authenticates inbound metadata and returns the
-/// corresponding user principal.
+/// The OSS provider always returns [`Principal::local`]. Product runtimes can
+/// install a provider that authenticates inbound metadata and returns the
+/// corresponding stable principal identity and actor kind. A provider must
+/// classify a given [`PrincipalId`] consistently across requests.
 #[tonic::async_trait]
-pub trait UserPrincipalProvider: Send + Sync + std::fmt::Debug {
-    /// Returns the user principal for one inbound gRPC request.
+pub trait PrincipalProvider: Send + Sync + std::fmt::Debug {
+    /// Returns the principal for one inbound gRPC request.
     ///
     /// # Errors
     ///
-    /// Returns [`UserPrincipalProviderError`] when transport metadata is
+    /// Returns [`PrincipalProviderError`] when transport metadata is
     /// malformed, the provider cannot authenticate the request, or principal
     /// selection fails.
     async fn principal_for_metadata(
         &self,
         metadata: &tonic::metadata::MetadataMap,
-    ) -> Result<UserPrincipal, UserPrincipalProviderError>;
+    ) -> Result<Principal, PrincipalProviderError>;
 }
 
-/// Default OSS principal provider for single-user local mode.
+/// Default OSS principal provider for local mode.
 #[derive(Debug, Default)]
-pub struct SingleUserPrincipalProvider;
+pub struct LocalPrincipalProvider;
 
 #[tonic::async_trait]
-impl UserPrincipalProvider for SingleUserPrincipalProvider {
+impl PrincipalProvider for LocalPrincipalProvider {
     async fn principal_for_metadata(
         &self,
         _metadata: &tonic::metadata::MetadataMap,
-    ) -> Result<UserPrincipal, UserPrincipalProviderError> {
-        Ok(UserPrincipal::local())
+    ) -> Result<Principal, PrincipalProviderError> {
+        Ok(Principal::local())
     }
 }
 
@@ -187,7 +248,8 @@ pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppE
 #[cfg(test)]
 mod tests {
     use super::{
-        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider, parse_path_segment,
+        LOCAL_PRINCIPAL_ID, LocalPrincipalProvider, Principal, PrincipalId, PrincipalKind,
+        PrincipalProvider, parse_path_segment,
     };
 
     #[test]
@@ -217,39 +279,45 @@ mod tests {
     }
 
     #[test]
-    fn user_principal_rejects_whitespace_anywhere() {
-        for invalid in [" saul", "saul ", "alice bob", "alice\tbob", "alice\nbob"] {
-            let error = UserPrincipal::for_user(invalid).expect_err("whitespace should fail");
+    fn principal_id_rejects_empty_whitespace_and_control_characters() {
+        for invalid in [
+            "",
+            " saul",
+            "saul ",
+            "alice bob",
+            "alice\tbob",
+            "alice\nbob",
+            "alice\0bob",
+        ] {
+            let error = PrincipalId::parse(invalid).expect_err("invalid principal id");
 
-            assert!(
-                error
-                    .to_string()
-                    .contains("user id must not contain whitespace")
-            );
+            assert!(error.to_string().contains("principal id must be non-empty"));
         }
     }
 
     #[test]
-    fn user_principal_rejects_path_segments_and_reserved_local_id() {
-        for invalid in ["team/saul", r"team\saul", ".", "..", "local"] {
-            UserPrincipal::for_user(invalid).expect_err("invalid user id should fail");
-        }
+    fn principal_id_rejects_reserved_local_identity() {
+        PrincipalId::parse(LOCAL_PRINCIPAL_ID).expect_err("local identity must stay app-owned");
     }
 
     #[test]
-    fn user_principal_preserves_valid_id() {
-        let principal = UserPrincipal::for_user("saul").expect("valid user");
+    fn principal_preserves_canonical_opaque_id_and_explicit_kind() {
+        let id = PrincipalId::parse("product:principal/saul").expect("valid principal id");
+        let principal = Principal::new(id.clone(), PrincipalKind::Agent);
 
-        assert_eq!(principal.user_id(), "saul");
+        assert_eq!(principal.id(), &id);
+        assert_eq!(principal.id().as_str(), "product:principal/saul");
+        assert_eq!(principal.kind(), PrincipalKind::Agent);
     }
 
     #[tokio::test]
-    async fn single_user_provider_returns_local_principal() {
-        let principal = SingleUserPrincipalProvider
+    async fn local_provider_returns_local_principal() {
+        let principal = LocalPrincipalProvider
             .principal_for_metadata(&tonic::metadata::MetadataMap::new())
             .await
             .expect("local principal");
 
-        assert_eq!(principal, UserPrincipal::local());
+        assert_eq!(principal, Principal::local());
+        assert_eq!(principal.kind(), PrincipalKind::User);
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -66,7 +66,8 @@ pub use bootstrap::{
 };
 pub use coral_engine::{EngineExtensions, QuerySource};
 pub use identity::{
-    SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError,
+    LocalPrincipalProvider, Principal, PrincipalId, PrincipalKind, PrincipalProvider,
+    PrincipalProviderError,
 };
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,

--- a/crates/coral-app/src/request_context.rs
+++ b/crates/coral-app/src/request_context.rs
@@ -1,6 +1,6 @@
 //! Request-scoped app context selected at the transport boundary.
 
-use crate::identity::UserPrincipal;
+use crate::identity::Principal;
 
 /// Request-scoped data that domain services may need after authentication.
 ///
@@ -9,11 +9,11 @@ use crate::identity::UserPrincipal;
 /// principal-aware call signature again.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RequestContext {
-    principal: UserPrincipal,
+    principal: Principal,
 }
 
 impl RequestContext {
-    pub(crate) fn new(principal: UserPrincipal) -> Self {
+    pub(crate) fn new(principal: Principal) -> Self {
         Self { principal }
     }
 
@@ -24,7 +24,7 @@ impl RequestContext {
             reason = "request principals stay encapsulated for downstream authorization and attribution"
         )
     )]
-    pub(crate) fn principal(&self) -> &UserPrincipal {
+    pub(crate) fn principal(&self) -> &Principal {
         &self.principal
     }
 }
@@ -32,12 +32,15 @@ impl RequestContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::PrincipalKind;
 
     #[test]
     fn exposes_request_principal() {
-        let principal = UserPrincipal::for_user("saul").expect("valid user");
+        let principal = Principal::parse("product:principal:saul", PrincipalKind::User)
+            .expect("valid principal");
         let context = RequestContext::new(principal.clone());
 
         assert_eq!(context.principal(), &principal);
+        assert_eq!(context.principal().kind(), PrincipalKind::User);
     }
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -33,9 +33,7 @@ use crate::catalog::discovery::{
     CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
     ColumnSearchResult, DescribeTableResult,
 };
-use crate::identity::{
-    UserPrincipalProvider, UserPrincipalProviderError, UserPrincipalProviderErrorKind,
-};
+use crate::identity::{PrincipalProvider, PrincipalProviderError, PrincipalProviderErrorKind};
 use crate::query::manager::QueryManagerError;
 use crate::request_context::RequestContext;
 use crate::task::id::TaskId;
@@ -43,7 +41,7 @@ use crate::workspaces::WorkspaceName;
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 
-const USER_PRINCIPAL_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
+const PRINCIPAL_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 struct GrpcServerSpan(tracing::Span);
@@ -78,14 +76,12 @@ impl Extractor for MetadataExtractor<'_> {
 /// covered by the same principal-selection path.
 #[derive(Clone)]
 pub(crate) struct GrpcRequestContextLayer {
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    principal_provider: Arc<dyn PrincipalProvider>,
 }
 
 impl GrpcRequestContextLayer {
-    pub(crate) fn new(user_principal_provider: Arc<dyn UserPrincipalProvider>) -> Self {
-        Self {
-            user_principal_provider,
-        }
+    pub(crate) fn new(principal_provider: Arc<dyn PrincipalProvider>) -> Self {
+        Self { principal_provider }
     }
 }
 
@@ -95,7 +91,7 @@ impl<S> Layer<S> for GrpcRequestContextLayer {
     fn layer(&self, inner: S) -> Self::Service {
         GrpcRequestContextService {
             inner,
-            user_principal_provider: Arc::clone(&self.user_principal_provider),
+            principal_provider: Arc::clone(&self.principal_provider),
         }
     }
 }
@@ -103,7 +99,7 @@ impl<S> Layer<S> for GrpcRequestContextLayer {
 #[derive(Clone)]
 pub(crate) struct GrpcRequestContextService<S> {
     inner: S,
-    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    principal_provider: Arc<dyn PrincipalProvider>,
 }
 
 impl<S, B, ResBody> Service<http::Request<B>> for GrpcRequestContextService<S>
@@ -132,7 +128,7 @@ where
             |method| GrpcMethodMetadata::new(method.service.as_str(), method.method.as_str()),
         );
         let request_metadata = MetadataMap::from_headers(request.headers().clone());
-        let user_principal_provider = Arc::clone(&self.user_principal_provider);
+        let principal_provider = Arc::clone(&self.principal_provider);
         let span = grpc_span_for_metadata(&method_metadata, &request_metadata);
         request
             .extensions_mut()
@@ -145,9 +141,9 @@ where
         Box::pin(
             async move {
                 match principal_for_request(
-                    user_principal_provider.as_ref(),
+                    principal_provider.as_ref(),
                     &request_metadata,
-                    USER_PRINCIPAL_PROVIDER_TIMEOUT,
+                    PRINCIPAL_PROVIDER_TIMEOUT,
                 )
                 .await
                 {
@@ -158,7 +154,7 @@ where
                         inner.call(request).await
                     }
                     Err(error) => {
-                        let status = user_principal_provider_status(&error);
+                        let status = principal_provider_status(&error);
                         record_grpc_status(&span, status.code(), Some(&status));
                         Ok(status.into_http())
                     }
@@ -170,26 +166,24 @@ where
 }
 
 async fn principal_for_request(
-    provider: &dyn UserPrincipalProvider,
+    provider: &dyn PrincipalProvider,
     metadata: &MetadataMap,
     timeout: Duration,
-) -> Result<crate::identity::UserPrincipal, UserPrincipalProviderError> {
+) -> Result<crate::identity::Principal, PrincipalProviderError> {
     tokio::time::timeout(timeout, provider.principal_for_metadata(metadata))
         .await
         .unwrap_or_else(|_| {
-            Err(UserPrincipalProviderError::unavailable(
-                "user principal provider timed out",
+            Err(PrincipalProviderError::unavailable(
+                "principal provider timed out",
             ))
         })
 }
 
-fn user_principal_provider_status(error: &UserPrincipalProviderError) -> Status {
+fn principal_provider_status(error: &PrincipalProviderError) -> Status {
     let (code, prefix) = match error.kind() {
-        UserPrincipalProviderErrorKind::Unauthenticated => {
-            (Code::Unauthenticated, "unauthenticated")
-        }
-        UserPrincipalProviderErrorKind::Unavailable => (Code::Unavailable, "unavailable"),
-        UserPrincipalProviderErrorKind::Internal => (Code::Internal, "internal"),
+        PrincipalProviderErrorKind::Unauthenticated => (Code::Unauthenticated, "unauthenticated"),
+        PrincipalProviderErrorKind::Unavailable => (Code::Unavailable, "unavailable"),
+        PrincipalProviderErrorKind::Internal => (Code::Internal, "internal"),
     };
     status_with_bounded_detail(code, format!("{prefix}: {}", error.client_message()))
 }
@@ -614,13 +608,12 @@ mod tests {
 
     use super::{
         GRPC_REQUEST_ERROR_MESSAGE, GrpcMethodMetadata, GrpcServerMethod, annotate_request_context,
-        grpc_method, grpc_span_for_metadata, instrument_grpc, query_status,
-        query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
-        table_to_proto, user_principal_provider_status, workspace_name_from_proto,
-        workspace_to_proto,
+        grpc_method, grpc_span_for_metadata, instrument_grpc, principal_provider_status,
+        query_status, query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
+        table_to_proto, workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
-    use crate::identity::UserPrincipalProviderError;
+    use crate::identity::PrincipalProviderError;
     use crate::query::manager::QueryManagerError;
     use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
@@ -754,26 +747,26 @@ mod tests {
     }
 
     #[test]
-    fn user_principal_provider_status_preserves_failure_class() {
+    fn principal_provider_status_preserves_failure_class() {
         let cases = [
             (
-                UserPrincipalProviderError::unauthenticated("bad token"),
+                PrincipalProviderError::unauthenticated("bad token"),
                 Code::Unauthenticated,
                 "unauthenticated: bad token",
             ),
             (
-                UserPrincipalProviderError::unavailable("key service offline"),
+                PrincipalProviderError::unavailable("key service offline"),
                 Code::Unavailable,
                 "unavailable: key service offline",
             ),
             (
-                UserPrincipalProviderError::internal("invalid principal selection"),
+                PrincipalProviderError::internal("invalid principal selection"),
                 Code::Internal,
                 "internal: invalid principal selection",
             ),
         ];
         for (error, code, message) in cases {
-            let status = user_principal_provider_status(&error);
+            let status = principal_provider_status(&error);
             assert_eq!(status.code(), code);
             assert_eq!(status.message(), message);
         }

--- a/crates/coral-app/tests/grpc/health_service_tests.rs
+++ b/crates/coral-app/tests/grpc/health_service_tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use coral_app::{UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError};
+use coral_app::{Principal, PrincipalProvider, PrincipalProviderError};
 use coral_client::local::ServerBuilder;
 use tempfile::TempDir;
 use tonic::Code;
@@ -9,16 +9,16 @@ use tonic_health::pb::health_check_response::ServingStatus;
 use tonic_health::pb::health_client::HealthClient;
 
 #[derive(Debug)]
-struct UnavailableUserPrincipalProvider;
+struct UnavailablePrincipalProvider;
 
 #[tonic::async_trait]
-impl UserPrincipalProvider for UnavailableUserPrincipalProvider {
+impl PrincipalProvider for UnavailablePrincipalProvider {
     async fn principal_for_metadata(
         &self,
         _metadata: &tonic::metadata::MetadataMap,
-    ) -> Result<UserPrincipal, UserPrincipalProviderError> {
-        Err(UserPrincipalProviderError::unavailable(
-            "user principal provider unavailable",
+    ) -> Result<Principal, PrincipalProviderError> {
+        Err(PrincipalProviderError::unavailable(
+            "principal provider unavailable",
         ))
     }
 }
@@ -28,7 +28,7 @@ async fn grpc_health_is_process_liveness_only() {
     let temp = TempDir::new().expect("temp dir");
     let server = ServerBuilder::new()
         .with_config_dir(temp.path())
-        .with_user_principal_provider(Arc::new(UnavailableUserPrincipalProvider))
+        .with_principal_provider(Arc::new(UnavailablePrincipalProvider))
         .start()
         .await
         .expect("start server");


### PR DESCRIPTION
## Summary

- replace the user-specific request identity seam with opaque `PrincipalId` and `Principal` types
- add a closed `PrincipalKind` (`User` or `Agent`) that authenticated providers must supply explicitly and keep stable for a principal ID
- keep actor kind available to future authorization policy without treating it as a role or permission
- keep `LocalPrincipalProvider` as the OSS default and classify the local principal as a local User
- rename the public provider and server-builder APIs without compatibility aliases
- record the opaque-ID and stable-kind contract in internal `coral-app` contributor guidance

## Breaking change

`UserPrincipal`, `UserPrincipalProvider`, `UserPrincipalProviderError`, `SingleUserPrincipalProvider`, and `with_user_principal_provider` are replaced by their principal-generic equivalents. Non-local `Principal::new` and `Principal::parse` callers must now provide `PrincipalKind` explicitly.

## Validation

- `make rust-checks` at the top of the stack — 2,067 passed, 5 skipped
- focused identity and request-context coverage
- exact-head independent Standards and Spec reviews — no unresolved findings

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
