### PR TITLE
feat(reef): wire function explorer

### DIFF
--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -48,6 +48,10 @@ async function renderSidebar(
       },
       {
         element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        path: routePattern('workspaceFunctions'),
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
         path: routePattern('workspaceTrace'),
       },
       {
@@ -158,6 +162,18 @@ describe('Sidebar', () => {
     await expect
       .element(screen.getByRole('link', { name: 'Schema' }))
       .toHaveAttribute('href', routePath('workspaceSchema', { workspaceId: 'analytics' }))
+  })
+
+  it('keeps function navigation in the active workspace', async () => {
+    const screen = await renderSidebar(
+      false,
+      routePath('workspaceFunctions', { workspaceId: 'analytics' }),
+      WORKSPACES,
+    )
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Functions' }))
+      .toHaveAttribute('href', routePath('workspaceFunctions', { workspaceId: 'analytics' }))
   })
 
   it('shows the active workspace and lists every local workspace', async () => {
@@ -296,6 +312,10 @@ describe('Sidebar', () => {
         workspaceId: 'analytics',
       }),
       routePath('workspaceSchema', { workspaceId: 'default' }),
+    ],
+    [
+      routePath('workspaceFunctions', { workspaceId: 'analytics' }),
+      routePath('workspaceFunctions', { workspaceId: 'default' }),
     ],
     [
       routePath('workspaceTrace', { traceId: 'trace-1', workspaceId: 'analytics' }),

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -48,12 +48,16 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const schemaPath = workspaceNavTarget
     ? routePath('workspaceSchema', { workspaceId: workspaceNavTarget.name })
     : routePath('home')
+  const functionsPath = workspaceNavTarget
+    ? routePath('workspaceFunctions', { workspaceId: workspaceNavTarget.name })
+    : routePath('home')
   const tracesPath = workspaceNavTarget
     ? routePath('workspaceTraces', { workspaceId: workspaceNavTarget.name })
     : routePath('home')
   const workspaceNavItems = [
     { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
     { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
+    { icon: 'Braces', label: 'Functions', paths: [functionsPath], to: functionsPath },
     { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
   ] satisfies NavItem[]
   const settingsPath = routePath('settings')

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -2,6 +2,7 @@ import { createClient } from '@connectrpc/connect'
 import { createGrpcWebTransport } from '@connectrpc/connect-web'
 
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
+import { FunctionService } from '@/generated/coral/v1/functions_pb'
 import { QueryService } from '@/generated/coral/v1/query_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
 import { TraceService } from '@/generated/coral/v1/traces_pb'
@@ -23,6 +24,10 @@ export function catalogClientForRequest(request: Request) {
     CatalogService,
     createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) }),
   )
+}
+
+export function functionClientForRequest(request: Request) {
+  return createClient(FunctionService, coralTransportForRequest(request))
 }
 
 export function queryClientForRequest(request: Request) {

--- a/apps/reef/app/lib/workspace-routing.test.ts
+++ b/apps/reef/app/lib/workspace-routing.test.ts
@@ -11,6 +11,7 @@ describe('workspace routing', () => {
     ['/workspaces/default/sources/github', '/workspaces/team%20alpha/sources'],
     ['/workspaces/default/schema', '/workspaces/team%20alpha/schema'],
     ['/workspaces/default/schema/github/issues', '/workspaces/team%20alpha/schema'],
+    ['/workspaces/default/functions', '/workspaces/team%20alpha/functions'],
     ['/workspaces/default/traces/trace-1', '/workspaces/team%20alpha/traces'],
     ['/settings', '/workspaces/team%20alpha/sources'],
   ])('targets the corresponding section for %s', (pathname, expectedPath) => {

--- a/apps/reef/app/lib/workspace-routing.ts
+++ b/apps/reef/app/lib/workspace-routing.ts
@@ -16,6 +16,12 @@ export function workspaceFromParams(params: { workspaceId?: string }): Workspace
 }
 
 export function workspacePathForCurrentSection(workspaceId: string, pathname: string): string {
+  const isFunctionsSection = matchPath(
+    { end: false, path: routePattern('workspaceFunctions') },
+    pathname,
+  )
+  if (isFunctionsSection) return routePath('workspaceFunctions', { workspaceId })
+
   const isSchemaSection = matchPath({ end: false, path: routePattern('workspaceSchema') }, pathname)
   if (isSchemaSection) return routePath('workspaceSchema', { workspaceId })
 

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -17,6 +17,7 @@ export default [
       route('oauth-import', 'routes/source-oauth-import.ts'),
       route(':sourceName', 'routes/source-detail.tsx'),
     ]),
+    route(routePattern('workspaceFunctions'), 'routes/functions.tsx'),
     route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
       index('routes/schema-empty.tsx'),
       route(':schemaName/:tableName', 'routes/schema-table.tsx'),

--- a/apps/reef/app/routes/functions.server.test.ts
+++ b/apps/reef/app/routes/functions.server.test.ts
@@ -1,0 +1,58 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import {
+  FunctionRuntimeInvalidSchema,
+  FunctionRuntimeReadySchema,
+  FunctionSchema,
+} from '@/generated/coral/v1/functions_pb'
+
+import { toFunctionDetails } from './functions'
+
+describe('functions route mapping', () => {
+  it('maps available runtime metadata to function details', () => {
+    const fn = create(FunctionSchema, {
+      name: 'review_queue',
+      runtime: {
+        case: 'ready',
+        value: create(FunctionRuntimeReadySchema, {
+          arguments: [
+            { dataType: 'Utf8', name: 'owner' },
+            { dataType: 'Utf8', name: 'repo' },
+          ],
+          description: 'Pull requests waiting for review.',
+          resultColumns: [
+            { dataType: 'Int64', name: 'number', nullable: false },
+            { dataType: 'Utf8', name: 'title', nullable: true },
+          ],
+        }),
+      },
+    })
+
+    expect(toFunctionDetails(fn)).toEqual({
+      arguments: [
+        { dataType: 'Utf8', name: 'owner' },
+        { dataType: 'Utf8', name: 'repo' },
+      ],
+      description: 'Pull requests waiting for review.',
+      name: 'review_queue',
+      resultColumns: [
+        { dataType: 'Int64', name: 'number', nullable: false },
+        { dataType: 'Utf8', name: 'title', nullable: true },
+      ],
+      sources: [],
+    })
+  })
+
+  it('omits functions that are not currently available', () => {
+    const fn = create(FunctionSchema, {
+      name: 'broken_function',
+      runtime: {
+        case: 'invalid',
+        value: create(FunctionRuntimeInvalidSchema, { reason: 'Invalid SQL' }),
+      },
+    })
+
+    expect(toFunctionDetails(fn)).toBeNull()
+  })
+})

--- a/apps/reef/app/routes/functions.tsx
+++ b/apps/reef/app/routes/functions.tsx
@@ -1,0 +1,54 @@
+import { create } from '@bufbuild/protobuf'
+
+import type { Route } from './+types/functions'
+
+import type { FunctionDetailsProps } from '@/components/functions'
+import { ListFunctionsRequestSchema, type Function } from '@/generated/coral/v1/functions_pb'
+import { functionClientForRequest } from '@/lib/coral-request.server'
+import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+import { FunctionsIndex } from '@/views/functions/functions-index'
+
+export interface FunctionsRouteData {
+  functions: FunctionDetailsProps[]
+  loadError: string | null
+}
+
+export async function loader({ params, request }: Route.LoaderArgs): Promise<FunctionsRouteData> {
+  try {
+    const workspace = workspaceFromParams(params)
+    const response = await functionClientForRequest(request).listFunctions(
+      create(ListFunctionsRequestSchema, { workspace }),
+      { signal: request.signal },
+    )
+    return {
+      functions: response.functions
+        .map(toFunctionDetails)
+        .filter((fn): fn is FunctionDetailsProps => fn !== null)
+        .toSorted((left, right) => left.name.localeCompare(right.name)),
+      loadError: null,
+    }
+  } catch (error) {
+    return { functions: [], loadError: errorMessage(error) }
+  }
+}
+
+export default function FunctionsRoute({ loaderData }: Route.ComponentProps) {
+  return <FunctionsIndex {...loaderData} />
+}
+
+export function toFunctionDetails(fn: Function): FunctionDetailsProps | null {
+  if (fn.runtime.case !== 'ready') return null
+  const ready = fn.runtime.value
+  return {
+    arguments: ready.arguments.map(({ dataType, name }) => ({ dataType, name })),
+    description: ready.description || ready.tableFunction?.description || '',
+    name: fn.name,
+    resultColumns: ready.resultColumns.map(({ dataType, name, nullable }) => ({
+      dataType,
+      name,
+      nullable,
+    })),
+    sources: [],
+  }
+}

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -7,6 +7,7 @@ const CANONICAL_PATTERNS = {
   home: '/',
   settings: '/settings',
   workspaces: '/workspaces',
+  workspaceFunctions: '/workspaces/:workspaceId/functions',
   workspaceSchema: '/workspaces/:workspaceId/schema',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
   workspaceSchemaTableFunction:
@@ -38,6 +39,7 @@ describe('route map', () => {
       home: routePath('home'),
       settings: routePath('settings'),
       workspaces: routePath('workspaces'),
+      workspaceFunctions: routePath('workspaceFunctions', { workspaceId: 'analytics' }),
       workspaceSchema: routePath('workspaceSchema', { workspaceId: 'analytics' }),
       workspaceSchemaTable: routePath('workspaceSchemaTable', {
         schemaName: 'github',
@@ -69,6 +71,7 @@ describe('route map', () => {
       home: '/',
       settings: '/settings',
       workspaces: '/workspaces',
+      workspaceFunctions: '/workspaces/analytics/functions',
       workspaceSchema: '/workspaces/analytics/schema',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSchemaTableFunction: '/workspaces/analytics/schema/github/functions/search_issues',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -3,6 +3,7 @@ import type { RouteObject } from 'react-router'
 
 const HOME_PATH = '/'
 const WORKSPACES_PATH = '/workspaces'
+const WORKSPACE_FUNCTIONS_PATH = '/workspaces/:workspaceId/functions'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
 const WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH =
@@ -27,6 +28,13 @@ export const routeDefinitions = {
   workspaces: {
     path: WORKSPACES_PATH,
     toPath: () => WORKSPACES_PATH,
+  },
+  workspaceFunctions: {
+    path: WORKSPACE_FUNCTIONS_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_FUNCTIONS_PATH, {
+        workspaceId: params.workspaceId,
+      }),
   },
   workspaceSchema: {
     path: WORKSPACE_SCHEMA_PATH,

--- a/apps/reef/app/views/functions/functions-index.css.ts
+++ b/apps/reef/app/views/functions/functions-index.css.ts
@@ -1,0 +1,12 @@
+import { style } from '@vanilla-extract/css'
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+})
+
+export const error = style({
+  padding: 16,
+})

--- a/apps/reef/app/views/functions/functions-index.test.tsx
+++ b/apps/reef/app/views/functions/functions-index.test.tsx
@@ -1,0 +1,58 @@
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { FunctionsIndex } from './functions-index'
+
+function renderFunctions(props: React.ComponentProps<typeof FunctionsIndex>) {
+  const router = createMemoryRouter(
+    [{ element: <FunctionsIndex {...props} />, path: '/functions' }],
+    { initialEntries: ['/functions'] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+describe('FunctionsIndex', () => {
+  it('renders available function details and changes the selection', async () => {
+    const screen = await renderFunctions({
+      functions: [
+        {
+          arguments: [{ dataType: 'Utf8', name: 'owner' }],
+          description: 'Pull requests waiting for review.',
+          name: 'review_queue',
+          resultColumns: [{ dataType: 'Int64', name: 'number', nullable: false }],
+          sources: [],
+        },
+        {
+          arguments: [],
+          description: 'Recently opened incidents.',
+          name: 'recent_incidents',
+          resultColumns: [{ dataType: 'Utf8', name: 'id', nullable: false }],
+          sources: [],
+        },
+      ],
+      loadError: null,
+    })
+
+    await expect.element(screen.getByText('Functions', { exact: true })).toBeVisible()
+    await expect.element(screen.getByRole('heading', { name: 'review_queue' })).toBeVisible()
+    await expect.element(screen.getByText('Pull requests waiting for review.')).toBeVisible()
+    await expect.element(screen.getByText('owner')).toBeVisible()
+    await expect.element(screen.getByText('number')).toBeVisible()
+
+    await screen.getByRole('button', { name: 'recent_incidents' }).click()
+
+    await expect.element(screen.getByText('Recently opened incidents.')).toBeVisible()
+    await expect.element(screen.getByRole('heading', { name: 'recent_incidents' })).toBeVisible()
+  })
+
+  it('renders empty and error states', async () => {
+    const empty = await renderFunctions({ functions: [], loadError: null })
+    await expect.element(empty.getByText('No functions available.')).toBeVisible()
+    empty.unmount()
+
+    const failed = await renderFunctions({ functions: [], loadError: 'Sidecar unavailable' })
+    await expect.element(failed.getByText("Couldn't load functions")).toBeVisible()
+    await expect.element(failed.getByText('Sidecar unavailable')).toBeVisible()
+  })
+})

--- a/apps/reef/app/views/functions/functions-index.tsx
+++ b/apps/reef/app/views/functions/functions-index.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useRevalidator } from 'react-router'
+
+import { ErrorBanner } from '@/components/error-banner'
+import { FunctionExplorer, type FunctionDetailsProps } from '@/components/functions'
+import { PageHeader } from '@/views/traces/page-header'
+
+import * as styles from './functions-index.css'
+
+export function FunctionsIndex({
+  functions,
+  loadError,
+}: {
+  functions: FunctionDetailsProps[]
+  loadError: string | null
+}) {
+  const revalidator = useRevalidator()
+  const [selectedName, setSelectedName] = useState<string>()
+  const activeName = functions.some((fn) => fn.name === selectedName)
+    ? selectedName
+    : functions[0]?.name
+
+  if (!loadError) {
+    return (
+      <FunctionExplorer
+        functions={functions}
+        onSelect={setSelectedName}
+        selectedName={activeName}
+      />
+    )
+  }
+
+  return (
+    <section aria-label="Functions" className={styles.root}>
+      <PageHeader title="Functions" />
+      <div className={styles.error}>
+        <ErrorBanner
+          message={loadError}
+          onRetry={() => revalidator.revalidate()}
+          title="Couldn't load functions"
+        />
+      </div>
+    </section>
+  )
+}

--- a/apps/reef/buf.gen.yaml
+++ b/apps/reef/buf.gen.yaml
@@ -10,6 +10,7 @@ inputs:
     paths:
       - ../../crates/coral-api/proto/coral/v1/resources.proto
       - ../../crates/coral-api/proto/coral/v1/catalog.proto
+      - ../../crates/coral-api/proto/coral/v1/functions.proto
       - ../../crates/coral-api/proto/coral/v1/query.proto
       - ../../crates/coral-api/proto/coral/v1/sources.proto
       - ../../crates/coral-api/proto/coral/v1/traces.proto


### PR DESCRIPTION
## Summary

Says on the tin. Wiring up data to the actual page, adding it to the Sidebar + adding route.
In follow-up PRs, will add the plumbing to retrieve more data from the backend (function body and sources used)

## Test plan

<img width="1268" height="819" alt="image" src="https://github.com/user-attachments/assets/32d7365b-5de7-4d43-a3b1-9240c7c39f43" />
