### PR TITLE
feat(reef/wax): Add MCP clients settings component

### DIFF
--- a/apps/reef/app/components/mcp-clients-settings/index.ts
+++ b/apps/reef/app/components/mcp-clients-settings/index.ts
@@ -1,0 +1,5 @@
+export {
+  McpClientsSettings,
+  type McpClientSettingsItem,
+  type McpClientsSettingsProps,
+} from './mcp-clients-settings'

--- a/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.css.ts
+++ b/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.css.ts
@@ -1,0 +1,53 @@
+import { style } from '@vanilla-extract/css'
+
+import { breakpoints } from '@/styles/theme.css'
+import { theme } from '@/wax/theme/theme.css'
+
+const MOBILE_QUERY = `screen and (max-width: ${breakpoints.mobile})`
+
+export const section = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+})
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+})
+
+export const statusCell = style({
+  paddingBlock: '24px',
+  paddingInline: '12px',
+  textAlign: 'center',
+})
+
+export const tableContainer = style({
+  background: theme.surface.card,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '10px',
+  overflow: 'hidden',
+})
+
+export const table = style({
+  tableLayout: 'fixed',
+})
+
+export const workspaceColumn = style({
+  width: '260px',
+  '@media': {
+    [MOBILE_QUERY]: {
+      width: '180px',
+    },
+  },
+})
+
+export const workspaceTrigger = style({
+  justifyContent: 'space-between',
+})
+
+export const workspaceMenu = style({
+  maxWidth: 'calc(100vw - 32px)',
+  width: '228px',
+})

--- a/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.stories.tsx
+++ b/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { fn } from 'storybook/test'
+
+import { McpClientsSettings } from './mcp-clients-settings'
+
+const meta = {
+  args: {
+    clients: [
+      { configuredWorkspace: 'default', id: 'claude-code', name: 'Claude Code' },
+      { id: 'codex', name: 'Codex' },
+    ],
+    onWorkspaceChange: fn(),
+    workspaces: [{ name: 'default' }, { name: 'analytics' }],
+  },
+  component: McpClientsSettings,
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div style={{ maxWidth: 960 }}>
+      <McpClientsSettings {...args} />
+    </div>
+  ),
+  tags: ['autodocs'],
+  title: 'Components/McpClientsSettings',
+} satisfies Meta<typeof McpClientsSettings>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Loading: Story = {
+  args: { clients: [], loading: true },
+}
+
+export const Empty: Story = {
+  args: { clients: [] },
+}
+
+export const Error: Story = {
+  args: { clients: [], error: 'Unable to read MCP client configurations.' },
+}

--- a/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.tsx
+++ b/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.tsx
@@ -1,0 +1,145 @@
+import { Banner, Button, Menu, Table, Typography } from '@/wax/components'
+
+import * as styles from './mcp-clients-settings.css'
+
+const NOT_CONFIGURED = 'not-configured'
+const WORKSPACE_ACCESS_PREFIX = 'workspace:'
+
+export interface McpClientSettingsItem {
+  readonly configuredWorkspace?: string
+  readonly id: string
+  readonly name: string
+}
+
+export interface McpClientsSettingsProps {
+  readonly clients: ReadonlyArray<McpClientSettingsItem>
+  readonly error?: string
+  readonly loading?: boolean
+  readonly onWorkspaceChange: (clientId: string, workspaceName?: string) => void
+  readonly workspaces: ReadonlyArray<{ name: string }>
+}
+
+export function McpClientsSettings({
+  clients,
+  error,
+  loading = false,
+  onWorkspaceChange,
+  workspaces,
+}: McpClientsSettingsProps) {
+  const status = loading ? (
+    <Typography.BodySmall role="status" variant="tertiary">
+      Loading MCP clients…
+    </Typography.BodySmall>
+  ) : error ? (
+    <Typography.BodySmall role="alert" variant="error">
+      {error}
+    </Typography.BodySmall>
+  ) : clients.length === 0 ? (
+    <Typography.BodySmall variant="tertiary">
+      No supported MCP clients detected.
+    </Typography.BodySmall>
+  ) : null
+
+  return (
+    <section className={styles.section}>
+      <header className={styles.header}>
+        <Typography.HeadingLarge as="h1">MCP Clients</Typography.HeadingLarge>
+        <Typography.Body variant="secondary">
+          Choose the Coral workspace each MCP client can access.{' '}
+          <Button.ExternalLink
+            href="https://withcoral.com/docs/guides/use-coral-over-mcp"
+            size="small"
+          >
+            Learn more
+          </Button.ExternalLink>
+        </Typography.Body>
+      </header>
+
+      <Banner>
+        This page shows only global MCP configurations. Project-specific and other connections will
+        not appear here.
+      </Banner>
+
+      <div className={styles.tableContainer}>
+        <Table.Wrapper>
+          <Table.Root className={styles.table}>
+            <Table.Head>
+              <Table.Row>
+                <Table.HeaderCell>MCP client</Table.HeaderCell>
+                <Table.HeaderCell className={styles.workspaceColumn}>Workspace</Table.HeaderCell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {status ? (
+                <Table.Row>
+                  <td className={styles.statusCell} colSpan={2}>
+                    {status}
+                  </td>
+                </Table.Row>
+              ) : (
+                clients.map((client) => {
+                  const access =
+                    client.configuredWorkspace === undefined
+                      ? NOT_CONFIGURED
+                      : workspaceAccessValue(client.configuredWorkspace)
+                  const accessLabel =
+                    client.configuredWorkspace === undefined
+                      ? 'Not configured'
+                      : client.configuredWorkspace
+
+                  return (
+                    <Table.Row key={client.id}>
+                      <Table.Cell>
+                        <Typography.BodyStrong variant="primary">
+                          {client.name}
+                        </Typography.BodyStrong>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Menu.Container>
+                          <Menu.Trigger
+                            className={styles.workspaceTrigger}
+                            render={<Button.Container fullWidth variant="secondary" />}
+                          >
+                            <Button.Text>{accessLabel}</Button.Text>
+                            <Button.Icon name="ChevronDown" />
+                          </Menu.Trigger>
+                          <Menu.Content align="end" className={styles.workspaceMenu}>
+                            <Menu.RadioGroup
+                              onValueChange={(value) => {
+                                onWorkspaceChange(
+                                  client.id,
+                                  value === NOT_CONFIGURED
+                                    ? undefined
+                                    : value.slice(WORKSPACE_ACCESS_PREFIX.length),
+                                )
+                              }}
+                              value={access}
+                            >
+                              <Menu.RadioItem value={NOT_CONFIGURED}>Not configured</Menu.RadioItem>
+                              {workspaces.map((workspace) => (
+                                <Menu.RadioItem
+                                  key={workspace.name}
+                                  value={workspaceAccessValue(workspace.name)}
+                                >
+                                  {workspace.name}
+                                </Menu.RadioItem>
+                              ))}
+                            </Menu.RadioGroup>
+                          </Menu.Content>
+                        </Menu.Container>
+                      </Table.Cell>
+                    </Table.Row>
+                  )
+                })
+              )}
+            </Table.Body>
+          </Table.Root>
+        </Table.Wrapper>
+      </div>
+    </section>
+  )
+}
+
+function workspaceAccessValue(workspaceName: string): string {
+  return `${WORKSPACE_ACCESS_PREFIX}${workspaceName}`
+}

--- a/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.tsx
+++ b/apps/reef/app/components/mcp-clients-settings/mcp-clients-settings.tsx
@@ -43,7 +43,7 @@ export function McpClientsSettings({
   return (
     <section className={styles.section}>
       <header className={styles.header}>
-        <Typography.HeadingLarge as="h1">MCP Clients</Typography.HeadingLarge>
+        <Typography.HeadingLarge as="h2">MCP Clients</Typography.HeadingLarge>
         <Typography.Body variant="secondary">
           Choose the Coral workspace each MCP client can access.{' '}
           <Button.ExternalLink


### PR DESCRIPTION
## Summary

Presentational components needed for the upcoming 1-click MCP client configuration UI.

## Test plan

<img width="812" height="335" alt="image" src="https://github.com/user-attachments/assets/8a9764c2-6461-47e6-9309-e8e72ac88893" />
<img width="818" height="287" alt="image" src="https://github.com/user-attachments/assets/7948b240-a926-47db-8962-c567dc4f36ea" />
<img width="809" height="297" alt="image" src="https://github.com/user-attachments/assets/eaa6337b-602c-43aa-b8cb-83283a521f45" />
<img width="809" height="291" alt="image" src="https://github.com/user-attachments/assets/f0fd2cc5-0ca7-4501-9f4a-c42cba493ea9" />
