### PR TITLE
feat(reef): show saved function bodies

### DIFF
--- a/apps/reef/app/routes/functions.server.test.ts
+++ b/apps/reef/app/routes/functions.server.test.ts
@@ -25,6 +25,7 @@ describe('functions route mapping', () => {
             { dataType: 'Int64', name: 'number', nullable: false },
             { dataType: 'Utf8', name: 'title', nullable: true },
           ],
+          sqlBody: 'select * from github.pull_requests',
         }),
       },
     })
@@ -34,6 +35,7 @@ describe('functions route mapping', () => {
         { dataType: 'Utf8', name: 'owner' },
         { dataType: 'Utf8', name: 'repo' },
       ],
+      body: 'select * from github.pull_requests',
       description: 'Pull requests waiting for review.',
       name: 'review_queue',
       resultColumns: [

--- a/apps/reef/app/routes/functions.tsx
+++ b/apps/reef/app/routes/functions.tsx
@@ -42,6 +42,7 @@ export function toFunctionDetails(fn: Function): FunctionDetailsProps | null {
   const ready = fn.runtime.value
   return {
     arguments: ready.arguments.map(({ dataType, name }) => ({ dataType, name })),
+    body: ready.sqlBody,
     description: ready.description || ready.tableFunction?.description || '',
     name: fn.name,
     resultColumns: ready.resultColumns.map(({ dataType, name, nullable }) => ({

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -36,6 +36,8 @@ message FunctionRuntimeReady {
   FunctionTableFunctionPublish table_function = 3;
   // Result columns inferred from the planned function SQL.
   repeated TableFunctionResultColumn result_columns = 4;
+  // Executable SQL body parsed from the installed artifact.
+  string sql_body = 5;
 }
 
 // Validation failure for an installed function that is not currently queryable.

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -7,7 +7,9 @@ use coral_api::v1::{
     FunctionTableFunctionPublish, ListFunctionsRequest, ListFunctionsResponse,
     TableFunctionResultColumn, function,
 };
-use coral_engine::{UdfRuntimeDefinition, UdfRuntimeTableFunctionPublish};
+use coral_engine::{
+    UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimeTableFunctionPublish,
+};
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
@@ -115,6 +117,9 @@ fn runtime_function_to_proto(
     function: UdfRuntimeDefinition,
 ) -> Function {
     let name = function.name;
+    let UdfRuntimeImplementation::CoralSql { query: sql_body } = function.implementation else {
+        unreachable!("unsupported function runtime implementation")
+    };
     Function {
         workspace: Some(workspace_to_proto(workspace_name)),
         name,
@@ -141,6 +146,7 @@ fn runtime_function_to_proto(
                     description: String::new(),
                 })
                 .collect(),
+            sql_body,
         })),
     }
 }

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -39,11 +39,13 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         .await
         .expect("create workspace");
 
+    let sql_body = "select cast($value as VARCHAR) as value";
+    let sql = function_sql(sql_body);
     let added = harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
             workspace: Some(work.clone()),
-            sql: function_sql("select cast($value as VARCHAR) as value"),
+            sql: sql.clone(),
         }))
         .await
         .expect("add function")
@@ -55,6 +57,7 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
     let Some(function::Runtime::Ready(ready)) = added.runtime else {
         panic!("expected runtime-ready function");
     };
+    assert_eq!(ready.sql_body, sql_body);
     assert_eq!(
         ready.table_function.expect("table function").guide,
         "Use this function to echo a typed value."
@@ -81,6 +84,11 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         .into_inner()
         .functions;
     assert_eq!(work_functions.len(), 1);
+    let listed = work_functions.into_iter().next().expect("listed function");
+    let Some(function::Runtime::Ready(ready)) = listed.runtime else {
+        panic!("expected listed runtime-ready function");
+    };
+    assert_eq!(ready.sql_body, sql_body);
 
     harness
         .function_client()


### PR DESCRIPTION
## Summary

Initially lifterd the implementation from #19191, then opted for a simpler one.
The goal is retrieving saved function bodies to be shown in the UI

## Test plan

<img width="1266" height="810" alt="image" src="https://github.com/user-attachments/assets/f475bc34-07b6-41da-bef2-5d1cc575208e" />
