### PR TITLE
fix(engine): bind table-function arguments by declared type

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -16,22 +16,37 @@ use coral_spec::{
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
-use datafusion::logical_expr::Expr;
 use datafusion::prelude::SessionContext;
+use serde_json::Value;
+
+/// One table-function argument after SQL literal evaluation and
+/// manifest-directed coercion.
+#[derive(Debug, Clone)]
+pub(crate) struct BoundSourceFunctionValue {
+    /// Value encoded according to the manifest-declared type.
+    pub(crate) value: Value,
+    /// Original scalar spelling used by the existing `values:` contract.
+    pub(crate) source_text: String,
+}
+
+/// `None` represents SQL `NULL`.
+pub(crate) type BoundSourceFunctionArg = Option<BoundSourceFunctionValue>;
 
 /// Provider factory for one registered source-scoped table function.
 ///
-/// Implementations bind one call site's positional arguments (manifest order,
-/// NULL meaning "absent") into a scannable provider. Binding is pure argument
-/// validation plus request-value capture — no I/O happens until the returned
-/// provider is scanned.
+/// Implementations map one call site's manifest-bound positional arguments
+/// (`None` meaning SQL `NULL`) into a scannable provider. Mapping is pure
+/// argument validation plus request-value capture — no I/O happens until the
+/// returned provider is scanned.
 pub(crate) trait SourceFunctionProviderFactory: std::fmt::Debug + Send + Sync {
     /// Manifest-declared result schema for this function.
     fn schema(&self) -> SchemaRef;
 
-    /// Binds positional call arguments into a provider for one call site.
-    fn provider_for_args(&self, args: &[Expr])
-    -> datafusion::error::Result<Arc<dyn TableProvider>>;
+    /// Maps manifest-bound positional arguments into a provider for one call site.
+    fn provider_for_args(
+        &self,
+        args: &[BoundSourceFunctionArg],
+    ) -> datafusion::error::Result<Arc<dyn TableProvider>>;
 }
 
 #[derive(Debug, Clone)]
@@ -432,7 +447,7 @@ pub(crate) mod test_support {
 
         fn provider_for_args(
             &self,
-            _args: &[Expr],
+            _args: &[BoundSourceFunctionArg],
         ) -> datafusion::error::Result<Arc<dyn TableProvider>> {
             Err(DataFusionError::Internal(
                 "stub source function factory cannot bind arguments".to_string(),

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
-use coral_spec::SourceTableFunctionSpec;
+use coral_spec::{ManifestDataType, SourceTableFunctionSpec};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
@@ -19,13 +19,12 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 
 use crate::SourceObservationSurfaceKind;
-use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::provider::{HttpJsonExecRequest, http_json_exec};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
-use crate::backends::shared::filter_expr::literal_to_string;
 use crate::backends::shared::source_observation::SourceObservationPublishers;
+use crate::backends::{BoundSourceFunctionArg, SourceFunctionProviderFactory};
 
 struct FunctionCallContext<'a> {
     source_schema: &'a str,
@@ -88,7 +87,7 @@ impl SourceFunctionProviderFactory for HttpSourceTableFunction {
         Arc::clone(&self.state.schema)
     }
 
-    fn provider_for_args(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+    fn provider_for_args(&self, args: &[BoundSourceFunctionArg]) -> Result<Arc<dyn TableProvider>> {
         let arg_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
         Ok(Arc::new(HttpSourceFunctionCallTableProvider {
             state: Arc::clone(&self.state),
@@ -164,7 +163,7 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
 fn bind_function_args(
     source_schema: &str,
     function: &SourceTableFunctionSpec,
-    args: &[Expr],
+    args: &[BoundSourceFunctionArg],
 ) -> Result<HashMap<String, String>> {
     let context = FunctionCallContext {
         source_schema,
@@ -176,14 +175,23 @@ fn bind_function_args(
     let mut arg_values = HashMap::with_capacity(function.args.len());
 
     for (index, spec) in function.args.iter().enumerate() {
-        let Some(value) = resolve_call_arg_literal(&context, spec.name.as_str(), args.get(index))?
-        else {
+        let Some(value) = args.get(index).and_then(Option::as_ref) else {
             if spec.required {
                 required_missing.push(spec.name.as_str());
             }
             continue;
         };
-        ensure_call_arg_allowed_value(&context, spec.name.as_str(), &value, &spec.values)?;
+        ensure_call_arg_allowed_value(
+            &context,
+            spec.name.as_str(),
+            &value.source_text,
+            &spec.values,
+        )?;
+        let value = match (spec.data_type, &value.value) {
+            (ManifestDataType::Json, value) => value.to_string(),
+            (_, serde_json::Value::String(value)) => value.clone(),
+            (_, value) => value.to_string(),
+        };
         arg_values.insert(spec.bind.arg.clone(), value);
     }
 
@@ -211,35 +219,6 @@ fn ensure_no_extra_args(
         )));
     }
     Ok(())
-}
-
-fn resolve_call_arg_literal(
-    context: &FunctionCallContext<'_>,
-    arg_name: &str,
-    expr: Option<&Expr>,
-) -> Result<Option<String>> {
-    let Some(expr) = expr else {
-        return Ok(None);
-    };
-    if is_null_literal(expr) {
-        return Ok(None);
-    }
-    let Some(value) = literal_to_string(expr) else {
-        return Err(DataFusionError::Plan(format!(
-            "{}.{} argument '{}' must be a literal",
-            context.source_schema, context.function_name, arg_name
-        )));
-    };
-    Ok(Some(value))
-}
-
-fn is_null_literal(expr: &Expr) -> bool {
-    match expr {
-        Expr::Literal(value, _) => value.is_null(),
-        Expr::Cast(cast) => is_null_literal(cast.expr.as_ref()),
-        Expr::TryCast(cast) => is_null_literal(cast.expr.as_ref()),
-        _ => false,
-    }
 }
 
 fn ensure_call_arg_allowed_value(

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -9,19 +9,17 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::scalar::ScalarValue;
 use serde_json::Value;
 
 use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
 use crate::SourceObservationSurfaceKind;
-use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
-use crate::backends::shared::scalar::timestamp_to_rfc3339;
 use crate::backends::shared::source_observation::SourceObservationPublishers;
+use crate::backends::{BoundSourceFunctionArg, SourceFunctionProviderFactory};
 
 #[derive(Clone)]
 pub(super) struct McpSourceTableFunction {
@@ -102,7 +100,7 @@ impl SourceFunctionProviderFactory for McpSourceTableFunction {
         Arc::clone(&self.state.schema)
     }
 
-    fn provider_for_args(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+    fn provider_for_args(&self, args: &[BoundSourceFunctionArg]) -> Result<Arc<dyn TableProvider>> {
         let arg_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
         Ok(Arc::new(McpFunctionCallTableProvider {
             state: Arc::clone(&self.state),
@@ -205,7 +203,7 @@ struct FunctionCallContext<'a> {
 fn bind_function_args(
     source_schema: &str,
     function: &McpTableFunctionSpec,
-    args: &[Expr],
+    args: &[BoundSourceFunctionArg],
 ) -> Result<HashMap<String, Value>> {
     let context = FunctionCallContext {
         source_schema,
@@ -217,15 +215,19 @@ fn bind_function_args(
     let mut arg_values = HashMap::with_capacity(function.args().len());
 
     for (index, spec) in function.args().iter().enumerate() {
-        let Some(value) = resolve_call_arg_literal(&context, spec.name.as_str(), args.get(index))?
-        else {
+        let Some(value) = args.get(index).and_then(Option::as_ref) else {
             if spec.required {
                 required_missing.push(spec.name.as_str());
             }
             continue;
         };
-        ensure_call_arg_allowed_value(&context, spec.name.as_str(), &value, &spec.values)?;
-        arg_values.insert(spec.bind.arg.clone(), value);
+        ensure_call_arg_allowed_value(
+            &context,
+            spec.name.as_str(),
+            &value.source_text,
+            &spec.values,
+        )?;
+        arg_values.insert(spec.bind.arg.clone(), value.value.clone());
     }
 
     if !required_missing.is_empty() {
@@ -255,44 +257,6 @@ fn ensure_no_extra_args(
     Ok(())
 }
 
-fn resolve_call_arg_literal(
-    context: &FunctionCallContext<'_>,
-    arg_name: &str,
-    expr: Option<&Expr>,
-) -> Result<Option<Value>> {
-    let Some(expr) = expr else {
-        return Ok(None);
-    };
-    if is_null_literal(expr) {
-        return Ok(None);
-    }
-    let Some(value) = literal_to_json_value(expr) else {
-        return Err(DataFusionError::Plan(format!(
-            "{}.{} argument '{}' must be a literal",
-            context.source_schema, context.function_name, arg_name
-        )));
-    };
-    Ok(Some(value))
-}
-
-fn is_null_literal(expr: &Expr) -> bool {
-    match expr {
-        Expr::Literal(value, _) => value.is_null(),
-        Expr::Cast(cast) => is_null_literal(cast.expr.as_ref()),
-        Expr::TryCast(cast) => is_null_literal(cast.expr.as_ref()),
-        _ => false,
-    }
-}
-
-fn literal_to_json_value(expr: &Expr) -> Option<Value> {
-    match expr {
-        Expr::Literal(value, _) => scalar_value_to_json(value),
-        Expr::Cast(cast) => literal_to_json_value(cast.expr.as_ref()),
-        Expr::TryCast(cast) => literal_to_json_value(cast.expr.as_ref()),
-        _ => None,
-    }
-}
-
 /// Renders the typed function call args as the `String` map `convert_items`
 /// expects when resolving `expr.kind: from_arg`. Strings pass through as-is;
 /// other JSON scalars are stringified so a column reading `from_arg` sees the
@@ -310,42 +274,13 @@ fn arg_values_as_strings(arg_values: &HashMap<String, Value>) -> HashMap<String,
         .collect()
 }
 
-fn scalar_value_to_json(value: &ScalarValue) -> Option<Value> {
-    match value {
-        ScalarValue::Utf8(Some(value))
-        | ScalarValue::LargeUtf8(Some(value))
-        | ScalarValue::Utf8View(Some(value)) => Some(Value::String(value.clone())),
-        ScalarValue::Boolean(Some(value)) => Some(Value::Bool(*value)),
-        ScalarValue::Int8(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::Int16(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::Int32(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::Int64(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::UInt8(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::UInt16(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::UInt32(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::UInt64(Some(value)) => Some(Value::from(*value)),
-        ScalarValue::Float32(Some(value)) => {
-            serde_json::Number::from_f64(f64::from(*value)).map(Value::Number)
-        }
-        ScalarValue::Float64(Some(value)) => {
-            serde_json::Number::from_f64(*value).map(Value::Number)
-        }
-        value => timestamp_to_rfc3339(value).map(Value::String),
-    }
-}
-
 fn ensure_call_arg_allowed_value(
     context: &FunctionCallContext<'_>,
     arg: &str,
-    value: &Value,
+    value: &str,
     allowed_values: &[String],
 ) -> Result<()> {
-    let comparable_value = value_for_allowed_value_check(value);
-    if !allowed_values.is_empty()
-        && !allowed_values
-            .iter()
-            .any(|allowed| allowed == comparable_value.as_str())
-    {
+    if !allowed_values.is_empty() && !allowed_values.iter().any(|allowed| allowed == value) {
         return Err(DataFusionError::Plan(format!(
             "{}.{} argument '{arg}' has invalid value '{value}'; expected one of: {}",
             context.source_schema,
@@ -356,16 +291,10 @@ fn ensure_call_arg_allowed_value(
     Ok(())
 }
 
-fn value_for_allowed_value_check(value: &Value) -> String {
-    match value {
-        Value::String(value) => value.clone(),
-        other => other.to_string(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::backends::shared::scalar::timestamp_to_rfc3339;
+    use datafusion::scalar::ScalarValue;
 
     #[test]
     fn timestamp_scalar_serializes_as_json_string() {
@@ -373,8 +302,8 @@ mod tests {
             ScalarValue::TimestampMicrosecond(Some(1_704_067_200_000_000), Some("+00:00".into()));
 
         assert_eq!(
-            scalar_value_to_json(&timestamp),
-            Some(Value::String("2024-01-01T00:00:00Z".to_string()))
+            timestamp_to_rfc3339(&timestamp),
+            Some("2024-01-01T00:00:00Z".to_string())
         );
     }
 }

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -49,6 +49,38 @@ impl McpToolCaller for FakeMcpCaller {
     }
 }
 
+#[derive(Debug)]
+struct SchemaValidatingMcpCaller;
+
+#[async_trait]
+impl McpToolCaller for SchemaValidatingMcpCaller {
+    async fn call_tool(
+        &self,
+        _relation: &str,
+        _tool_name: &str,
+        arguments: JsonObject,
+    ) -> Result<Value> {
+        let include_archived = arguments
+            .get("include_archived")
+            .cloned()
+            .unwrap_or(Value::Null);
+        serde_json::from_value::<bool>(include_archived.clone()).map_err(|error| {
+            DataFusionError::Plan(format!(
+                "MCP tool expected boolean argument include_archived, got \
+                 {include_archived}: {error}"
+            ))
+        })?;
+        if let Some(filter) = arguments.get("workflow_runs_filter") {
+            serde_json::from_value::<JsonObject>(filter.clone()).map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "MCP tool expected object argument workflow_runs_filter, got {filter}: {error}"
+                ))
+            })?;
+        }
+        Ok(json!({ "items": [] }))
+    }
+}
+
 /// Records each MCP tool call and returns a fixed payload for table tests.
 #[derive(Debug)]
 struct FakeMcpTableCaller {
@@ -271,6 +303,11 @@ fn mcp_typed_args_manifest() -> coral_spec::ValidatedSourceManifest {
                     "type": "Float64",
                     "required": true,
                     "bind": { "arg": "threshold" }
+                },
+                {
+                    "name": "workflow_runs_filter",
+                    "type": "Json",
+                    "bind": { "arg": "workflow_runs_filter" }
                 }
             ],
             "response": {
@@ -427,7 +464,7 @@ async fn mcp_table_function_declared_arg_types_keep_existing_call_behavior() {
              query => 'issue', \
              limit => 10, \
              include_archived => true, \
-             threshold => 0.75)",
+             threshold => 1)",
         )
         .await
         .expect("typed function query should plan")
@@ -445,7 +482,58 @@ async fn mcp_table_function_declared_arg_types_keep_existing_call_behavior() {
     );
     assert_eq!(call.1.get("limit"), Some(&Value::from(10)));
     assert_eq!(call.1.get("include_archived"), Some(&Value::Bool(true)));
-    assert_eq!(call.1.get("threshold"), Some(&json!(0.75)));
+    assert_eq!(call.1.get("threshold"), Some(&json!(1.0)));
+}
+
+#[tokio::test]
+async fn mcp_table_function_coerces_compatible_string_to_declared_boolean() {
+    let ctx = SessionContext::new();
+    register_test_sources(
+        &ctx,
+        compile_sources(
+            mcp_typed_args_manifest(),
+            Arc::new(SchemaValidatingMcpCaller),
+        ),
+    );
+
+    ctx.sql(
+        "SELECT title FROM test_mcp.typed_search(\
+         query => 'issue', \
+         limit => 10, \
+         include_archived => 'true', \
+         threshold => 0.75)",
+    )
+    .await
+    .expect("typed function query should plan")
+    .collect()
+    .await
+    .expect("MCP tool should receive include_archived as a JSON boolean");
+}
+
+#[tokio::test]
+async fn mcp_table_function_parses_declared_json_object_argument() {
+    let ctx = SessionContext::new();
+    register_test_sources(
+        &ctx,
+        compile_sources(
+            mcp_typed_args_manifest(),
+            Arc::new(SchemaValidatingMcpCaller),
+        ),
+    );
+
+    ctx.sql(
+        "SELECT title FROM test_mcp.typed_search(\
+         query => 'issue', \
+         limit => 10, \
+         include_archived => true, \
+         threshold => 0.75, \
+         workflow_runs_filter => '{\"status\":\"completed\"}')",
+    )
+    .await
+    .expect("typed function query should plan")
+    .collect()
+    .await
+    .expect("MCP tool should receive workflow_runs_filter as a JSON object");
 }
 
 #[tokio::test]

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -70,13 +70,6 @@ impl McpToolCaller for SchemaValidatingMcpCaller {
                  {include_archived}: {error}"
             ))
         })?;
-        if let Some(filter) = arguments.get("workflow_runs_filter") {
-            serde_json::from_value::<JsonObject>(filter.clone()).map_err(|error| {
-                DataFusionError::Plan(format!(
-                    "MCP tool expected object argument workflow_runs_filter, got {filter}: {error}"
-                ))
-            })?;
-        }
         Ok(json!({ "items": [] }))
     }
 }
@@ -513,12 +506,12 @@ async fn mcp_table_function_coerces_compatible_string_to_declared_boolean() {
 #[tokio::test]
 async fn mcp_table_function_parses_declared_json_object_argument() {
     let ctx = SessionContext::new();
+    let caller = Arc::new(FakeMcpCaller {
+        calls: Mutex::new(Vec::new()),
+    });
     register_test_sources(
         &ctx,
-        compile_sources(
-            mcp_typed_args_manifest(),
-            Arc::new(SchemaValidatingMcpCaller),
-        ),
+        compile_sources(mcp_typed_args_manifest(), caller.clone()),
     );
 
     ctx.sql(
@@ -534,6 +527,13 @@ async fn mcp_table_function_parses_declared_json_object_argument() {
     .collect()
     .await
     .expect("MCP tool should receive workflow_runs_filter as a JSON object");
+
+    let calls = caller.calls.lock().expect("calls lock");
+    let call = calls.first().expect("one MCP call should be recorded");
+    assert_eq!(
+        call.1.get("workflow_runs_filter"),
+        Some(&json!({ "status": "completed" }))
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -81,11 +81,12 @@ pub(crate) mod common;
 mod composite;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CompiledBackendSource, RegisteredInput, RegisteredSource,
-    RegisteredTable, RegisteredTableFunction, RegisteredTableFunctionArgument,
-    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_schema, registered_columns_from_specs,
-    required_filter_names, schema_from_columns, validate_lookup_key_filter_backend_support,
+    BackendSchemaRegistration, BoundSourceFunctionArg, BoundSourceFunctionValue,
+    CompiledBackendSource, RegisteredInput, RegisteredSource, RegisteredTable,
+    RegisteredTableFunction, RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
+    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
+    schema_from_columns, validate_lookup_key_filter_backend_support,
 };
 
 pub(crate) mod file;

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -1,6 +1,10 @@
 //! Source-runtime orchestration: registration into `DataFusion`, system catalog
 //! tables, and schema plumbing.
 
+use datafusion::common::ScalarValue;
+use datafusion::error::Result;
+use datafusion::logical_expr::Expr;
+
 pub(crate) mod catalog;
 pub(crate) mod dependent_join;
 pub(crate) mod error;
@@ -15,3 +19,31 @@ pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;
 pub(crate) mod udf_calls;
 pub(crate) mod udfs;
+
+fn literal_scalar_value(expr: &Expr) -> Result<Option<ScalarValue>> {
+    match unalias(expr) {
+        Expr::Literal(value, _) => Ok(Some(value.clone())),
+        Expr::Cast(cast) => Ok(literal_scalar_value(&cast.expr)?
+            .map(|value| value.cast_to(cast.field.data_type()))
+            .transpose()?),
+        Expr::TryCast(cast) => {
+            let Some(value) = literal_scalar_value(&cast.expr)? else {
+                return Ok(None);
+            };
+            Ok(Some(value.cast_to(cast.field.data_type()).unwrap_or(
+                ScalarValue::try_new_null(cast.field.data_type())?,
+            )))
+        }
+        Expr::Negative(expr) => Ok(literal_scalar_value(expr)?
+            .map(|value| value.arithmetic_negate())
+            .transpose()?),
+        _ => Ok(None),
+    }
+}
+
+fn unalias(mut expr: &Expr) -> &Expr {
+    while let Expr::Alias(alias) = expr {
+        expr = &alias.expr;
+    }
+    expr
+}

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -334,7 +334,7 @@ fn bind_function_arg(
     if value.is_null() {
         return Ok(None);
     }
-    let source_text = literal_to_string(expr);
+    let source_text = function_arg_source_text(expr);
 
     if argument.data_type == ManifestDataType::Json {
         let Some(value) = value.try_as_str().flatten() else {
@@ -426,6 +426,13 @@ fn bind_function_arg(
         value
     };
     Ok(Some(BoundSourceFunctionValue { value, source_text }))
+}
+
+fn function_arg_source_text(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Negative(value) => literal_to_string(value).map(|value| format!("-{value}")),
+        _ => literal_to_string(expr),
+    }
 }
 
 fn bound_value_to_json(
@@ -615,6 +622,17 @@ mod tests {
         )
         .expect_err("UInt64 overflow should be rejected");
         assert!(error.to_string().contains("expected Int64"));
+    }
+
+    #[test]
+    fn utf8_binding_preserves_negative_zero_source_text() {
+        let expr = Expr::Negative(Box::new(Expr::Literal(ScalarValue::Int64(Some(0)), None)));
+        let value = bind_function_arg("test.function", &argument(ManifestDataType::Utf8), &expr)
+            .expect("negative zero should bind")
+            .expect("negative zero should not bind as NULL");
+
+        assert_eq!(value.source_text, "-0");
+        assert_eq!(value.value, serde_json::json!("-0"));
     }
 
     #[test]

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -16,10 +16,11 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use datafusion::arrow::datatypes::DataType;
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::Transformed;
-use datafusion::common::{DFSchema, DFSchemaRef, TableReference};
-use datafusion::datasource::provider_as_source;
+use datafusion::common::{DFSchema, DFSchemaRef, ScalarValue, TableReference};
+use datafusion::datasource::{TableProvider, provider_as_source};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::planner::{
     PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
@@ -31,9 +32,13 @@ use datafusion::logical_expr::{
 use datafusion::optimizer::AnalyzerRule;
 use datafusion::prelude::SessionContext;
 
+use crate::backends::shared::filter_expr::literal_to_string;
+use crate::backends::shared::scalar::timestamp_to_rfc3339;
 use crate::backends::{
-    RegisteredTableFunction, RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
+    BoundSourceFunctionArg, BoundSourceFunctionValue, RegisteredTableFunction,
+    RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
 };
+use crate::runtime::literal_scalar_value;
 use crate::runtime::scoped_table_functions::{
     ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature,
     available_functions_hint, call_parts, find_placeholder, lower_named_args_to_positional_exprs,
@@ -163,7 +168,7 @@ impl RelationPlanner for SourceFunctionRegistry {
         // inside SQL planning. Binding is pure value capture (no I/O), so the
         // analyzer repeating it later is cheap.
         if !node.has_parameter_placeholders() {
-            node.factory.provider_for_args(&node.call_args)?;
+            node.provider_for_bound_args()?;
         }
 
         let plan = LogicalPlan::Extension(Extension {
@@ -295,9 +300,17 @@ impl SourceFunctionNode {
         )
     }
 
+    fn provider_for_bound_args(&self) -> Result<Arc<dyn TableProvider>> {
+        let args = self
+            .declared_args_with_call_exprs()
+            .map(|(argument, expr)| bind_function_arg(&self.display_name, argument, expr))
+            .collect::<Result<Vec<_>>>()?;
+        self.factory.provider_for_args(&args)
+    }
+
     fn to_provider_scan(&self) -> Result<LogicalPlan> {
         self.reject_unbound_parameters()?;
-        let provider = self.factory.provider_for_args(&self.call_args)?;
+        let provider = self.provider_for_bound_args()?;
         LogicalPlanBuilder::scan(
             self.table_reference.clone(),
             provider_as_source(provider),
@@ -305,6 +318,146 @@ impl SourceFunctionNode {
         )?
         .build()
     }
+}
+
+fn bind_function_arg(
+    function: &str,
+    argument: &SourceFunctionArgument,
+    expr: &Expr,
+) -> Result<BoundSourceFunctionArg> {
+    let Some(value) = literal_scalar_value(expr)? else {
+        return Err(DataFusionError::Plan(format!(
+            "{function} argument '{}' must be a literal",
+            argument.name
+        )));
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let source_text = literal_to_string(expr);
+
+    if argument.data_type == ManifestDataType::Json {
+        let Some(value) = value.try_as_str().flatten() else {
+            return Err(argument_type_error(function, argument, &value));
+        };
+        return serde_json::from_str(value)
+            .map(|value: serde_json::Value| {
+                let source_text = source_text.unwrap_or_else(|| value.to_string());
+                Some(BoundSourceFunctionValue { value, source_text })
+            })
+            .map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "{function} argument '{}' expected Json: {error}",
+                    argument.name
+                ))
+            });
+    }
+
+    let target_type = crate::types::arrow_data_type(argument.data_type);
+    let source_type = value.data_type();
+    let compatible = source_type == target_type
+        || crate::types::is_string_family(&source_type)
+        || (argument.data_type == ManifestDataType::Timestamp
+            && matches!(source_type, DataType::Timestamp(_, _)))
+        || (argument.data_type == ManifestDataType::Int64
+            && matches!(
+                source_type,
+                DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+            ))
+        || (argument.data_type == ManifestDataType::Float64
+            && matches!(
+                source_type,
+                DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+                    | DataType::Float32
+            ))
+        || (argument.data_type == ManifestDataType::Utf8
+            && matches!(
+                source_type,
+                DataType::Int8
+                    | DataType::Int16
+                    | DataType::Int32
+                    | DataType::Int64
+                    | DataType::UInt8
+                    | DataType::UInt16
+                    | DataType::UInt32
+                    | DataType::UInt64
+                    | DataType::Float32
+                    | DataType::Float64
+                    | DataType::Boolean
+                    | DataType::Timestamp(_, _)
+            ));
+    if !compatible {
+        return Err(argument_type_error(function, argument, &value));
+    }
+
+    let value = value.cast_to(&target_type).map_err(|error| {
+        DataFusionError::Plan(format!(
+            "{function} argument '{}' expected {}: {error}",
+            argument.name,
+            argument.data_type.as_manifest_str()
+        ))
+    })?;
+    let value = bound_value_to_json(value, argument.data_type).ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "{function} argument '{}' could not be encoded",
+            argument.name
+        ))
+    })?;
+    let source_text = source_text.unwrap_or_else(|| match &value {
+        serde_json::Value::String(value) => value.clone(),
+        value => value.to_string(),
+    });
+    let value = if argument.data_type == ManifestDataType::Utf8 {
+        serde_json::Value::String(source_text.clone())
+    } else {
+        value
+    };
+    Ok(Some(BoundSourceFunctionValue { value, source_text }))
+}
+
+fn bound_value_to_json(
+    value: ScalarValue,
+    data_type: ManifestDataType,
+) -> Option<serde_json::Value> {
+    match data_type {
+        ManifestDataType::Utf8 => value
+            .try_as_str()
+            .flatten()
+            .map(|value| serde_json::Value::String(value.to_owned())),
+        ManifestDataType::Int64 => i64::try_from(value).ok().map(serde_json::Value::from),
+        ManifestDataType::Float64 => f64::try_from(value)
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(serde_json::Value::Number),
+        ManifestDataType::Boolean => bool::try_from(value).ok().map(serde_json::Value::Bool),
+        ManifestDataType::Timestamp => timestamp_to_rfc3339(&value).map(serde_json::Value::String),
+        ManifestDataType::Json => None,
+    }
+}
+
+fn argument_type_error(
+    function: &str,
+    argument: &SourceFunctionArgument,
+    value: &ScalarValue,
+) -> DataFusionError {
+    DataFusionError::Plan(format!(
+        "{function} argument '{}' expected {}, got {value:?}",
+        argument.name,
+        argument.data_type.as_manifest_str()
+    ))
 }
 
 // Node identity is the function name plus its declared argument signature and
@@ -420,6 +573,49 @@ impl AnalyzerRule for SourceFunctionAnalyzerRule {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn argument(data_type: ManifestDataType) -> SourceFunctionArgument {
+        SourceFunctionArgument {
+            name: "value".to_string(),
+            data_type,
+        }
+    }
+
+    #[test]
+    fn numeric_binding_accepts_unsigned_values_and_rejects_overflow() {
+        let int_value = Expr::Literal(ScalarValue::UInt64(Some(10)), None);
+        assert_eq!(
+            bind_function_arg(
+                "test.function",
+                &argument(ManifestDataType::Int64),
+                &int_value
+            )
+            .expect("UInt64 value should fit in Int64")
+            .map(|value| value.value),
+            Some(serde_json::json!(10))
+        );
+
+        let float_value = Expr::Literal(ScalarValue::UInt32(Some(10)), None);
+        assert_eq!(
+            bind_function_arg(
+                "test.function",
+                &argument(ManifestDataType::Float64),
+                &float_value
+            )
+            .expect("UInt32 value should convert to Float64")
+            .map(|value| value.value),
+            Some(serde_json::json!(10.0))
+        );
+
+        let overflow = Expr::Literal(ScalarValue::UInt64(Some(u64::MAX)), None);
+        let error = bind_function_arg(
+            "test.function",
+            &argument(ManifestDataType::Int64),
+            &overflow,
+        )
+        .expect_err("UInt64 overflow should be rejected");
+        assert!(error.to_string().contains("expected Int64"));
+    }
 
     #[test]
     fn install_analyzer_is_idempotent() {

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -12,6 +12,7 @@ use datafusion::logical_expr::Expr;
 use crate::runtime::catalog::{
     CatalogTableFunction, CatalogTableFunctionArgument, CatalogTableFunctionResultColumn,
 };
+use crate::runtime::literal_scalar_value;
 use crate::runtime::query::{QueryRuntimeAdapter, query_parameter_scalar_value};
 use crate::runtime::scoped_table_functions::{ScopedTableFunctionName, qualified_name};
 use crate::types::parameter_binding_is_string_shaped;
@@ -231,34 +232,6 @@ fn udf_argument_value(
                 scalar_literal_kind(&value)
             ))
         })
-}
-
-fn literal_scalar_value(expr: &Expr) -> DataFusionResult<Option<ScalarValue>> {
-    match unalias(expr) {
-        Expr::Literal(value, _) => Ok(Some(value.clone())),
-        Expr::Cast(cast) => Ok(literal_scalar_value(&cast.expr)?
-            .map(|value| value.cast_to(cast.field.data_type()))
-            .transpose()?),
-        Expr::TryCast(cast) => {
-            let Some(value) = literal_scalar_value(&cast.expr)? else {
-                return Ok(None);
-            };
-            Ok(Some(value.cast_to(cast.field.data_type()).unwrap_or(
-                ScalarValue::try_new_null(cast.field.data_type())?,
-            )))
-        }
-        Expr::Negative(expr) => Ok(literal_scalar_value(expr)?
-            .map(|value| value.arithmetic_negate())
-            .transpose()?),
-        _ => Ok(None),
-    }
-}
-
-fn unalias(mut expr: &Expr) -> &Expr {
-    while let Expr::Alias(alias) = expr {
-        expr = &alias.expr;
-    }
-    expr
 }
 
 pub(crate) fn udf_param_values(params: &QueryParameters) -> Vec<(String, ScalarValue)> {

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -3,11 +3,11 @@
 //!
 //! This module is the home for the canonical `ManifestDataType`-to-Arrow
 //! type-level policy and Arrow-to-manifest inference.
-//! Value-level `ManifestDataType` switches still live with their backends
-//! (`convert_items` in `backends/shared/mapping.rs` builds Arrow arrays per
-//! variant, and `coerce_filter_value` / `coerce_call_arg_value` in the MCP
-//! backend coerce JSON values). All of those matches are wildcard-free, so
-//! adding a `ManifestDataType` variant breaks each of them loudly.
+//! Value-level `ManifestDataType` switches live at their execution seams:
+//! `convert_items` in `backends/shared/mapping.rs` builds Arrow arrays,
+//! table-function binding lives in `runtime::source_functions`, and MCP filter
+//! binding lives in its backend. These matches are wildcard-free, so adding a
+//! `ManifestDataType` variant breaks each of them loudly.
 
 use coral_spec::ManifestDataType;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -1181,6 +1181,104 @@ async fn source_scoped_table_function_builds_http_search_request() {
 }
 
 #[tokio::test]
+async fn source_scoped_table_function_preserves_float_spelling_for_default_utf8_argument() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Integral float",
+                "score": 1.0
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest(
+        "default_utf8_argument",
+        &server.uri(),
+    ));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM default_utf8_argument.search_issues(q => 1.0)",
+        )
+        .await
+        .expect("default Utf8 arguments should preserve scalar stringification"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "Integral float" })]);
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_checks_allowed_values_before_numeric_coercion() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "1.0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Allowed numeric value",
+                "score": 1.0
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = search_function_manifest("numeric_allowed_value", &server.uri());
+    manifest["functions"][0]["args"][0]["type"] = json!("Float64");
+    manifest["functions"][0]["args"][0]["values"] = json!(["1"]);
+    let source = build_source(manifest);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM numeric_allowed_value.search_issues(q => 1)",
+        )
+        .await
+        .expect("allowed values should use the source literal spelling"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "Allowed numeric value" })]);
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_preserves_serialized_json_string_argument() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "\"exact\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Exact JSON string",
+                "score": 1.0
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = search_function_manifest("json_string_argument", &server.uri());
+    manifest["functions"][0]["args"][0]["type"] = json!("Json");
+    let source = build_source(manifest);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM json_string_argument.search_issues(q => '\"exact\"')",
+        )
+        .await
+        .expect("HTTP JSON arguments should retain their serialized representation"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "Exact JSON string" })]);
+}
+
+#[tokio::test]
 async fn execution_provenance_records_source_scoped_table_functions() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -1181,7 +1181,7 @@ async fn source_scoped_table_function_builds_http_search_request() {
 }
 
 #[tokio::test]
-async fn source_scoped_table_function_preserves_float_spelling_for_default_utf8_argument() {
+async fn source_scoped_table_function_normalizes_integral_float_for_default_utf8_argument() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/api/search/issues"))
@@ -1207,7 +1207,7 @@ async fn source_scoped_table_function_preserves_float_spelling_for_default_utf8_
             "SELECT title FROM default_utf8_argument.search_issues(q => 1.0)",
         )
         .await
-        .expect("default Utf8 arguments should preserve scalar stringification"),
+        .expect("default Utf8 arguments should normalize scalar stringification"),
     );
 
     assert_eq!(rows, vec![json!({ "title": "Integral float" })]);


### PR DESCRIPTION
## Intent

Table-function arguments retain their manifest-declared types, but runtime execution previously passed raw DataFusion expressions to HTTP and MCP factories. MCP then serialized the SQL literal's incidental type, so a declared Boolean or Json argument supplied as compatible SQL text reached the tool as a JSON string.

## What Changed

- Bind table-function literals once in `SourceFunctionNode`, before `provider_for_args`, for both eager planning and parameter-substitution analysis.
- Coerce compatible values through the manifest type's Arrow representation using a conservative, explicit matrix.
- Parse declared Json arguments into structured JSON and preserve typed Boolean, numeric, and timestamp values.
- Pass only crate-private bound values across the factory boundary; HTTP and MCP now only encode those values for their transports.
- Preserve the original scalar spelling separately for existing `values:` checks and default-Utf8 HTTP rendering.
- Reuse the existing UDF literal/cast evaluator for aliases, casts, try-casts, negative literals, and parameter substitution.

## Ownership / Boundaries

The binder lives in `coral-engine`'s source-function runtime because the runtime owns the join between SQL expressions and manifest declarations. Backend factories no longer interpret DataFusion expressions. HTTP remains responsible for text request encoding; MCP remains responsible for JSON transport.

No catalog, proto, client, manifest-schema, or public API surface changed.

## Compatibility / User Impact

Compatible SQL strings such as `'true'`, `'10'`, and JSON text now reach MCP tools as JSON Boolean, integer, and structured values when the manifest declares those types. Required, optional/NULL, allowed-value, default-Utf8 HTTP, and existing typed-call behavior are preserved. Incompatible inputs and overflow fail during planning before backend I/O.

## Not in This PR

- A shared table-filter/request-value refactor.
- Catalog or proto propagation of function argument types.
- Arbitrary Arrow casts outside the explicit compatibility matrix.

## Validation

- `make rust-checks`
  - formatting and workspace clippy passed
  - 2,061 tests passed; 2 skipped
  - rustdoc passed with warnings denied
- Focused Boolean, Json, unsigned numeric, allowed-value, and default-Utf8 HTTP regressions passed.
- Structured Codex autoreview completed cleanly with no actionable findings.
- A temporary schema-validating stdio MCP endpoint was installed in the live Coral config:
  - eager SQL and parameterized `execute_sql_with_params` calls both passed
  - the endpoint observed JSON string, integer, Boolean, number, and object wire types
  - invalid Boolean, Int64 overflow, malformed JSON, and schema-invalid JSON were rejected at their expected boundaries
- Existing live GitHub and Linear table-function queries remained successful.