### PR TITLE
feat(spec): infer wrapped-list row paths as operation metadata

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1837,7 +1837,7 @@ surface:
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Mcp { pagination } => pagination,
+            coral_spec::v4::OperationMetadata::Mcp { pagination, .. } => pagination,
             coral_spec::v4::OperationMetadata::Rest { .. } => panic!("expected MCP metadata"),
         };
         assert!(pagination.cursor.is_none());

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -632,6 +632,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Rest {
+                    row_path: Vec::new(),
                     pagination,
                     lookup_keys: Vec::new(),
                 },
@@ -704,6 +705,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Rest {
+                    row_path: Vec::new(),
                     pagination: PaginationSpec::default(),
                     lookup_keys,
                 },
@@ -828,6 +830,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Mcp {
+                    row_path: Vec::new(),
                     pagination: McpOperationPagination {
                         cursor: pagination,
                         offset: offset_pagination,

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -69,7 +69,6 @@ pub enum OutputCardinality {
     None,
     Singleton,
     List,
-    WrappedList,
     Unknown,
 }
 

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,8 +7,8 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v7";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
-pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v1";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v10";
+pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v2";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v11";
 
 mod artifacts;
 mod diagnostics;
@@ -20,6 +20,7 @@ mod operation_metadata;
 mod projections;
 mod schema;
 mod surfaces;
+mod wrapped_lists;
 
 #[cfg(test)]
 mod manifest_tests;
@@ -47,6 +48,7 @@ pub use manifest::{
     V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
+pub(crate) use operation_metadata::resolve_output_row_type_ref;
 pub use operation_metadata::{
     ImportedSurface, McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
     ValidatedSurfacePlan, validate_operation_metadata_structure, validate_semantic_ir_structure,

--- a/crates/coral-spec/src/v4/operation_metadata/mod.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/mod.rs
@@ -14,5 +14,6 @@ pub use model::{
     ImportedSurface, McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
 };
 pub use plan::ValidatedSurfacePlan;
+pub(crate) use policy::resolve_output_row_type_ref;
 pub use policy::validate_operation_metadata_structure;
 pub use structural::validate_semantic_ir_structure;

--- a/crates/coral-spec/src/v4/operation_metadata/model.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/model.rs
@@ -43,13 +43,28 @@ pub struct OperationMetadataCatalog {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OperationMetadata {
     Rest {
+        #[serde(default)]
+        row_path: Vec<String>,
         #[serde(serialize_with = "serialize_rest_operation_pagination")]
         pagination: PaginationSpec,
         lookup_keys: Vec<String>,
     },
     Mcp {
+        #[serde(default)]
+        row_path: Vec<String>,
         pagination: McpOperationPagination,
     },
+}
+
+impl OperationMetadata {
+    /// Path from the response root to the property holding this operation's
+    /// rows. Empty when the response root is already the row collection.
+    #[must_use]
+    pub fn row_path(&self) -> &[String] {
+        match self {
+            Self::Rest { row_path, .. } | Self::Mcp { row_path, .. } => row_path,
+        }
+    }
 }
 
 fn serialize_rest_operation_pagination<S>(

--- a/crates/coral-spec/src/v4/operation_metadata/plan.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/plan.rs
@@ -2,10 +2,11 @@ use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
-use crate::v4::ir::{IrInputLocation, IrOperation, SemanticIr};
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
 use crate::v4::operation_metadata::model::{OperationMetadata, OperationMetadataCatalog};
 use crate::v4::operation_metadata::policy::{
-    rest_pagination_owned_inputs, validate_operation_metadata_structure,
+    resolve_output_row_type_ref, rest_pagination_owned_inputs,
+    validate_operation_metadata_structure,
 };
 use crate::v4::operation_metadata::structural::validate_semantic_ir_structure;
 use crate::{PaginationSpec, Result};
@@ -70,6 +71,45 @@ impl ValidatedSurfacePlan {
     }
 
     #[must_use]
+    /// Returns the path from the response root to an operation's rows.
+    pub fn output_row_path(&self, operation_id: &str) -> &[String] {
+        self.metadata_for_operation(operation_id).row_path()
+    }
+
+    #[must_use]
+    /// Returns the REST row type that remains after applying the operation's
+    /// row path.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the operation is absent, is not a REST operation, or the
+    /// validated-plan invariant that its row path resolves has been violated.
+    pub fn rest_output_type_ref(&self, operation_id: &str) -> &str {
+        let operation = self
+            .semantic_ir
+            .operations
+            .iter()
+            .find(|operation| operation.id == operation_id)
+            .expect("validated plan contains the requested operation");
+        assert!(
+            matches!(operation.execution, IrExecutionAttachment::Rest(_)),
+            "MCP operation has no REST output type"
+        );
+        let types = self
+            .semantic_ir
+            .types
+            .iter()
+            .map(|ty| (ty.id.as_str(), ty))
+            .collect();
+        resolve_output_row_type_ref(
+            &operation.output,
+            self.output_row_path(operation_id),
+            &types,
+        )
+        .expect("validated row path resolves to an output type")
+    }
+
+    #[must_use]
     /// Returns effective REST pagination for a REST operation.
     ///
     /// # Panics
@@ -93,7 +133,7 @@ impl ValidatedSurfacePlan {
         operation_id: &str,
     ) -> (Option<&McpPaginationSpec>, Option<&McpOffsetPaginationSpec>) {
         match self.metadata_for_operation(operation_id) {
-            OperationMetadata::Mcp { pagination } => {
+            OperationMetadata::Mcp { pagination, .. } => {
                 (pagination.cursor.as_ref(), pagination.offset.as_ref())
             }
             OperationMetadata::Rest { .. } => panic!("MCP operation has REST metadata"),
@@ -125,7 +165,7 @@ impl ValidatedSurfacePlan {
                     && rest_pagination_owned_inputs(operation, pagination)
                         .is_ok_and(|owned| owned.contains(input_name))
             }
-            OperationMetadata::Mcp { pagination } => {
+            OperationMetadata::Mcp { pagination, .. } => {
                 location == IrInputLocation::ToolArg
                     && (pagination
                         .cursor

--- a/crates/coral-spec/src/v4/operation_metadata/policy.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/policy.rs
@@ -4,7 +4,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::v4::ir::{
-    IrExecutionAttachment, IrInputLocation, IrOperation, IrScalarType, SemanticIr,
+    IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationOutput, IrScalarType, IrType,
+    IrTypeShape, SemanticIr,
 };
 use crate::v4::operation_metadata::model::{
     McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
@@ -22,6 +23,11 @@ pub fn validate_operation_metadata_structure(
         .iter()
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<BTreeMap<_, _>>();
+    let types = semantic_ir
+        .types
+        .iter()
+        .map(|ty| (ty.id.as_str(), ty))
+        .collect::<BTreeMap<_, _>>();
 
     for operation_id in metadata.operations.keys() {
         if !operations.contains_key(operation_id.as_str()) {
@@ -36,7 +42,7 @@ pub fn validate_operation_metadata_structure(
                 "operation metadata is missing operation '{operation_id}'"
             ))
         })?;
-        validate_operation_metadata(operation, effective)?;
+        validate_operation_metadata(operation, effective, &types)?;
     }
     Ok(())
 }
@@ -44,15 +50,24 @@ pub fn validate_operation_metadata_structure(
 fn validate_operation_metadata(
     operation: &IrOperation,
     metadata: &OperationMetadata,
+    types: &BTreeMap<&str, &IrType>,
 ) -> Result<()> {
     match (&operation.execution, metadata) {
         (
             IrExecutionAttachment::Rest(_),
             OperationMetadata::Rest {
+                row_path,
                 pagination,
                 lookup_keys,
             },
         ) => {
+            validate_row_path(operation, row_path)?;
+            resolve_output_row_type_ref(&operation.output, row_path, types).map_err(|error| {
+                ManifestError::validation(format!(
+                    "operation '{}' output row path is invalid: {error}",
+                    operation.id
+                ))
+            })?;
             if pagination.mode == PaginationMode::None
                 && !rest_pagination_is_canonical_none(pagination)
             {
@@ -65,7 +80,17 @@ fn validate_operation_metadata(
             let pagination_inputs = validate_rest_pagination(operation, pagination)?;
             validate_lookup_keys(operation, lookup_keys, &pagination_inputs)
         }
-        (IrExecutionAttachment::Mcp(_), OperationMetadata::Mcp { pagination }) => {
+        (
+            IrExecutionAttachment::Mcp(_),
+            OperationMetadata::Mcp {
+                row_path,
+                pagination,
+            },
+        ) => {
+            // MCP output types stay opaque JSON, so an MCP row path is only
+            // checked for hygiene; the runtime resolves it against the decoded
+            // tool result.
+            validate_row_path(operation, row_path)?;
             validate_mcp_pagination(operation, pagination)
         }
         (IrExecutionAttachment::Rest(_), OperationMetadata::Mcp { .. }) => {
@@ -81,6 +106,59 @@ fn validate_operation_metadata(
             )))
         }
     }
+}
+
+fn validate_row_path(operation: &IrOperation, row_path: &[String]) -> Result<()> {
+    if row_path
+        .iter()
+        .any(|segment| segment.trim().is_empty() || segment != segment.trim())
+    {
+        return Err(ManifestError::validation(format!(
+            "operation '{}' output row path contains a blank or padded segment",
+            operation.id
+        )));
+    }
+    Ok(())
+}
+
+/// Resolves the type of the rows an operation yields once its row path is
+/// applied, or the declared output type when the path is empty.
+pub(crate) fn resolve_output_row_type_ref<'a>(
+    output: &'a IrOperationOutput,
+    row_path: &[String],
+    types: &BTreeMap<&str, &'a IrType>,
+) -> std::result::Result<&'a str, String> {
+    if row_path.is_empty() {
+        return Ok(&output.type_ref);
+    }
+
+    let mut type_ref = output.type_ref.as_str();
+    for segment in row_path {
+        let ty = types
+            .get(type_ref)
+            .ok_or_else(|| format!("type '{type_ref}' is missing"))?;
+        let IrTypeShape::Object { fields } = &ty.shape else {
+            return Err(format!(
+                "segment '{segment}' traverses non-object type '{type_ref}'"
+            ));
+        };
+        let field = fields
+            .iter()
+            .find(|field| field.name == *segment)
+            .ok_or_else(|| format!("type '{type_ref}' has no field '{segment}'"))?;
+        type_ref = &field.type_ref;
+    }
+
+    let ty = types
+        .get(type_ref)
+        .ok_or_else(|| format!("type '{type_ref}' is missing"))?;
+    let IrTypeShape::List { item_type_ref } = &ty.shape else {
+        return Err(format!("terminal type '{type_ref}' is not a list"));
+    };
+    if item_type_ref != "json" && !types.contains_key(item_type_ref.as_str()) {
+        return Err(format!("list item type '{item_type_ref}' is missing"));
+    }
+    Ok(item_type_ref)
 }
 
 fn validate_rest_pagination(

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -150,6 +150,7 @@ fn plan_rejects_mcp_offset_pagination_starting_past_first_page() {
     }
     let operation_id = operation.id.clone();
     let metadata_with_offset_start = |offset_start| OperationMetadata::Mcp {
+        row_path: Vec::new(),
         pagination: crate::v4::McpOperationPagination {
             cursor: None,
             offset: Some(crate::backends::mcp::McpOffsetPaginationSpec {
@@ -199,9 +200,13 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
         !yaml.contains("lookup_keys:"),
         "unexpected policy in IR: {yaml}"
     );
+    assert!(
+        !yaml.contains("row_path:"),
+        "unexpected policy in IR: {yaml}"
+    );
     assert!(matches!(
         imported.operation_metadata.operations.values().next(),
-        Some(OperationMetadata::Rest { pagination, lookup_keys })
+        Some(OperationMetadata::Rest { pagination, lookup_keys, .. })
             if pagination.page_param.as_deref() == Some("page")
                 && lookup_keys == &["state"]
     ));
@@ -210,6 +215,7 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
 #[test]
 fn disabled_rest_pagination_serializes_only_its_mode() {
     let metadata = OperationMetadata::Rest {
+        row_path: Vec::new(),
         pagination: crate::PaginationSpec::default(),
         lookup_keys: Vec::new(),
     };

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1615,7 +1615,7 @@ fn imported_mcp_items_surface() -> (V4SourceManifest, ImportedSurface) {
     };
     let mut imported =
         import_mcp_surface(&manifest, &manifest.surface, &catalog).expect("MCP import");
-    let OperationMetadata::Mcp { pagination } = imported
+    let OperationMetadata::Mcp { pagination, .. } = imported
         .operation_metadata
         .operations
         .get_mut("list_items")

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -231,9 +231,7 @@ pub(super) fn projection_name(operation: &IrOperation, is_search: bool) -> Strin
         OutputCardinality::Singleton if operation.inputs.iter().any(|input| input.required) => {
             format!("get_{entity}")
         }
-        OutputCardinality::List | OutputCardinality::WrappedList | OutputCardinality::Singleton => {
-            entity
-        }
+        OutputCardinality::List | OutputCardinality::Singleton => entity,
         OutputCardinality::None | OutputCardinality::Unknown => {
             normalize_identifier(&operation.id, "projection")
         }

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -1,6 +1,7 @@
 use crate::v4::ir::{
     IrEntityCandidate, IrExecutionAttachment, IrOperation, McpExecutionAttachment,
 };
+use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
 use crate::v4::{McpOperationPagination, OperationMetadata};
 
 use super::import::McpImporter;
@@ -23,9 +24,18 @@ impl McpImporter<'_> {
 
         let inputs = imported_inputs.inputs;
         let output = self.import_output(operation_id, tool.output_schema.as_ref());
+        let row_path = tool.output_schema.as_ref().map_or_else(Vec::new, |schema| {
+            infer_wrapped_list_row_path(WrappedListInferenceContext {
+                operation_name: &tool.name,
+                inputs: &inputs,
+                schema_root: schema,
+                response_schema: schema,
+            })
+        });
         let (pagination, offset_pagination) = infer_mcp_pagination_contracts(
             &inputs,
             &output,
+            &row_path,
             tool.output_schema.as_ref(),
             &tool.input_schema,
         );
@@ -55,6 +65,7 @@ impl McpImporter<'_> {
         Some((
             operation,
             OperationMetadata::Mcp {
+                row_path,
                 pagination: McpOperationPagination {
                     cursor: pagination,
                     offset: offset_pagination,

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -7,13 +7,14 @@ use crate::v4::surfaces::json_schema::json_schema_type_contains;
 pub(super) fn infer_mcp_pagination_contracts(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     output_schema: Option<&Value>,
     input_schema: &Value,
 ) -> (Option<McpPaginationSpec>, Option<McpOffsetPaginationSpec>) {
-    let pagination = infer_mcp_pagination(inputs, output, output_schema);
+    let pagination = infer_mcp_pagination(inputs, output, row_path, output_schema);
     let offset_pagination = pagination
         .is_none()
-        .then(|| infer_mcp_offset_pagination(inputs, output, input_schema))
+        .then(|| infer_mcp_offset_pagination(inputs, output, row_path, input_schema))
         .flatten();
     (pagination, offset_pagination)
 }
@@ -21,12 +22,10 @@ pub(super) fn infer_mcp_pagination_contracts(
 fn infer_mcp_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     output_schema: Option<&Value>,
 ) -> Option<McpPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
+    if !is_list_like_output(output, row_path) {
         return None;
     }
     let cursor_arg = cursor_input_name(inputs)?;
@@ -41,12 +40,10 @@ fn infer_mcp_pagination(
 fn infer_mcp_offset_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     input_schema: &Value,
 ) -> Option<McpOffsetPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
+    if !is_list_like_output(output, row_path) {
         return None;
     }
     let properties = input_schema.get("properties").and_then(Value::as_object)?;
@@ -69,6 +66,12 @@ fn infer_mcp_offset_pagination(
         offset_start: offset.default,
         max_pages: None,
     })
+}
+
+/// A wrapped-list envelope is a singleton by cardinality but yields rows, so it
+/// paginates like a declared list.
+fn is_list_like_output(output: &IrOperationOutput, row_path: &[String]) -> bool {
+    output.cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 
 struct OffsetPaginationInput<'a> {

--- a/crates/coral-spec/src/v4/surfaces/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/mod.rs
@@ -1,4 +1,4 @@
-mod json_schema;
+pub(in crate::v4) mod json_schema;
 mod mcp;
 mod openapi;
 

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -6,7 +6,7 @@ use crate::v4::OperationMetadata;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
     HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-    IrOperationNaming, IrScalarType, OutputCardinality, RestExecutionAttachment,
+    IrOperationNaming, IrOperationOutput, IrScalarType, OutputCardinality, RestExecutionAttachment,
     RestParameterBinding, RestRequestBody,
 };
 use crate::v4::lookup_keys::infer_rest_lookup_keys;
@@ -15,7 +15,11 @@ use crate::v4::surfaces::json_schema::{
     json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
     json_schema_type_display,
 };
-use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
+use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
+use crate::{
+    ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
+    v4::resolve_output_row_type_ref,
+};
 
 use super::import::OpenApiImporter;
 use super::responses::OpenApiResponsePaginationContext;
@@ -45,7 +49,13 @@ impl OpenApiImporter<'_> {
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
         let (output, response, entity, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
-        let pagination = detect_pagination(&parameters, &pagination_context);
+        let row_path = self.infer_row_path(
+            raw_operation_id.unwrap_or(&operation_id),
+            &parameters,
+            &pagination_context,
+            &output,
+        );
+        let pagination = detect_pagination(&parameters, &pagination_context, &row_path);
         let lookup_keys = infer_rest_lookup_keys(&parameters, &pagination);
         let rest_parameters = parameters
             .iter()
@@ -91,10 +101,42 @@ impl OpenApiImporter<'_> {
         Ok((
             operation,
             OperationMetadata::Rest {
+                row_path,
                 pagination,
                 lookup_keys,
             },
         ))
+    }
+
+    /// Infers where the rows of a wrapped-list response live, discarding a path
+    /// the imported types cannot resolve so the importer never emits metadata
+    /// that fails plan validation.
+    fn infer_row_path(
+        &self,
+        operation_name: &str,
+        parameters: &[IrOperationInput],
+        pagination_context: &OpenApiResponsePaginationContext,
+        output: &IrOperationOutput,
+    ) -> Vec<String> {
+        let row_path = infer_wrapped_list_row_path(WrappedListInferenceContext {
+            operation_name,
+            inputs: parameters,
+            schema_root: self.document,
+            response_schema: &pagination_context.schema,
+        });
+        if row_path.is_empty() {
+            return row_path;
+        }
+        let types = self
+            .types
+            .iter()
+            .map(|(id, ty)| (id.as_str(), ty))
+            .collect::<BTreeMap<_, _>>();
+        if resolve_output_row_type_ref(output, &row_path, &types).is_ok() {
+            row_path
+        } else {
+            Vec::new()
+        }
     }
 
     fn import_parameters(
@@ -303,8 +345,9 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
 fn detect_pagination(
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
+    row_path: &[String],
 ) -> PaginationSpec {
-    if !is_paginated_cardinality(context.cardinality) {
+    if !is_list_like_output(context.cardinality, row_path) {
         return PaginationSpec::default();
     }
     detect_link_header_pagination(inputs, context)
@@ -578,11 +621,10 @@ fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
         && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
 }
 
-fn is_paginated_cardinality(cardinality: OutputCardinality) -> bool {
-    matches!(
-        cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    )
+/// A wrapped-list envelope is a singleton by cardinality but yields rows, so it
+/// paginates like a declared list.
+fn is_list_like_output(cardinality: OutputCardinality, row_path: &[String]) -> bool {
+    cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 
 fn page_size_spec(input: &IrOperationInput) -> PageSizeSpec {

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -1,0 +1,610 @@
+//! Heuristic inference of wrapped-list row paths for `OpenAPI` and MCP surfaces.
+//!
+//! A "wrapped list" response wraps rows inside an envelope: the declared type is
+//! an object, but the rows live at a nested path such as `items` or
+//! `results.data`. Providers do not declare which property holds the rows, so
+//! Coral guesses, and a wrong guess reshapes a whole relation: a resource object
+//! with a `fields: [...]` child would become a list of those fields.
+//!
+//! The guess is therefore an opinion, not a fact. It is recorded in operation
+//! metadata, where it is visible and overridable, and never in the semantic IR.
+//!
+//! Inference excludes aggressively. Picking a candidate array is not enough; the
+//! response or the operation must also carry evidence that it really is a page
+//! envelope (see [`has_envelope_evidence`]). A missed envelope leaves a JSON
+//! column the user can still unnest; a wrong envelope silently discards the
+//! declared resource.
+
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value};
+
+use crate::v4::ir::{IrInputLocation, IrOperationInput};
+use crate::v4::surfaces::json_schema::{
+    JsonSchemaWalkError, json_schema_type_contains, with_resolved_json_schema,
+};
+
+const MAX_DEPTH: usize = 8;
+
+/// Property names that conventionally hold the rows of a page envelope, in
+/// preference order.
+const PREFERRED_ROW_PROPERTIES: &[&str] = &["items", "data", "results", "rows"];
+
+/// Envelope metadata names, matched together with the declared JSON type so a
+/// resource field only counts as evidence when name and type agree.
+const METADATA_OBJECT_NAMES: &[&str] = &[
+    "meta",
+    "metadata",
+    "paging",
+    "pagination",
+    "pageinfo",
+    "links",
+    "cursor",
+    "cursors",
+];
+const METADATA_STRING_NAMES: &[&str] = &[
+    "cursor",
+    "next",
+    "nextcursor",
+    "nextpage",
+    "nextpagetoken",
+    "nexttoken",
+    "nexturl",
+    "nextlink",
+    "endcursor",
+    "continuationtoken",
+    "scrollid",
+];
+const METADATA_INTEGER_NAMES: &[&str] = &[
+    "count",
+    "total",
+    "totalcount",
+    "totalresults",
+    "totalsize",
+    "totalitems",
+    "resultcount",
+    "page",
+    "pages",
+    "pagecount",
+    "perpage",
+    "pagesize",
+];
+const METADATA_BOOLEAN_NAMES: &[&str] = &[
+    "hasmore",
+    "hasnext",
+    "hasnextpage",
+    "hasprevious",
+    "incompleteresults",
+    "moreresults",
+    "truncated",
+];
+
+/// Envelope metadata names paired with the JSON type they must declare.
+const METADATA_LEXICON: [(&[&str], &str); 4] = [
+    (METADATA_OBJECT_NAMES, "object"),
+    (METADATA_STRING_NAMES, "string"),
+    (METADATA_INTEGER_NAMES, "integer"),
+    (METADATA_BOOLEAN_NAMES, "boolean"),
+];
+
+/// Request-side names that mark an operation as paginated. This is a syntactic
+/// check on declared inputs rather than a look at the inferred `PaginationSpec`,
+/// because pagination inference consumes the row path this module produces.
+const PAGINATION_INPUT_NAMES: &[&str] = &[
+    "page",
+    "pagenumber",
+    "pagetoken",
+    "pagesize",
+    "perpage",
+    "limit",
+    "maxresults",
+    "offset",
+    "cursor",
+    "startcursor",
+    "continuationtoken",
+    "after",
+    "nexttoken",
+    "nextcursor",
+    "iterator",
+];
+
+/// Inputs available to wrapped-list inference.
+///
+/// The operation name is deliberately part of the context even though the
+/// current policy never reads it. Naming signals (plural nouns, `list`/`search`
+/// prefixes) can be added here without changing every surface importer.
+#[derive(Clone, Copy)]
+pub(in crate::v4) struct WrappedListInferenceContext<'a> {
+    pub(in crate::v4) operation_name: &'a str,
+    pub(in crate::v4) inputs: &'a [IrOperationInput],
+    /// Document the response schema was taken from, used to resolve `$ref`.
+    pub(in crate::v4) schema_root: &'a Value,
+    pub(in crate::v4) response_schema: &'a Value,
+}
+
+/// Returns the path from the response root to the property holding the rows, or
+/// an empty path when the response is not recognized as a wrapped list.
+pub(in crate::v4) fn infer_wrapped_list_row_path(
+    context: WrappedListInferenceContext<'_>,
+) -> Vec<String> {
+    let _ = context.operation_name;
+    let paginated_operation = declares_pagination_input(context.inputs);
+    candidate_row_path(
+        context.schema_root,
+        context.response_schema,
+        paginated_operation,
+        false,
+        &mut BTreeSet::new(),
+        0,
+    )
+    .ok()
+    .flatten()
+    .unwrap_or_default()
+}
+
+/// Walks the envelope, returning the first candidate path that also carries
+/// envelope evidence.
+///
+/// `inherited_evidence` records that an ancestor level looked like an envelope.
+/// It admits a conventionally named row property one level down — the
+/// `{success, results: {data: [...]}, pagination}` shape — but deliberately not
+/// the sole-array fallback, which would let a nested resource's only array child
+/// inherit its parent's envelope evidence.
+fn candidate_row_path<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    paginated_operation: bool,
+    inherited_evidence: bool,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> Result<Option<Vec<String>>, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, resolving_refs, next_depth| {
+            // Composed schemas describe a merge Coral does not model here, so
+            // their properties cannot be read as a complete envelope.
+            if schema_uses_composition(resolved) {
+                return Ok(None);
+            }
+            if !json_schema_type_contains(resolved, "object") {
+                return Ok(None);
+            }
+            let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
+                return Ok(None);
+            };
+            let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth)?;
+            let accept_preferred = paginated_operation || inherited_evidence || evidence;
+            let accept_fallback = paginated_operation || evidence;
+
+            for name in PREFERRED_ROW_PROPERTIES {
+                if let Some(property) = properties.get(*name)
+                    && schema_has_type(root, property, resolving_refs, next_depth, "array")?
+                {
+                    return Ok(accept_preferred.then(|| vec![(*name).to_string()]));
+                }
+            }
+
+            // Recurse only through the same preferred names: nested envelopes
+            // such as `results.data` are worth finding, an unrestricted walk of
+            // every resource child is not.
+            for name in PREFERRED_ROW_PROPERTIES {
+                if let Some(property) = properties.get(*name)
+                    && let Some(mut path) = candidate_row_path(
+                        root,
+                        property,
+                        paginated_operation,
+                        inherited_evidence || evidence,
+                        resolving_refs,
+                        next_depth,
+                    )?
+                {
+                    path.insert(0, (*name).to_string());
+                    return Ok(Some(path));
+                }
+            }
+
+            let mut arrays = Vec::new();
+            for (name, property) in properties {
+                // An array named like envelope metadata is a link or token
+                // collection, never the rows the envelope is wrapping.
+                if is_metadata_name(name) {
+                    continue;
+                }
+                if schema_has_type(root, property, resolving_refs, next_depth, "array")? {
+                    arrays.push(name);
+                }
+            }
+            match arrays.as_slice() {
+                [name] => Ok(accept_fallback.then(|| vec![(*name).clone()])),
+                [] | [_, _, ..] => Ok(None),
+            }
+        },
+    )
+}
+
+/// Reports whether the properties of an envelope level read as list metadata.
+///
+/// A single agreeing name-and-type pair is enough: providers rarely put a
+/// `has_more` boolean or a `next_cursor` string on a plain resource.
+fn has_envelope_evidence<'a>(
+    root: &'a Value,
+    properties: &'a Map<String, Value>,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> Result<bool, JsonSchemaWalkError<'a>> {
+    // A sole property is the envelope itself: `{"data": [...]}` has nothing
+    // else it could be.
+    if properties.len() == 1 {
+        return Ok(true);
+    }
+    for (name, property) in properties {
+        let normalized = normalized_name(name);
+        for (names, expected) in METADATA_LEXICON {
+            if names.contains(&normalized.as_str())
+                && schema_has_type(root, property, resolving_refs, depth, expected)?
+            {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn is_metadata_name(name: &str) -> bool {
+    let normalized = normalized_name(name);
+    METADATA_LEXICON
+        .iter()
+        .any(|(names, _)| names.contains(&normalized.as_str()))
+}
+
+fn declares_pagination_input(inputs: &[IrOperationInput]) -> bool {
+    inputs
+        .iter()
+        .filter(|input| {
+            matches!(
+                input.location,
+                IrInputLocation::Query | IrInputLocation::ToolArg
+            )
+        })
+        .any(|input| PAGINATION_INPUT_NAMES.contains(&normalized_name(&input.name).as_str()))
+}
+
+fn schema_uses_composition(schema: &Value) -> bool {
+    ["allOf", "anyOf", "oneOf", "not"]
+        .iter()
+        .any(|keyword| schema.get(*keyword).is_some())
+}
+
+fn schema_has_type<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    expected: &str,
+) -> Result<bool, JsonSchemaWalkError<'a>> {
+    match with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, _, _| {
+            Ok(!schema_uses_composition(resolved) && json_schema_type_contains(resolved, expected))
+        },
+    ) {
+        Ok(matched) => Ok(matched),
+        // An unresolvable or cyclic property is not the row collection, but it
+        // must not abandon inference for its siblings.
+        Err(_) => Ok(false),
+    }
+}
+
+/// Collapses case and separators so `perPage`, `per_page`, and `per-page` all
+/// match the lexicon entry `perpage`.
+fn normalized_name(name: &str) -> String {
+    name.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
+
+    use super::{WrappedListInferenceContext, infer_wrapped_list_row_path};
+
+    fn inputs(specs: &[(&str, IrInputLocation)]) -> Vec<IrOperationInput> {
+        specs
+            .iter()
+            .map(|(name, location)| IrOperationInput {
+                name: (*name).to_string(),
+                location: *location,
+                required: false,
+                data_type: IrScalarType::String,
+                default_value: None,
+                description: String::new(),
+            })
+            .collect()
+    }
+
+    fn row_path(schema: &Value, operation_inputs: &[IrOperationInput]) -> Vec<String> {
+        infer_wrapped_list_row_path(WrappedListInferenceContext {
+            operation_name: "list_things",
+            inputs: operation_inputs,
+            schema_root: schema,
+            response_schema: schema,
+        })
+    }
+
+    #[test]
+    fn selects_preferred_property_when_a_metadata_sibling_agrees() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "incomplete_results": {"type": "boolean"},
+                "items": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["items"]);
+    }
+
+    #[test]
+    fn selects_nested_preferred_property_through_wrapper_objects() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "success": {"type": "boolean"},
+                "results": {
+                    "type": "object",
+                    "properties": {
+                        "data": {"type": "array", "items": {"type": "object"}},
+                    },
+                },
+                "pagination": {"type": "object"},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["results", "data"]);
+    }
+
+    #[test]
+    fn selects_sole_array_property_when_a_metadata_sibling_agrees() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "repositories": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["repositories"]);
+    }
+
+    #[test]
+    fn selects_the_only_property_of_a_pure_envelope() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["data"]);
+    }
+
+    #[test]
+    fn selects_candidate_of_a_paginated_operation_without_metadata_siblings() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "success": {"type": "boolean"},
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+        assert_eq!(
+            row_path(
+                &schema,
+                &inputs(&[("start_cursor", IrInputLocation::Query)])
+            ),
+            ["data"]
+        );
+    }
+
+    #[test]
+    fn ignores_resource_objects_with_named_array_children() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "items": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(
+            row_path(&schema, &inputs(&[("bundle_id", IrInputLocation::Path)])).is_empty(),
+            "a path parameter is not a pagination signal"
+        );
+    }
+
+    #[test]
+    fn ignores_resource_objects_with_sole_array_children() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "number"},
+                "content_type": {"type": "string"},
+                "item_url": {"type": "string"},
+                "fields": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_metadata_names_whose_declared_type_disagrees() {
+        // A resource may carry a `count` string; only an integer `count` reads
+        // as a result total.
+        let string_count = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "count": {"type": "string"},
+                "steps": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+        let integer_count = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "count": {"type": "integer"},
+                "steps": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&string_count, &[]).is_empty());
+        assert_eq!(row_path(&integer_count, &[]), ["steps"]);
+    }
+
+    #[test]
+    fn ignores_metadata_named_arrays_as_row_candidates() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "links": {"type": "array", "items": {"type": "string"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn does_not_let_a_nested_resource_inherit_envelope_evidence() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_responses_without_arrays() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "nextCursor": {"type": "string"},
+            },
+        });
+
+        assert!(
+            row_path(&schema, &inputs(&[("cursor", IrInputLocation::Query)])).is_empty(),
+            "a singleton with a cursor field has no row collection"
+        );
+    }
+
+    #[test]
+    fn ignores_multiple_array_properties_without_a_preferred_name() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "issues": {"type": "array", "items": {"type": "object"}},
+                "pull_requests": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_composed_schemas() {
+        let schema = json!({
+            "allOf": [{
+                "type": "object",
+                "properties": {
+                    "total_count": {"type": "integer"},
+                    "items": {"type": "array", "items": {"type": "object"}},
+                },
+            }],
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn resolves_local_refs() {
+        let schema = json!({
+            "$ref": "#/components/schemas/Page",
+            "components": {
+                "schemas": {
+                    "Page": {
+                        "type": "object",
+                        "properties": {
+                            "has_more": {"type": "boolean"},
+                            "data": {"$ref": "#/components/schemas/Rows"},
+                        },
+                    },
+                    "Rows": {"type": "array", "items": {"type": "object"}},
+                },
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["data"]);
+    }
+
+    #[test]
+    fn ignores_ref_cycles() {
+        let schema = json!({
+            "$ref": "#/components/schemas/Node",
+            "components": {
+                "schemas": {
+                    "Node": {"$ref": "#/components/schemas/Node"},
+                },
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_envelopes_nested_past_the_depth_cap() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+        for _ in 0..super::MAX_DEPTH {
+            schema = json!({
+                "type": "object",
+                "properties": {"results": schema},
+            });
+        }
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+}


### PR DESCRIPTION
Re-introduce detection of wrapped-list responses, removed by #1494 and #1935 because the inference was recorded as fact in the semantic IR while being a guess that could pick the wrong array.

Detection now lives in one shared library call used by both surface importers, and its result is stored in operation metadata, where it is an auditable, overridable opinion rather than an imported fact.

The heuristic is also stricter than the one that was removed. Picking a candidate array is no longer enough: the response or the operation must carry evidence that it is a page envelope, so a resource object with a `fields: [...]` or `items: [...]` child stays an envelope.

A non-empty row path also makes an operation list-like again, so REST and MCP pagination inference apply to wrapped lists.

Also removes `OutputCardinality::WrappedList`, which has had no construction site since #1935.

Claude-Session: https://claude.ai/code/session_01X6bVqSWVAqcr3U8A1wj3Bv

Part of #1910.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
