### PR TITLE
test(spec): cover wrapped-list row paths end to end

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1466,11 +1466,15 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id: {type: integer}
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: integer}
 "
     }
 
@@ -1773,21 +1777,26 @@ surface:
     }
 
     #[test]
-    fn build_v4_materialization_persists_lookup_keys_in_operation_metadata() {
+    fn build_v4_materialization_persists_inferred_policy_in_operation_metadata() {
         let (_state, _descriptor, layout, _manifest_yaml, _manifest) = setup_materialization();
         let surface_dir = layout.v4_materialized_dir(&workspace_name(), &source_name());
         let metadata: OperationMetadataCatalog =
             read_yaml(&surface_dir.join(OPERATION_METADATA_FILENAME))
                 .expect("read operation metadata");
-        let lookup_keys = match metadata
+        let (row_path, lookup_keys) = match metadata
             .operations
             .values()
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Rest { lookup_keys, .. } => lookup_keys,
+            coral_spec::v4::OperationMetadata::Rest {
+                row_path,
+                lookup_keys,
+                ..
+            } => (row_path, lookup_keys),
             coral_spec::v4::OperationMetadata::Mcp { .. } => panic!("expected REST metadata"),
         };
+        assert_eq!(row_path, &["items"]);
         assert_eq!(lookup_keys, &["state"]);
     }
 
@@ -2222,6 +2231,45 @@ surface:
         assert!(
             !q.lookup_key,
             "loading must not enable a persisted lookup key"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_rejects_row_path_override_the_projection_cannot_serve() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let mut metadata = installed_operation_metadata(&layout);
+        let coral_spec::v4::OperationMetadata::Rest { row_path, .. } = metadata
+            .operations
+            .values_mut()
+            .next()
+            .expect("operation metadata")
+        else {
+            panic!("expected REST metadata");
+        };
+        // The materialized projection has issue columns because the rows come
+        // from `items`; making the envelope the row makes them unreadable.
+        row_path.clear();
+        write_operation_metadata_override(&layout, &metadata);
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("row path override incompatible with persisted columns must fail");
+
+        assert!(
+            matches!(
+                error,
+                AppError::MissingOrIncompatibleV4Materialization { .. }
+            ),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("column 'id' reads field 'id'"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -213,6 +213,62 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
 }
 
 #[test]
+fn plan_rejects_blank_or_unresolvable_rest_row_paths() {
+    let (_manifest, mut imported) = imported();
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    *row_path = vec![" ".to_string()];
+    let error = imported
+        .validated_plan()
+        .expect_err("blank row path must fail");
+    assert!(
+        error.to_string().contains("blank or padded segment"),
+        "unexpected error: {error}"
+    );
+
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    // The operation returns a declared array, so no path can traverse it.
+    *row_path = vec!["missing".to_string()];
+    let error = imported
+        .validated_plan()
+        .expect_err("unresolvable row path must fail");
+    assert!(
+        error.to_string().contains("traverses non-object type"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn operation_metadata_without_a_row_path_defaults_to_the_response_root() {
+    let metadata: OperationMetadata = serde_yaml::from_str(
+        r"
+type: rest
+pagination:
+  mode: none
+lookup_keys: []
+",
+    )
+    .expect("metadata without a row path");
+
+    assert!(metadata.row_path().is_empty());
+}
+
+#[test]
 fn disabled_rest_pagination_serializes_only_its_mode() {
     let metadata = OperationMetadata::Rest {
         row_path: Vec::new(),

--- a/sources/v4/github/manifest.yaml
+++ b/sources/v4/github/manifest.yaml
@@ -53,9 +53,6 @@ surface:
       from: literal
       value: coral-dsl-v4
 test_queries:
-  - >-
-    SELECT total_count, incomplete_results, search_type
-    FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue')
-    LIMIT 1
+  - SELECT id, number, title, state FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 5
   - SELECT id, number, title, state FROM github_v4.issues_list_for_repo(owner => 'octocat', repo => 'Hello-World') LIMIT 5
   - SELECT id, number, title FROM github_v4.issues_get(owner => 'octocat', repo => 'Hello-World', issue_number => 1)


### PR DESCRIPTION
Adds the coverage the preceding commits did not need in order to compile: row-path hygiene and resolution failures in plan validation, the `#[serde(default)]` fallback for metadata written before row paths existed, and rejection of a row-path override that strips a materialized projection of the fields its columns read.

The OpenAPI materialization fixture now returns a wrapped list, so `build_v4_materialization` asserts the persisted metadata carries the inferred row path alongside the inferred lookup keys.

Also restores the GitHub search smoke query #1494 rewrote to select envelope metadata. `sources/v4/x/manifest.yaml` needs no change: its existing query against the `{data, meta}` envelope only starts working again now.

Claude-Session: https://claude.ai/code/session_01X6bVqSWVAqcr3U8A1wj3Bv

Part of #1910.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
