### PR TITLE
fix(desktop): propagate protocol response cancellation

### DIFF
--- a/apps/desktop/src/main/app-renderer.ts
+++ b/apps/desktop/src/main/app-renderer.ts
@@ -4,6 +4,7 @@ import { extname, join, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { app, protocol } from 'electron'
 import { RouterContextProvider, createRequestHandler, type ServerBuild } from 'react-router'
+import { createRequestCancellationBridge } from './request-cancellation'
 import { repoRoot } from './sidecar'
 
 // The renderer is served over a custom, non-network scheme instead of a TCP
@@ -182,12 +183,7 @@ async function reactRouterResponse(
   request: Request,
   resolveSidecarBaseUrl: () => Promise<string>,
 ): Promise<Response> {
-  // Electron cancels the response body when the renderer aborts a custom-protocol
-  // fetch, but not the handler request. Restore that link for React Router.
-  const abortController = new AbortController()
-  const routedRequest = new Request(request, {
-    signal: AbortSignal.any([request.signal, abortController.signal]),
-  })
+  const cancellation = createRequestCancellationBridge(request)
 
   try {
     await refreshServerSidecarEndpoint(resolveSidecarBaseUrl)
@@ -196,25 +192,9 @@ async function reactRouterResponse(
   }
 
   const handler = await loadReactRouterHandler()
-  const response = await handler(routedRequest, new RouterContextProvider() as never)
+  const response = await handler(cancellation.request, new RouterContextProvider() as never)
   const securedResponse = await secureDocumentResponse(response, request.method === 'HEAD')
-  return abortRequestOnResponseCancel(securedResponse, abortController)
-}
-
-function abortRequestOnResponseCancel(
-  response: Response,
-  abortController: AbortController,
-): Response {
-  if (!response.body) return response
-
-  const bridge = new TransformStream<Uint8Array, Uint8Array>()
-  void response.body.pipeTo(bridge.writable).catch((reason) => abortController.abort(reason))
-
-  return new Response(bridge.readable, {
-    headers: response.headers,
-    status: response.status,
-    statusText: response.statusText,
-  })
+  return cancellation.wrapResponse(securedResponse)
 }
 
 async function secureDocumentResponse(response: Response, headOnly: boolean): Promise<Response> {

--- a/apps/desktop/src/main/app-renderer.ts
+++ b/apps/desktop/src/main/app-renderer.ts
@@ -182,6 +182,13 @@ async function reactRouterResponse(
   request: Request,
   resolveSidecarBaseUrl: () => Promise<string>,
 ): Promise<Response> {
+  // Electron cancels the response body when the renderer aborts a custom-protocol
+  // fetch, but not the handler request. Restore that link for React Router.
+  const abortController = new AbortController()
+  const routedRequest = new Request(request, {
+    signal: AbortSignal.any([request.signal, abortController.signal]),
+  })
+
   try {
     await refreshServerSidecarEndpoint(resolveSidecarBaseUrl)
   } catch (error) {
@@ -189,8 +196,25 @@ async function reactRouterResponse(
   }
 
   const handler = await loadReactRouterHandler()
-  const response = await handler(request, new RouterContextProvider() as never)
-  return secureDocumentResponse(response, request.method === 'HEAD')
+  const response = await handler(routedRequest, new RouterContextProvider() as never)
+  const securedResponse = await secureDocumentResponse(response, request.method === 'HEAD')
+  return abortRequestOnResponseCancel(securedResponse, abortController)
+}
+
+function abortRequestOnResponseCancel(
+  response: Response,
+  abortController: AbortController,
+): Response {
+  if (!response.body) return response
+
+  const bridge = new TransformStream<Uint8Array, Uint8Array>()
+  void response.body.pipeTo(bridge.writable).catch((reason) => abortController.abort(reason))
+
+  return new Response(bridge.readable, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
 }
 
 async function secureDocumentResponse(response: Response, headOnly: boolean): Promise<Response> {

--- a/apps/desktop/src/main/request-cancellation.test.ts
+++ b/apps/desktop/src/main/request-cancellation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createRequestCancellationBridge } from './request-cancellation'
+
+describe('createRequestCancellationBridge', () => {
+  it('aborts the request and upstream body when the response is cancelled', async () => {
+    const cancelUpstream = vi.fn()
+    const upstreamBody = new ReadableStream<Uint8Array>({ cancel: cancelUpstream })
+    const cancellation = createRequestCancellationBridge(new Request('https://app.test/oauth'))
+    const aborted = new Promise<void>((resolve) => {
+      cancellation.request.signal.addEventListener('abort', () => resolve(), { once: true })
+    })
+    const response = cancellation.wrapResponse(new Response(upstreamBody))
+    const reason = new Error('renderer cancelled')
+
+    await response.body!.cancel(reason)
+    await aborted
+
+    expect(cancellation.request.signal.reason).toBe(reason)
+    expect(cancelUpstream).toHaveBeenCalledWith(reason)
+  })
+})

--- a/apps/desktop/src/main/request-cancellation.ts
+++ b/apps/desktop/src/main/request-cancellation.ts
@@ -1,0 +1,23 @@
+// Electron cancels the response body when the renderer aborts a custom-protocol
+// fetch, but not the handler request. Restore that link for React Router.
+export function createRequestCancellationBridge(request: Request) {
+  const abortController = new AbortController()
+
+  return {
+    request: new Request(request, {
+      signal: AbortSignal.any([request.signal, abortController.signal]),
+    }),
+    wrapResponse(response: Response): Response {
+      if (!response.body) return response
+
+      const bridge = new TransformStream<Uint8Array, Uint8Array>()
+      void response.body.pipeTo(bridge.writable).catch((reason) => abortController.abort(reason))
+
+      return new Response(bridge.readable, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      })
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Electron cancels the response body when the renderer aborts a custom-protocol fetch, but it does not abort the request passed to React Router. This could leave operations such as OAuth device flows running after cancellation.

Ie you could start the OAuth handshake in the UI, cancel it, but this wouldn't be propagated correctly, so finishing the flow would still import the source.