### PR TITLE
fix(reef): remove final table row border

### DIFF
--- a/apps/reef/app/wax/components/table/table.css.ts
+++ b/apps/reef/app/wax/components/table/table.css.ts
@@ -106,6 +106,9 @@ export const tr = style({
     'tbody &:hover': {
       backgroundColor: tableVars.rowHoverBackground.value,
     },
+    'tbody &:last-child': {
+      borderBottom: 'none',
+    },
   },
 })
 


### PR DESCRIPTION
## Summary

Says on the tin. Removes the ugly double border from the bottom of the table

## Test plan

| Before | After |
| ------ | ------ |
|  <img width="421" height="86" alt="image" src="https://github.com/user-attachments/assets/505d5e9e-bf01-47ba-bcf7-02c520091742" /> | <img width="373" height="84" alt="image" src="https://github.com/user-attachments/assets/a39495c5-0334-4f4a-b515-21b27dedf15d" /> |

