### PR TITLE
feat(spec): re-introduce wrapped-list detection as operation metadata

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1831,16 +1831,22 @@ surface:
         let metadata: OperationMetadataCatalog =
             read_yaml(&build.temp_dir.join(OPERATION_METADATA_FILENAME))
                 .expect("read operation metadata");
-        let pagination = match metadata
+        let (row_path, pagination) = match metadata
             .operations
             .values()
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Mcp { pagination, .. } => pagination,
+            coral_spec::v4::OperationMetadata::Mcp {
+                row_path,
+                pagination,
+            } => (row_path, pagination),
             coral_spec::v4::OperationMetadata::Rest { .. } => panic!("expected MCP metadata"),
         };
-        assert!(pagination.cursor.is_none());
+        assert_eq!(row_path, &["items"]);
+        let cursor = pagination.cursor.as_ref().expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
         assert!(pagination.offset.is_none());
 
         let projections: ProjectionCatalog =

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1837,7 +1837,7 @@ surface:
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Mcp { pagination } => pagination,
+            coral_spec::v4::OperationMetadata::Mcp { pagination, .. } => pagination,
             coral_spec::v4::OperationMetadata::Rest { .. } => panic!("expected MCP metadata"),
         };
         assert!(pagination.cursor.is_none());

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1466,11 +1466,15 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id: {type: integer}
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: integer}
 "
     }
 
@@ -1773,21 +1777,26 @@ surface:
     }
 
     #[test]
-    fn build_v4_materialization_persists_lookup_keys_in_operation_metadata() {
+    fn build_v4_materialization_persists_inferred_policy_in_operation_metadata() {
         let (_state, _descriptor, layout, _manifest_yaml, _manifest) = setup_materialization();
         let surface_dir = layout.v4_materialized_dir(&workspace_name(), &source_name());
         let metadata: OperationMetadataCatalog =
             read_yaml(&surface_dir.join(OPERATION_METADATA_FILENAME))
                 .expect("read operation metadata");
-        let lookup_keys = match metadata
+        let (row_path, lookup_keys) = match metadata
             .operations
             .values()
             .next()
             .expect("operation metadata")
         {
-            coral_spec::v4::OperationMetadata::Rest { lookup_keys, .. } => lookup_keys,
+            coral_spec::v4::OperationMetadata::Rest {
+                row_path,
+                lookup_keys,
+                ..
+            } => (row_path, lookup_keys),
             coral_spec::v4::OperationMetadata::Mcp { .. } => panic!("expected REST metadata"),
         };
+        assert_eq!(row_path, &["items"]);
         assert_eq!(lookup_keys, &["state"]);
     }
 
@@ -2222,6 +2231,45 @@ surface:
         assert!(
             !q.lookup_key,
             "loading must not enable a persisted lookup key"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_rejects_row_path_override_the_projection_cannot_serve() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let mut metadata = installed_operation_metadata(&layout);
+        let coral_spec::v4::OperationMetadata::Rest { row_path, .. } = metadata
+            .operations
+            .values_mut()
+            .next()
+            .expect("operation metadata")
+        else {
+            panic!("expected REST metadata");
+        };
+        // The materialized projection has issue columns because the rows come
+        // from `items`; making the envelope the row makes them unreadable.
+        row_path.clear();
+        write_operation_metadata_override(&layout, &metadata);
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("row path override incompatible with persisted columns must fail");
+
+        assert!(
+            matches!(
+                error,
+                AppError::MissingOrIncompatibleV4Materialization { .. }
+            ),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("column 'id' reads field 'id'"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -238,6 +238,10 @@ fn http_manifest_for_surface(
             })?;
         let rest = rest_execution_for_operation(operation)?;
         let pagination = materialized_surface.plan.rest_pagination(&operation.id);
+        let response = response_with_row_path(
+            rest.response.response.clone(),
+            materialized_surface.plan.output_row_path(&operation.id),
+        );
         let request = request_spec_for_projection(projection, operation)
             .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
         let columns = projection_column_specs(projection);
@@ -256,7 +260,7 @@ fn http_manifest_for_surface(
                     },
                     request,
                     requests: Vec::new(),
-                    response: rest.response.response.clone(),
+                    response: response.clone(),
                     pagination: pagination.clone(),
                 });
             }
@@ -271,7 +275,7 @@ fn http_manifest_for_surface(
                     detail_hints: projection.detail_hints.clone(),
                     args: projection_arg_specs(projection),
                     request,
-                    response: rest.response.response.clone(),
+                    response,
                     pagination: pagination.clone(),
                     columns,
                 });
@@ -348,11 +352,13 @@ fn mcp_manifest_for_surface(
         };
         let (cursor_pagination, offset_pagination) =
             materialized_surface.plan.mcp_pagination(&operation.id);
+        let row_path = materialized_surface.plan.output_row_path(&operation.id);
         match &projection.kind {
             ProjectionKind::Table => {
                 tables.push(mcp_table_spec(
                     projection,
                     mcp,
+                    row_path,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -362,6 +368,7 @@ fn mcp_manifest_for_surface(
                     projection,
                     *function_kind,
                     mcp,
+                    row_path,
                     cursor_pagination.cloned(),
                     offset_pagination.cloned(),
                 ));
@@ -386,6 +393,7 @@ fn mcp_manifest_for_surface(
 fn mcp_table_spec(
     projection: &Projection,
     mcp: &coral_spec::v4::McpExecutionAttachment,
+    row_path: &[String],
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableSpec {
@@ -406,7 +414,7 @@ fn mcp_table_spec(
         limit_binding: None,
         pagination,
         offset_pagination,
-        response: ResponseSpec::default(),
+        response: response_with_row_path(ResponseSpec::default(), row_path),
     }
 }
 
@@ -414,6 +422,7 @@ fn mcp_table_function_spec(
     projection: &Projection,
     function_kind: SourceTableFunctionKind,
     mcp: &coral_spec::v4::McpExecutionAttachment,
+    row_path: &[String],
     pagination: Option<coral_spec::backends::mcp::McpPaginationSpec>,
     offset_pagination: Option<coral_spec::backends::mcp::McpOffsetPaginationSpec>,
 ) -> McpTableFunctionSpec {
@@ -431,11 +440,17 @@ fn mcp_table_function_spec(
             detail_hints: projection.detail_hints.clone(),
             args: mcp_projection_arg_specs(projection),
             request: RequestSpec::default(),
-            response: ResponseSpec::default(),
+            response: response_with_row_path(ResponseSpec::default(), row_path),
             pagination: PaginationSpec::default(),
             columns: projection_column_specs(projection),
         },
     }
+}
+
+/// Points row extraction at the property an operation's rows are wrapped in.
+fn response_with_row_path(mut response: ResponseSpec, row_path: &[String]) -> ResponseSpec {
+    response.rows_path = row_path.to_vec();
+    response
 }
 
 fn mcp_filter_bindings(projection: &Projection) -> Vec<McpTableFilterBinding> {
@@ -515,7 +530,7 @@ mod tests {
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
         AcceptedIdentityRequirement, Fingerprint, FingerprintSurface, HttpMethod,
-        IdentityRequirements, IrExecutionAttachment, IrInputLocation, IrOperation,
+        IdentityRequirements, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
         IrOperationInput, IrOperationOutput, IrScalarType, IrType, IrTypeShape,
         MCP_IMPORTER_VERSION, MaterializedSurface, McpExecutionAttachment, McpOperationPagination,
         McpRuntimeConfig, OPENAPI_IMPORTER_VERSION, OPERATION_METADATA_GENERATOR_VERSION,
@@ -844,6 +859,104 @@ mod tests {
             normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
             raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
         }
+    }
+
+    /// A REST surface whose operation declares an envelope wrapping its rows in
+    /// `items`.
+    fn rest_wrapped_list_materialized_surface(operation_id: &str) -> MaterializedSurface {
+        let semantic_ir = SemanticIr {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "github_v4".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+            operations: vec![IrOperation {
+                id: operation_id.to_string(),
+                method_name: operation_id.to_string(),
+                description: String::new(),
+                deprecated: false,
+                read_only: true,
+                naming: None,
+                inputs: Vec::new(),
+                output: IrOperationOutput {
+                    cardinality: coral_spec::v4::OutputCardinality::Singleton,
+                    type_ref: "envelope".to_string(),
+                },
+                entity: None,
+                execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
+                    method: HttpMethod::Get,
+                    path_template: "/items".to_string(),
+                    parameters: Vec::new(),
+                    request_body: None,
+                    response: RestResponseAttachment {
+                        status_code: 200,
+                        media_type: "application/json".to_string(),
+                        response: ResponseSpec::default(),
+                    },
+                })),
+                diagnostics: Vec::new(),
+            }],
+            types: vec![
+                test_object_type("item"),
+                IrType {
+                    id: "item_list".to_string(),
+                    shape: IrTypeShape::List {
+                        item_type_ref: "item".to_string(),
+                    },
+                    nullable: false,
+                    description: String::new(),
+                },
+                IrType {
+                    id: "envelope".to_string(),
+                    shape: IrTypeShape::Object {
+                        fields: vec![IrField {
+                            name: "items".to_string(),
+                            type_ref: "item_list".to_string(),
+                            required: true,
+                            nullable: false,
+                            description: String::new(),
+                        }],
+                    },
+                    nullable: false,
+                    description: String::new(),
+                },
+            ],
+            diagnostics: Vec::new(),
+        };
+        let operation_metadata = OperationMetadataCatalog {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "github_v4".to_string(),
+            generator_version: Some(OPERATION_METADATA_GENERATOR_VERSION.to_string()),
+            operations: BTreeMap::from([(
+                operation_id.to_string(),
+                OperationMetadata::Rest {
+                    row_path: vec!["items".to_string()],
+                    pagination: PaginationSpec::default(),
+                    lookup_keys: Vec::new(),
+                },
+            )]),
+        };
+        MaterializedSurface {
+            plan: ValidatedSurfacePlan::new(semantic_ir, operation_metadata).expect("plan"),
+            source_document_sha256: None,
+            normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
+            raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
+        }
+    }
+
+    fn mcp_wrapped_list_materialized_surface(operation_id: &str) -> MaterializedSurface {
+        let mut surface = mcp_materialized_surface_with_pagination(operation_id, None);
+        let mut operation_metadata = surface.plan.operation_metadata().clone();
+        operation_metadata.operations.insert(
+            operation_id.to_string(),
+            OperationMetadata::Mcp {
+                row_path: vec!["items".to_string()],
+                pagination: McpOperationPagination::default(),
+            },
+        );
+        surface.plan =
+            ValidatedSurfacePlan::new(surface.plan.semantic_ir().clone(), operation_metadata)
+                .expect("plan");
+        surface
     }
 
     fn test_input(name: &str, location: IrInputLocation) -> IrOperationInput {
@@ -1275,6 +1388,103 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["q", "state"],
             "function arguments must still be sent as query parameters"
+        );
+    }
+
+    #[test]
+    fn http_runtime_component_applies_the_operation_row_path() {
+        let manifest = manifest_with_surface(openapi_surface());
+        let component_for = |projection| {
+            let materialized = V4MaterializedSource {
+                fingerprint: Some(fingerprint(SurfaceType::OpenApi, "github_v4")),
+                surface: rest_wrapped_list_materialized_surface("rest_list_issues"),
+                projections: ProjectionCatalog {
+                    artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                    source_name: "github_v4".to_string(),
+                    generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                    projections: vec![projection],
+                    diagnostics: Vec::new(),
+                },
+                diagnostics: Vec::new(),
+            };
+            let component = runtime_component_for_v4_source(&manifest, &materialized)
+                .expect("runtime component")
+                .expect("published component");
+            let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+                panic!("expected HTTP component");
+            };
+            http
+        };
+
+        let table_http = component_for(published_projection("rest_list_issues"));
+        assert_eq!(
+            table_http
+                .tables
+                .first()
+                .expect("HTTP table")
+                .response
+                .rows_path,
+            ["items"]
+        );
+
+        let function_http = component_for(published_function_projection("rest_list_issues"));
+        assert_eq!(
+            function_http
+                .functions
+                .first()
+                .expect("HTTP function")
+                .response
+                .rows_path,
+            ["items"]
+        );
+    }
+
+    #[test]
+    fn mcp_runtime_component_applies_the_operation_row_path() {
+        let manifest = manifest_with_surface(mcp_surface());
+        let component_for = |projection| {
+            let materialized = V4MaterializedSource {
+                fingerprint: Some(fingerprint(SurfaceType::Mcp, "github_v4")),
+                surface: mcp_wrapped_list_materialized_surface("mcp_list_issues"),
+                projections: ProjectionCatalog {
+                    artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                    source_name: "github_v4".to_string(),
+                    generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                    projections: vec![projection],
+                    diagnostics: Vec::new(),
+                },
+                diagnostics: Vec::new(),
+            };
+            let component = runtime_component_for_v4_source(&manifest, &materialized)
+                .expect("runtime component")
+                .expect("published component");
+            let coral_engine::RuntimeSourceComponent::Mcp(mcp) = component else {
+                panic!("expected MCP component");
+            };
+            mcp
+        };
+
+        let table_mcp = component_for(published_projection("mcp_list_issues"));
+        assert_eq!(
+            table_mcp
+                .tables
+                .first()
+                .expect("MCP table")
+                .response
+                .rows_path,
+            ["items"]
+        );
+
+        let function_mcp = component_for(published_function_projection("mcp_list_issues"));
+        assert_eq!(
+            function_mcp
+                .functions
+                .first()
+                .expect("MCP function")
+                .common
+                .response
+                .rows_path,
+            ["items"]
         );
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -632,6 +632,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Rest {
+                    row_path: Vec::new(),
                     pagination,
                     lookup_keys: Vec::new(),
                 },
@@ -704,6 +705,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Rest {
+                    row_path: Vec::new(),
                     pagination: PaginationSpec::default(),
                     lookup_keys,
                 },
@@ -828,6 +830,7 @@ mod tests {
             operations: BTreeMap::from([(
                 operation_id.to_string(),
                 OperationMetadata::Mcp {
+                    row_path: Vec::new(),
                     pagination: McpOperationPagination {
                         cursor: pagination,
                         offset: offset_pagination,

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -69,7 +69,6 @@ pub enum OutputCardinality {
     None,
     Singleton,
     List,
-    WrappedList,
     Unknown,
 }
 

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -18,6 +18,7 @@ mod manifest;
 mod naming;
 mod operation_metadata;
 mod projections;
+mod response_cursors;
 mod schema;
 mod surfaces;
 mod wrapped_lists;

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,8 +7,8 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v7";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
-pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v1";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v10";
+pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v2";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v11";
 
 mod artifacts;
 mod diagnostics;
@@ -20,6 +20,7 @@ mod operation_metadata;
 mod projections;
 mod schema;
 mod surfaces;
+mod wrapped_lists;
 
 #[cfg(test)]
 mod manifest_tests;
@@ -47,6 +48,7 @@ pub use manifest::{
     V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
+pub(crate) use operation_metadata::resolve_output_row_type_ref;
 pub use operation_metadata::{
     ImportedSurface, McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
     ValidatedSurfacePlan, validate_operation_metadata_structure, validate_semantic_ir_structure,

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1901,6 +1901,105 @@ paths:
     );
 }
 
+/// Wrapped-list inference resolves `$ref` when it decides a response is an
+/// envelope, so cursor discovery has to resolve it too: a row path without a
+/// cursor is a table that silently stops after its first page.
+#[test]
+fn importer_finds_a_cursor_inside_a_referenced_envelope_metadata_object() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: referenced_meta
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /things:
+    get:
+      operationId: listThings
+      parameters:
+        - {name: cursor, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ThingPage'}
+  /widgets:
+    get:
+      operationId: listWidgets
+      parameters:
+        - {name: cursor, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: {$ref: '#/components/schemas/Thing'}
+                  pageInfo:
+                    type: object
+                    properties:
+                      end_cursor: {$ref: '#/components/schemas/Cursor'}
+components:
+  schemas:
+    Cursor:
+      type: string
+    Thing:
+      type: object
+      properties:
+        id: {type: string}
+    PageMeta:
+      type: object
+      properties:
+        next_cursor: {type: string}
+    ThingPage:
+      type: object
+      properties:
+        data:
+          type: array
+          items: {$ref: '#/components/schemas/Thing'}
+        meta: {$ref: '#/components/schemas/PageMeta'}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    // A referenced `meta` sibling: the reference is what supplies the envelope
+    // evidence, so the row path depends on resolving exactly what the cursor
+    // walk must also see.
+    assert_eq!(imported_row_path(&ir, "listthings"), ["data"]);
+    let referenced_meta = imported_rest_pagination(&ir, "listthings");
+    assert_eq!(referenced_meta.mode, PaginationMode::CursorQuery);
+    assert_eq!(referenced_meta.cursor_param.as_deref(), Some("cursor"));
+    assert_eq!(
+        referenced_meta.response_cursor_path,
+        ["meta", "next_cursor"]
+    );
+
+    // An inline `pageInfo` whose token is itself a reference.
+    assert_eq!(imported_row_path(&ir, "listwidgets"), ["data"]);
+    let referenced_token = imported_rest_pagination(&ir, "listwidgets");
+    assert_eq!(referenced_token.mode, PaginationMode::CursorQuery);
+    assert_eq!(
+        referenced_token.response_cursor_path,
+        ["pageInfo", "end_cursor"]
+    );
+}
+
 #[test]
 fn importer_treats_path_parameters_as_required_when_required_is_omitted() {
     let manifest = parse_source_manifest_yaml(

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2001,12 +2001,18 @@ components:
 }
 
 /// Row-path inference asks the pagination detectors whether an operation is
-/// paginated rather than predicting their answer, so every alias they accept is
-/// envelope evidence. Predicting it used to deadlock these two: no row path
-/// because the alias was unknown, and no pagination because the gate needs a row
-/// path.
+/// paginated rather than predicting their answer, so a contract binding any
+/// request input is envelope evidence — one case per way `binds_pagination_input`
+/// can be satisfied. Predicting the answer used to deadlock the two inferences:
+/// no row path because an alias was unknown, and no pagination because the gate
+/// needs a row path. `skip`/`take` and `$skip`/`$top` are the aliases that
+/// deadlocked.
 #[test]
-fn importer_infers_row_paths_for_every_pagination_alias_the_detectors_accept() {
+#[expect(
+    clippy::too_many_lines,
+    reason = "Every mode shares one envelope fixture, which is what makes the inputs the only variable."
+)]
+fn importer_infers_row_paths_when_pagination_detection_binds_a_request_input() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: aliases
@@ -2048,6 +2054,30 @@ paths:
           content:
             application/json:
               schema: {$ref: '#/components/schemas/Envelope'}
+  /cursor:
+    get:
+      operationId: cursorList
+      parameters:
+        - {name: cursor, in: query, schema: {type: string}}
+      responses:
+        '200':
+          headers:
+            X-Next-Cursor:
+              schema: {type: string}
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Envelope'}
+  /page:
+    get:
+      operationId: pageList
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Envelope'}
   /unpaginated:
     get:
       operationId: unpaginatedGet
@@ -2073,9 +2103,14 @@ components:
     )
     .expect("import");
 
-    // The envelope carries no metadata sibling, so the operation's own inputs
-    // are the only evidence available.
-    for operation_id in ["skiptakelist", "odatalist"] {
+    // Every operation returns the same envelope, and it carries no metadata
+    // sibling, so the operation's own inputs are the only evidence available.
+    for (operation_id, mode) in [
+        ("skiptakelist", PaginationMode::Offset),
+        ("odatalist", PaginationMode::Offset),
+        ("cursorlist", PaginationMode::CursorQuery),
+        ("pagelist", PaginationMode::Page),
+    ] {
         assert_eq!(
             imported_row_path(&ir, operation_id),
             ["data"],
@@ -2083,7 +2118,7 @@ components:
         );
         assert_eq!(
             imported_rest_pagination(&ir, operation_id).mode,
-            PaginationMode::Offset,
+            mode,
             "{operation_id} should paginate"
         );
     }

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2078,6 +2078,20 @@ paths:
           content:
             application/json:
               schema: {$ref: '#/components/schemas/Envelope'}
+  /link-header:
+    get:
+      operationId: linkHeaderList
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Envelope'}
   /unpaginated:
     get:
       operationId: unpaginatedGet
@@ -2110,6 +2124,10 @@ components:
         ("odatalist", PaginationMode::Offset),
         ("cursorlist", PaginationMode::CursorQuery),
         ("pagelist", PaginationMode::Page),
+        // Link-header detection is tried first, so this reaches
+        // `binds_pagination_input` by a different route than `pagelist` does —
+        // and it is the shape most real paginated endpoints use.
+        ("linkheaderlist", PaginationMode::LinkHeader),
     ] {
         assert_eq!(
             imported_row_path(&ir, operation_id),

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -21,6 +21,15 @@ fn imported_rest_pagination<'a>(
     }
 }
 
+fn imported_row_path<'a>(surface: &'a ImportedSurface, operation_id: &str) -> &'a [String] {
+    surface
+        .operation_metadata
+        .operations
+        .get(operation_id)
+        .expect("operation metadata")
+        .row_path()
+}
+
 #[test]
 fn extracts_openapi_document_metadata() {
     let metadata = openapi_document_metadata(
@@ -252,7 +261,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_common_envelope_objects_as_singletons() {
+fn importer_infers_row_paths_for_common_envelope_objects() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: statusgator
@@ -302,7 +311,10 @@ components:
     )
     .expect("import");
     let operation = ir.operations.first().expect("operation");
+    // The IR keeps the declared envelope; only the metadata says where its rows
+    // are.
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(imported_row_path(&ir, "listincidents"), ["data"]);
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -316,9 +328,9 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("success"), Some(&ManifestDataType::Boolean));
-    assert_eq!(columns.get("data"), Some(&ManifestDataType::Json));
-    assert_eq!(columns.get("pagination"), Some(&ManifestDataType::Json));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.get("name"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 2);
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -328,7 +340,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_single_array_payload_objects_as_singletons() {
+fn importer_infers_row_path_for_a_sole_array_payload_beside_a_total() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -377,6 +389,13 @@ components:
     .expect("import");
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    assert_eq!(
+        imported_row_path(
+            &ir,
+            "actions_list_selected_repositories_enabled_github_actions_organization"
+        ),
+        ["repositories"]
+    );
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -386,8 +405,9 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("total_count"), Some(&ManifestDataType::Int64));
-    assert_eq!(columns.get("repositories"), Some(&ManifestDataType::Json));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("name"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 2);
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -397,7 +417,7 @@ components:
 }
 
 #[test]
-fn importer_keeps_search_result_objects_as_singletons() {
+fn importer_prefers_a_named_row_property_over_other_arrays() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: github
@@ -456,6 +476,11 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    // `lexical_fallback_reason` is an array too; the conventional row name wins.
+    assert_eq!(
+        imported_row_path(&ir, "search_issues_and_pull_requests"),
+        ["items"]
+    );
 
     let catalog =
         generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
@@ -465,21 +490,13 @@ paths:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(columns.get("total_count"), Some(&ManifestDataType::Int64));
-    assert_eq!(
-        columns.get("incomplete_results"),
-        Some(&ManifestDataType::Boolean)
-    );
-    assert_eq!(columns.get("items"), Some(&ManifestDataType::Json));
-    assert_eq!(columns.get("search_type"), Some(&ManifestDataType::Utf8));
-    assert_eq!(
-        columns.get("lexical_fallback_reason"),
-        Some(&ManifestDataType::Json)
-    );
-    assert!(!columns.contains_key("id"));
-    assert!(!columns.contains_key("number"));
-    assert!(!columns.contains_key("title"));
-    assert!(!columns.contains_key("state"));
+    assert_eq!(columns.get("id"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("number"), Some(&ManifestDataType::Int64));
+    assert_eq!(columns.get("title"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.get("state"), Some(&ManifestDataType::Utf8));
+    assert_eq!(columns.len(), 4);
+    assert!(!columns.contains_key("total_count"));
+    assert!(!columns.contains_key("lexical_fallback_reason"));
 }
 
 #[test]
@@ -580,6 +597,9 @@ components:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    // A project item is a resource, not a page of its `fields`: nothing in the
+    // response or the request says otherwise.
+    assert!(imported_row_path(&ir, "projects_get_org_item").is_empty());
 
     let row_type = ir
         .types
@@ -660,6 +680,9 @@ paths:
 
     let operation = ir.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    // A bundle's `items` is a conventional row name, but a bundle is still a
+    // resource: no metadata sibling, no pagination parameter.
+    assert!(imported_row_path(&ir, "bundles_get").is_empty());
 }
 
 #[test]
@@ -1759,16 +1782,17 @@ paths:
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<BTreeMap<_, _>>();
 
-    for operation_id in [
-        "cursor_list",
-        "pagination_token_list",
-        "iterator_list",
-        "start_cursor_list",
-        "nested_next_list",
-        "singleton_get",
-        "cursor_header_list",
-        "cursor_page_list",
-        "numeric_page_list",
+    // Each of these declares an envelope object, so cardinality stays
+    // Singleton; the inferred row path is what makes them paginate.
+    for (operation_id, mode) in [
+        ("cursor_list", PaginationMode::CursorQuery),
+        ("pagination_token_list", PaginationMode::CursorQuery),
+        ("iterator_list", PaginationMode::CursorQuery),
+        ("start_cursor_list", PaginationMode::CursorQuery),
+        ("nested_next_list", PaginationMode::CursorQuery),
+        ("cursor_header_list", PaginationMode::CursorQuery),
+        ("cursor_page_list", PaginationMode::CursorQuery),
+        ("numeric_page_list", PaginationMode::Page),
     ] {
         let operation = operations.get(operation_id).expect("operation");
         assert_eq!(
@@ -1776,12 +1800,26 @@ paths:
             OutputCardinality::Singleton,
             "{operation_id}"
         );
+        assert!(
+            !imported_row_path(&ir, operation_id).is_empty(),
+            "{operation_id}"
+        );
         assert_eq!(
             imported_rest_pagination(&ir, operation_id).mode,
-            PaginationMode::None,
+            mode,
             "{operation_id}"
         );
     }
+
+    // A singleton with a cursor query parameter has no row collection to page
+    // through, so the parameter stays an ordinary input.
+    let singleton = operations.get("singleton_get").expect("singleton");
+    assert_eq!(singleton.output.cardinality, OutputCardinality::Singleton);
+    assert!(imported_row_path(&ir, "singleton_get").is_empty());
+    assert_eq!(
+        imported_rest_pagination(&ir, "singleton_get").mode,
+        PaginationMode::None
+    );
 
     let link = imported_rest_pagination(&ir, "link_list");
     assert_eq!(link.mode, PaginationMode::LinkHeader);

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2000,6 +2000,156 @@ components:
     );
 }
 
+/// Row-path inference asks the pagination detectors whether an operation is
+/// paginated rather than predicting their answer, so every alias they accept is
+/// envelope evidence. Predicting it used to deadlock these two: no row path
+/// because the alias was unknown, and no pagination because the gate needs a row
+/// path.
+#[test]
+fn importer_infers_row_paths_for_every_pagination_alias_the_detectors_accept() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: aliases
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /skip-take:
+    get:
+      operationId: skipTakeList
+      parameters:
+        - {name: skip, in: query, schema: {type: integer, default: 0}}
+        - {name: take, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Envelope'}
+  /odata:
+    get:
+      operationId: odataList
+      parameters:
+        - {name: $skip, in: query, schema: {type: integer, default: 0}}
+        - {name: $top, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Envelope'}
+  /unpaginated:
+    get:
+      operationId: unpaginatedGet
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Envelope'}
+components:
+  schemas:
+    Envelope:
+      type: object
+      properties:
+        success: {type: boolean}
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    // The envelope carries no metadata sibling, so the operation's own inputs
+    // are the only evidence available.
+    for operation_id in ["skiptakelist", "odatalist"] {
+        assert_eq!(
+            imported_row_path(&ir, operation_id),
+            ["data"],
+            "{operation_id} should be unwrapped"
+        );
+        assert_eq!(
+            imported_rest_pagination(&ir, operation_id).mode,
+            PaginationMode::Offset,
+            "{operation_id} should paginate"
+        );
+    }
+
+    // The same envelope without pagination inputs stays a singleton: nothing
+    // says this response is a page rather than a resource.
+    assert!(imported_row_path(&ir, "unpaginatedget").is_empty());
+}
+
+/// A `Link` response header alone is not envelope evidence. GitHub declares one
+/// on singleton resources, where treating it as evidence would promote an
+/// incidental array to the whole relation.
+#[test]
+fn importer_does_not_treat_a_bare_link_header_as_envelope_evidence() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: link_header_singleton
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /runners/{runner_id}:
+    get:
+      operationId: getRunner
+      parameters:
+        - {name: runner_id, in: path, required: true, schema: {type: integer}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name: {type: string}
+                  public_ips:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        prefix: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    assert!(
+        imported_row_path(&ir, "getrunner").is_empty(),
+        "a runner is a resource, not a page of its IP addresses"
+    );
+}
+
 #[test]
 fn importer_treats_path_parameters_as_required_when_required_is_omitted() {
     let manifest = parse_source_manifest_yaml(

--- a/crates/coral-spec/src/v4/operation_metadata/mod.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/mod.rs
@@ -14,5 +14,6 @@ pub use model::{
     ImportedSurface, McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
 };
 pub use plan::ValidatedSurfacePlan;
+pub(crate) use policy::resolve_output_row_type_ref;
 pub use policy::validate_operation_metadata_structure;
 pub use structural::validate_semantic_ir_structure;

--- a/crates/coral-spec/src/v4/operation_metadata/model.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/model.rs
@@ -43,13 +43,28 @@ pub struct OperationMetadataCatalog {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OperationMetadata {
     Rest {
+        #[serde(default)]
+        row_path: Vec<String>,
         #[serde(serialize_with = "serialize_rest_operation_pagination")]
         pagination: PaginationSpec,
         lookup_keys: Vec<String>,
     },
     Mcp {
+        #[serde(default)]
+        row_path: Vec<String>,
         pagination: McpOperationPagination,
     },
+}
+
+impl OperationMetadata {
+    /// Path from the response root to the property holding this operation's
+    /// rows. Empty when the response root is already the row collection.
+    #[must_use]
+    pub fn row_path(&self) -> &[String] {
+        match self {
+            Self::Rest { row_path, .. } | Self::Mcp { row_path, .. } => row_path,
+        }
+    }
 }
 
 fn serialize_rest_operation_pagination<S>(

--- a/crates/coral-spec/src/v4/operation_metadata/plan.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/plan.rs
@@ -2,10 +2,11 @@ use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
-use crate::v4::ir::{IrInputLocation, IrOperation, SemanticIr};
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
 use crate::v4::operation_metadata::model::{OperationMetadata, OperationMetadataCatalog};
 use crate::v4::operation_metadata::policy::{
-    rest_pagination_owned_inputs, validate_operation_metadata_structure,
+    resolve_output_row_type_ref, rest_pagination_owned_inputs,
+    validate_operation_metadata_structure,
 };
 use crate::v4::operation_metadata::structural::validate_semantic_ir_structure;
 use crate::{PaginationSpec, Result};
@@ -70,6 +71,45 @@ impl ValidatedSurfacePlan {
     }
 
     #[must_use]
+    /// Returns the path from the response root to an operation's rows.
+    pub fn output_row_path(&self, operation_id: &str) -> &[String] {
+        self.metadata_for_operation(operation_id).row_path()
+    }
+
+    #[must_use]
+    /// Returns the REST row type that remains after applying the operation's
+    /// row path.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the operation is absent, is not a REST operation, or the
+    /// validated-plan invariant that its row path resolves has been violated.
+    pub fn rest_output_type_ref(&self, operation_id: &str) -> &str {
+        let operation = self
+            .semantic_ir
+            .operations
+            .iter()
+            .find(|operation| operation.id == operation_id)
+            .expect("validated plan contains the requested operation");
+        assert!(
+            matches!(operation.execution, IrExecutionAttachment::Rest(_)),
+            "MCP operation has no REST output type"
+        );
+        let types = self
+            .semantic_ir
+            .types
+            .iter()
+            .map(|ty| (ty.id.as_str(), ty))
+            .collect();
+        resolve_output_row_type_ref(
+            &operation.output,
+            self.output_row_path(operation_id),
+            &types,
+        )
+        .expect("validated row path resolves to an output type")
+    }
+
+    #[must_use]
     /// Returns effective REST pagination for a REST operation.
     ///
     /// # Panics
@@ -93,7 +133,7 @@ impl ValidatedSurfacePlan {
         operation_id: &str,
     ) -> (Option<&McpPaginationSpec>, Option<&McpOffsetPaginationSpec>) {
         match self.metadata_for_operation(operation_id) {
-            OperationMetadata::Mcp { pagination } => {
+            OperationMetadata::Mcp { pagination, .. } => {
                 (pagination.cursor.as_ref(), pagination.offset.as_ref())
             }
             OperationMetadata::Rest { .. } => panic!("MCP operation has REST metadata"),
@@ -125,7 +165,7 @@ impl ValidatedSurfacePlan {
                     && rest_pagination_owned_inputs(operation, pagination)
                         .is_ok_and(|owned| owned.contains(input_name))
             }
-            OperationMetadata::Mcp { pagination } => {
+            OperationMetadata::Mcp { pagination, .. } => {
                 location == IrInputLocation::ToolArg
                     && (pagination
                         .cursor

--- a/crates/coral-spec/src/v4/operation_metadata/plan.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/plan.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -16,6 +18,13 @@ use crate::{PaginationSpec, Result};
 pub struct ValidatedSurfacePlan {
     semantic_ir: SemanticIr,
     operation_metadata: OperationMetadataCatalog,
+    /// Row type each REST operation yields once its row path is applied.
+    ///
+    /// Resolved once, because resolving one walks the whole type catalog and a
+    /// validated plan is immutable. Rebuilt on deserialization, so it stays out
+    /// of the serialized form.
+    #[serde(skip)]
+    rest_row_type_refs: BTreeMap<String, String>,
 }
 
 impl<'de> Deserialize<'de> for ValidatedSurfacePlan {
@@ -41,9 +50,11 @@ impl ValidatedSurfacePlan {
     ) -> Result<Self> {
         validate_semantic_ir_structure(&semantic_ir)?;
         validate_operation_metadata_structure(&semantic_ir, &operation_metadata)?;
+        let rest_row_type_refs = resolve_rest_row_type_refs(&semantic_ir, &operation_metadata);
         Ok(Self {
             semantic_ir,
             operation_metadata,
+            rest_row_type_refs,
         })
     }
 
@@ -85,28 +96,10 @@ impl ValidatedSurfacePlan {
     /// Panics when the operation is absent, is not a REST operation, or the
     /// validated-plan invariant that its row path resolves has been violated.
     pub fn rest_output_type_ref(&self, operation_id: &str) -> &str {
-        let operation = self
-            .semantic_ir
-            .operations
-            .iter()
-            .find(|operation| operation.id == operation_id)
-            .expect("validated plan contains the requested operation");
-        assert!(
-            matches!(operation.execution, IrExecutionAttachment::Rest(_)),
-            "MCP operation has no REST output type"
-        );
-        let types = self
-            .semantic_ir
-            .types
-            .iter()
-            .map(|ty| (ty.id.as_str(), ty))
-            .collect();
-        resolve_output_row_type_ref(
-            &operation.output,
-            self.output_row_path(operation_id),
-            &types,
-        )
-        .expect("validated row path resolves to an output type")
+        self.rest_row_type_refs
+            .get(operation_id)
+            .expect("validated plan resolves a row type for every REST operation")
+            .as_str()
     }
 
     #[must_use]
@@ -177,4 +170,33 @@ impl ValidatedSurfacePlan {
             }
         }
     }
+}
+
+/// Resolves every REST operation's row type against one shared type index.
+///
+/// Runs after structural validation, so a resolution failure cannot happen for
+/// a valid plan; skipping one leaves `rest_output_type_ref` to panic, which is
+/// the contract it already documents.
+fn resolve_rest_row_type_refs(
+    semantic_ir: &SemanticIr,
+    operation_metadata: &OperationMetadataCatalog,
+) -> BTreeMap<String, String> {
+    let types = semantic_ir
+        .types
+        .iter()
+        .map(|ty| (ty.id.as_str(), ty))
+        .collect::<BTreeMap<_, _>>();
+    semantic_ir
+        .operations
+        .iter()
+        .filter(|operation| matches!(operation.execution, IrExecutionAttachment::Rest(_)))
+        .filter_map(|operation| {
+            let row_path = operation_metadata
+                .operations
+                .get(&operation.id)
+                .map_or(&[][..], OperationMetadata::row_path);
+            let type_ref = resolve_output_row_type_ref(&operation.output, row_path, &types).ok()?;
+            Some((operation.id.clone(), type_ref.to_string()))
+        })
+        .collect()
 }

--- a/crates/coral-spec/src/v4/operation_metadata/policy.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/policy.rs
@@ -4,7 +4,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::v4::ir::{
-    IrExecutionAttachment, IrInputLocation, IrOperation, IrScalarType, SemanticIr,
+    IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationOutput, IrScalarType, IrType,
+    IrTypeShape, SemanticIr,
 };
 use crate::v4::operation_metadata::model::{
     McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
@@ -22,6 +23,11 @@ pub fn validate_operation_metadata_structure(
         .iter()
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<BTreeMap<_, _>>();
+    let types = semantic_ir
+        .types
+        .iter()
+        .map(|ty| (ty.id.as_str(), ty))
+        .collect::<BTreeMap<_, _>>();
 
     for operation_id in metadata.operations.keys() {
         if !operations.contains_key(operation_id.as_str()) {
@@ -36,7 +42,7 @@ pub fn validate_operation_metadata_structure(
                 "operation metadata is missing operation '{operation_id}'"
             ))
         })?;
-        validate_operation_metadata(operation, effective)?;
+        validate_operation_metadata(operation, effective, &types)?;
     }
     Ok(())
 }
@@ -44,15 +50,24 @@ pub fn validate_operation_metadata_structure(
 fn validate_operation_metadata(
     operation: &IrOperation,
     metadata: &OperationMetadata,
+    types: &BTreeMap<&str, &IrType>,
 ) -> Result<()> {
     match (&operation.execution, metadata) {
         (
             IrExecutionAttachment::Rest(_),
             OperationMetadata::Rest {
+                row_path,
                 pagination,
                 lookup_keys,
             },
         ) => {
+            validate_row_path(operation, row_path)?;
+            resolve_output_row_type_ref(&operation.output, row_path, types).map_err(|error| {
+                ManifestError::validation(format!(
+                    "operation '{}' output row path is invalid: {error}",
+                    operation.id
+                ))
+            })?;
             if pagination.mode == PaginationMode::None
                 && !rest_pagination_is_canonical_none(pagination)
             {
@@ -65,7 +80,17 @@ fn validate_operation_metadata(
             let pagination_inputs = validate_rest_pagination(operation, pagination)?;
             validate_lookup_keys(operation, lookup_keys, &pagination_inputs)
         }
-        (IrExecutionAttachment::Mcp(_), OperationMetadata::Mcp { pagination }) => {
+        (
+            IrExecutionAttachment::Mcp(_),
+            OperationMetadata::Mcp {
+                row_path,
+                pagination,
+            },
+        ) => {
+            // MCP output types stay opaque JSON, so an MCP row path is only
+            // checked for hygiene; the runtime resolves it against the decoded
+            // tool result.
+            validate_row_path(operation, row_path)?;
             validate_mcp_pagination(operation, pagination)
         }
         (IrExecutionAttachment::Rest(_), OperationMetadata::Mcp { .. }) => {
@@ -81,6 +106,59 @@ fn validate_operation_metadata(
             )))
         }
     }
+}
+
+fn validate_row_path(operation: &IrOperation, row_path: &[String]) -> Result<()> {
+    if row_path
+        .iter()
+        .any(|segment| segment.trim().is_empty() || segment != segment.trim())
+    {
+        return Err(ManifestError::validation(format!(
+            "operation '{}' output row path contains a blank or padded segment",
+            operation.id
+        )));
+    }
+    Ok(())
+}
+
+/// Resolves the type of the rows an operation yields once its row path is
+/// applied, or the declared output type when the path is empty.
+pub(crate) fn resolve_output_row_type_ref<'a>(
+    output: &'a IrOperationOutput,
+    row_path: &[String],
+    types: &BTreeMap<&str, &'a IrType>,
+) -> std::result::Result<&'a str, String> {
+    if row_path.is_empty() {
+        return Ok(&output.type_ref);
+    }
+
+    let mut type_ref = output.type_ref.as_str();
+    for segment in row_path {
+        let ty = types
+            .get(type_ref)
+            .ok_or_else(|| format!("type '{type_ref}' is missing"))?;
+        let IrTypeShape::Object { fields } = &ty.shape else {
+            return Err(format!(
+                "segment '{segment}' traverses non-object type '{type_ref}'"
+            ));
+        };
+        let field = fields
+            .iter()
+            .find(|field| field.name == *segment)
+            .ok_or_else(|| format!("type '{type_ref}' has no field '{segment}'"))?;
+        type_ref = &field.type_ref;
+    }
+
+    let ty = types
+        .get(type_ref)
+        .ok_or_else(|| format!("type '{type_ref}' is missing"))?;
+    let IrTypeShape::List { item_type_ref } = &ty.shape else {
+        return Err(format!("terminal type '{type_ref}' is not a list"));
+    };
+    if item_type_ref != "json" && !types.contains_key(item_type_ref.as_str()) {
+        return Err(format!("list item type '{item_type_ref}' is missing"));
+    }
+    Ok(item_type_ref)
 }
 
 fn validate_rest_pagination(

--- a/crates/coral-spec/src/v4/operation_metadata/policy.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/policy.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::v4::ir::{
     IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationOutput, IrScalarType, IrType,
-    IrTypeShape, SemanticIr,
+    IrTypeShape, OutputCardinality, SemanticIr,
 };
 use crate::v4::operation_metadata::model::{
     McpOperationPagination, OperationMetadata, OperationMetadataCatalog,
@@ -130,6 +130,14 @@ pub(crate) fn resolve_output_row_type_ref<'a>(
 ) -> std::result::Result<&'a str, String> {
     if row_path.is_empty() {
         return Ok(&output.type_ref);
+    }
+
+    // A row path selects from the response root, but a declared list is already
+    // the rows: its `type_ref` describes one of them. Traversing from there
+    // would check the path against a single row's fields while the runtime
+    // applies it to the enclosing array, where it selects nothing.
+    if output.cardinality == OutputCardinality::List {
+        return Err("row path must be empty when the response root is already a list".to_string());
     }
 
     let mut type_ref = output.type_ref.as_str();

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -150,6 +150,7 @@ fn plan_rejects_mcp_offset_pagination_starting_past_first_page() {
     }
     let operation_id = operation.id.clone();
     let metadata_with_offset_start = |offset_start| OperationMetadata::Mcp {
+        row_path: Vec::new(),
         pagination: crate::v4::McpOperationPagination {
             cursor: None,
             offset: Some(crate::backends::mcp::McpOffsetPaginationSpec {
@@ -199,9 +200,13 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
         !yaml.contains("lookup_keys:"),
         "unexpected policy in IR: {yaml}"
     );
+    assert!(
+        !yaml.contains("row_path:"),
+        "unexpected policy in IR: {yaml}"
+    );
     assert!(matches!(
         imported.operation_metadata.operations.values().next(),
-        Some(OperationMetadata::Rest { pagination, lookup_keys })
+        Some(OperationMetadata::Rest { pagination, lookup_keys, .. })
             if pagination.page_param.as_deref() == Some("page")
                 && lookup_keys == &["state"]
     ));
@@ -210,6 +215,7 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
 #[test]
 fn disabled_rest_pagination_serializes_only_its_mode() {
     let metadata = OperationMetadata::Rest {
+        row_path: Vec::new(),
         pagination: crate::PaginationSpec::default(),
         lookup_keys: Vec::new(),
     };

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -213,6 +213,62 @@ fn semantic_ir_serialization_contains_facts_not_inferred_policy() {
 }
 
 #[test]
+fn plan_rejects_blank_or_unresolvable_rest_row_paths() {
+    let (_manifest, mut imported) = imported();
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    *row_path = vec![" ".to_string()];
+    let error = imported
+        .validated_plan()
+        .expect_err("blank row path must fail");
+    assert!(
+        error.to_string().contains("blank or padded segment"),
+        "unexpected error: {error}"
+    );
+
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    // The operation returns a declared array, so no path can traverse it.
+    *row_path = vec!["missing".to_string()];
+    let error = imported
+        .validated_plan()
+        .expect_err("unresolvable row path must fail");
+    assert!(
+        error.to_string().contains("traverses non-object type"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn operation_metadata_without_a_row_path_defaults_to_the_response_root() {
+    let metadata: OperationMetadata = serde_yaml::from_str(
+        r"
+type: rest
+pagination:
+  mode: none
+lookup_keys: []
+",
+    )
+    .expect("metadata without a row path");
+
+    assert!(metadata.row_path().is_empty());
+}
+
+#[test]
 fn disabled_rest_pagination_serializes_only_its_mode() {
     let metadata = OperationMetadata::Rest {
         row_path: Vec::new(),

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -242,15 +242,95 @@ fn plan_rejects_blank_or_unresolvable_rest_row_paths() {
     else {
         panic!("expected REST metadata");
     };
-    // The operation returns a declared array, so no path can traverse it.
+    // The operation returns a declared array, which already *is* the rows, so
+    // no path applies: the runtime would select the segment from the array.
     *row_path = vec!["missing".to_string()];
     let error = imported
         .validated_plan()
-        .expect_err("unresolvable row path must fail");
+        .expect_err("a row path on a declared list must fail");
     assert!(
-        error.to_string().contains("traverses non-object type"),
+        error
+            .to_string()
+            .contains("row path must be empty when the response root is already a list"),
         "unexpected error: {error}"
     );
+}
+
+/// A singleton envelope is the case a row path is *for*, so resolution has to
+/// keep checking that the path reaches an array of rows.
+#[test]
+fn plan_rejects_rest_row_paths_a_singleton_response_cannot_resolve() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  file: /tmp/openapi.yaml
+  base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: {type: integer}
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+",
+    )
+    .expect("import");
+
+    for (row_path, fragment) in [
+        (vec!["missing".to_string()], "has no field 'missing'"),
+        (vec!["total".to_string()], "is not a list"),
+        (
+            vec!["data".to_string(), "id".to_string()],
+            "traverses non-object type",
+        ),
+    ] {
+        let mut imported = imported.clone();
+        let OperationMetadata::Rest {
+            row_path: metadata_row_path,
+            ..
+        } = imported
+            .operation_metadata
+            .operations
+            .values_mut()
+            .next()
+            .expect("metadata")
+        else {
+            panic!("expected REST metadata");
+        };
+        *metadata_row_path = row_path.clone();
+        let error = imported
+            .validated_plan()
+            .expect_err("unresolvable row path must fail");
+        assert!(
+            error.to_string().contains(fragment),
+            "row path {row_path:?}: unexpected error: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1355,7 +1355,7 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
 }
 
 #[test]
-fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
+fn generated_mcp_projection_keeps_an_inferred_cursor_internal() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1410,16 +1410,17 @@ fn generated_mcp_projection_exposes_cursor_without_pagination_metadata() {
         .find(|input| input.wire_name == "cursor")
         .expect("cursor input");
 
-    assert_eq!(cursor.sql_exposure, SqlInputExposure::FunctionArg);
+    // Pagination owns the cursor of a wrapped-list tool, so SQL never binds it.
+    assert_eq!(cursor.sql_exposure, SqlInputExposure::Internal);
     assert!(
         mcp_projection_arg_specs(projection)
             .iter()
-            .any(|arg| arg.bind.arg == "cursor")
+            .all(|arg| arg.bind.arg != "cursor")
     );
 }
 
 #[test]
-fn generated_mcp_projection_with_only_cursor_is_table_function_without_pagination_metadata() {
+fn generated_mcp_projection_with_only_an_inferred_cursor_is_a_table() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
@@ -1467,17 +1468,16 @@ fn generated_mcp_projection_with_only_cursor_is_table_function_without_paginatio
         .find(|projection| projection.operation_id == "list_items")
         .expect("mcp projection");
 
-    assert!(matches!(
-        projection.kind,
-        ProjectionKind::TableFunction { .. }
-    ));
+    // The cursor is the tool's only argument and pagination owns it, so the
+    // projection has nothing left to take as a function argument.
+    assert!(matches!(projection.kind, ProjectionKind::Table));
     assert_eq!(
         projection
             .inputs
             .iter()
-            .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
+            .filter(|input| input.sql_exposure != SqlInputExposure::Internal)
             .count(),
-        1
+        0
     );
 }
 

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1631,6 +1631,53 @@ fn imported_mcp_items_surface() -> (V4SourceManifest, ImportedSurface) {
     (manifest, imported)
 }
 
+fn imported_wrapped_items_surface() -> (V4SourceManifest, ImportedSurface) {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  file: /tmp/openapi.yaml
+  base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                        title: {type: string}
+",
+    )
+    .expect("import");
+    (manifest, imported)
+}
+
 fn imported_required_account_surface() -> (V4SourceManifest, ImportedSurface) {
     let manifest = parse_source_manifest_yaml(
         r"
@@ -1734,6 +1781,52 @@ fn projection_input_at_mut<'a>(
         .iter_mut()
         .find(|input| input.wire_name == wire_name && input.source_location == location)
         .expect("projection input")
+}
+
+#[test]
+fn generated_projection_columns_come_from_the_wrapped_list_row_type() {
+    let (manifest, imported) = imported_wrapped_items_surface();
+    let plan = imported.validated_plan().expect("plan");
+    assert_eq!(plan.output_row_path("items_list"), ["items"]);
+
+    let catalog = generate_projection_catalog(&manifest, &plan).expect("projections");
+    let projection = catalog.projections.first().expect("projection");
+    assert_eq!(
+        projection
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        ["id", "title"]
+    );
+}
+
+#[test]
+fn projection_compatibility_rejects_columns_the_effective_row_path_cannot_yield() {
+    let (manifest, mut imported) = imported_wrapped_items_surface();
+    let catalog = generate_projection_catalog(&manifest, &imported.validated_plan().expect("plan"))
+        .expect("projections");
+
+    // Overriding the row path back to the envelope root leaves the snapshot's
+    // columns describing rows the operation no longer yields.
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .get_mut("items_list")
+        .expect("items_list metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    row_path.clear();
+    let plan = imported.validated_plan().expect("plan");
+
+    let error =
+        validate_projection_compatibility(&plan, &catalog).expect_err("stale columns must fail");
+
+    assert!(
+        error.to_string().contains("column 'id' reads field 'id'"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1678,6 +1678,74 @@ paths:
     (manifest, imported)
 }
 
+/// An envelope offering row paths of three different shapes: `items` yields
+/// objects, `tags` yields scalars, and `blobs` yields rows whose item type the
+/// importer could not resolve.
+fn imported_mixed_row_shapes_surface() -> (V4SourceManifest, ImportedSurface) {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  file: /tmp/openapi.yaml
+  base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  tags:
+                    type: array
+                    items: {type: string}
+                  blobs:
+                    type: array
+                    items: {$ref: '#/components/schemas/Missing'}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                        title: {type: string}
+",
+    )
+    .expect("import");
+    (manifest, imported)
+}
+
+fn override_row_path(imported: &mut ImportedSurface, operation_id: &str, path: &[&str]) {
+    let OperationMetadata::Rest { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .get_mut(operation_id)
+        .expect("operation metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    *row_path = path.iter().map(|segment| (*segment).to_string()).collect();
+}
+
 fn imported_required_account_surface() -> (V4SourceManifest, ImportedSurface) {
     let manifest = parse_source_manifest_yaml(
         r"
@@ -1827,6 +1895,74 @@ fn projection_compatibility_rejects_columns_the_effective_row_path_cannot_yield(
         error.to_string().contains("column 'id' reads field 'id'"),
         "unexpected error: {error}"
     );
+}
+
+/// A row path may legitimately select an array of scalars, so the plan accepts
+/// the override. The snapshot's field columns cannot survive it: a source path
+/// against a string row resolves to null on every row rather than failing.
+#[test]
+fn projection_compatibility_rejects_field_columns_when_the_rows_are_scalars() {
+    let (manifest, mut imported) = imported_mixed_row_shapes_surface();
+    let catalog = generate_projection_catalog(&manifest, &imported.validated_plan().expect("plan"))
+        .expect("projections");
+    override_row_path(&mut imported, "items_list", &["tags"]);
+    let plan = imported.validated_plan().expect("plan");
+
+    let error = validate_projection_compatibility(&plan, &catalog)
+        .expect_err("field columns must not survive a scalar row path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("is not an object and names no fields"),
+        "unexpected error: {error}"
+    );
+}
+
+/// The same hole one step earlier: a row type the semantic IR carries no entry
+/// for names no fields either, and an unresolved item type reaches exactly that
+/// state through the `json` sentinel.
+#[test]
+fn projection_compatibility_rejects_field_columns_when_the_row_type_is_absent() {
+    let (manifest, mut imported) = imported_mixed_row_shapes_surface();
+    let catalog = generate_projection_catalog(&manifest, &imported.validated_plan().expect("plan"))
+        .expect("projections");
+    override_row_path(&mut imported, "items_list", &["blobs"]);
+    let plan = imported.validated_plan().expect("plan");
+    assert_eq!(plan.rest_output_type_ref("items_list"), "json");
+
+    let error = validate_projection_compatibility(&plan, &catalog)
+        .expect_err("field columns must not survive an opaque row path");
+
+    assert!(
+        error
+            .to_string()
+            .contains("is not an object and names no fields"),
+        "unexpected error: {error}"
+    );
+}
+
+/// The rule is about source paths, not row shapes: a catalog generated for
+/// non-object rows projects them whole, and stays compatible.
+#[test]
+fn projection_compatibility_accepts_whole_row_columns_for_non_object_rows() {
+    for row_path in [["tags"], ["blobs"]] {
+        let (manifest, mut imported) = imported_mixed_row_shapes_surface();
+        override_row_path(&mut imported, "items_list", &row_path);
+        let plan = imported.validated_plan().expect("plan");
+        let catalog = generate_projection_catalog(&manifest, &plan).expect("projections");
+        assert!(
+            catalog
+                .projections
+                .iter()
+                .flat_map(|projection| &projection.columns)
+                .all(|column| column.source_path.is_empty()),
+            "non-object rows are projected whole"
+        );
+
+        validate_projection_compatibility(&plan, &catalog)
+            .expect("a catalog generated for these rows is compatible with them");
+    }
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1780,6 +1780,7 @@ paths:
                           type: object
                           properties:
                             login: {type: string}
+                            '0': {type: string}
                         tags:
                           type: array
                           items: {type: string}
@@ -2077,6 +2078,18 @@ fn projection_compatibility_walks_every_segment_of_a_nested_source_path() {
         // A map admits any key, and an opaque payload admits anything at all.
         (&["labels", "any_key"][..], Ok(())),
         (&["extra", "anything", "deep"][..], Ok(())),
+        // ...but not a numeric one: runtime reads that as an array index, so it
+        // selects nothing however the payload is shaped. `owner` really does
+        // declare a field named `0`, so this is the numeric rule rejecting it
+        // rather than the missing-field rule.
+        (
+            &["owner", "0"][..],
+            Err("is read as an array index and so selects nothing"),
+        ),
+        (
+            &["labels", "0"][..],
+            Err("is read as an array index and so selects nothing"),
+        ),
         // The first segment is still checked as before.
         (&["nope", "deeper"][..], Err("which has no such field")),
     ] {

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1615,7 +1615,7 @@ fn imported_mcp_items_surface() -> (V4SourceManifest, ImportedSurface) {
     };
     let mut imported =
         import_mcp_surface(&manifest, &manifest.surface, &catalog).expect("MCP import");
-    let OperationMetadata::Mcp { pagination } = imported
+    let OperationMetadata::Mcp { pagination, .. } = imported
         .operation_metadata
         .operations
         .get_mut("list_items")

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1734,6 +1734,87 @@ paths:
     (manifest, imported)
 }
 
+/// Rows whose fields cover every `IrTypeShape` a nested source path can be
+/// walked through: an object, a list, a map, an opaque payload, and a scalar.
+fn imported_nested_row_surface() -> (V4SourceManifest, ImportedSurface) {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  file: /tmp/openapi.yaml
+  base_url: https://api.example.com
+",
+    )
+    .expect("manifest")
+    .as_v4()
+    .expect("v4")
+    .clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_count: {type: integer}
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                        owner:
+                          type: object
+                          properties:
+                            login: {type: string}
+                        tags:
+                          type: array
+                          items: {type: string}
+                        extra: {}
+                        labels:
+                          type: object
+                          additionalProperties: {type: string}
+",
+    )
+    .expect("import");
+    (manifest, imported)
+}
+
+/// Replaces the catalog's columns with a single column reading `source_path`,
+/// standing in for a hand-authored projection override.
+fn compatibility_of_source_path(
+    catalog: &ProjectionCatalog,
+    source_path: &[&str],
+) -> ProjectionCatalog {
+    let mut catalog = catalog.clone();
+    let projection = catalog.projections.first_mut().expect("projection");
+    projection.columns = vec![ProjectionColumn {
+        name: "probe".to_string(),
+        data_type: ManifestDataType::Json,
+        source_path: source_path
+            .iter()
+            .map(|segment| (*segment).to_string())
+            .collect(),
+        nullable: true,
+        description: String::new(),
+        do_not_index: false,
+    }];
+    catalog
+}
+
 fn override_row_path(imported: &mut ImportedSurface, operation_id: &str, path: &[&str]) {
     let OperationMetadata::Rest { row_path, .. } = imported
         .operation_metadata
@@ -1962,6 +2043,60 @@ fn projection_compatibility_accepts_whole_row_columns_for_non_object_rows() {
 
         validate_projection_compatibility(&plan, &catalog)
             .expect("a catalog generated for these rows is compatible with them");
+    }
+}
+
+/// The generator never nests a source path, but an authored override may, and
+/// runtime follows every segment. Each case is the shape reached *before* the
+/// final segment deciding whether that segment is selectable.
+#[test]
+fn projection_compatibility_walks_every_segment_of_a_nested_source_path() {
+    let (manifest, imported) = imported_nested_row_surface();
+    let plan = imported.validated_plan().expect("plan");
+    let generated = generate_projection_catalog(&manifest, &plan).expect("projections");
+
+    for (source_path, expected) in [
+        // An object names its fields, so a real one resolves and a bogus one
+        // cannot.
+        (&["owner", "login"][..], Ok(())),
+        (
+            &["owner", "nope"][..],
+            Err("type 'items_list_row_items_item_owner' has no field 'nope'"),
+        ),
+        // A scalar has nothing below it at all.
+        (
+            &["id", "nope"][..],
+            Err("names no fields, so segment 'nope' cannot be selected"),
+        ),
+        // `get_path_value` indexes arrays numerically, and only numerically.
+        (&["tags", "0"][..], Ok(())),
+        (
+            &["tags", "name"][..],
+            Err("is a list, so segment 'name' must be a numeric index"),
+        ),
+        // A map admits any key, and an opaque payload admits anything at all.
+        (&["labels", "any_key"][..], Ok(())),
+        (&["extra", "anything", "deep"][..], Ok(())),
+        // The first segment is still checked as before.
+        (&["nope", "deeper"][..], Err("which has no such field")),
+    ] {
+        let catalog = compatibility_of_source_path(&generated, source_path);
+        let outcome = validate_projection_compatibility(&plan, &catalog);
+        match expected {
+            Ok(()) => {
+                outcome.unwrap_or_else(|error| {
+                    panic!("source path {source_path:?} should be compatible: {error}")
+                });
+            }
+            Err(fragment) => {
+                let error =
+                    outcome.expect_err(&format!("source path {source_path:?} should be rejected"));
+                assert!(
+                    error.to_string().contains(fragment),
+                    "source path {source_path:?}: unexpected error: {error}"
+                );
+            }
+        }
     }
 }
 

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -129,7 +129,7 @@ fn generate_projection(
             }
         })
         .collect::<Vec<_>>();
-    let columns = projection_columns(type_by_id, operation);
+    let columns = projection_columns(plan, type_by_id, operation);
     let name = generated_projection_name(operation, is_search);
     let guide = projection_guide(&kind, &inputs, is_search);
     let projection = Projection {
@@ -299,6 +299,7 @@ fn type_index(ir: &SemanticIr) -> TypeIndex<'_> {
 }
 
 fn projection_columns(
+    plan: &ValidatedSurfacePlan,
     type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
 ) -> Vec<ProjectionColumn> {
@@ -325,7 +326,9 @@ fn projection_columns(
             },
         ];
     }
-    let Some(row_type) = type_by_id.get(operation.output.type_ref.as_str()) else {
+    // A wrapped-list operation declares an envelope but yields the rows nested
+    // inside it, so columns come from the type its row path selects.
+    let Some(row_type) = type_by_id.get(plan.rest_output_type_ref(&operation.id)) else {
         return vec![ProjectionColumn {
             name: "value".to_string(),
             data_type: ManifestDataType::Json,

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -231,9 +231,7 @@ pub(super) fn projection_name(operation: &IrOperation, is_search: bool) -> Strin
         OutputCardinality::Singleton if operation.inputs.iter().any(|input| input.required) => {
             format!("get_{entity}")
         }
-        OutputCardinality::List | OutputCardinality::WrappedList | OutputCardinality::Singleton => {
-            entity
-        }
+        OutputCardinality::List | OutputCardinality::Singleton => entity,
         OutputCardinality::None | OutputCardinality::Unknown => {
             normalize_identifier(&operation.id, "projection")
         }

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrTypeShape};
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation, IrType, IrTypeShape};
 use crate::v4::operation_metadata::ValidatedSurfacePlan;
 use crate::v4::projections::{
     Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
@@ -20,6 +20,12 @@ pub fn validate_projection_compatibility(
         .iter()
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<BTreeMap<_, _>>();
+    let types = plan
+        .semantic_ir()
+        .types
+        .iter()
+        .map(|ty| (ty.id.as_str(), ty))
+        .collect::<BTreeMap<_, _>>();
     for projection in &projections.projections {
         let Some(operation) = operations.get(projection.operation_id.as_str()) else {
             return Err(ManifestError::validation(format!(
@@ -28,100 +34,106 @@ pub fn validate_projection_compatibility(
             )));
         };
         if matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
-            validate_projection_columns(plan, projection, &operation.id)?;
+            validate_projection_columns(plan, &types, projection, &operation.id)?;
         }
-        let public_exposure = public_exposure_for_kind(&projection.kind);
-        for input in &projection.inputs {
-            let Some(operation_input) = operation.inputs.iter().find(|operation_input| {
-                operation_input.location == input.source_location
-                    && operation_input.name == input.wire_name
-            }) else {
-                return Err(ManifestError::validation(format!(
-                    "projection '{}' input '{}' does not match a {:?} input named '{}' on operation '{}'",
-                    projection.name,
-                    input.name,
-                    input.source_location,
-                    input.wire_name,
-                    operation.id
-                )));
-            };
+        validate_projection_inputs(plan, projection, operation)?;
+    }
+    Ok(())
+}
 
-            let pagination_owned =
-                plan.pagination_owns_input(operation, &input.wire_name, input.source_location);
-            if pagination_owned && input.sql_exposure != SqlInputExposure::Internal {
+/// Checks that a projection's inputs bind to the operation's, and that each is
+/// exposed to SQL in a way request lowering can actually honour.
+fn validate_projection_inputs(
+    plan: &ValidatedSurfacePlan,
+    projection: &Projection,
+    operation: &IrOperation,
+) -> Result<()> {
+    let public_exposure = public_exposure_for_kind(&projection.kind);
+    for input in &projection.inputs {
+        let Some(operation_input) = operation.inputs.iter().find(|operation_input| {
+            operation_input.location == input.source_location
+                && operation_input.name == input.wire_name
+        }) else {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' input '{}' does not match a {:?} input named '{}' on operation '{}'",
+                projection.name, input.name, input.source_location, input.wire_name, operation.id
+            )));
+        };
+
+        let pagination_owned =
+            plan.pagination_owns_input(operation, &input.wire_name, input.source_location);
+        if pagination_owned && input.sql_exposure != SqlInputExposure::Internal {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' input '{}' on operation '{}' is owned by pagination but has sql_exposure '{}'; pagination-owned inputs must be internal",
+                projection.name,
+                input.name,
+                operation.id,
+                sql_exposure_name(input.sql_exposure)
+            )));
+        }
+
+        if input.lookup_key {
+            if !matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
                 return Err(ManifestError::validation(format!(
-                    "projection '{}' input '{}' on operation '{}' is owned by pagination but has sql_exposure '{}'; pagination-owned inputs must be internal",
+                    "projection '{}' input '{}' on operation '{}' has lookup_key=true, but lookup keys are only valid for REST inputs",
+                    projection.name, input.name, operation.id
+                )));
+            }
+            // The metadata allowlist is keyed by wire name alone, and only
+            // query parameters can enter it. A header, cookie, or body
+            // input sharing an allowlisted query name is never lowered into
+            // a request, so a dependent join must not bind to it.
+            if input.source_location != IrInputLocation::Query {
+                return Err(ManifestError::validation(format!(
+                    "projection '{}' input '{}' on operation '{}' has lookup_key=true with source location {:?}; lookup keys are only valid for query inputs",
+                    projection.name, input.name, operation.id, input.source_location
+                )));
+            }
+            if input.sql_exposure != SqlInputExposure::Filter {
+                return Err(ManifestError::validation(format!(
+                    "projection '{}' input '{}' on operation '{}' has lookup_key=true with sql_exposure '{}'; lookup keys must be exposed as filters",
                     projection.name,
                     input.name,
                     operation.id,
                     sql_exposure_name(input.sql_exposure)
                 )));
             }
-
-            if input.lookup_key {
-                if !matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
-                    return Err(ManifestError::validation(format!(
-                        "projection '{}' input '{}' on operation '{}' has lookup_key=true, but lookup keys are only valid for REST inputs",
-                        projection.name, input.name, operation.id
-                    )));
-                }
-                // The metadata allowlist is keyed by wire name alone, and only
-                // query parameters can enter it. A header, cookie, or body
-                // input sharing an allowlisted query name is never lowered into
-                // a request, so a dependent join must not bind to it.
-                if input.source_location != IrInputLocation::Query {
-                    return Err(ManifestError::validation(format!(
-                        "projection '{}' input '{}' on operation '{}' has lookup_key=true with source location {:?}; lookup keys are only valid for query inputs",
-                        projection.name, input.name, operation.id, input.source_location
-                    )));
-                }
-                if input.sql_exposure != SqlInputExposure::Filter {
-                    return Err(ManifestError::validation(format!(
-                        "projection '{}' input '{}' on operation '{}' has lookup_key=true with sql_exposure '{}'; lookup keys must be exposed as filters",
-                        projection.name,
-                        input.name,
-                        operation.id,
-                        sql_exposure_name(input.sql_exposure)
-                    )));
-                }
-                if !plan.input_is_lookup_key(&operation.id, &input.wire_name) {
-                    return Err(ManifestError::validation(format!(
-                        "projection '{}' input '{}' on operation '{}' has lookup_key=true, but wire input '{}' is not authorised by the operation metadata lookup-key allowlist",
-                        projection.name, input.name, operation.id, input.wire_name
-                    )));
-                }
-            }
-
-            // Runtime package assembly reads filters from table projections and
-            // arguments from table function projections, so the other exposure
-            // is unbindable: the input silently disappears from every request.
-            if input.sql_exposure != SqlInputExposure::Internal
-                && input.sql_exposure != public_exposure
-            {
+            if !plan.input_is_lookup_key(&operation.id, &input.wire_name) {
                 return Err(ManifestError::validation(format!(
-                    "projection '{}' input '{}' on operation '{}' has sql_exposure '{}'; {} projections expose non-internal inputs as {}",
-                    projection.name,
-                    input.name,
-                    operation.id,
-                    sql_exposure_name(input.sql_exposure),
-                    projection_kind_name(&projection.kind),
-                    public_exposure_plural(public_exposure)
+                    "projection '{}' input '{}' on operation '{}' has lookup_key=true, but wire input '{}' is not authorised by the operation metadata lookup-key allowlist",
+                    projection.name, input.name, operation.id, input.wire_name
                 )));
             }
+        }
 
-            // Internal inputs are dropped by request lowering, so internalizing
-            // an input the provider requires makes every request incomplete.
-            // The generator hides such projections instead of publishing them.
-            if input.sql_exposure == SqlInputExposure::Internal
-                && operation_input.required
-                && !pagination_owned
-                && projection.visibility == ProjectionVisibility::Published
-            {
-                return Err(ManifestError::validation(format!(
-                    "projection '{}' input '{}' on operation '{}' is required by the operation but has sql_exposure 'internal'; published projections cannot internalize required inputs",
-                    projection.name, input.name, operation.id
-                )));
-            }
+        // Runtime package assembly reads filters from table projections and
+        // arguments from table function projections, so the other exposure
+        // is unbindable: the input silently disappears from every request.
+        if input.sql_exposure != SqlInputExposure::Internal && input.sql_exposure != public_exposure
+        {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' input '{}' on operation '{}' has sql_exposure '{}'; {} projections expose non-internal inputs as {}",
+                projection.name,
+                input.name,
+                operation.id,
+                sql_exposure_name(input.sql_exposure),
+                projection_kind_name(&projection.kind),
+                public_exposure_plural(public_exposure)
+            )));
+        }
+
+        // Internal inputs are dropped by request lowering, so internalizing
+        // an input the provider requires makes every request incomplete.
+        // The generator hides such projections instead of publishing them.
+        if input.sql_exposure == SqlInputExposure::Internal
+            && operation_input.required
+            && !pagination_owned
+            && projection.visibility == ProjectionVisibility::Published
+        {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' input '{}' on operation '{}' is required by the operation but has sql_exposure 'internal'; published projections cannot internalize required inputs",
+                projection.name, input.name, operation.id
+            )));
         }
     }
     Ok(())
@@ -137,6 +149,7 @@ pub fn validate_projection_compatibility(
 /// catalog too.
 fn validate_projection_columns(
     plan: &ValidatedSurfacePlan,
+    types: &BTreeMap<&str, &IrType>,
     projection: &Projection,
     operation_id: &str,
 ) -> Result<()> {
@@ -144,11 +157,8 @@ fn validate_projection_columns(
     // Only an object row type names its fields. Every other shape is projected
     // whole, as a single column with no source path — including a `json` row,
     // which the semantic IR carries no entry for at all.
-    let row_fields = plan
-        .semantic_ir()
-        .types
-        .iter()
-        .find(|ty| ty.id == row_type_ref)
+    let row_fields = types
+        .get(row_type_ref)
         .and_then(|row_type| match &row_type.shape {
             IrTypeShape::Object { fields } => Some(fields.as_slice()),
             IrTypeShape::Scalar(_)
@@ -169,12 +179,67 @@ fn validate_projection_columns(
                 projection.name, column.name
             )));
         };
-        if !fields.iter().any(|field| field.name == *field_name) {
+        let Some(field) = fields.iter().find(|field| field.name == *field_name) else {
             return Err(ManifestError::validation(format!(
                 "projection '{}' column '{}' reads field '{field_name}', but the rows operation '{operation_id}' yields have type '{row_type_ref}', which has no such field",
                 projection.name, column.name
             )));
+        };
+        // The generator only ever emits one segment, but an authored override
+        // may nest, and runtime follows every segment it is given.
+        let nested = column.source_path.get(1..).unwrap_or_default();
+        if let Err(reason) = walk_source_path(&field.type_ref, nested, types) {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' column '{}' reads source path '{}', but {reason}",
+                projection.name,
+                column.name,
+                column.source_path.join(".")
+            )));
         }
+    }
+    Ok(())
+}
+
+/// Follows the segments below a column's first, stopping as soon as the type it
+/// has reached can no longer say anything about the rest.
+fn walk_source_path(
+    type_ref: &str,
+    segments: &[String],
+    types: &BTreeMap<&str, &IrType>,
+) -> std::result::Result<(), String> {
+    let mut type_ref = type_ref;
+    for segment in segments {
+        // A type the IR does not carry describes nothing, exactly like `json`.
+        let Some(ty) = types.get(type_ref) else {
+            return Ok(());
+        };
+        type_ref = match &ty.shape {
+            IrTypeShape::Object { fields } => {
+                let Some(field) = fields.iter().find(|field| field.name == *segment) else {
+                    return Err(format!("type '{type_ref}' has no field '{segment}'"));
+                };
+                field.type_ref.as_str()
+            }
+            // Any key selects a map value, so no segment can be ruled out.
+            IrTypeShape::Map { value_type_ref } => value_type_ref.as_str(),
+            // `get_path_value` indexes an array by a numeric segment, so one is
+            // selectable and anything else is not.
+            IrTypeShape::List { item_type_ref } => {
+                if segment.parse::<usize>().is_err() {
+                    return Err(format!(
+                        "type '{type_ref}' is a list, so segment '{segment}' must be a numeric index"
+                    ));
+                }
+                item_type_ref.as_str()
+            }
+            // Opaque payloads are unknowable at import time, not known-wrong.
+            IrTypeShape::Json => return Ok(()),
+            IrTypeShape::Scalar(_) | IrTypeShape::Enum { .. } => {
+                return Err(format!(
+                    "type '{type_ref}' names no fields, so segment '{segment}' cannot be selected"
+                ));
+            }
+        };
     }
     Ok(())
 }

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -3,10 +3,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::v4::ir::{IrExecutionAttachment, IrInputLocation};
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrTypeShape};
 use crate::v4::operation_metadata::ValidatedSurfacePlan;
 use crate::v4::projections::{
-    ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
+    Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
 };
 use crate::{ManifestError, Result};
 
@@ -27,6 +27,9 @@ pub fn validate_projection_compatibility(
                 projection.name, projection.operation_id
             )));
         };
+        if matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
+            validate_projection_columns(plan, projection, &operation.id)?;
+        }
         let public_exposure = public_exposure_for_kind(&projection.kind);
         for input in &projection.inputs {
             let Some(operation_input) = operation.inputs.iter().find(|operation_input| {
@@ -119,6 +122,47 @@ pub fn validate_projection_compatibility(
                     projection.name, input.name, operation.id
                 )));
             }
+        }
+    }
+    Ok(())
+}
+
+/// Checks that a REST projection's columns describe the rows the effective
+/// operation policy actually yields.
+///
+/// The projection catalog is a snapshot: an operation-metadata override that
+/// moves the row path elsewhere leaves the materialized columns pointing at
+/// fields the new rows do not have. Rather than reconcile the snapshot at load
+/// time, reject the combination and let the user regenerate or override the
+/// catalog too.
+fn validate_projection_columns(
+    plan: &ValidatedSurfacePlan,
+    projection: &Projection,
+    operation_id: &str,
+) -> Result<()> {
+    let row_type_ref = plan.rest_output_type_ref(operation_id);
+    let Some(row_type) = plan
+        .semantic_ir()
+        .types
+        .iter()
+        .find(|ty| ty.id == row_type_ref)
+    else {
+        return Ok(());
+    };
+    // Only an object row type names its fields. Scalar, list, and opaque JSON
+    // rows are projected whole, and their columns carry no source path.
+    let IrTypeShape::Object { fields } = &row_type.shape else {
+        return Ok(());
+    };
+    for column in &projection.columns {
+        let Some(field_name) = column.source_path.first() else {
+            continue;
+        };
+        if !fields.iter().any(|field| field.name == *field_name) {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' column '{}' reads field '{field_name}', but the rows operation '{operation_id}' yields have type '{row_type_ref}', which has no such field",
+                projection.name, column.name
+            )));
         }
     }
     Ok(())

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -141,22 +141,33 @@ fn validate_projection_columns(
     operation_id: &str,
 ) -> Result<()> {
     let row_type_ref = plan.rest_output_type_ref(operation_id);
-    let Some(row_type) = plan
+    // Only an object row type names its fields. Every other shape is projected
+    // whole, as a single column with no source path — including a `json` row,
+    // which the semantic IR carries no entry for at all.
+    let row_fields = plan
         .semantic_ir()
         .types
         .iter()
         .find(|ty| ty.id == row_type_ref)
-    else {
-        return Ok(());
-    };
-    // Only an object row type names its fields. Scalar, list, and opaque JSON
-    // rows are projected whole, and their columns carry no source path.
-    let IrTypeShape::Object { fields } = &row_type.shape else {
-        return Ok(());
-    };
+        .and_then(|row_type| match &row_type.shape {
+            IrTypeShape::Object { fields } => Some(fields.as_slice()),
+            IrTypeShape::Scalar(_)
+            | IrTypeShape::List { .. }
+            | IrTypeShape::Map { .. }
+            | IrTypeShape::Enum { .. }
+            | IrTypeShape::Json => None,
+        });
     for column in &projection.columns {
         let Some(field_name) = column.source_path.first() else {
             continue;
+        };
+        // A source path against a row that names nothing is not merely stale:
+        // it resolves to null on every row, silently.
+        let Some(fields) = row_fields else {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' column '{}' reads field '{field_name}', but the rows operation '{operation_id}' yields have type '{row_type_ref}', which is not an object and names no fields",
+                projection.name, column.name
+            )));
         };
         if !fields.iter().any(|field| field.name == *field_name) {
             return Err(ManifestError::validation(format!(

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -202,6 +202,14 @@ fn validate_projection_columns(
 
 /// Follows the segments below a column's first, stopping as soon as the type it
 /// has reached can no longer say anything about the rest.
+///
+/// `get_path_value` reads a segment that parses as an integer only as an array
+/// index, never as a key, so whether a segment is numeric decides as much as the
+/// shape it lands on does. The generator can emit a numeric *first* segment, for
+/// a resource whose field really is named `0`, and those columns already resolve
+/// to null; rejecting them here would make a freshly generated catalog fail its
+/// own validation, so the rule applies only below the first segment, where
+/// nothing but an authored override can put one.
 fn walk_source_path(
     type_ref: &str,
     segments: &[String],
@@ -213,19 +221,27 @@ fn walk_source_path(
         let Some(ty) = types.get(type_ref) else {
             return Ok(());
         };
+        let numeric = segment.parse::<usize>().is_ok();
         type_ref = match &ty.shape {
             IrTypeShape::Object { fields } => {
+                if numeric {
+                    return Err(numeric_segment_error(type_ref, segment));
+                }
                 let Some(field) = fields.iter().find(|field| field.name == *segment) else {
                     return Err(format!("type '{type_ref}' has no field '{segment}'"));
                 };
                 field.type_ref.as_str()
             }
-            // Any key selects a map value, so no segment can be ruled out.
-            IrTypeShape::Map { value_type_ref } => value_type_ref.as_str(),
-            // `get_path_value` indexes an array by a numeric segment, so one is
-            // selectable and anything else is not.
+            // Any key selects a map value, so only a numeric one is ruled out.
+            IrTypeShape::Map { value_type_ref } => {
+                if numeric {
+                    return Err(numeric_segment_error(type_ref, segment));
+                }
+                value_type_ref.as_str()
+            }
+            // An array is the one shape a numeric segment does address.
             IrTypeShape::List { item_type_ref } => {
-                if segment.parse::<usize>().is_err() {
+                if !numeric {
                     return Err(format!(
                         "type '{type_ref}' is a list, so segment '{segment}' must be a numeric index"
                     ));
@@ -242,6 +258,12 @@ fn walk_source_path(
         };
     }
     Ok(())
+}
+
+fn numeric_segment_error(type_ref: &str, segment: &str) -> String {
+    format!(
+        "type '{type_ref}' is keyed by name, but segment '{segment}' is read as an array index and so selects nothing"
+    )
 }
 
 const fn public_exposure_for_kind(kind: &ProjectionKind) -> SqlInputExposure {

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -1,0 +1,238 @@
+//! Ref-aware discovery of the response property that carries a continuation
+//! token.
+//!
+//! Both surfaces ask the same question of a response schema: which property
+//! holds the cursor for the next page? They ask it of different vocabularies —
+//! `OpenAPI` accepts a wider set of names than MCP — so the lexicon is a
+//! parameter, but the walk itself is shared.
+//!
+//! The walk resolves `$ref` because the responses it now runs against are page
+//! envelopes, and an envelope's `meta`/`pageInfo` sibling is routinely a
+//! reference to a shared component. Wrapped-list inference already resolves
+//! refs when it decides a response *is* an envelope (see
+//! [`crate::v4::wrapped_lists`]); if cursor discovery did not, the two halves of
+//! one decision would disagree, and an operation would be presented as a
+//! paginated table that silently stops after its first page.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::v4::surfaces::json_schema::{
+    JsonSchemaWalkError, json_schema_type_contains, with_resolved_json_schema,
+};
+
+const MAX_DEPTH: usize = 8;
+
+/// Returns the path from the response root to the property holding the
+/// continuation token, or `None` when no property matches `cursor_tokens`.
+///
+/// Names are matched after collapsing case and separators, so `nextCursor`,
+/// `next_cursor`, and `next-cursor` all match the token `nextcursor`.
+pub(in crate::v4) fn find_response_cursor_path(
+    root: &Value,
+    schema: &Value,
+    cursor_tokens: &[&str],
+) -> Option<Vec<String>> {
+    cursor_path(root, schema, cursor_tokens, &mut BTreeSet::new(), 0)
+        .ok()
+        .flatten()
+}
+
+/// Prefers a cursor on the level being walked before descending, so a nested
+/// `meta.next_cursor` never wins over one the envelope declares itself.
+fn cursor_path<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    cursor_tokens: &[&str],
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> Result<Option<Vec<String>>, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, resolving_refs, next_depth| {
+            let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
+                return Ok(None);
+            };
+            for (name, property) in properties {
+                if cursor_tokens.contains(&normalized_name(name).as_str())
+                    && property_allows_string(root, property, resolving_refs, next_depth)
+                {
+                    return Ok(Some(vec![name.clone()]));
+                }
+            }
+            for (name, property) in properties {
+                if !property_is_object(root, property, resolving_refs, next_depth) {
+                    continue;
+                }
+                if let Some(mut path) =
+                    cursor_path(root, property, cursor_tokens, resolving_refs, next_depth)?
+                {
+                    path.insert(0, name.clone());
+                    return Ok(Some(path));
+                }
+            }
+            Ok(None)
+        },
+    )
+}
+
+/// A conventionally named property is accepted unless it declares a type that
+/// rules a token out. An unresolvable or cyclic reference declares nothing, so
+/// it cannot rule anything out either.
+fn property_allows_string(
+    root: &Value,
+    schema: &Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> bool {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, _, _| {
+            Ok(json_schema_type_contains(resolved, "string") || resolved.get("type").is_none())
+        },
+    )
+    .unwrap_or(true)
+}
+
+/// Descent is the opposite case: a property that cannot be resolved into an
+/// object is not one to search.
+fn property_is_object(
+    root: &Value,
+    schema: &Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> bool {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, _, _| Ok(json_schema_type_contains(resolved, "object")),
+    )
+    .unwrap_or(false)
+}
+
+fn normalized_name(name: &str) -> String {
+    name.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::find_response_cursor_path;
+
+    const TOKENS: &[&str] = &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
+
+    #[test]
+    fn finds_a_cursor_declared_on_the_response_root() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "items": {"type": "array", "items": {"type": "object"}},
+                "next_cursor": {"type": "string"},
+            },
+        });
+
+        assert_eq!(
+            find_response_cursor_path(&schema, &schema, TOKENS),
+            Some(vec!["next_cursor".to_string()])
+        );
+    }
+
+    #[test]
+    fn finds_a_cursor_inside_a_referenced_metadata_object() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "items": {"type": "array", "items": {"type": "object"}},
+                "meta": {"$ref": "#/$defs/PageMeta"},
+            },
+            "$defs": {
+                "PageMeta": {
+                    "type": "object",
+                    "properties": {"nextCursor": {"type": ["string", "null"]}},
+                },
+            },
+        });
+
+        assert_eq!(
+            find_response_cursor_path(&schema, &schema, TOKENS),
+            Some(vec!["meta".to_string(), "nextCursor".to_string()])
+        );
+    }
+
+    #[test]
+    fn finds_a_cursor_that_is_itself_a_reference() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "items": {"type": "array", "items": {"type": "object"}},
+                "next_token": {"$ref": "#/$defs/Token"},
+            },
+            "$defs": {"Token": {"type": "string"}},
+        });
+
+        assert_eq!(
+            find_response_cursor_path(&schema, &schema, TOKENS),
+            Some(vec!["next_token".to_string()])
+        );
+    }
+
+    #[test]
+    fn resolves_a_referenced_response_root() {
+        let root = json!({
+            "$defs": {
+                "Page": {
+                    "type": "object",
+                    "properties": {"end_cursor": {"type": "string"}},
+                },
+            },
+        });
+
+        assert_eq!(
+            find_response_cursor_path(&root, &json!({"$ref": "#/$defs/Page"}), TOKENS),
+            Some(vec!["end_cursor".to_string()])
+        );
+    }
+
+    #[test]
+    fn rejects_a_conventional_name_whose_referenced_type_is_not_a_string() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"$ref": "#/$defs/Count"}},
+            "$defs": {"Count": {"type": "integer"}},
+        });
+
+        assert_eq!(find_response_cursor_path(&schema, &schema, TOKENS), None);
+    }
+
+    #[test]
+    fn a_self_referential_envelope_terminates() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"page": {"$ref": "#/$defs/Page"}},
+            "$defs": {
+                "Page": {
+                    "type": "object",
+                    "properties": {"page": {"$ref": "#/$defs/Page"}},
+                },
+            },
+        });
+
+        assert_eq!(find_response_cursor_path(&schema, &schema, TOKENS), None);
+    }
+}

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -1007,6 +1007,56 @@ surface:
         assert!(offset.is_none());
     }
 
+    /// Tool schemas routinely put their page metadata in `$defs`. Row-path
+    /// inference resolves those references, so cursor discovery has to as well,
+    /// or the tool becomes a table that stops after its first page.
+    #[test]
+    fn infers_cursor_pagination_through_a_referenced_metadata_object() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "list-items",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "cursor": {"type": "string"},
+                        "limit": {"type": "integer"}
+                    }
+                }),
+                Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {"id": {"type": "string"}}
+                            }
+                        },
+                        "meta": {"$ref": "#/$defs/PageMeta"}
+                    },
+                    "$defs": {
+                        "PageMeta": {
+                            "type": "object",
+                            "properties": {
+                                "nextCursor": {"type": ["string", "null"]}
+                            }
+                        }
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_items"), ["items"]);
+        let (cursor, offset) = plan.mcp_pagination("list_items");
+        let cursor = cursor.expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
+        assert!(offset.is_none());
+    }
+
     #[test]
     fn infers_offset_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -934,6 +934,15 @@ surface:
             wrapped_items.output.cardinality,
             OutputCardinality::Singleton
         );
+        // The IR keeps the declared envelope shape; the row path is metadata.
+        assert_eq!(
+            ir.operation_metadata
+                .operations
+                .get("wrapped_items")
+                .expect("metadata")
+                .row_path(),
+            ["items"]
+        );
         let wrapped_fields = row_fields(&ir, "wrapped_items_row");
         assert_eq!(field(wrapped_fields, "items").type_ref, "mcp_json");
         assert!(wrapped_fields.iter().any(|field| field.name == "raw"));
@@ -951,7 +960,7 @@ surface:
     }
 
     #[test]
-    fn does_not_infer_cursor_pagination_for_wrapped_list_envelopes() {
+    fn infers_cursor_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-items",
@@ -990,13 +999,16 @@ surface:
         let operation = operation(&ir, "list_items");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
         let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_items"), ["items"]);
         let (cursor, offset) = plan.mcp_pagination("list_items");
-        assert!(cursor.is_none());
+        let cursor = cursor.expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
         assert!(offset.is_none());
     }
 
     #[test]
-    fn does_not_infer_offset_pagination_for_wrapped_list_envelopes() {
+    fn infers_offset_pagination_for_wrapped_list_envelopes() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
                 "list-catalog",
@@ -1044,10 +1056,18 @@ surface:
         let surface = &v4.surface;
         let ir = import_mcp_surface(v4, surface, &catalog).expect("import");
         let plan = ir.validated_plan().expect("plan");
+        assert_eq!(plan.output_row_path("list_catalog"), ["items"]);
         let (cursor, offset) = plan.mcp_pagination("list_catalog");
         assert!(cursor.is_none());
-        assert!(offset.is_none());
+        let offset = offset.expect("offset pagination");
+        assert_eq!(offset.limit_arg, "limit");
+        assert_eq!(offset.default_limit, 50);
+        assert_eq!(offset.max_limit, 200);
+        assert_eq!(offset.offset_arg, "offset");
+        assert_eq!(offset.offset_start, 0);
 
+        // `limit` and `offset` are the tool's only arguments, and pagination
+        // now owns both, so nothing is left to expose as a function argument.
         let projections = generate_projection_catalog(v4, &ir.validated_plan().expect("plan"))
             .expect("projection catalog");
         let projection = projections
@@ -1055,12 +1075,9 @@ surface:
             .iter()
             .find(|projection| projection.operation_id == "list_catalog")
             .expect("projection");
-        assert!(matches!(
-            projection.kind,
-            crate::v4::ProjectionKind::TableFunction { .. }
-        ));
+        assert!(matches!(projection.kind, crate::v4::ProjectionKind::Table));
         for input in &projection.inputs {
-            assert_eq!(input.sql_exposure, SqlInputExposure::FunctionArg);
+            assert_eq!(input.sql_exposure, SqlInputExposure::Internal);
         }
     }
 
@@ -1151,6 +1168,16 @@ surface:
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "get_item");
         assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+        // `items` is a conventional row name, but nothing else about the tool
+        // says this is a page of them.
+        assert!(
+            ir.operation_metadata
+                .operations
+                .get("get_item")
+                .expect("metadata")
+                .row_path()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -1,6 +1,7 @@
 use crate::v4::ir::{
     IrEntityCandidate, IrExecutionAttachment, IrOperation, McpExecutionAttachment,
 };
+use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
 use crate::v4::{McpOperationPagination, OperationMetadata};
 
 use super::import::McpImporter;
@@ -23,9 +24,18 @@ impl McpImporter<'_> {
 
         let inputs = imported_inputs.inputs;
         let output = self.import_output(operation_id, tool.output_schema.as_ref());
+        let row_path = tool.output_schema.as_ref().map_or_else(Vec::new, |schema| {
+            infer_wrapped_list_row_path(WrappedListInferenceContext {
+                operation_name: &tool.name,
+                inputs: &inputs,
+                schema_root: schema,
+                response_schema: schema,
+            })
+        });
         let (pagination, offset_pagination) = infer_mcp_pagination_contracts(
             &inputs,
             &output,
+            &row_path,
             tool.output_schema.as_ref(),
             &tool.input_schema,
         );
@@ -55,6 +65,7 @@ impl McpImporter<'_> {
         Some((
             operation,
             OperationMetadata::Mcp {
+                row_path,
                 pagination: McpOperationPagination {
                     cursor: pagination,
                     offset: offset_pagination,

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -6,7 +6,9 @@ use crate::v4::{McpOperationPagination, OperationMetadata};
 
 use super::import::McpImporter;
 use super::model::McpToolDescriptor;
-use super::pagination::infer_mcp_pagination_contracts;
+use super::pagination::{
+    McpPaginationContracts, detect_mcp_pagination_contracts, is_list_like_output,
+};
 
 impl McpImporter<'_> {
     pub(super) fn import_tool(
@@ -24,21 +26,26 @@ impl McpImporter<'_> {
 
         let inputs = imported_inputs.inputs;
         let output = self.import_output(operation_id, tool.output_schema.as_ref());
+        let contracts = detect_mcp_pagination_contracts(
+            &inputs,
+            tool.output_schema.as_ref(),
+            &tool.input_schema,
+        );
         let row_path = tool.output_schema.as_ref().map_or_else(Vec::new, |schema| {
             infer_wrapped_list_row_path(WrappedListInferenceContext {
                 operation_name: &tool.name,
-                inputs: &inputs,
+                paginated_operation: contracts.is_paginated(),
                 schema_root: schema,
                 response_schema: schema,
             })
         });
-        let (pagination, offset_pagination) = infer_mcp_pagination_contracts(
-            &inputs,
-            &output,
-            &row_path,
-            tool.output_schema.as_ref(),
-            &tool.input_schema,
-        );
+        // A contract only becomes this tool's pagination once Coral reads its
+        // result as a list, whether by declaration or by row path.
+        let contracts = if is_list_like_output(&output, &row_path) {
+            contracts
+        } else {
+            McpPaginationContracts::default()
+        };
         let operation = IrOperation {
             id: operation_id.to_string(),
             method_name: "tools/call".to_string(),
@@ -67,8 +74,8 @@ impl McpImporter<'_> {
             OperationMetadata::Mcp {
                 row_path,
                 pagination: McpOperationPagination {
-                    cursor: pagination,
-                    offset: offset_pagination,
+                    cursor: contracts.cursor,
+                    offset: contracts.offset,
                 },
             },
         ))

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 use crate::v4::ir::{IrOperationInput, IrOperationOutput, IrScalarType, OutputCardinality};
-use crate::v4::surfaces::json_schema::json_schema_type_contains;
+use crate::v4::response_cursors::find_response_cursor_path;
 
 pub(super) fn infer_mcp_pagination_contracts(
     inputs: &[IrOperationInput],
@@ -25,11 +25,19 @@ fn infer_mcp_pagination(
     row_path: &[String],
     output_schema: Option<&Value>,
 ) -> Option<McpPaginationSpec> {
+    /// Response property names that conventionally carry a continuation token.
+    const RESPONSE_CURSOR_TOKENS: &[&str] =
+        &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
+
     if !is_list_like_output(output, row_path) {
         return None;
     }
     let cursor_arg = cursor_input_name(inputs)?;
-    let response_cursor_path = find_response_cursor_path(output_schema?)?;
+    // A tool's output schema is its own reference root, so `$defs` entries
+    // resolve against the schema itself.
+    let output_schema = output_schema?;
+    let response_cursor_path =
+        find_response_cursor_path(output_schema, output_schema, RESPONSE_CURSOR_TOKENS)?;
     Some(McpPaginationSpec {
         cursor_arg: cursor_arg.to_string(),
         response_cursor_path,
@@ -140,31 +148,6 @@ fn cursor_input_name(inputs: &[IrOperationInput]) -> Option<&str> {
             CURSOR_INPUTS.contains(&normalized.as_str())
         })
         .map(|input| input.name.as_str())
-}
-
-pub(super) fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {
-    let properties = schema.get("properties").and_then(Value::as_object)?;
-    for (name, property) in properties {
-        if is_response_cursor_property(name, property) {
-            return Some(vec![name.clone()]);
-        }
-    }
-    for (name, property) in properties {
-        if !json_schema_type_contains(property, "object") {
-            continue;
-        }
-        if let Some(mut path) = find_response_cursor_path(property) {
-            path.insert(0, name.clone());
-            return Some(path);
-        }
-    }
-    None
-}
-
-fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
-    const RESPONSE_CURSORS: &[&str] = &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
-    RESPONSE_CURSORS.contains(&cursor_token(name).as_str())
-        && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
 }
 
 fn cursor_token(value: &str) -> String {

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -7,13 +7,14 @@ use crate::v4::surfaces::json_schema::json_schema_type_contains;
 pub(super) fn infer_mcp_pagination_contracts(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     output_schema: Option<&Value>,
     input_schema: &Value,
 ) -> (Option<McpPaginationSpec>, Option<McpOffsetPaginationSpec>) {
-    let pagination = infer_mcp_pagination(inputs, output, output_schema);
+    let pagination = infer_mcp_pagination(inputs, output, row_path, output_schema);
     let offset_pagination = pagination
         .is_none()
-        .then(|| infer_mcp_offset_pagination(inputs, output, input_schema))
+        .then(|| infer_mcp_offset_pagination(inputs, output, row_path, input_schema))
         .flatten();
     (pagination, offset_pagination)
 }
@@ -21,12 +22,10 @@ pub(super) fn infer_mcp_pagination_contracts(
 fn infer_mcp_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     output_schema: Option<&Value>,
 ) -> Option<McpPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
+    if !is_list_like_output(output, row_path) {
         return None;
     }
     let cursor_arg = cursor_input_name(inputs)?;
@@ -41,12 +40,10 @@ fn infer_mcp_pagination(
 fn infer_mcp_offset_pagination(
     inputs: &[IrOperationInput],
     output: &IrOperationOutput,
+    row_path: &[String],
     input_schema: &Value,
 ) -> Option<McpOffsetPaginationSpec> {
-    if !matches!(
-        output.cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    ) {
+    if !is_list_like_output(output, row_path) {
         return None;
     }
     let properties = input_schema.get("properties").and_then(Value::as_object)?;
@@ -69,6 +66,12 @@ fn infer_mcp_offset_pagination(
         offset_start: offset.default,
         max_pages: None,
     })
+}
+
+/// A wrapped-list envelope is a singleton by cardinality but yields rows, so it
+/// paginates like a declared list.
+fn is_list_like_output(output: &IrOperationOutput, row_path: &[String]) -> bool {
+    output.cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 
 struct OffsetPaginationInput<'a> {

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -4,34 +4,44 @@ use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 use crate::v4::ir::{IrOperationInput, IrOperationOutput, IrScalarType, OutputCardinality};
 use crate::v4::response_cursors::find_response_cursor_path;
 
-pub(super) fn infer_mcp_pagination_contracts(
+/// Pagination contracts a tool's arguments and output schema describe, before
+/// any decision about whether its result is read as a list.
+#[derive(Default)]
+pub(super) struct McpPaginationContracts {
+    pub(super) cursor: Option<McpPaginationSpec>,
+    pub(super) offset: Option<McpOffsetPaginationSpec>,
+}
+
+impl McpPaginationContracts {
+    pub(super) const fn is_paginated(&self) -> bool {
+        self.cursor.is_some() || self.offset.is_some()
+    }
+}
+
+/// Neither detector consults the row path, so this runs first and answers the
+/// question wrapped-list inference needs — is this tool paginated? — without the
+/// two inferences having to predict each other.
+pub(super) fn detect_mcp_pagination_contracts(
     inputs: &[IrOperationInput],
-    output: &IrOperationOutput,
-    row_path: &[String],
     output_schema: Option<&Value>,
     input_schema: &Value,
-) -> (Option<McpPaginationSpec>, Option<McpOffsetPaginationSpec>) {
-    let pagination = infer_mcp_pagination(inputs, output, row_path, output_schema);
-    let offset_pagination = pagination
+) -> McpPaginationContracts {
+    let cursor = infer_mcp_pagination(inputs, output_schema);
+    let offset = cursor
         .is_none()
-        .then(|| infer_mcp_offset_pagination(inputs, output, row_path, input_schema))
+        .then(|| infer_mcp_offset_pagination(inputs, input_schema))
         .flatten();
-    (pagination, offset_pagination)
+    McpPaginationContracts { cursor, offset }
 }
 
 fn infer_mcp_pagination(
     inputs: &[IrOperationInput],
-    output: &IrOperationOutput,
-    row_path: &[String],
     output_schema: Option<&Value>,
 ) -> Option<McpPaginationSpec> {
     /// Response property names that conventionally carry a continuation token.
     const RESPONSE_CURSOR_TOKENS: &[&str] =
         &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
 
-    if !is_list_like_output(output, row_path) {
-        return None;
-    }
     let cursor_arg = cursor_input_name(inputs)?;
     // A tool's output schema is its own reference root, so `$defs` entries
     // resolve against the schema itself.
@@ -47,13 +57,8 @@ fn infer_mcp_pagination(
 
 fn infer_mcp_offset_pagination(
     inputs: &[IrOperationInput],
-    output: &IrOperationOutput,
-    row_path: &[String],
     input_schema: &Value,
 ) -> Option<McpOffsetPaginationSpec> {
-    if !is_list_like_output(output, row_path) {
-        return None;
-    }
     let properties = input_schema.get("properties").and_then(Value::as_object)?;
     let limit = offset_pagination_input(inputs, properties.get("limit")?, "limit")?;
     if limit.default == 0
@@ -78,7 +83,7 @@ fn infer_mcp_offset_pagination(
 
 /// A wrapped-list envelope is a singleton by cardinality but yields rows, so it
 /// paginates like a declared list.
-fn is_list_like_output(output: &IrOperationOutput, row_path: &[String]) -> bool {
+pub(super) fn is_list_like_output(output: &IrOperationOutput, row_path: &[String]) -> bool {
     output.cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 

--- a/crates/coral-spec/src/v4/surfaces/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/mod.rs
@@ -1,4 +1,4 @@
-mod json_schema;
+pub(in crate::v4) mod json_schema;
 mod mcp;
 mod openapi;
 

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -6,7 +6,7 @@ use crate::v4::OperationMetadata;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
     HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-    IrOperationNaming, IrScalarType, OutputCardinality, RestExecutionAttachment,
+    IrOperationNaming, IrOperationOutput, IrScalarType, OutputCardinality, RestExecutionAttachment,
     RestParameterBinding, RestRequestBody,
 };
 use crate::v4::lookup_keys::infer_rest_lookup_keys;
@@ -15,7 +15,11 @@ use crate::v4::surfaces::json_schema::{
     json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
     json_schema_type_display,
 };
-use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
+use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
+use crate::{
+    ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
+    v4::resolve_output_row_type_ref,
+};
 
 use super::import::OpenApiImporter;
 use super::responses::OpenApiResponsePaginationContext;
@@ -45,7 +49,13 @@ impl OpenApiImporter<'_> {
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
         let (output, response, entity, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
-        let pagination = detect_pagination(&parameters, &pagination_context);
+        let row_path = self.infer_row_path(
+            raw_operation_id.unwrap_or(&operation_id),
+            &parameters,
+            &pagination_context,
+            &output,
+        );
+        let pagination = detect_pagination(&parameters, &pagination_context, &row_path);
         let lookup_keys = infer_rest_lookup_keys(&parameters, &pagination);
         let rest_parameters = parameters
             .iter()
@@ -91,10 +101,42 @@ impl OpenApiImporter<'_> {
         Ok((
             operation,
             OperationMetadata::Rest {
+                row_path,
                 pagination,
                 lookup_keys,
             },
         ))
+    }
+
+    /// Infers where the rows of a wrapped-list response live, discarding a path
+    /// the imported types cannot resolve so the importer never emits metadata
+    /// that fails plan validation.
+    fn infer_row_path(
+        &self,
+        operation_name: &str,
+        parameters: &[IrOperationInput],
+        pagination_context: &OpenApiResponsePaginationContext,
+        output: &IrOperationOutput,
+    ) -> Vec<String> {
+        let row_path = infer_wrapped_list_row_path(WrappedListInferenceContext {
+            operation_name,
+            inputs: parameters,
+            schema_root: self.document,
+            response_schema: &pagination_context.schema,
+        });
+        if row_path.is_empty() {
+            return row_path;
+        }
+        let types = self
+            .types
+            .iter()
+            .map(|(id, ty)| (id.as_str(), ty))
+            .collect::<BTreeMap<_, _>>();
+        if resolve_output_row_type_ref(output, &row_path, &types).is_ok() {
+            row_path
+        } else {
+            Vec::new()
+        }
     }
 
     fn import_parameters(
@@ -303,8 +345,9 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
 fn detect_pagination(
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
+    row_path: &[String],
 ) -> PaginationSpec {
-    if !is_paginated_cardinality(context.cardinality) {
+    if !is_list_like_output(context.cardinality, row_path) {
         return PaginationSpec::default();
     }
     detect_link_header_pagination(inputs, context)
@@ -578,11 +621,10 @@ fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
         && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
 }
 
-fn is_paginated_cardinality(cardinality: OutputCardinality) -> bool {
-    matches!(
-        cardinality,
-        OutputCardinality::List | OutputCardinality::WrappedList
-    )
+/// A wrapped-list envelope is a singleton by cardinality but yields rows, so it
+/// paginates like a declared list.
+fn is_list_like_output(cardinality: OutputCardinality, row_path: &[String]) -> bool {
+    cardinality == OutputCardinality::List || !row_path.is_empty()
 }
 
 fn page_size_spec(input: &IrOperationInput) -> PageSizeSpec {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -11,6 +11,7 @@ use crate::v4::ir::{
 };
 use crate::v4::lookup_keys::infer_rest_lookup_keys;
 use crate::v4::naming::normalize_identifier;
+use crate::v4::response_cursors::find_response_cursor_path;
 use crate::v4::surfaces::json_schema::{
     json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
     json_schema_type_display,
@@ -55,7 +56,8 @@ impl OpenApiImporter<'_> {
             &pagination_context,
             &output,
         );
-        let pagination = detect_pagination(&parameters, &pagination_context, &row_path);
+        let pagination =
+            detect_pagination(self.document, &parameters, &pagination_context, &row_path);
         let lookup_keys = infer_rest_lookup_keys(&parameters, &pagination);
         let rest_parameters = parameters
             .iter()
@@ -343,6 +345,7 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
 }
 
 fn detect_pagination(
+    document: &Value,
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
     row_path: &[String],
@@ -351,7 +354,7 @@ fn detect_pagination(
         return PaginationSpec::default();
     }
     detect_link_header_pagination(inputs, context)
-        .or_else(|| detect_cursor_query_pagination(inputs, context))
+        .or_else(|| detect_cursor_query_pagination(document, inputs, context))
         .or_else(|| detect_offset_pagination(inputs))
         .or_else(|| detect_page_pagination(inputs))
         .unwrap_or_default()
@@ -378,9 +381,25 @@ fn detect_link_header_pagination(
 }
 
 fn detect_cursor_query_pagination(
+    document: &Value,
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
 ) -> Option<PaginationSpec> {
+    /// Response property names that conventionally carry a continuation token.
+    const RESPONSE_CURSOR_TOKENS: &[&str] = &[
+        "after",
+        "continuationtoken",
+        "cursor",
+        "endcursor",
+        "iterator",
+        "next",
+        "nextcursor",
+        "nextmarker",
+        "nextpage",
+        "nextpagetoken",
+        "nexttoken",
+    ];
+
     let cursor_input = find_optional_string_query_input(
         inputs,
         &[
@@ -406,7 +425,12 @@ fn detect_cursor_query_pagination(
         return None;
     }
 
-    let response_cursor_path = find_response_cursor_path(&context.schema).unwrap_or_default();
+    // The pagination context holds the response schema with only its own `$ref`
+    // resolved, so the document is still needed to see inside a referenced
+    // metadata sibling.
+    let response_cursor_path =
+        find_response_cursor_path(document, &context.schema, RESPONSE_CURSOR_TOKENS)
+            .unwrap_or_default();
     let response_cursor_header = response_cursor_header(context);
     if response_cursor_path.is_empty() && response_cursor_header.is_none() {
         return None;
@@ -581,44 +605,6 @@ fn response_header_allows_string(header: &Value) -> bool {
     header.get("schema").is_none_or(|schema| {
         json_schema_type_contains(schema, "string") || schema.get("type").is_none()
     })
-}
-
-fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {
-    let properties = schema.get("properties").and_then(Value::as_object)?;
-    for (name, property) in properties {
-        if is_response_cursor_property(name, property) {
-            return Some(vec![name.clone()]);
-        }
-    }
-    for (name, property) in properties {
-        if !json_schema_type_contains(property, "object") {
-            continue;
-        }
-        if let Some(mut path) = find_response_cursor_path(property) {
-            path.insert(0, name.clone());
-            return Some(path);
-        }
-    }
-    None
-}
-
-fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
-    const RESPONSE_CURSOR_TOKENS: &[&str] = &[
-        "after",
-        "continuationtoken",
-        "cursor",
-        "endcursor",
-        "iterator",
-        "next",
-        "nextcursor",
-        "nextmarker",
-        "nextpage",
-        "nextpagetoken",
-        "nexttoken",
-    ];
-
-    RESPONSE_CURSOR_TOKENS.contains(&name_token(name).as_str())
-        && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
 }
 
 /// A wrapped-list envelope is a singleton by cardinality but yields rows, so it

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -50,14 +50,19 @@ impl OpenApiImporter<'_> {
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
         let (output, response, entity, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
+        let contract = detect_pagination_contract(self.document, &parameters, &pagination_context);
         let row_path = self.infer_row_path(
             raw_operation_id.unwrap_or(&operation_id),
-            &parameters,
+            contract.as_ref().is_some_and(binds_pagination_input),
             &pagination_context,
             &output,
         );
-        let pagination =
-            detect_pagination(self.document, &parameters, &pagination_context, &row_path);
+        // A contract only becomes this operation's pagination once Coral reads
+        // the response as a list, whether by declaration or by row path.
+        let pagination = is_list_like_output(pagination_context.cardinality, &row_path)
+            .then_some(contract)
+            .flatten()
+            .unwrap_or_default();
         let lookup_keys = infer_rest_lookup_keys(&parameters, &pagination);
         let rest_parameters = parameters
             .iter()
@@ -116,13 +121,13 @@ impl OpenApiImporter<'_> {
     fn infer_row_path(
         &self,
         operation_name: &str,
-        parameters: &[IrOperationInput],
+        paginated_operation: bool,
         pagination_context: &OpenApiResponsePaginationContext,
         output: &IrOperationOutput,
     ) -> Vec<String> {
         let row_path = infer_wrapped_list_row_path(WrappedListInferenceContext {
             operation_name,
-            inputs: parameters,
+            paginated_operation,
             schema_root: self.document,
             response_schema: &pagination_context.schema,
         });
@@ -344,20 +349,35 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
         .unwrap_or(false)
 }
 
-fn detect_pagination(
+/// Finds the pagination contract the operation's inputs and response describe,
+/// independently of whether Coral will read the response as a list.
+///
+/// None of the detectors consults the row path, so this runs first and answers
+/// the question wrapped-list inference needs — is this operation paginated? —
+/// without the two inferences having to predict each other.
+fn detect_pagination_contract(
     document: &Value,
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
-    row_path: &[String],
-) -> PaginationSpec {
-    if !is_list_like_output(context.cardinality, row_path) {
-        return PaginationSpec::default();
-    }
+) -> Option<PaginationSpec> {
     detect_link_header_pagination(inputs, context)
         .or_else(|| detect_cursor_query_pagination(document, inputs, context))
         .or_else(|| detect_offset_pagination(inputs))
         .or_else(|| detect_page_pagination(inputs))
-        .unwrap_or_default()
+}
+
+/// Whether a detected contract binds any request input.
+///
+/// Only this narrower question is envelope evidence. `Link` header detection
+/// reads no input at all, and providers declare that header on singleton
+/// resources too — GitHub does, on `GET /orgs/{org}/actions/hosted-runners/{id}`
+/// among others. Treating a bare header as evidence would promote a resource's
+/// incidental array, such as that runner's `public_ips`, to the whole relation.
+fn binds_pagination_input(contract: &PaginationSpec) -> bool {
+    contract.cursor_param.is_some()
+        || contract.offset_param.is_some()
+        || contract.page_param.is_some()
+        || contract.page_size.is_some()
 }
 
 fn detect_link_header_pagination(

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -176,13 +176,13 @@ fn candidate_row_path<'a>(
             let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
                 return Ok(None);
             };
-            let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth)?;
+            let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth);
             let accept_preferred = paginated_operation || inherited_evidence || evidence;
             let accept_fallback = paginated_operation || evidence;
 
             for name in PREFERRED_ROW_PROPERTIES {
                 if let Some(property) = properties.get(*name)
-                    && schema_has_type(root, property, resolving_refs, next_depth, "array")?
+                    && schema_has_type(root, property, resolving_refs, next_depth, "array")
                 {
                     return Ok(accept_preferred.then(|| vec![(*name).to_string()]));
                 }
@@ -214,7 +214,7 @@ fn candidate_row_path<'a>(
                 if is_metadata_name(name) {
                     continue;
                 }
-                if schema_has_type(root, property, resolving_refs, next_depth, "array")? {
+                if schema_has_type(root, property, resolving_refs, next_depth, "array") {
                     arrays.push(name);
                 }
             }
@@ -230,28 +230,24 @@ fn candidate_row_path<'a>(
 ///
 /// A single agreeing name-and-type pair is enough: providers rarely put a
 /// `has_more` boolean or a `next_cursor` string on a plain resource.
-fn has_envelope_evidence<'a>(
-    root: &'a Value,
-    properties: &'a Map<String, Value>,
+fn has_envelope_evidence(
+    root: &Value,
+    properties: &Map<String, Value>,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
-) -> Result<bool, JsonSchemaWalkError<'a>> {
+) -> bool {
     // A sole property is the envelope itself: `{"data": [...]}` has nothing
     // else it could be.
     if properties.len() == 1 {
-        return Ok(true);
+        return true;
     }
-    for (name, property) in properties {
+    properties.iter().any(|(name, property)| {
         let normalized = normalized_name(name);
-        for (names, expected) in METADATA_LEXICON {
-            if names.contains(&normalized.as_str())
-                && schema_has_type(root, property, resolving_refs, depth, expected)?
-            {
-                return Ok(true);
-            }
-        }
-    }
-    Ok(false)
+        METADATA_LEXICON.iter().any(|(names, expected)| {
+            names.contains(&normalized.as_str())
+                && schema_has_type(root, property, resolving_refs, depth, expected)
+        })
+    })
 }
 
 fn is_metadata_name(name: &str) -> bool {
@@ -279,14 +275,16 @@ fn schema_uses_composition(schema: &Value) -> bool {
         .any(|keyword| schema.get(*keyword).is_some())
 }
 
-fn schema_has_type<'a>(
-    root: &'a Value,
-    schema: &'a Value,
+/// An unresolvable or cyclic property simply does not declare the type asked
+/// about; it must not abandon inference for its siblings.
+fn schema_has_type(
+    root: &Value,
+    schema: &Value,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
     expected: &str,
-) -> Result<bool, JsonSchemaWalkError<'a>> {
-    match with_resolved_json_schema(
+) -> bool {
+    with_resolved_json_schema(
         root,
         schema,
         resolving_refs,
@@ -295,12 +293,8 @@ fn schema_has_type<'a>(
         |resolved, _, _| {
             Ok(!schema_uses_composition(resolved) && json_schema_type_contains(resolved, expected))
         },
-    ) {
-        Ok(matched) => Ok(matched),
-        // An unresolvable or cyclic property is not the row collection, but it
-        // must not abandon inference for its siblings.
-        Err(_) => Ok(false),
-    }
+    )
+    .unwrap_or(false)
 }
 
 /// Collapses case and separators so `perPage`, `per_page`, and `per-page` all

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -32,13 +32,14 @@ const PREFERRED_ROW_PROPERTIES: &[&str] = &["items", "data", "results", "rows"];
 
 /// Envelope metadata names, matched together with the declared JSON type so a
 /// resource field only counts as evidence when name and type agree.
+// `links` is deliberately absent: a HAL-style `_links` object is at least as
+// common on a singleton resource as on a page envelope.
 const METADATA_OBJECT_NAMES: &[&str] = &[
     "meta",
     "metadata",
     "paging",
     "pagination",
     "pageinfo",
-    "links",
     "cursor",
     "cursors",
 ];
@@ -472,12 +473,32 @@ mod tests {
     }
 
     #[test]
+    fn ignores_hal_style_link_objects_on_resources() {
+        // GitHub's `activity/get-feeds` shape: a resource whose only array is
+        // incidental and whose `_links` object describes relations, not pages.
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "timeline_url": {"type": "string"},
+                "user_url": {"type": "string"},
+                "current_user_organization_urls": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "_links": {"type": "object"},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
     fn ignores_metadata_named_arrays_as_row_candidates() {
         let schema = json!({
             "type": "object",
             "properties": {
                 "has_more": {"type": "boolean"},
-                "links": {"type": "array", "items": {"type": "string"}},
+                "cursors": {"type": "array", "items": {"type": "string"}},
             },
         });
 

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -19,7 +19,6 @@ use std::collections::BTreeSet;
 
 use serde_json::{Map, Value};
 
-use crate::v4::ir::{IrInputLocation, IrOperationInput};
 use crate::v4::surfaces::json_schema::{
     JsonSchemaWalkError, json_schema_type_contains, with_resolved_json_schema,
 };
@@ -88,27 +87,6 @@ const METADATA_LEXICON: [(&[&str], &str); 4] = [
     (METADATA_BOOLEAN_NAMES, "boolean"),
 ];
 
-/// Request-side names that mark an operation as paginated. This is a syntactic
-/// check on declared inputs rather than a look at the inferred `PaginationSpec`,
-/// because pagination inference consumes the row path this module produces.
-const PAGINATION_INPUT_NAMES: &[&str] = &[
-    "page",
-    "pagenumber",
-    "pagetoken",
-    "pagesize",
-    "perpage",
-    "limit",
-    "maxresults",
-    "offset",
-    "cursor",
-    "startcursor",
-    "continuationtoken",
-    "after",
-    "nexttoken",
-    "nextcursor",
-    "iterator",
-];
-
 /// Inputs available to wrapped-list inference.
 ///
 /// The operation name is deliberately part of the context even though the
@@ -117,7 +95,11 @@ const PAGINATION_INPUT_NAMES: &[&str] = &[
 #[derive(Clone, Copy)]
 pub(in crate::v4) struct WrappedListInferenceContext<'a> {
     pub(in crate::v4) operation_name: &'a str,
-    pub(in crate::v4) inputs: &'a [IrOperationInput],
+    /// Whether the surface's own pagination detection found a contract on this
+    /// operation. Each surface answers this before inferring a row path, so
+    /// that the vocabulary of pagination parameter names lives with the
+    /// detectors that own it rather than being predicted here.
+    pub(in crate::v4) paginated_operation: bool,
     /// Document the response schema was taken from, used to resolve `$ref`.
     pub(in crate::v4) schema_root: &'a Value,
     pub(in crate::v4) response_schema: &'a Value,
@@ -129,11 +111,10 @@ pub(in crate::v4) fn infer_wrapped_list_row_path(
     context: WrappedListInferenceContext<'_>,
 ) -> Vec<String> {
     let _ = context.operation_name;
-    let paginated_operation = declares_pagination_input(context.inputs);
     candidate_row_path(
         context.schema_root,
         context.response_schema,
-        paginated_operation,
+        context.paginated_operation,
         false,
         &mut BTreeSet::new(),
         0,
@@ -258,18 +239,6 @@ fn is_metadata_name(name: &str) -> bool {
         .any(|(names, _)| names.contains(&normalized.as_str()))
 }
 
-fn declares_pagination_input(inputs: &[IrOperationInput]) -> bool {
-    inputs
-        .iter()
-        .filter(|input| {
-            matches!(
-                input.location,
-                IrInputLocation::Query | IrInputLocation::ToolArg
-            )
-        })
-        .any(|input| PAGINATION_INPUT_NAMES.contains(&normalized_name(&input.name).as_str()))
-}
-
 fn schema_uses_composition(schema: &Value) -> bool {
     ["allOf", "anyOf", "oneOf", "not"]
         .iter()
@@ -311,28 +280,12 @@ fn normalized_name(name: &str) -> String {
 mod tests {
     use serde_json::{Value, json};
 
-    use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
-
     use super::{WrappedListInferenceContext, infer_wrapped_list_row_path};
 
-    fn inputs(specs: &[(&str, IrInputLocation)]) -> Vec<IrOperationInput> {
-        specs
-            .iter()
-            .map(|(name, location)| IrOperationInput {
-                name: (*name).to_string(),
-                location: *location,
-                required: false,
-                data_type: IrScalarType::String,
-                default_value: None,
-                description: String::new(),
-            })
-            .collect()
-    }
-
-    fn row_path(schema: &Value, operation_inputs: &[IrOperationInput]) -> Vec<String> {
+    fn row_path(schema: &Value, paginated_operation: bool) -> Vec<String> {
         infer_wrapped_list_row_path(WrappedListInferenceContext {
             operation_name: "list_things",
-            inputs: operation_inputs,
+            paginated_operation,
             schema_root: schema,
             response_schema: schema,
         })
@@ -349,7 +302,7 @@ mod tests {
             },
         });
 
-        assert_eq!(row_path(&schema, &[]), ["items"]);
+        assert_eq!(row_path(&schema, false), ["items"]);
     }
 
     #[test]
@@ -368,7 +321,7 @@ mod tests {
             },
         });
 
-        assert_eq!(row_path(&schema, &[]), ["results", "data"]);
+        assert_eq!(row_path(&schema, false), ["results", "data"]);
     }
 
     #[test]
@@ -381,7 +334,7 @@ mod tests {
             },
         });
 
-        assert_eq!(row_path(&schema, &[]), ["repositories"]);
+        assert_eq!(row_path(&schema, false), ["repositories"]);
     }
 
     #[test]
@@ -393,7 +346,7 @@ mod tests {
             },
         });
 
-        assert_eq!(row_path(&schema, &[]), ["data"]);
+        assert_eq!(row_path(&schema, false), ["data"]);
     }
 
     #[test]
@@ -406,14 +359,8 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
-        assert_eq!(
-            row_path(
-                &schema,
-                &inputs(&[("start_cursor", IrInputLocation::Query)])
-            ),
-            ["data"]
-        );
+        assert!(row_path(&schema, false).is_empty());
+        assert_eq!(row_path(&schema, true), ["data"]);
     }
 
     #[test]
@@ -427,8 +374,8 @@ mod tests {
         });
 
         assert!(
-            row_path(&schema, &inputs(&[("bundle_id", IrInputLocation::Path)])).is_empty(),
-            "a path parameter is not a pagination signal"
+            row_path(&schema, false).is_empty(),
+            "an unpaginated resource is not an envelope"
         );
     }
 
@@ -444,7 +391,7 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -468,8 +415,8 @@ mod tests {
             },
         });
 
-        assert!(row_path(&string_count, &[]).is_empty());
-        assert_eq!(row_path(&integer_count, &[]), ["steps"]);
+        assert!(row_path(&string_count, false).is_empty());
+        assert_eq!(row_path(&integer_count, false), ["steps"]);
     }
 
     #[test]
@@ -489,7 +436,7 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -502,7 +449,7 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -521,7 +468,7 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -535,7 +482,7 @@ mod tests {
         });
 
         assert!(
-            row_path(&schema, &inputs(&[("cursor", IrInputLocation::Query)])).is_empty(),
+            row_path(&schema, true).is_empty(),
             "a singleton with a cursor field has no row collection"
         );
     }
@@ -551,7 +498,7 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -566,7 +513,7 @@ mod tests {
             }],
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -587,7 +534,7 @@ mod tests {
             },
         });
 
-        assert_eq!(row_path(&schema, &[]), ["data"]);
+        assert_eq!(row_path(&schema, false), ["data"]);
     }
 
     #[test]
@@ -601,7 +548,7 @@ mod tests {
             },
         });
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 
     #[test]
@@ -620,6 +567,6 @@ mod tests {
             });
         }
 
-        assert!(row_path(&schema, &[]).is_empty());
+        assert!(row_path(&schema, false).is_empty());
     }
 }

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -1,0 +1,610 @@
+//! Heuristic inference of wrapped-list row paths for `OpenAPI` and MCP surfaces.
+//!
+//! A "wrapped list" response wraps rows inside an envelope: the declared type is
+//! an object, but the rows live at a nested path such as `items` or
+//! `results.data`. Providers do not declare which property holds the rows, so
+//! Coral guesses, and a wrong guess reshapes a whole relation: a resource object
+//! with a `fields: [...]` child would become a list of those fields.
+//!
+//! The guess is therefore an opinion, not a fact. It is recorded in operation
+//! metadata, where it is visible and overridable, and never in the semantic IR.
+//!
+//! Inference excludes aggressively. Picking a candidate array is not enough; the
+//! response or the operation must also carry evidence that it really is a page
+//! envelope (see [`has_envelope_evidence`]). A missed envelope leaves a JSON
+//! column the user can still unnest; a wrong envelope silently discards the
+//! declared resource.
+
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value};
+
+use crate::v4::ir::{IrInputLocation, IrOperationInput};
+use crate::v4::surfaces::json_schema::{
+    JsonSchemaWalkError, json_schema_type_contains, with_resolved_json_schema,
+};
+
+const MAX_DEPTH: usize = 8;
+
+/// Property names that conventionally hold the rows of a page envelope, in
+/// preference order.
+const PREFERRED_ROW_PROPERTIES: &[&str] = &["items", "data", "results", "rows"];
+
+/// Envelope metadata names, matched together with the declared JSON type so a
+/// resource field only counts as evidence when name and type agree.
+const METADATA_OBJECT_NAMES: &[&str] = &[
+    "meta",
+    "metadata",
+    "paging",
+    "pagination",
+    "pageinfo",
+    "links",
+    "cursor",
+    "cursors",
+];
+const METADATA_STRING_NAMES: &[&str] = &[
+    "cursor",
+    "next",
+    "nextcursor",
+    "nextpage",
+    "nextpagetoken",
+    "nexttoken",
+    "nexturl",
+    "nextlink",
+    "endcursor",
+    "continuationtoken",
+    "scrollid",
+];
+const METADATA_INTEGER_NAMES: &[&str] = &[
+    "count",
+    "total",
+    "totalcount",
+    "totalresults",
+    "totalsize",
+    "totalitems",
+    "resultcount",
+    "page",
+    "pages",
+    "pagecount",
+    "perpage",
+    "pagesize",
+];
+const METADATA_BOOLEAN_NAMES: &[&str] = &[
+    "hasmore",
+    "hasnext",
+    "hasnextpage",
+    "hasprevious",
+    "incompleteresults",
+    "moreresults",
+    "truncated",
+];
+
+/// Envelope metadata names paired with the JSON type they must declare.
+const METADATA_LEXICON: [(&[&str], &str); 4] = [
+    (METADATA_OBJECT_NAMES, "object"),
+    (METADATA_STRING_NAMES, "string"),
+    (METADATA_INTEGER_NAMES, "integer"),
+    (METADATA_BOOLEAN_NAMES, "boolean"),
+];
+
+/// Request-side names that mark an operation as paginated. This is a syntactic
+/// check on declared inputs rather than a look at the inferred `PaginationSpec`,
+/// because pagination inference consumes the row path this module produces.
+const PAGINATION_INPUT_NAMES: &[&str] = &[
+    "page",
+    "pagenumber",
+    "pagetoken",
+    "pagesize",
+    "perpage",
+    "limit",
+    "maxresults",
+    "offset",
+    "cursor",
+    "startcursor",
+    "continuationtoken",
+    "after",
+    "nexttoken",
+    "nextcursor",
+    "iterator",
+];
+
+/// Inputs available to wrapped-list inference.
+///
+/// The operation name is deliberately part of the context even though the
+/// current policy never reads it. Naming signals (plural nouns, `list`/`search`
+/// prefixes) can be added here without changing every surface importer.
+#[derive(Clone, Copy)]
+pub(in crate::v4) struct WrappedListInferenceContext<'a> {
+    pub(in crate::v4) operation_name: &'a str,
+    pub(in crate::v4) inputs: &'a [IrOperationInput],
+    /// Document the response schema was taken from, used to resolve `$ref`.
+    pub(in crate::v4) schema_root: &'a Value,
+    pub(in crate::v4) response_schema: &'a Value,
+}
+
+/// Returns the path from the response root to the property holding the rows, or
+/// an empty path when the response is not recognized as a wrapped list.
+pub(in crate::v4) fn infer_wrapped_list_row_path(
+    context: WrappedListInferenceContext<'_>,
+) -> Vec<String> {
+    let _ = context.operation_name;
+    let paginated_operation = declares_pagination_input(context.inputs);
+    candidate_row_path(
+        context.schema_root,
+        context.response_schema,
+        paginated_operation,
+        false,
+        &mut BTreeSet::new(),
+        0,
+    )
+    .ok()
+    .flatten()
+    .unwrap_or_default()
+}
+
+/// Walks the envelope, returning the first candidate path that also carries
+/// envelope evidence.
+///
+/// `inherited_evidence` records that an ancestor level looked like an envelope.
+/// It admits a conventionally named row property one level down — the
+/// `{success, results: {data: [...]}, pagination}` shape — but deliberately not
+/// the sole-array fallback, which would let a nested resource's only array child
+/// inherit its parent's envelope evidence.
+fn candidate_row_path<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    paginated_operation: bool,
+    inherited_evidence: bool,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> Result<Option<Vec<String>>, JsonSchemaWalkError<'a>> {
+    with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, resolving_refs, next_depth| {
+            // Composed schemas describe a merge Coral does not model here, so
+            // their properties cannot be read as a complete envelope.
+            if schema_uses_composition(resolved) {
+                return Ok(None);
+            }
+            if !json_schema_type_contains(resolved, "object") {
+                return Ok(None);
+            }
+            let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
+                return Ok(None);
+            };
+            let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth)?;
+            let accept_preferred = paginated_operation || inherited_evidence || evidence;
+            let accept_fallback = paginated_operation || evidence;
+
+            for name in PREFERRED_ROW_PROPERTIES {
+                if let Some(property) = properties.get(*name)
+                    && schema_has_type(root, property, resolving_refs, next_depth, "array")?
+                {
+                    return Ok(accept_preferred.then(|| vec![(*name).to_string()]));
+                }
+            }
+
+            // Recurse only through the same preferred names: nested envelopes
+            // such as `results.data` are worth finding, an unrestricted walk of
+            // every resource child is not.
+            for name in PREFERRED_ROW_PROPERTIES {
+                if let Some(property) = properties.get(*name)
+                    && let Some(mut path) = candidate_row_path(
+                        root,
+                        property,
+                        paginated_operation,
+                        inherited_evidence || evidence,
+                        resolving_refs,
+                        next_depth,
+                    )?
+                {
+                    path.insert(0, (*name).to_string());
+                    return Ok(Some(path));
+                }
+            }
+
+            let mut arrays = Vec::new();
+            for (name, property) in properties {
+                // An array named like envelope metadata is a link or token
+                // collection, never the rows the envelope is wrapping.
+                if is_metadata_name(name) {
+                    continue;
+                }
+                if schema_has_type(root, property, resolving_refs, next_depth, "array")? {
+                    arrays.push(name);
+                }
+            }
+            match arrays.as_slice() {
+                [name] => Ok(accept_fallback.then(|| vec![(*name).clone()])),
+                [] | [_, _, ..] => Ok(None),
+            }
+        },
+    )
+}
+
+/// Reports whether the properties of an envelope level read as list metadata.
+///
+/// A single agreeing name-and-type pair is enough: providers rarely put a
+/// `has_more` boolean or a `next_cursor` string on a plain resource.
+fn has_envelope_evidence<'a>(
+    root: &'a Value,
+    properties: &'a Map<String, Value>,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+) -> Result<bool, JsonSchemaWalkError<'a>> {
+    // A sole property is the envelope itself: `{"data": [...]}` has nothing
+    // else it could be.
+    if properties.len() == 1 {
+        return Ok(true);
+    }
+    for (name, property) in properties {
+        let normalized = normalized_name(name);
+        for (names, expected) in METADATA_LEXICON {
+            if names.contains(&normalized.as_str())
+                && schema_has_type(root, property, resolving_refs, depth, expected)?
+            {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn is_metadata_name(name: &str) -> bool {
+    let normalized = normalized_name(name);
+    METADATA_LEXICON
+        .iter()
+        .any(|(names, _)| names.contains(&normalized.as_str()))
+}
+
+fn declares_pagination_input(inputs: &[IrOperationInput]) -> bool {
+    inputs
+        .iter()
+        .filter(|input| {
+            matches!(
+                input.location,
+                IrInputLocation::Query | IrInputLocation::ToolArg
+            )
+        })
+        .any(|input| PAGINATION_INPUT_NAMES.contains(&normalized_name(&input.name).as_str()))
+}
+
+fn schema_uses_composition(schema: &Value) -> bool {
+    ["allOf", "anyOf", "oneOf", "not"]
+        .iter()
+        .any(|keyword| schema.get(*keyword).is_some())
+}
+
+fn schema_has_type<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    expected: &str,
+) -> Result<bool, JsonSchemaWalkError<'a>> {
+    match with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        MAX_DEPTH,
+        |resolved, _, _| {
+            Ok(!schema_uses_composition(resolved) && json_schema_type_contains(resolved, expected))
+        },
+    ) {
+        Ok(matched) => Ok(matched),
+        // An unresolvable or cyclic property is not the row collection, but it
+        // must not abandon inference for its siblings.
+        Err(_) => Ok(false),
+    }
+}
+
+/// Collapses case and separators so `perPage`, `per_page`, and `per-page` all
+/// match the lexicon entry `perpage`.
+fn normalized_name(name: &str) -> String {
+    name.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
+
+    use super::{WrappedListInferenceContext, infer_wrapped_list_row_path};
+
+    fn inputs(specs: &[(&str, IrInputLocation)]) -> Vec<IrOperationInput> {
+        specs
+            .iter()
+            .map(|(name, location)| IrOperationInput {
+                name: (*name).to_string(),
+                location: *location,
+                required: false,
+                data_type: IrScalarType::String,
+                default_value: None,
+                description: String::new(),
+            })
+            .collect()
+    }
+
+    fn row_path(schema: &Value, operation_inputs: &[IrOperationInput]) -> Vec<String> {
+        infer_wrapped_list_row_path(WrappedListInferenceContext {
+            operation_name: "list_things",
+            inputs: operation_inputs,
+            schema_root: schema,
+            response_schema: schema,
+        })
+    }
+
+    #[test]
+    fn selects_preferred_property_when_a_metadata_sibling_agrees() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "incomplete_results": {"type": "boolean"},
+                "items": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["items"]);
+    }
+
+    #[test]
+    fn selects_nested_preferred_property_through_wrapper_objects() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "success": {"type": "boolean"},
+                "results": {
+                    "type": "object",
+                    "properties": {
+                        "data": {"type": "array", "items": {"type": "object"}},
+                    },
+                },
+                "pagination": {"type": "object"},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["results", "data"]);
+    }
+
+    #[test]
+    fn selects_sole_array_property_when_a_metadata_sibling_agrees() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "repositories": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["repositories"]);
+    }
+
+    #[test]
+    fn selects_the_only_property_of_a_pure_envelope() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["data"]);
+    }
+
+    #[test]
+    fn selects_candidate_of_a_paginated_operation_without_metadata_siblings() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "success": {"type": "boolean"},
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+        assert_eq!(
+            row_path(
+                &schema,
+                &inputs(&[("start_cursor", IrInputLocation::Query)])
+            ),
+            ["data"]
+        );
+    }
+
+    #[test]
+    fn ignores_resource_objects_with_named_array_children() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "items": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(
+            row_path(&schema, &inputs(&[("bundle_id", IrInputLocation::Path)])).is_empty(),
+            "a path parameter is not a pagination signal"
+        );
+    }
+
+    #[test]
+    fn ignores_resource_objects_with_sole_array_children() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "number"},
+                "content_type": {"type": "string"},
+                "item_url": {"type": "string"},
+                "fields": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_metadata_names_whose_declared_type_disagrees() {
+        // A resource may carry a `count` string; only an integer `count` reads
+        // as a result total.
+        let string_count = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "count": {"type": "string"},
+                "steps": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+        let integer_count = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "count": {"type": "integer"},
+                "steps": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&string_count, &[]).is_empty());
+        assert_eq!(row_path(&integer_count, &[]), ["steps"]);
+    }
+
+    #[test]
+    fn ignores_metadata_named_arrays_as_row_candidates() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "links": {"type": "array", "items": {"type": "string"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn does_not_let_a_nested_resource_inherit_envelope_evidence() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_responses_without_arrays() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "nextCursor": {"type": "string"},
+            },
+        });
+
+        assert!(
+            row_path(&schema, &inputs(&[("cursor", IrInputLocation::Query)])).is_empty(),
+            "a singleton with a cursor field has no row collection"
+        );
+    }
+
+    #[test]
+    fn ignores_multiple_array_properties_without_a_preferred_name() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "total_count": {"type": "integer"},
+                "issues": {"type": "array", "items": {"type": "object"}},
+                "pull_requests": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_composed_schemas() {
+        let schema = json!({
+            "allOf": [{
+                "type": "object",
+                "properties": {
+                    "total_count": {"type": "integer"},
+                    "items": {"type": "array", "items": {"type": "object"}},
+                },
+            }],
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn resolves_local_refs() {
+        let schema = json!({
+            "$ref": "#/components/schemas/Page",
+            "components": {
+                "schemas": {
+                    "Page": {
+                        "type": "object",
+                        "properties": {
+                            "has_more": {"type": "boolean"},
+                            "data": {"$ref": "#/components/schemas/Rows"},
+                        },
+                    },
+                    "Rows": {"type": "array", "items": {"type": "object"}},
+                },
+            },
+        });
+
+        assert_eq!(row_path(&schema, &[]), ["data"]);
+    }
+
+    #[test]
+    fn ignores_ref_cycles() {
+        let schema = json!({
+            "$ref": "#/components/schemas/Node",
+            "components": {
+                "schemas": {
+                    "Node": {"$ref": "#/components/schemas/Node"},
+                },
+            },
+        });
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+
+    #[test]
+    fn ignores_envelopes_nested_past_the_depth_cap() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+        for _ in 0..super::MAX_DEPTH {
+            schema = json!({
+                "type": "object",
+                "properties": {"results": schema},
+            });
+        }
+
+        assert!(row_path(&schema, &[]).is_empty());
+    }
+}

--- a/sources/v4/github/manifest.yaml
+++ b/sources/v4/github/manifest.yaml
@@ -53,9 +53,6 @@ surface:
       from: literal
       value: coral-dsl-v4
 test_queries:
-  - >-
-    SELECT total_count, incomplete_results, search_type
-    FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue')
-    LIMIT 1
+  - SELECT id, number, title, state FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 5
   - SELECT id, number, title, state FROM github_v4.issues_list_for_repo(owner => 'octocat', repo => 'Hello-World') LIMIT 5
   - SELECT id, number, title FROM github_v4.issues_get(owner => 'octocat', repo => 'Hello-World', issue_number => 1)


### PR DESCRIPTION
Closes #1910.

## Summary

- Re-introduce wrapped-list detection in one shared library call used by both the OpenAPI and MCP surface importers.
- Store the result as a `row_path` on `OperationMetadata`, not in the semantic IR.
- Gate the inference on *envelope evidence*, so the misfires #1494 objected to do not come back.
- Derive projection columns from the row type the path selects, and carry the path into the runtime package as `ResponseSpec.rows_path`.
- Reject an operation-metadata override whose row path invalidates the materialized projection columns.

## Why

A wrapped list wraps rows inside an envelope: the declared type is an object, but the rows live at a nested path such as `items` or `results.data`.

#1494 removed detection from the OpenAPI surface and #1935 removed it from MCP and from the IR. The objection was not that the inference was useless — it was that a guess was being recorded as fact. A resource object with a `fields: [...]` or `items: [...]` child was silently reclassified as a list of those children, and nothing in the artifacts said it had happened or let a user correct it.

Since #1884 split facts (semantic IR) from opinions (operation metadata), there is a right place for it. `row_path` is inferred policy: visible in `operation-metadata.yaml`, overridable, and validated against the IR when the plan is built.

Without it, today:

- Wrapped-list operations produce envelope-shaped relations (`total_count: Int, items: Json`) instead of one column per row field.
- They are classified as singletons, so no pagination is inferred and `page`/`per_page` fall out of pagination ownership into the lookup-key allowlist.
- `sources/v4/x/manifest.yaml` still declares `SELECT id, text FROM x_v4.search_recents(...)`, which cannot work against the `{data, meta}` envelope the X API returns.
- `sources/v4/github/manifest.yaml` had its search smoke query rewritten by #1494 to select envelope metadata instead of issue rows. This PR restores it.

## The evidence gate

Candidate selection is the same as the heuristic that was removed: a conventionally named array (`items`, `data`, `results`, `rows`, including nested chains of those), otherwise the sole non-metadata array.

What is new is that a candidate is only accepted when something corroborates it:

1. **Metadata sibling.** Some level along the path has a sibling that reads as list metadata, matched on normalized name *and* declared type — an integer `total_count`, a boolean `has_more`, a string `next_cursor`, an object `pagination`. A resource field only counts when name and type agree.
2. **Pure envelope.** The array is the only property of its containing object (`{"data": [...]}`).
3. **Paginated operation.** The operation declares a pagination-shaped query parameter or tool argument. This is a syntactic check on input names, deliberately not the inferred `PaginationSpec`, because pagination inference consumes the row path.

So the two shapes #1494 called out stay envelopes:

| Response | Inputs | Row path |
| --- | --- | --- |
| `{total_count, incomplete_results, items}` | `q, per_page, page` | `[items]` |
| `{success, results: {data}, pagination}` | — | `[results, data]` |
| `{data}` | `pageToken` | `[data]` |
| `{id, items}` (bundle resource) | `bundle_id` path param | `[]` |
| `{id, content_type, …, fields}` (project item) | — | `[]` |

The two tests covering those regressions keep their existing expectations and now assert an empty row path explicitly.

## Behavior change

For a response shaped like:

```json
{ "total_count": 2, "items": [{"id": 1, "title": "A"}, {"id": 2, "title": "B"}] }
```

Coral generated one envelope row with `total_count` and `items` (JSON) columns. It now generates two rows with `id` and `title` columns, and infers pagination for the operation.

Two consequences follow from the operation becoming list-like, rather than from any new code:

- REST wrapped lists paginate again, so their page parameters return to pagination ownership and out of the lookup-key allowlist.
- MCP wrapped-list tools whose only public arguments were `limit`/`offset`/`cursor` flip from `TableFunction` to `Table`, because pagination now owns those arguments.

`OutputCardinality::WrappedList` is also removed. It has had no construction site since #1935.

## Overrides

#1958 made `projections.yaml` an immutable snapshot: effective operation metadata never reconciles it at load time. A row-path override therefore has to fail closed, or the snapshot's columns would silently read fields the new rows do not have.

`validate_projection_compatibility` now checks that every REST projection column with a source path reads a field of the row type the effective row path selects. The existing caller maps that to `MissingOrIncompatibleV4Materialization` or `InvalidV4ProjectionOverride` depending on catalog origin.

## Validation

- `make rust-checks` — 2,141 tests passed, 5 skipped; fmt, clippy `-D warnings`, and rustdoc pass.
- `make lint-sources`
- Imported GitHub's live OpenAPI descriptor with `coral source add`. 128 of its 1,209 operations got a row path, and I reviewed all of them. All but one were genuine list endpoints; `activity/get-feeds` was a singleton resource whose HAL-style `_links` object matched the metadata lexicon and promoted an incidental `current_user_organization_urls` array to being its rows. The last commit drops `links` from the lexicon — re-importing changes exactly that one operation and leaves the other 127 identical. `search_issues_and_pull_requests` infers `row_path: [items]` with page pagination; `issues_get` infers an empty path and no pagination.

Two gaps in that live check, since I only had a placeholder token: the three GitHub smoke queries returned 401, so this confirms the columns resolve at plan time and the requests are well-formed but not that the responses parse. And I did not run the `x_v4` or `github_mcp` manifests, so the X query that should start working again is unverified.

## Judgement calls worth a look

- `git_get_tree` now infers `row_path: [tree]`. Its `truncated` boolean reads as a list-truncation signal, which I think is right, but a git tree is arguably a resource with a `sha` and `url`.
- The sole-array fallback still fires on arrays of scalars — `repos_get_all_topics` infers `[names]`, whose rows become a single `value` column rather than named columns.

Both are exactly what the override is for, but they are policy choices rather than obvious wins.
