### PR TITLE
fix(spec): reject projections a row-path override cannot yield

### DIFF
--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1631,6 +1631,53 @@ fn imported_mcp_items_surface() -> (V4SourceManifest, ImportedSurface) {
     (manifest, imported)
 }
 
+fn imported_wrapped_items_surface() -> (V4SourceManifest, ImportedSurface) {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  file: /tmp/openapi.yaml
+  base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                        title: {type: string}
+",
+    )
+    .expect("import");
+    (manifest, imported)
+}
+
 fn imported_required_account_surface() -> (V4SourceManifest, ImportedSurface) {
     let manifest = parse_source_manifest_yaml(
         r"
@@ -1734,6 +1781,52 @@ fn projection_input_at_mut<'a>(
         .iter_mut()
         .find(|input| input.wire_name == wire_name && input.source_location == location)
         .expect("projection input")
+}
+
+#[test]
+fn generated_projection_columns_come_from_the_wrapped_list_row_type() {
+    let (manifest, imported) = imported_wrapped_items_surface();
+    let plan = imported.validated_plan().expect("plan");
+    assert_eq!(plan.output_row_path("items_list"), ["items"]);
+
+    let catalog = generate_projection_catalog(&manifest, &plan).expect("projections");
+    let projection = catalog.projections.first().expect("projection");
+    assert_eq!(
+        projection
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        ["id", "title"]
+    );
+}
+
+#[test]
+fn projection_compatibility_rejects_columns_the_effective_row_path_cannot_yield() {
+    let (manifest, mut imported) = imported_wrapped_items_surface();
+    let catalog = generate_projection_catalog(&manifest, &imported.validated_plan().expect("plan"))
+        .expect("projections");
+
+    // Overriding the row path back to the envelope root leaves the snapshot's
+    // columns describing rows the operation no longer yields.
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .get_mut("items_list")
+        .expect("items_list metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    row_path.clear();
+    let plan = imported.validated_plan().expect("plan");
+
+    let error =
+        validate_projection_compatibility(&plan, &catalog).expect_err("stale columns must fail");
+
+    assert!(
+        error.to_string().contains("column 'id' reads field 'id'"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -3,10 +3,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::v4::ir::{IrExecutionAttachment, IrInputLocation};
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrTypeShape};
 use crate::v4::operation_metadata::ValidatedSurfacePlan;
 use crate::v4::projections::{
-    ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
+    Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
 };
 use crate::{ManifestError, Result};
 
@@ -27,6 +27,9 @@ pub fn validate_projection_compatibility(
                 projection.name, projection.operation_id
             )));
         };
+        if matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
+            validate_projection_columns(plan, projection, &operation.id)?;
+        }
         let public_exposure = public_exposure_for_kind(&projection.kind);
         for input in &projection.inputs {
             let Some(operation_input) = operation.inputs.iter().find(|operation_input| {
@@ -119,6 +122,47 @@ pub fn validate_projection_compatibility(
                     projection.name, input.name, operation.id
                 )));
             }
+        }
+    }
+    Ok(())
+}
+
+/// Checks that a REST projection's columns describe the rows the effective
+/// operation policy actually yields.
+///
+/// The projection catalog is a snapshot: an operation-metadata override that
+/// moves the row path elsewhere leaves the materialized columns pointing at
+/// fields the new rows do not have. Rather than reconcile the snapshot at load
+/// time, reject the combination and let the user regenerate or override the
+/// catalog too.
+fn validate_projection_columns(
+    plan: &ValidatedSurfacePlan,
+    projection: &Projection,
+    operation_id: &str,
+) -> Result<()> {
+    let row_type_ref = plan.rest_output_type_ref(operation_id);
+    let Some(row_type) = plan
+        .semantic_ir()
+        .types
+        .iter()
+        .find(|ty| ty.id == row_type_ref)
+    else {
+        return Ok(());
+    };
+    // Only an object row type names its fields. Scalar, list, and opaque JSON
+    // rows are projected whole, and their columns carry no source path.
+    let IrTypeShape::Object { fields } = &row_type.shape else {
+        return Ok(());
+    };
+    for column in &projection.columns {
+        let Some(field_name) = column.source_path.first() else {
+            continue;
+        };
+        if !fields.iter().any(|field| field.name == *field_name) {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' column '{}' reads field '{field_name}', but the rows operation '{operation_id}' yields have type '{row_type_ref}', which has no such field",
+                projection.name, column.name
+            )));
         }
     }
     Ok(())


### PR DESCRIPTION
`projections.yaml` is an immutable snapshot: since #1958, effective operation metadata never reconciles it at load time. A row-path override that moves the rows elsewhere would therefore leave the snapshot's columns reading fields the new rows do not have.

Load-time compatibility validation now checks that every REST projection column with a source path reads a field of the row type the effective row path selects, so an incompatible artifact combination is rejected rather than silently producing empty columns.

Claude-Session: https://claude.ai/code/session_01X6bVqSWVAqcr3U8A1wj3Bv

Part of #1910.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
