### PR TITLE
fix(reef): fix DS button hover background

### DIFF
--- a/apps/reef/app/components/functions/function-explorer.css.ts
+++ b/apps/reef/app/components/functions/function-explorer.css.ts
@@ -51,11 +51,6 @@ export const list = style({
 export const listRow = style({
   borderRadius: 4,
   justifyContent: 'flex-start',
-  selectors: {
-    '&:hover:not(:disabled)': {
-      background: theme.surface.onMainContentSubtle,
-    },
-  },
 })
 
 export const functionName = style({

--- a/apps/reef/app/views/schema-explorer/schema-explorer.css.ts
+++ b/apps/reef/app/views/schema-explorer/schema-explorer.css.ts
@@ -67,11 +67,6 @@ export const treeRow = style({
   borderRadius: 4,
   gap: 6,
   justifyContent: 'flex-start',
-  selectors: {
-    '&:hover:not(:disabled)': {
-      background: theme.surface.onMainContentSubtle,
-    },
-  },
 })
 
 export const connectorName = style({

--- a/apps/reef/app/wax/components/button/button.css.ts
+++ b/apps/reef/app/wax/components/button/button.css.ts
@@ -230,7 +230,7 @@ export const button = recipe({
         vars: assignVars(buttonVars, {
           backgroundActive: theme.button.bare.hover,
           backgroundBase: 'transparent',
-          backgroundHover: 'transparent',
+          backgroundHover: theme.button.bare.hover,
           shadow: 'none',
         }),
       },


### PR DESCRIPTION
## Summary

Before this PR, hovering on an active element would "downgrade" it visually to hover. We shouldn't.
We also had a bit of unnecessary code handling the hover, which isn't needed because our beautiful DS button already handles that.

## Test plan

Go to schema, hover on the active table, it says `active`