### PR TITLE
fix(spec): stop treating a HAL links object as envelope evidence

### DIFF
--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -32,13 +32,14 @@ const PREFERRED_ROW_PROPERTIES: &[&str] = &["items", "data", "results", "rows"];
 
 /// Envelope metadata names, matched together with the declared JSON type so a
 /// resource field only counts as evidence when name and type agree.
+// `links` is deliberately absent: a HAL-style `_links` object is at least as
+// common on a singleton resource as on a page envelope.
 const METADATA_OBJECT_NAMES: &[&str] = &[
     "meta",
     "metadata",
     "paging",
     "pagination",
     "pageinfo",
-    "links",
     "cursor",
     "cursors",
 ];
@@ -472,12 +473,32 @@ mod tests {
     }
 
     #[test]
+    fn ignores_hal_style_link_objects_on_resources() {
+        // GitHub's `activity/get-feeds` shape: a resource whose only array is
+        // incidental and whose `_links` object describes relations, not pages.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "timeline_url": {"type": "string"},
+                "user_url": {"type": "string"},
+                "current_user_organization_urls": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "_links": {"type": "object"},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
     fn ignores_metadata_named_arrays_as_row_candidates() {
         let schema = json!({
             "type": "object",
             "properties": {
                 "has_more": {"type": "boolean"},
-                "links": {"type": "array", "items": {"type": "string"}},
+                "cursors": {"type": "array", "items": {"type": "string"}},
             },
         });
 


### PR DESCRIPTION
Importing GitHub's real OpenAPI descriptor inferred a row path for 128 of its 1,209 operations. All but one were genuine list endpoints; the exception was `activity/get-feeds`, a singleton resource whose `_links` object matched the envelope-metadata lexicon and so promoted an incidental `current_user_organization_urls` array to the operation's rows.

A HAL-style `_links` object is at least as common on a resource as on a page envelope, so it is too weak to carry the inference on its own. Pagination link containers that do mean it are named `pagination`, `paging`, or `meta`, which the lexicon still covers.

Re-importing the same descriptor drops exactly that one operation and leaves the other 127 unchanged.

Claude-Session: https://claude.ai/code/session_01X6bVqSWVAqcr3U8A1wj3Bv

Closes #1910.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
