### PR TITLE
feat(spec): derive wrapped-list rows in projections and at runtime

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1831,16 +1831,22 @@ surface:
         let metadata: OperationMetadataCatalog =
             read_yaml(&build.temp_dir.join(OPERATION_METADATA_FILENAME))
                 .expect("read operation metadata");
-        let pagination = match metadata
+        let (row_path, pagination) = match metadata
             .operations
             .values()
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Mcp { pagination, .. } => pagination,
+            coral_spec::v4::OperationMetadata::Mcp {
+                row_path,
+                pagination,
+            } => (row_path, pagination),
             coral_spec::v4::OperationMetadata::Rest { .. } => panic!("expected MCP metadata"),
         };
-        assert!(pagination.cursor.is_none());
+        assert_eq!(row_path, &["items"]);
+        let cursor = pagination.cursor.as_ref().expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
         assert!(pagination.offset.is_none());
 
         let projections: ProjectionCatalog =

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -238,6 +238,10 @@ fn http_manifest_for_surface(
             })?;
         let rest = rest_execution_for_operation(operation)?;
         let pagination = materialized_surface.plan.rest_pagination(&operation.id);
+        let response = response_with_row_path(
+            rest.response.response.clone(),
+            materialized_surface.plan.output_row_path(&operation.id),
+        );
         let request = request_spec_for_projection(projection, operation)
             .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
         let columns = projection_column_specs(projection);
@@ -256,7 +260,7 @@ fn http_manifest_for_surface(
                     },
                     request,
                     requests: Vec::new(),
-                    response: rest.response.response.clone(),
+                    response: response.clone(),
                     pagination: pagination.clone(),
                 });
             }
@@ -271,7 +275,7 @@ fn http_manifest_for_surface(
                     detail_hints: projection.detail_hints.clone(),
                     args: projection_arg_specs(projection),
                     request,
-                    response: rest.response.response.clone(),
+                    response,
                     pagination: pagination.clone(),
                     columns,
                 });
@@ -348,11 +352,13 @@ fn mcp_manifest_for_surface(
         };
         let (cursor_pagination, offset_pagination) =
             materialized_surface.plan.mcp_pagination(&operation.id);
+        let row_path = materialized_surface.plan.output_row_path(&operation.id);
         match &projection.kind {
             ProjectionKind::Table => {
                 tables.push(mcp_table_spec(
                     projection,
                     mcp,
+                    row_path,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -362,6 +368,7 @@ fn mcp_manifest_for_surface(
                     projection,
                     *function_kind,
                     mcp,
+                    row_path,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -386,6 +393,7 @@ fn mcp_manifest_for_surface(
 fn mcp_table_spec(
     projection: &Projection,
     mcp: &coral_spec::v4::McpExecutionAttachment,
+    row_path: &[String],
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableSpec {
@@ -406,7 +414,7 @@ fn mcp_table_spec(
         limit_binding: None,
         pagination,
         offset_pagination,
-        response: ResponseSpec::default(),
+        response: response_with_row_path(ResponseSpec::default(), row_path),
     }
 }
 
@@ -414,6 +422,7 @@ fn mcp_table_function_spec(
     projection: &Projection,
     function_kind: SourceTableFunctionKind,
     mcp: &coral_spec::v4::McpExecutionAttachment,
+    row_path: &[String],
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableFunctionSpec {
@@ -431,11 +440,17 @@ fn mcp_table_function_spec(
             detail_hints: projection.detail_hints.clone(),
             args: mcp_projection_arg_specs(projection),
             request: RequestSpec::default(),
-            response: ResponseSpec::default(),
+            response: response_with_row_path(ResponseSpec::default(), row_path),
             pagination: PaginationSpec::default(),
             columns: projection_column_specs(projection),
         },
     }
+}
+
+/// Points row extraction at the property an operation's rows are wrapped in.
+fn response_with_row_path(mut response: ResponseSpec, row_path: &[String]) -> ResponseSpec {
+    response.rows_path = row_path.to_vec();
+    response
 }
 
 fn mcp_filter_bindings(projection: &Projection) -> Vec<McpTableFilterBinding> {
@@ -515,7 +530,7 @@ mod tests {
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
         AcceptedIdentityRequirement, Fingerprint, FingerprintSurface, HttpMethod,
-        IdentityRequirements, IrExecutionAttachment, IrInputLocation, IrOperation,
+        IdentityRequirements, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
         IrOperationInput, IrOperationOutput, IrScalarType, IrType, IrTypeShape,
         MCP_IMPORTER_VERSION, MaterializedSurface, McpExecutionAttachment, McpOperationPagination,
         McpRuntimeConfig, OPENAPI_IMPORTER_VERSION, OPERATION_METADATA_GENERATOR_VERSION,
@@ -844,6 +859,104 @@ mod tests {
             normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
             raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
         }
+    }
+
+    /// A REST surface whose operation declares an envelope wrapping its rows in
+    /// `items`.
+    fn rest_wrapped_list_materialized_surface(operation_id: &str) -> MaterializedSurface {
+        let semantic_ir = SemanticIr {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "github_v4".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+            operations: vec![IrOperation {
+                id: operation_id.to_string(),
+                method_name: operation_id.to_string(),
+                description: String::new(),
+                deprecated: false,
+                read_only: true,
+                naming: None,
+                inputs: Vec::new(),
+                output: IrOperationOutput {
+                    cardinality: coral_spec::v4::OutputCardinality::Singleton,
+                    type_ref: "envelope".to_string(),
+                },
+                entity: None,
+                execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
+                    method: HttpMethod::Get,
+                    path_template: "/items".to_string(),
+                    parameters: Vec::new(),
+                    request_body: None,
+                    response: RestResponseAttachment {
+                        status_code: 200,
+                        media_type: "application/json".to_string(),
+                        response: ResponseSpec::default(),
+                    },
+                })),
+                diagnostics: Vec::new(),
+            }],
+            types: vec![
+                test_object_type("item"),
+                IrType {
+                    id: "item_list".to_string(),
+                    shape: IrTypeShape::List {
+                        item_type_ref: "item".to_string(),
+                    },
+                    nullable: false,
+                    description: String::new(),
+                },
+                IrType {
+                    id: "envelope".to_string(),
+                    shape: IrTypeShape::Object {
+                        fields: vec![IrField {
+                            name: "items".to_string(),
+                            type_ref: "item_list".to_string(),
+                            required: true,
+                            nullable: false,
+                            description: String::new(),
+                        }],
+                    },
+                    nullable: false,
+                    description: String::new(),
+                },
+            ],
+            diagnostics: Vec::new(),
+        };
+        let operation_metadata = OperationMetadataCatalog {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "github_v4".to_string(),
+            generator_version: Some(OPERATION_METADATA_GENERATOR_VERSION.to_string()),
+            operations: BTreeMap::from([(
+                operation_id.to_string(),
+                OperationMetadata::Rest {
+                    row_path: vec!["items".to_string()],
+                    pagination: PaginationSpec::default(),
+                    lookup_keys: Vec::new(),
+                },
+            )]),
+        };
+        MaterializedSurface {
+            plan: ValidatedSurfacePlan::new(semantic_ir, operation_metadata).expect("plan"),
+            source_document_sha256: None,
+            normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
+            raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
+        }
+    }
+
+    fn mcp_wrapped_list_materialized_surface(operation_id: &str) -> MaterializedSurface {
+        let mut surface = mcp_materialized_surface_with_pagination(operation_id, None);
+        let mut operation_metadata = surface.plan.operation_metadata().clone();
+        operation_metadata.operations.insert(
+            operation_id.to_string(),
+            OperationMetadata::Mcp {
+                row_path: vec!["items".to_string()],
+                pagination: McpOperationPagination::default(),
+            },
+        );
+        surface.plan =
+            ValidatedSurfacePlan::new(surface.plan.semantic_ir().clone(), operation_metadata)
+                .expect("plan");
+        surface
     }
 
     fn test_input(name: &str, location: IrInputLocation) -> IrOperationInput {
@@ -1275,6 +1388,103 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["q", "state"],
             "function arguments must still be sent as query parameters"
+        );
+    }
+
+    #[test]
+    fn http_runtime_component_applies_the_operation_row_path() {
+        let manifest = manifest_with_surface(openapi_surface());
+        let component_for = |projection| {
+            let materialized = V4MaterializedSource {
+                fingerprint: Some(fingerprint(SurfaceType::OpenApi, "github_v4")),
+                surface: rest_wrapped_list_materialized_surface("rest_list_issues"),
+                projections: ProjectionCatalog {
+                    artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                    source_name: "github_v4".to_string(),
+                    generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                    projections: vec![projection],
+                    diagnostics: Vec::new(),
+                },
+                diagnostics: Vec::new(),
+            };
+            let component = runtime_component_for_v4_source(&manifest, &materialized)
+                .expect("runtime component")
+                .expect("published component");
+            let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+                panic!("expected HTTP component");
+            };
+            http
+        };
+
+        let table_http = component_for(published_projection("rest_list_issues"));
+        assert_eq!(
+            table_http
+                .tables
+                .first()
+                .expect("HTTP table")
+                .response
+                .rows_path,
+            ["items"]
+        );
+
+        let function_http = component_for(published_function_projection("rest_list_issues"));
+        assert_eq!(
+            function_http
+                .functions
+                .first()
+                .expect("HTTP function")
+                .response
+                .rows_path,
+            ["items"]
+        );
+    }
+
+    #[test]
+    fn mcp_runtime_component_applies_the_operation_row_path() {
+        let manifest = manifest_with_surface(mcp_surface());
+        let component_for = |projection| {
+            let materialized = V4MaterializedSource {
+                fingerprint: Some(fingerprint(SurfaceType::Mcp, "github_v4")),
+                surface: mcp_wrapped_list_materialized_surface("mcp_list_issues"),
+                projections: ProjectionCatalog {
+                    artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                    source_name: "github_v4".to_string(),
+                    generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                    projections: vec![projection],
+                    diagnostics: Vec::new(),
+                },
+                diagnostics: Vec::new(),
+            };
+            let component = runtime_component_for_v4_source(&manifest, &materialized)
+                .expect("runtime component")
+                .expect("published component");
+            let coral_engine::RuntimeSourceComponent::Mcp(mcp) = component else {
+                panic!("expected MCP component");
+            };
+            mcp
+        };
+
+        let table_mcp = component_for(published_projection("mcp_list_issues"));
+        assert_eq!(
+            table_mcp
+                .tables
+                .first()
+                .expect("MCP table")
+                .response
+                .rows_path,
+            ["items"]
+        );
+
+        let function_mcp = component_for(published_function_projection("mcp_list_issues"));
+        assert_eq!(
+            function_mcp
+                .functions
+                .first()
+                .expect("MCP function")
+                .common
+                .response
+                .rows_path,
+            ["items"]
         );
     }
 

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -21,6 +21,15 @@ fn imported_rest_pagination<'a>(
     }
 }
 
+fn imported_row_path<'a>(surface: &'a ImportedSurface, operation_id: &str) -> &'a [String] {
+    surface
+        .operation_metadata
+        .operations
+        .get(operation_id)
+        .expect("operation metadata")
+        .row_path()
+}
+
 #[test]
 fn extracts_openapi_document_metadata() {
     let metadata = openapi_document_metadata(
@@ -252,7 +261,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_common_envelope_objects_as_singletons() {
+fn importer_infers_row_paths_for_common_envelope_objects() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: statusgator
@@ -302,7 +311,10 @@ components:
     )
     .expect("import");
     let operation = ir.operations.first().expect("operation");
+    // The IR keeps the declared envelope; only the metadata says where its rows
+    // are.
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(imported_row_path(&ir, "listincidents"), ["data"]);
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -316,9 +328,9 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("success"), Some(&ManifestDataType::Boolean));
-    assert_eq!(columns.get("data"), Some(&ManifestDataType::Json));
-    assert_eq!(columns.get("pagination"), Some(&ManifestDataType::Json));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.get("name"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 2);
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -328,7 +340,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_single_array_payload_objects_as_singletons() {
+fn importer_infers_row_path_for_a_sole_array_payload_beside_a_total() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -377,6 +389,13 @@ components:
     .expect("import");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(
+        imported_row_path(
+            &ir,
+            "actions_list_selected_repositories_enabled_github_actions_organization"
+        ),
+        ["repositories"]
+    );
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -386,8 +405,9 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("total_count"), Some(&ManifestDataType::Int64));
-    assert_eq!(columns.get("repositories"), Some(&ManifestDataType::Json));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("name"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 2);
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -397,7 +417,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_search_result_objects_as_singletons() {
+fn importer_prefers_a_named_row_property_over_other_arrays() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -456,6 +476,11 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    // `lexical_fallback_reason` is an array too; the conventional row name wins.
+    assert_eq!(
+        imported_row_path(&ir, "search_issues_and_pull_requests"),
+        ["items"]
+    );
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -465,21 +490,13 @@ paths:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("total_count"), Some(&ManifestDataType::Int64));
-    assert_eq!(
-        columns.get("incomplete_results"),
-        Some(&ManifestDataType::Boolean)
-    );
-    assert_eq!(columns.get("items"), Some(&ManifestDataType::Json));
-    assert_eq!(columns.get("search_type"), Some(&ManifestDataType::Utf8));
-    assert_eq!(
-        columns.get("lexical_fallback_reason"),
-        Some(&ManifestDataType::Json)
-    );
-    assert!(!columns.contains_key("id"));
-    assert!(!columns.contains_key("number"));
-    assert!(!columns.contains_key("title"));
-    assert!(!columns.contains_key("state"));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("number"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("title"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.get("state"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 4);
+    assert!(!columns.contains_key("total_count"));
+    assert!(!columns.contains_key("lexical_fallback_reason"));
 }
 
 #[test]
@@ -580,6 +597,9 @@ components:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    // A project item is a resource, not a page of its `fields`: nothing in the
+    // response or the request says otherwise.
+    assert!(imported_row_path(&ir, "projects_get_org_item").is_empty());
 
     let row_type = ir
         .types
@@ -660,6 +680,9 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    // A bundle's `items` is a conventional row name, but a bundle is still a
+    // resource: no metadata sibling, no pagination parameter.
+    assert!(imported_row_path(&ir, "bundles_get").is_empty());
 }
 
 #[test]
@@ -1759,16 +1782,17 @@ paths:
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<BTreeMap<_, _>>();
 
-    for operation_id in [
-        "cursor_list",
-        "pagination_token_list",
-        "iterator_list",
-        "start_cursor_list",
-        "nested_next_list",
-        "singleton_get",
-        "cursor_header_list",
-        "cursor_page_list",
-        "numeric_page_list",
+    // Each of these declares an envelope object, so cardinality stays
+    // Singleton; the inferred row path is what makes them paginate.
+    for (operation_id, mode) in [
+        ("cursor_list", PaginationMode::CursorQuery),
+        ("pagination_token_list", PaginationMode::CursorQuery),
+        ("iterator_list", PaginationMode::CursorQuery),
+        ("start_cursor_list", PaginationMode::CursorQuery),
+        ("nested_next_list", PaginationMode::CursorQuery),
+        ("cursor_header_list", PaginationMode::CursorQuery),
+        ("cursor_page_list", PaginationMode::CursorQuery),
+        ("numeric_page_list", PaginationMode::Page),
     ] {
         let operation = operations.get(operation_id).expect("operation");
         assert_eq!(
@@ -1776,12 +1800,26 @@ paths:
             OutputCardinality::Singleton,
             "{operation_id}"
         );
+        assert!(
+            !imported_row_path(&ir, operation_id).is_empty(),
+            "{operation_id}"
+        );
         assert_eq!(
             imported_rest_pagination(&ir, operation_id).mode,
-            PaginationMode::None,
+            mode,
             "{operation_id}"
         );
     }
+
+    // A singleton with a cursor query parameter has no row collection to page
+    // through, so the parameter stays an ordinary input.
+    let singleton = operations.get("singleton_get").expect("singleton");
+    assert_eq!(singleton.output.cardinality, OutputCardinality::Singleton);
+    assert!(imported_row_path(&ir, "singleton_get").is_empty());
+    assert_eq!(
+        imported_rest_pagination(&ir, "singleton_get").mode,
+        PaginationMode::None
+    );
 
     let link = imported_rest_pagination(&ir, "link_list");
     assert_eq!(link.mode, PaginationMode::LinkHeader);

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1355,7 +1355,7 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
 }
 
 #[test]
-fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
+fn generated_mcp_projection_keeps_an_inferred_cursor_internal() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1410,16 +1410,17 @@ fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
         .find(|input| input.wire_name == "cursor")
         .expect("cursor input");
 
-    assert_eq!(cursor.sql_exposure, SqlInputExposure::FunctionArg);
+    // Pagination owns the cursor of a wrapped-list tool, so SQL never binds it.
+    assert_eq!(cursor.sql_exposure, SqlInputExposure::Internal);
     assert!(
         mcp_projection_arg_specs(projection)
             .iter()
-            .any(|arg| arg.bind.arg == "cursor")
+            .all(|arg| arg.bind.arg != "cursor")
     );
 }
 
 #[test]
-fn generated_mcp_projection_with_only_cursor_is_table_function_without_pagination_metadata() {
+fn generated_mcp_projection_with_only_an_inferred_cursor_is_a_table() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1467,17 +1468,16 @@ fn generated_mcp_projection_with_only_cursor_is_table_function_without_paginatio
         .find(|projection| projection.operation_id == "list_items")
         .expect("mcp projection");
 
-    assert!(matches!(
-        projection.kind,
-        ProjectionKind::TableFunction { .. }
-    ));
+    // The cursor is the tool's only argument and pagination owns it, so the
+    // projection has nothing left to take as a function argument.
+    assert!(matches!(projection.kind, ProjectionKind::Table));
     assert_eq!(
         projection
             .inputs
             .iter()
-            .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
+            .filter(|input| input.sql_exposure != SqlInputExposure::Internal)
             .count(),
-        1
+        0
     );
 }
 

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -129,7 +129,7 @@ fn generate_projection(
             }
         })
         .collect::<Vec<_>>();
-    let columns = projection_columns(type_by_id, operation);
+    let columns = projection_columns(plan, type_by_id, operation);
     let name = generated_projection_name(operation, is_search);
     let guide = projection_guide(&kind, &inputs, is_search);
     let projection = Projection {
@@ -299,6 +299,7 @@ fn type_index(ir: &SemanticIr) -> TypeIndex<'_> {
 }
 
 fn projection_columns(
+    plan: &ValidatedSurfacePlan,
     type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
 ) -> Vec<ProjectionColumn> {
@@ -325,7 +326,9 @@ fn projection_columns(
             },
         ];
     }
-    let Some(row_type) = type_by_id.get(operation.output.type_ref.as_str()) else {
+    // A wrapped-list operation declares an envelope but yields the rows nested
+    // inside it, so columns come from the type its row path selects.
+    let Some(row_type) = type_by_id.get(plan.rest_output_type_ref(&operation.id)) else {
         return vec![ProjectionColumn {
             name: "value".to_string(),
             data_type: ManifestDataType::Json,

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -934,6 +934,15 @@ surface:
             wrapped_items.output.cardinality,
             OutputCardinality::Singleton
         );
+        // The IR keeps the declared envelope shape; the row path is metadata.
+        assert_eq!(
+            ir.operation_metadata
+                .operations
+                .get("wrapped_items")
+                .expect("metadata")
+                .row_path(),
+            ["items"]
+        );
         let wrapped_fields = row_fields(&ir, "wrapped_items_row");
         assert_eq!(field(wrapped_fields, "items").type_ref, "mcp_json");
         assert!(wrapped_fields.iter().any(|field| field.name == "raw"));
@@ -951,7 +960,7 @@ surface:
     }
 
     #[test]
-    fn does_not_infer_cursor_pagination_for_wrapped_list_envelopes() {
+    fn infers_cursor_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-items",
@@ -990,13 +999,16 @@ surface:
         let operation = operation(&ir, "list_items");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
         let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_items"), ["items"]);
         let (cursor, offset) = plan.mcp_pagination("list_items");
-        assert!(cursor.is_none());
+        let cursor = cursor.expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
         assert!(offset.is_none());
     }
 
     #[test]
-    fn does_not_infer_offset_pagination_for_wrapped_list_envelopes() {
+    fn infers_offset_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-catalog",
@@ -1044,10 +1056,18 @@ surface:
         let surface = &v4.surface;
         let ir = import_mcp_surface(v4, surface, &catalog).expect("import");
         let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_catalog"), ["items"]);
         let (cursor, offset) = plan.mcp_pagination("list_catalog");
         assert!(cursor.is_none());
-        assert!(offset.is_none());
+        let offset = offset.expect("offset pagination");
+        assert_eq!(offset.limit_arg, "limit");
+        assert_eq!(offset.default_limit, 50);
+        assert_eq!(offset.max_limit, 200);
+        assert_eq!(offset.offset_arg, "offset");
+        assert_eq!(offset.offset_start, 0);
 
+        // `limit` and `offset` are the tool's only arguments, and pagination
+        // now owns both, so nothing is left to expose as a function argument.
         let projections = generate_projection_catalog(v4, &ir.validated_plan().expect("plan"))
             .expect("projection catalog");
         let projection = projections
@@ -1055,12 +1075,9 @@ surface:
             .iter()
             .find(|projection| projection.operation_id == "list_catalog")
             .expect("projection");
-        assert!(matches!(
-            projection.kind,
-            crate::v4::ProjectionKind::TableFunction { .. }
-        ));
+        assert!(matches!(projection.kind, crate::v4::ProjectionKind::Table));
         for input in &projection.inputs {
-            assert_eq!(input.sql_exposure, SqlInputExposure::FunctionArg);
+            assert_eq!(input.sql_exposure, SqlInputExposure::Internal);
         }
     }
 
@@ -1151,6 +1168,16 @@ surface:
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "get_item");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+        // `items` is a conventional row name, but nothing else about the tool
+        // says this is a page of them.
+        assert!(
+            ir.operation_metadata
+                .operations
+                .get("get_item")
+                .expect("metadata")
+                .row_path()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -176,13 +176,13 @@ fn candidate_row_path<'a>(
             let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
                 return Ok(None);
             };
-            let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth)?;
+            let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth);
             let accept_preferred = paginated_operation || inherited_evidence || evidence;
             let accept_fallback = paginated_operation || evidence;
 
             for name in PREFERRED_ROW_PROPERTIES {
                 if let Some(property) = properties.get(*name)
-                    && schema_has_type(root, property, resolving_refs, next_depth, "array")?
+                    && schema_has_type(root, property, resolving_refs, next_depth, "array")
                 {
                     return Ok(accept_preferred.then(|| vec![(*name).to_string()]));
                 }
@@ -214,7 +214,7 @@ fn candidate_row_path<'a>(
                 if is_metadata_name(name) {
                     continue;
                 }
-                if schema_has_type(root, property, resolving_refs, next_depth, "array")? {
+                if schema_has_type(root, property, resolving_refs, next_depth, "array") {
                     arrays.push(name);
                 }
             }
@@ -230,28 +230,24 @@ fn candidate_row_path<'a>(
 ///
 /// A single agreeing name-and-type pair is enough: providers rarely put a
 /// `has_more` boolean or a `next_cursor` string on a plain resource.
-fn has_envelope_evidence<'a>(
-    root: &'a Value,
-    properties: &'a Map<String, Value>,
+fn has_envelope_evidence(
+    root: &Value,
+    properties: &Map<String, Value>,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
-) -> Result<bool, JsonSchemaWalkError<'a>> {
+) -> bool {
     // A sole property is the envelope itself: `{"data": [...]}` has nothing
     // else it could be.
     if properties.len() == 1 {
-        return Ok(true);
+        return true;
     }
-    for (name, property) in properties {
+    properties.iter().any(|(name, property)| {
         let normalized = normalized_name(name);
-        for (names, expected) in METADATA_LEXICON {
-            if names.contains(&normalized.as_str())
-                && schema_has_type(root, property, resolving_refs, depth, expected)?
-            {
-                return Ok(true);
-            }
-        }
-    }
-    Ok(false)
+        METADATA_LEXICON.iter().any(|(names, expected)| {
+            names.contains(&normalized.as_str())
+                && schema_has_type(root, property, resolving_refs, depth, expected)
+        })
+    })
 }
 
 fn is_metadata_name(name: &str) -> bool {
@@ -279,14 +275,16 @@ fn schema_uses_composition(schema: &Value) -> bool {
         .any(|keyword| schema.get(*keyword).is_some())
 }
 
-fn schema_has_type<'a>(
-    root: &'a Value,
-    schema: &'a Value,
+/// An unresolvable or cyclic property simply does not declare the type asked
+/// about; it must not abandon inference for its siblings.
+fn schema_has_type(
+    root: &Value,
+    schema: &Value,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
     expected: &str,
-) -> Result<bool, JsonSchemaWalkError<'a>> {
-    match with_resolved_json_schema(
+) -> bool {
+    with_resolved_json_schema(
         root,
         schema,
         resolving_refs,
@@ -295,12 +293,8 @@ fn schema_has_type<'a>(
         |resolved, _, _| {
             Ok(!schema_uses_composition(resolved) && json_schema_type_contains(resolved, expected))
         },
-    ) {
-        Ok(matched) => Ok(matched),
-        // An unresolvable or cyclic property is not the row collection, but it
-        // must not abandon inference for its siblings.
-        Err(_) => Ok(false),
-    }
+    )
+    .unwrap_or(false)
 }
 
 /// Collapses case and separators so `perPage`, `per_page`, and `per-page` all


### PR DESCRIPTION
Projection columns for a REST wrapped list now come from the type its row path selects, so a search or list relation exposes one column per row field again instead of `total_count`/`items`. Column derivation happens only at generation time; `projections.yaml` stays the immutable snapshot #1958 made it.

The runtime package carries the same row path through `rows_path` on HTTP and MCP tables and table functions, where the shared response-row extractor already knows how to apply it.

Updates the behaviour assertions #1494 and #1935 inverted. The two tests covering the regressions those PRs objected to — a project item with `fields` and a bundle with `items` — keep their existing expectations and now assert an empty row path explicitly.

Claude-Session: https://claude.ai/code/session_01X6bVqSWVAqcr3U8A1wj3Bv

Part of #1910.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
