### PR TITLE
feat(reef): group functions by namespace

### DIFF
--- a/apps/reef/app/components/functions/function-details.stories.tsx
+++ b/apps/reef/app/components/functions/function-details.stories.tsx
@@ -19,6 +19,7 @@ where pull.state = 'open'
 order by pull.updated_at desc`,
     description: 'Pull requests waiting for review in a repository.',
     name: 'github_review_queue',
+    namespace: 'functions',
     resultColumns: [
       { dataType: 'Int64', name: 'number', nullable: false },
       { dataType: 'Utf8', name: 'title', nullable: false },

--- a/apps/reef/app/components/functions/function-details.tsx
+++ b/apps/reef/app/components/functions/function-details.tsx
@@ -22,6 +22,7 @@ export interface FunctionDetailsProps {
   body?: string
   description: string
   name: string
+  namespace: string
   resultColumns: FunctionDetailsResultColumn[]
   sources: string[]
 }

--- a/apps/reef/app/components/functions/function-explorer.css.ts
+++ b/apps/reef/app/components/functions/function-explorer.css.ts
@@ -50,7 +50,26 @@ export const list = style({
 
 export const listRow = style({
   borderRadius: 4,
+  gap: 6,
   justifyContent: 'flex-start',
+})
+
+export const namespaceName = style({
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const namespaceFunctionCount = style({
+  color: theme.content.tertiary,
+  marginInlineStart: 'auto',
+})
+
+export const namespaceFunctions = style({
+  display: 'flex',
+  flexDirection: 'column',
+  marginInlineStart: 16,
 })
 
 export const functionName = style({

--- a/apps/reef/app/components/functions/function-explorer.stories.tsx
+++ b/apps/reef/app/components/functions/function-explorer.stories.tsx
@@ -22,6 +22,7 @@ where pull.state = 'open'
 order by pull.updated_at desc`,
     description: 'Pull requests waiting for review in a repository.',
     name: 'review_queue',
+    namespace: 'engineering',
     resultColumns: [
       { dataType: 'Int64', name: 'number', nullable: false },
       { dataType: 'Utf8', name: 'title', nullable: false },
@@ -37,6 +38,7 @@ order by pull.updated_at desc`,
     ],
     description: 'Incidents opened since a point in time, filtered by severity.',
     name: 'recent_incidents',
+    namespace: 'operations',
     resultColumns: [
       { dataType: 'Utf8', name: 'id', nullable: false },
       { dataType: 'Utf8', name: 'title', nullable: false },
@@ -48,6 +50,7 @@ order by pull.updated_at desc`,
     arguments: [],
     description: 'Customer conversations that still need a response.',
     name: 'customer_follow_up',
+    namespace: 'operations',
     resultColumns: [
       { dataType: 'Utf8', name: 'conversation_id', nullable: false },
       { dataType: 'Utf8', name: 'summary', nullable: true },
@@ -98,11 +101,17 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   play: async ({ canvas, userEvent }) => {
+    await expect(canvas.getByRole('button', { name: /engineering/ })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    await userEvent.click(canvas.getByRole('button', { name: /engineering/ }))
     await expect(canvas.getByRole('button', { name: 'review_queue' })).toHaveAttribute(
       'aria-pressed',
       'true',
     )
 
+    await userEvent.click(canvas.getByRole('button', { name: /operations/ }))
     await userEvent.click(canvas.getByRole('button', { name: 'recent_incidents' }))
 
     await expect(canvas.getByRole('button', { name: 'recent_incidents' })).toHaveAttribute(

--- a/apps/reef/app/components/functions/function-explorer.tsx
+++ b/apps/reef/app/components/functions/function-explorer.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react'
+
 import { PageHeader } from '@/views/traces/page-header'
 import { Container as ButtonContainer } from '@/wax/components/button'
+import { Icon } from '@/wax/components/icon'
 import { Container as ScrollArea } from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 
@@ -12,8 +15,24 @@ export interface FunctionExplorerProps {
   selectedName?: string
 }
 
+interface FunctionNamespace {
+  functions: FunctionDetailsProps[]
+  name: string
+}
+
 export function FunctionExplorer({ functions, onSelect, selectedName }: FunctionExplorerProps) {
   const selectedFunction = functions.find((fn) => fn.name === selectedName)
+  const namespaces = groupFunctionsByNamespace(functions)
+  const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(() => new Set())
+
+  const toggleNamespace = (name: string) => {
+    setExpandedNamespaces((previous) => {
+      const next = new Set(previous)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
 
   return (
     <section aria-label="Functions explorer" className={styles.root}>
@@ -30,23 +49,60 @@ export function FunctionExplorer({ functions, onSelect, selectedName }: Function
               </div>
             ) : (
               <div className={styles.list}>
-                {functions.map((fn) => {
-                  const selected = fn.name === selectedName
+                {namespaces.map((namespace) => {
+                  const expanded = expandedNamespaces.has(namespace.name)
+                  const namespaceChildrenId = `function-namespace-${namespace.name}-items`
                   return (
-                    <ButtonContainer
-                      aria-pressed={selected}
-                      className={styles.listRow}
-                      fullWidth
-                      isActive={selected}
-                      key={fn.name}
-                      onClick={() => onSelect(fn.name)}
-                      size="22"
-                      variant="bare"
-                    >
-                      <Typography.BodyStrong className={styles.functionName}>
-                        {fn.name}
-                      </Typography.BodyStrong>
-                    </ButtonContainer>
+                    <div key={namespace.name}>
+                      <ButtonContainer
+                        aria-controls={namespaceChildrenId}
+                        aria-expanded={expanded}
+                        className={styles.listRow}
+                        fullWidth
+                        onClick={() => toggleNamespace(namespace.name)}
+                        size="22"
+                        variant="bare"
+                      >
+                        <Icon
+                          color="secondary"
+                          name={expanded ? 'ChevronDown' : 'ChevronRight'}
+                          size="14"
+                        />
+                        <Typography.BodyStrong className={styles.namespaceName}>
+                          {namespace.name}
+                        </Typography.BodyStrong>
+                        <Typography.BodySmall
+                          className={styles.namespaceFunctionCount}
+                          variant="tertiary"
+                        >
+                          {namespace.functions.length}
+                        </Typography.BodySmall>
+                      </ButtonContainer>
+
+                      {expanded ? (
+                        <div className={styles.namespaceFunctions} id={namespaceChildrenId}>
+                          {namespace.functions.map((fn) => {
+                            const selected = fn.name === selectedName
+                            return (
+                              <ButtonContainer
+                                aria-pressed={selected}
+                                className={styles.listRow}
+                                fullWidth
+                                isActive={selected}
+                                key={fn.name}
+                                onClick={() => onSelect(fn.name)}
+                                size="22"
+                                variant="bare"
+                              >
+                                <Typography.BodyStrong className={styles.functionName}>
+                                  {fn.name}
+                                </Typography.BodyStrong>
+                              </ButtonContainer>
+                            )
+                          })}
+                        </div>
+                      ) : null}
+                    </div>
                   )
                 })}
               </div>
@@ -68,4 +124,21 @@ export function FunctionExplorer({ functions, onSelect, selectedName }: Function
       </div>
     </section>
   )
+}
+
+function groupFunctionsByNamespace(functions: FunctionDetailsProps[]): FunctionNamespace[] {
+  const grouped = new Map<string, FunctionDetailsProps[]>()
+
+  for (const fn of functions) {
+    const namespace = grouped.get(fn.namespace)
+    if (namespace) namespace.push(fn)
+    else grouped.set(fn.namespace, [fn])
+  }
+
+  return [...grouped.entries()]
+    .map(([name, namespaceFunctions]) => ({
+      functions: namespaceFunctions.toSorted((left, right) => left.name.localeCompare(right.name)),
+      name,
+    }))
+    .toSorted((left, right) => left.name.localeCompare(right.name))
 }

--- a/apps/reef/app/components/functions/function-explorer.tsx
+++ b/apps/reef/app/components/functions/function-explorer.tsx
@@ -55,7 +55,7 @@ export function FunctionExplorer({ functions, onSelect, selectedName }: Function
                   return (
                     <div key={namespace.name}>
                       <ButtonContainer
-                        aria-controls={namespaceChildrenId}
+                        aria-controls={expanded ? namespaceChildrenId : undefined}
                         aria-expanded={expanded}
                         className={styles.listRow}
                         fullWidth

--- a/apps/reef/app/routes/functions.server.test.ts
+++ b/apps/reef/app/routes/functions.server.test.ts
@@ -5,6 +5,7 @@ import {
   FunctionRuntimeInvalidSchema,
   FunctionRuntimeReadySchema,
   FunctionSchema,
+  FunctionTableFunctionPublishSchema,
 } from '@/generated/coral/v1/functions_pb'
 
 import { toFunctionDetails } from './functions'
@@ -26,6 +27,10 @@ describe('functions route mapping', () => {
             { dataType: 'Utf8', name: 'title', nullable: true },
           ],
           sqlBody: 'select * from github.pull_requests',
+          tableFunction: create(FunctionTableFunctionPublishSchema, {
+            name: 'review_queue',
+            schemaName: 'functions',
+          }),
         }),
       },
     })
@@ -38,6 +43,7 @@ describe('functions route mapping', () => {
       body: 'select * from github.pull_requests',
       description: 'Pull requests waiting for review.',
       name: 'review_queue',
+      namespace: 'functions',
       resultColumns: [
         { dataType: 'Int64', name: 'number', nullable: false },
         { dataType: 'Utf8', name: 'title', nullable: true },
@@ -52,6 +58,18 @@ describe('functions route mapping', () => {
       runtime: {
         case: 'invalid',
         value: create(FunctionRuntimeInvalidSchema, { reason: 'Invalid SQL' }),
+      },
+    })
+
+    expect(toFunctionDetails(fn)).toBeNull()
+  })
+
+  it('omits functions without a SQL namespace', () => {
+    const fn = create(FunctionSchema, {
+      name: 'missing_publish_target',
+      runtime: {
+        case: 'ready',
+        value: create(FunctionRuntimeReadySchema),
       },
     })
 

--- a/apps/reef/app/routes/functions.tsx
+++ b/apps/reef/app/routes/functions.tsx
@@ -40,11 +40,13 @@ export default function FunctionsRoute({ loaderData }: Route.ComponentProps) {
 export function toFunctionDetails(fn: Function): FunctionDetailsProps | null {
   if (fn.runtime.case !== 'ready') return null
   const ready = fn.runtime.value
+  if (!ready.tableFunction?.schemaName) return null
   return {
     arguments: ready.arguments.map(({ dataType, name }) => ({ dataType, name })),
     body: ready.sqlBody,
     description: ready.description || ready.tableFunction?.description || '',
     name: fn.name,
+    namespace: ready.tableFunction.schemaName,
     resultColumns: ready.resultColumns.map(({ dataType, name, nullable }) => ({
       dataType,
       name,

--- a/apps/reef/app/views/functions/functions-index.test.tsx
+++ b/apps/reef/app/views/functions/functions-index.test.tsx
@@ -20,13 +20,23 @@ describe('FunctionsIndex', () => {
           arguments: [{ dataType: 'Utf8', name: 'owner' }],
           description: 'Pull requests waiting for review.',
           name: 'review_queue',
+          namespace: 'engineering',
           resultColumns: [{ dataType: 'Int64', name: 'number', nullable: false }],
+          sources: [],
+        },
+        {
+          arguments: [],
+          description: 'Failed deployments requiring investigation.',
+          name: 'deployment_failures',
+          namespace: 'operations',
+          resultColumns: [{ dataType: 'Utf8', name: 'id', nullable: false }],
           sources: [],
         },
         {
           arguments: [],
           description: 'Recently opened incidents.',
           name: 'recent_incidents',
+          namespace: 'operations',
           resultColumns: [{ dataType: 'Utf8', name: 'id', nullable: false }],
           sources: [],
         },
@@ -35,15 +45,35 @@ describe('FunctionsIndex', () => {
     })
 
     await expect.element(screen.getByText('Functions', { exact: true })).toBeVisible()
+    await expect
+      .element(screen.getByRole('button', { name: /engineering/ }))
+      .toHaveAttribute('aria-expanded', 'false')
+    await expect
+      .element(screen.getByRole('button', { name: /operations/ }))
+      .toHaveAttribute('aria-expanded', 'false')
+    await expect
+      .element(screen.getByRole('button', { name: 'deployment_failures' }))
+      .not.toBeInTheDocument()
     await expect.element(screen.getByRole('heading', { name: 'review_queue' })).toBeVisible()
     await expect.element(screen.getByText('Pull requests waiting for review.')).toBeVisible()
     await expect.element(screen.getByText('owner')).toBeVisible()
     await expect.element(screen.getByText('number')).toBeVisible()
 
+    await screen.getByRole('button', { name: /operations/ }).click()
+    await expect
+      .element(screen.getByRole('button', { name: /operations/ }))
+      .toHaveAttribute('aria-expanded', 'true')
+    await expect.element(screen.getByRole('button', { name: 'deployment_failures' })).toBeVisible()
+
     await screen.getByRole('button', { name: 'recent_incidents' }).click()
 
     await expect.element(screen.getByText('Recently opened incidents.')).toBeVisible()
     await expect.element(screen.getByRole('heading', { name: 'recent_incidents' })).toBeVisible()
+
+    await screen.getByRole('button', { name: /operations/ }).click()
+    await expect
+      .element(screen.getByRole('button', { name: 'recent_incidents' }))
+      .not.toBeInTheDocument()
   })
 
   it('renders empty and error states', async () => {

--- a/apps/reef/app/views/schema-explorer/schema.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.tsx
@@ -203,7 +203,7 @@ export function SchemaExplorer({
                     return (
                       <div key={connector.name}>
                         <ButtonContainer
-                          aria-controls={connectorChildrenId}
+                          aria-controls={expanded ? connectorChildrenId : undefined}
                           aria-expanded={expanded}
                           className={styles.treeRow}
                           fullWidth


### PR DESCRIPTION
## Summary

Users can specify any arbitrary namespace for the functions, we should expose that in the UI.
The UI was ready for this -- we can reuse our Schema UI.

## Test plan

<img width="1097" height="811" alt="image" src="https://github.com/user-attachments/assets/b5ada641-625c-4641-9a2c-df45883348bd" />
