### PR TITLE
feat(xtask): report inferred v4 row paths and pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,11 +150,21 @@
   `xtask/src/benchmarks/`, and the isolated benchmark package and fixtures live
   under `xtask/benchmarks/`. Skill export lives in `xtask/src/skills.rs`.
   Release signing and notarization automation lives in `xtask/src/release.rs`.
+  The DSL v4 inference report lives in `xtask/src/metadata_report.rs`.
 - Use `cargo run --locked -p xtask -- benchmark list-columns` to measure the
   complete MCP `list_columns` response for the checked-in synthetic wide-table
   fixture with the `o200k_base` tokenizer. The benchmark must call the real MCP
   tool in-process, report without enforcing a token budget, and keep
   benchmark-only code out of production crates.
+- Use `cargo run --locked -p xtask -- v4-metadata-report` before and after a
+  change to DSL v4 row-path or pagination inference, and diff the two reports.
+  It imports every non-MCP v4 source under `sources/v4` and emits one CSV row
+  per operation, so an unintended reshape in a source nobody was thinking about
+  shows up as a diff hunk. Pass `--cache-dir` so a before/after pair fetches
+  each descriptor once. It is deliberately not wired into CI: it fetches
+  multi-megabyte vendor descriptors over the network, and vendor descriptors
+  change under us, so a green run proves nothing about the commit that produced
+  it.
 - Universal Search relevance benchmarking also lives in the isolated
   `coral-benchmarks` package. Keep real catalog inventories, generated
   questions, collected queries, responses, focused corpora, and replay reports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,10 +157,10 @@
   tool in-process, report without enforcing a token budget, and keep
   benchmark-only code out of production crates.
 - Use `cargo run --locked -p xtask -- v4-metadata-report` before and after a
-  change to DSL v4 row-path or pagination inference, and diff the two reports.
-  It imports every non-MCP v4 source under `sources/v4` and emits one CSV row
-  per operation, so an unintended reshape in a source nobody was thinking about
-  shows up as a diff hunk. Pass `--cache-dir` so a before/after pair fetches
+  change to DSL v4 row-path, pagination, or lookup-key inference, and diff the
+  two reports. It imports every non-MCP v4 source under `sources/v4` and emits
+  one CSV row per operation, so an unintended reshape in a source nobody was
+  thinking about shows up as a diff hunk. Pass `--cache-dir` so a before/after pair fetches
   each descriptor once. It is deliberately not wired into CI: it fetches
   multi-megabyte vendor descriptors over the network, and vendor descriptors
   change under us, so a green run proves nothing about the commit that produced

--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -42,7 +42,10 @@ discovery, and normalized source-definition models.
   metadata. Consumers must pair both through `ValidatedSurfacePlan`, and
   runtime structural validation must accept a valid source with zero
   operations and zero projections.
-- Row-path and pagination inference are heuristics over vendor descriptors, so
-  changing either can quietly reshape relations in unrelated sources. Diff
-  `cargo run --locked -p xtask -- v4-metadata-report` across the change before
-  submitting.
+- Row-path, pagination and lookup-key inference are heuristics over vendor
+  descriptors, so changing any of them can quietly reshape relations in
+  unrelated sources. Diff `cargo run --locked -p xtask -- v4-metadata-report`
+  across the change before submitting. The three are coupled: the lookup-key
+  allowlist is whatever query parameters pagination did not claim, so a
+  pagination edit that changes which detector wins hands its displaced
+  parameters to the dependent-join planner.

--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -42,3 +42,7 @@ discovery, and normalized source-definition models.
   metadata. Consumers must pair both through `ValidatedSurfacePlan`, and
   runtime structural validation must accept a valid source with zero
   operations and zero projections.
+- Row-path and pagination inference are heuristics over vendor descriptors, so
+  changing either can quietly reshape relations in unrelated sources. Diff
+  `cargo run --locked -p xtask -- v4-metadata-report` across the change before
+  submitting.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,8 @@
 //!   - `release-desktop-macos-package` packages, signs, notarizes, and verifies
 //!     the prepared macOS desktop app.
 //!   - `openapi-hydrate` produces a self-contained JSON `OpenAPI` descriptor.
+//!   - `v4-metadata-report` reports inferred row paths and pagination contracts
+//!     for the v4 source catalog, for diffing across inference changes.
 
 #![allow(
     clippy::print_stderr,
@@ -36,6 +38,7 @@ mod benchmarks;
 mod detect;
 mod docs;
 mod env;
+mod metadata_report;
 mod openapi;
 mod perf;
 mod release;
@@ -73,6 +76,8 @@ enum Command {
     ReleaseDesktopMacosPackage(release::DesktopMacosPackageArgs),
     /// Hydrate reachable external `OpenAPI` references into JSON.
     OpenapiHydrate(openapi::HydrateArgs),
+    /// Report inferred row paths and pagination contracts for v4 sources.
+    V4MetadataReport(metadata_report::Args),
 }
 
 #[derive(Debug, clap::Args)]
@@ -125,5 +130,6 @@ fn run(command: &Command) -> Result<bool> {
         Command::ReleaseMacosSignNotarize(args) => release::macos_sign_notarize(args),
         Command::ReleaseDesktopMacosPackage(args) => release::desktop_macos_package(args),
         Command::OpenapiHydrate(args) => openapi::hydrate(args),
+        Command::V4MetadataReport(args) => metadata_report::run(args),
     }
 }

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -1,0 +1,323 @@
+//! `v4-metadata-report` xtask subcommand.
+//!
+//! Emits one deterministic line per imported v4 operation describing the
+//! inference outcomes that are opinions rather than facts: where the rows live
+//! and what pagination contract the operation was given.
+//!
+//! The point is diffing. Row-path and pagination inference are heuristics over
+//! vendor descriptors, so a change to either can quietly reshape a relation in
+//! a source nobody was thinking about. Running this before and after such a
+//! change turns "did anything else move?" from a question into a `diff`.
+//!
+//! Deliberately not wired into CI: it fetches multi-megabyte descriptors over
+//! the network, and vendor descriptors change under us, so a green run proves
+//! nothing about the commit that produced it.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use coral_spec::PaginationMode;
+use coral_spec::v4::{
+    OperationMetadata, SurfaceDescriptor, SurfaceType, V4SourceManifest, import_openapi_surface,
+};
+
+use crate::sources::load_catalog_manifests;
+
+/// Descriptor ceiling, matching `MAX_DESCRIPTOR_BYTES` in
+/// `coral-app`'s materialization path.
+///
+/// The report exists to reproduce what the app infers, so it reads descriptors
+/// the same way the app does: raw bytes straight into the importer, with no
+/// reference hydration and the same size ceiling. Microsoft Graph's v1.0
+/// description alone is ~38 MB.
+const MAX_DESCRIPTOR_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Timeout for descriptor fetches.
+const FETCH_TIMEOUT: Duration = Duration::from_mins(2);
+
+const HEADER: &str =
+    "source,operation_id,row_path,mode,page_size_param,cursor_param,offset_param,next_url_path";
+
+/// Arguments for the `v4-metadata-report` subcommand.
+#[derive(Debug, clap::Args)]
+pub(crate) struct Args {
+    /// Directory holding one subdirectory per v4 source manifest.
+    #[arg(long, default_value = "sources/v4")]
+    sources: PathBuf,
+
+    /// File to write the report to. Writes to stdout when omitted.
+    #[arg(long)]
+    out: Option<PathBuf>,
+
+    /// Directory for cached descriptor downloads. Reused across runs so a
+    /// before/after comparison fetches each descriptor once.
+    #[arg(long)]
+    cache_dir: Option<PathBuf>,
+
+    /// Restrict the report to these schema names. Repeatable.
+    #[arg(long = "source-name")]
+    source_names: Vec<String>,
+}
+
+/// One row of the report.
+struct OperationRow {
+    source: String,
+    operation_id: String,
+    row_path: String,
+    mode: String,
+    page_size_param: String,
+    cursor_param: String,
+    offset_param: String,
+    next_url_path: String,
+}
+
+impl OperationRow {
+    fn render(&self) -> String {
+        format!(
+            "{},{},{},{},{},{},{},{}",
+            self.source,
+            self.operation_id,
+            self.row_path,
+            self.mode,
+            self.page_size_param,
+            self.cursor_param,
+            self.offset_param,
+            self.next_url_path,
+        )
+    }
+}
+
+/// Import every v4 `OpenAPI` source under `--sources` and write the report.
+pub(crate) fn run(args: &Args) -> Result<bool> {
+    let manifests = load_catalog_manifests(&args.sources)
+        .with_context(|| format!("loading manifests from {}", args.sources.display()))?;
+
+    let mut rows = Vec::new();
+    for manifest in &manifests {
+        let schema_name = manifest.schema_name().to_owned();
+        if !args.source_names.is_empty() && !args.source_names.contains(&schema_name) {
+            continue;
+        }
+        let Some(v4) = manifest.as_v4() else {
+            eprintln!("skipping {schema_name}: not a DSL v4 manifest");
+            continue;
+        };
+        // An MCP surface enumerates its operations by calling a live,
+        // authenticated server, so it cannot be imported from a checkout.
+        if v4.surface.surface_type == SurfaceType::Mcp {
+            eprintln!("skipping {schema_name}: MCP surfaces need a live server to enumerate tools");
+            continue;
+        }
+        eprintln!("importing {schema_name} ...");
+        rows.extend(
+            import_source_rows(&schema_name, v4, args.cache_dir.as_deref())
+                .with_context(|| format!("importing {schema_name}"))?,
+        );
+    }
+
+    rows.sort_by(|left, right| {
+        (&left.source, &left.operation_id).cmp(&(&right.source, &right.operation_id))
+    });
+
+    let mut report = String::from(HEADER);
+    report.push('\n');
+    for row in &rows {
+        report.push_str(&row.render());
+        report.push('\n');
+    }
+
+    match &args.out {
+        Some(path) => {
+            if let Some(parent) = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+            }
+            fs::write(path, &report).with_context(|| format!("writing {}", path.display()))?;
+            eprintln!("wrote {} operations to {}", rows.len(), path.display());
+        }
+        None => {
+            io::stdout().lock().write_all(report.as_bytes())?;
+        }
+    }
+
+    Ok(true)
+}
+
+fn import_source_rows(
+    schema_name: &str,
+    manifest: &V4SourceManifest,
+    cache_dir: Option<&Path>,
+) -> Result<Vec<OperationRow>> {
+    let document = load_descriptor(schema_name, &manifest.surface.descriptor, cache_dir)?;
+    let imported = import_openapi_surface(manifest, &manifest.surface, &document)?;
+
+    let metadata: BTreeMap<&str, &OperationMetadata> = imported
+        .operation_metadata
+        .operations
+        .iter()
+        .map(|(id, entry)| (id.as_str(), entry))
+        .collect();
+
+    Ok(imported
+        .semantic_ir
+        .operations
+        .iter()
+        .map(|operation| {
+            let entry = metadata.get(operation.id.as_str());
+            let (row_path, pagination) = match entry {
+                Some(OperationMetadata::Rest {
+                    row_path,
+                    pagination,
+                    ..
+                }) => (join_path(row_path), Some(pagination)),
+                Some(OperationMetadata::Mcp { row_path, .. }) => (join_path(row_path), None),
+                None => (String::new(), None),
+            };
+            OperationRow {
+                source: schema_name.to_owned(),
+                operation_id: operation.id.clone(),
+                row_path,
+                mode: pagination.map_or_else(|| "-".to_owned(), |spec| mode_name(spec.mode)),
+                page_size_param: pagination
+                    .and_then(|spec| spec.page_size.as_ref())
+                    .and_then(|size| size.query_param.clone())
+                    .unwrap_or_default(),
+                cursor_param: pagination
+                    .and_then(|spec| spec.cursor_param.clone())
+                    .unwrap_or_default(),
+                offset_param: pagination
+                    .and_then(|spec| spec.offset_param.clone())
+                    .unwrap_or_default(),
+                // Always empty today: no pagination contract reads a next URL
+                // out of the response body yet. The column exists so the
+                // baseline captured before that lands has the same shape as the
+                // reports compared against it.
+                next_url_path: String::new(),
+            }
+        })
+        .collect())
+}
+
+/// Reads the descriptor, using `cache_dir` as a read-through cache so a
+/// before/after comparison does not re-download tens of megabytes.
+fn load_descriptor(
+    schema_name: &str,
+    descriptor: &SurfaceDescriptor,
+    cache_dir: Option<&Path>,
+) -> Result<Vec<u8>> {
+    let cached = cache_dir.map(|dir| dir.join(format!("{schema_name}.descriptor")));
+    if let Some(path) = &cached
+        && path.exists()
+    {
+        eprintln!("  using cached descriptor {}", path.display());
+        return fs::read(path).with_context(|| format!("reading {}", path.display()));
+    }
+
+    let bytes = match descriptor {
+        SurfaceDescriptor::File { file } => {
+            fs::read(file).with_context(|| format!("reading {}", file.display()))?
+        }
+        SurfaceDescriptor::Url { url } => fetch_descriptor(url)?,
+        SurfaceDescriptor::McpServer { .. } => {
+            bail!("MCP surfaces have no OpenAPI descriptor")
+        }
+    };
+    if bytes.len() as u64 > MAX_DESCRIPTOR_BYTES {
+        bail!(
+            "descriptor for {schema_name} is {} bytes, over the {MAX_DESCRIPTOR_BYTES} byte ceiling",
+            bytes.len()
+        );
+    }
+
+    if let Some(path) = &cached {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(path, &bytes).with_context(|| format!("writing {}", path.display()))?;
+    }
+    Ok(bytes)
+}
+
+fn fetch_descriptor(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()?;
+    let response = client
+        .get(url)
+        .send()
+        .with_context(|| format!("fetching {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        bail!("{url} returned HTTP {status}");
+    }
+    Ok(response.bytes()?.to_vec())
+}
+
+/// Renders a JSON path so an empty path is visibly empty rather than absent,
+/// and a nested path stays on one CSV field.
+fn join_path(path: &[String]) -> String {
+    path.join(".")
+}
+
+/// Renders the mode as the same token the artifact serializes.
+///
+/// Matched exhaustively on purpose: a new pagination mode must fail to compile
+/// here rather than silently report as something else.
+fn mode_name(mode: PaginationMode) -> String {
+    match mode {
+        PaginationMode::None => "none",
+        PaginationMode::Auto => "auto",
+        PaginationMode::CursorQuery => "cursor_query",
+        PaginationMode::CursorBody => "cursor_body",
+        PaginationMode::Page => "page",
+        PaginationMode::Offset => "offset",
+        PaginationMode::LinkHeader => "link_header",
+    }
+    .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HEADER, OperationRow, join_path};
+
+    #[test]
+    fn renders_a_row_with_the_same_field_count_as_the_header() {
+        let row = OperationRow {
+            source: "github_v4".to_owned(),
+            operation_id: "issues_list".to_owned(),
+            row_path: "items".to_owned(),
+            mode: "link_header".to_owned(),
+            page_size_param: "per_page".to_owned(),
+            cursor_param: String::new(),
+            offset_param: String::new(),
+            next_url_path: String::new(),
+        };
+
+        assert_eq!(
+            row.render().split(',').count(),
+            HEADER.split(',').count(),
+            "a row must line up with the header for the diff to be readable"
+        );
+    }
+
+    #[test]
+    fn joins_nested_row_paths_into_one_field() {
+        assert_eq!(join_path(&[]), "");
+        assert_eq!(join_path(&["value".to_owned()]), "value");
+        assert_eq!(
+            join_path(&["results".to_owned(), "data".to_owned()]),
+            "results.data"
+        );
+        assert!(
+            !join_path(&["results".to_owned(), "data".to_owned()]).contains(','),
+            "a nested path must not split across CSV fields"
+        );
+    }
+}

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{self, Write as _};
+use std::io::{self, Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -39,8 +39,20 @@ const MAX_DESCRIPTOR_BYTES: u64 = 64 * 1024 * 1024;
 /// Timeout for descriptor fetches.
 const FETCH_TIMEOUT: Duration = Duration::from_mins(2);
 
-const HEADER: &str =
-    "source,operation_id,row_path,mode,page_size_param,cursor_param,offset_param,next_url_path";
+/// Every `PaginationSpec` field the `OpenAPI` importer can populate, plus the
+/// row path.
+///
+/// The narrower set this started with hid real inference changes: swapping the
+/// `page` query parameter an operation is bound to, or the response path a
+/// cursor is read from, leaves `mode` untouched and so would not show up in the
+/// diff at all. A field the importer writes but this report drops is a change
+/// the report cannot see.
+const HEADER: &str = "source,operation_id,row_path,mode,\
+    page_size_param,page_size_default,page_size_max,\
+    page_param,page_start,\
+    cursor_param,response_cursor_path,response_cursor_header,\
+    offset_param,offset_start,offset_step,\
+    next_url_header,next_url_path";
 
 /// Arguments for the `v4-metadata-report` subcommand.
 #[derive(Debug, clap::Args)]
@@ -64,30 +76,71 @@ pub(crate) struct Args {
 }
 
 /// One row of the report.
+///
+/// Every field is pre-rendered to a string, and a field the operation's mode
+/// does not use is empty rather than zero: a column of `0`s on every
+/// unpaginated operation would bury the rows that actually moved.
 struct OperationRow {
     source: String,
     operation_id: String,
     row_path: String,
     mode: String,
     page_size_param: String,
+    page_size_default: String,
+    page_size_max: String,
+    page_param: String,
+    page_start: String,
     cursor_param: String,
+    response_cursor_path: String,
+    response_cursor_header: String,
     offset_param: String,
+    offset_start: String,
+    offset_step: String,
+    next_url_header: String,
     next_url_path: String,
 }
 
 impl OperationRow {
+    /// The fields in header order.
+    fn fields(&self) -> [&str; 17] {
+        [
+            &self.source,
+            &self.operation_id,
+            &self.row_path,
+            &self.mode,
+            &self.page_size_param,
+            &self.page_size_default,
+            &self.page_size_max,
+            &self.page_param,
+            &self.page_start,
+            &self.cursor_param,
+            &self.response_cursor_path,
+            &self.response_cursor_header,
+            &self.offset_param,
+            &self.offset_start,
+            &self.offset_step,
+            &self.next_url_header,
+            &self.next_url_path,
+        ]
+    }
+
     fn render(&self) -> String {
-        format!(
-            "{},{},{},{},{},{},{},{}",
-            self.source,
-            self.operation_id,
-            self.row_path,
-            self.mode,
-            self.page_size_param,
-            self.cursor_param,
-            self.offset_param,
-            self.next_url_path,
-        )
+        self.fields().map(escape_csv_field).join(",")
+    }
+}
+
+/// Quotes a field per RFC 4180 when it holds a delimiter, quote, or newline.
+///
+/// Operation IDs, parameter names and row-path segments all come from vendor
+/// descriptors, so nothing guarantees they are comma-free. An unescaped comma
+/// shifts every later field on that line, and the whole point of this report is
+/// that a `diff` hunk means an inference changed — not that a field slid
+/// sideways.
+fn escape_csv_field(field: &str) -> String {
+    if field.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_owned()
     }
 }
 
@@ -180,20 +233,47 @@ fn import_source_rows(
                 Some(OperationMetadata::Mcp { row_path, .. }) => (join_path(row_path), None),
                 None => (String::new(), None),
             };
+            let page_size = pagination.and_then(|spec| spec.page_size.as_ref());
+            let page_param = pagination
+                .and_then(|spec| spec.page_param.clone())
+                .unwrap_or_default();
+            let offset_param = pagination
+                .and_then(|spec| spec.offset_param.clone())
+                .unwrap_or_default();
             OperationRow {
                 source: schema_name.to_owned(),
                 operation_id: operation.id.clone(),
                 row_path,
                 mode: pagination.map_or_else(|| "-".to_owned(), |spec| mode_name(spec.mode)),
-                page_size_param: pagination
-                    .and_then(|spec| spec.page_size.as_ref())
+                page_size_param: page_size
                     .and_then(|size| size.query_param.clone())
                     .unwrap_or_default(),
+                page_size_default: page_size
+                    .map_or_else(String::new, |size| size.default.to_string()),
+                page_size_max: page_size.map_or_else(String::new, |size| size.max.to_string()),
+                // The start and step columns describe how their parameter is
+                // walked, so they only carry meaning when it is set.
+                page_start: option_number(pagination.map(|spec| spec.page_start), &page_param),
+                page_param,
                 cursor_param: pagination
                     .and_then(|spec| spec.cursor_param.clone())
                     .unwrap_or_default(),
-                offset_param: pagination
-                    .and_then(|spec| spec.offset_param.clone())
+                response_cursor_path: pagination
+                    .map_or_else(String::new, |spec| join_path(&spec.response_cursor_path)),
+                response_cursor_header: pagination
+                    .and_then(|spec| spec.response_cursor_header.clone())
+                    .unwrap_or_default(),
+                offset_start: option_number(
+                    pagination.map(|spec| spec.offset_start),
+                    &offset_param,
+                ),
+                offset_step: option_number(
+                    pagination.and_then(|spec| spec.offset_step),
+                    &offset_param,
+                ),
+                offset_param,
+                next_url_header: pagination
+                    .and_then(|spec| spec.next_url_header.clone())
                     .unwrap_or_default(),
                 // Always empty today: no pagination contract reads a next URL
                 // out of the response body yet. The column exists so the
@@ -249,7 +329,7 @@ fn fetch_descriptor(url: &str) -> Result<Vec<u8>> {
     let client = reqwest::blocking::Client::builder()
         .timeout(FETCH_TIMEOUT)
         .build()?;
-    let response = client
+    let mut response = client
         .get(url)
         .send()
         .with_context(|| format!("fetching {url}"))?;
@@ -257,13 +337,43 @@ fn fetch_descriptor(url: &str) -> Result<Vec<u8>> {
     if !status.is_success() {
         bail!("{url} returned HTTP {status}");
     }
-    Ok(response.bytes()?.to_vec())
+    // The same bounded read as `coral-app`'s materialization path: reject on the
+    // declared length when the server gives one, and cap the read itself so a
+    // chunked response cannot pull an unbounded body into memory before the
+    // ceiling is checked.
+    if let Some(length) = response.content_length()
+        && length > MAX_DESCRIPTOR_BYTES
+    {
+        bail!("{url} declares {length} bytes, over the {MAX_DESCRIPTOR_BYTES} byte ceiling");
+    }
+    let mut bytes = Vec::new();
+    response
+        .by_ref()
+        .take(MAX_DESCRIPTOR_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("reading {url}"))?;
+    if bytes.len() as u64 > MAX_DESCRIPTOR_BYTES {
+        bail!("{url} is over the {MAX_DESCRIPTOR_BYTES} byte ceiling");
+    }
+    Ok(bytes)
 }
 
 /// Renders a JSON path so an empty path is visibly empty rather than absent,
 /// and a nested path stays on one CSV field.
 fn join_path(path: &[String]) -> String {
     path.join(".")
+}
+
+/// Renders a pagination cursor's start or step, blank unless `param` binds it.
+///
+/// `PaginationSpec` defaults these to `0`, so an operation with no offset
+/// contract at all is indistinguishable from one deliberately started at zero.
+/// Keying off the parameter keeps the column empty in the first case.
+fn option_number(value: Option<i64>, param: &str) -> String {
+    match value {
+        Some(value) if !param.is_empty() => value.to_string(),
+        _ => String::new(),
+    }
 }
 
 /// Renders the mode as the same token the artifact serializes.
@@ -285,26 +395,87 @@ fn mode_name(mode: PaginationMode) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HEADER, OperationRow, join_path};
+    use super::{HEADER, OperationRow, escape_csv_field, join_path, option_number};
 
-    #[test]
-    fn renders_a_row_with_the_same_field_count_as_the_header() {
-        let row = OperationRow {
+    fn row() -> OperationRow {
+        OperationRow {
             source: "github_v4".to_owned(),
             operation_id: "issues_list".to_owned(),
             row_path: "items".to_owned(),
             mode: "link_header".to_owned(),
             page_size_param: "per_page".to_owned(),
+            page_size_default: "30".to_owned(),
+            page_size_max: "100".to_owned(),
+            page_param: "page".to_owned(),
+            page_start: "1".to_owned(),
             cursor_param: String::new(),
+            response_cursor_path: String::new(),
+            response_cursor_header: String::new(),
             offset_param: String::new(),
+            offset_start: String::new(),
+            offset_step: String::new(),
+            next_url_header: "Link".to_owned(),
             next_url_path: String::new(),
-        };
+        }
+    }
 
+    #[test]
+    fn renders_a_row_with_the_same_field_count_as_the_header() {
         assert_eq!(
-            row.render().split(',').count(),
+            row().render().split(',').count(),
             HEADER.split(',').count(),
             "a row must line up with the header for the diff to be readable"
         );
+    }
+
+    #[test]
+    fn reports_the_page_parameter_a_page_mode_operation_is_bound_to() {
+        let rendered = row().render();
+        let column = HEADER
+            .split(',')
+            .position(|column| column == "page_param")
+            .expect("page_param is a reported column");
+        let field = rendered
+            .split(',')
+            .nth(column)
+            .expect("a row carries every header column");
+
+        assert_eq!(
+            field, "page",
+            "rebinding the page parameter must show up in the diff even though the mode is unchanged"
+        );
+    }
+
+    #[test]
+    fn quotes_fields_that_would_otherwise_shift_later_columns() {
+        assert_eq!(escape_csv_field("plain"), "plain");
+        assert_eq!(escape_csv_field("a,b"), "\"a,b\"");
+        assert_eq!(escape_csv_field("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(escape_csv_field("two\nlines"), "\"two\nlines\"");
+    }
+
+    #[test]
+    fn escapes_descriptor_derived_fields_rather_than_splicing_them() {
+        let mut row = row();
+        row.operation_id = "weird,id\"with\nnewline".to_owned();
+        let rendered = row.render();
+
+        assert!(
+            rendered.starts_with("github_v4,\"weird,id\"\"with\nnewline\","),
+            "the descriptor-derived field must be quoted, not spliced: {rendered}"
+        );
+    }
+
+    #[test]
+    fn blanks_pagination_offsets_that_no_parameter_binds() {
+        assert_eq!(option_number(Some(0), "skip"), "0");
+        assert_eq!(option_number(Some(1), "page"), "1");
+        assert_eq!(
+            option_number(Some(0), ""),
+            "",
+            "a defaulted zero on an operation with no such parameter is not a contract"
+        );
+        assert_eq!(option_number(None, "skip"), "");
     }
 
     #[test]

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -1,13 +1,15 @@
 //! `v4-metadata-report` xtask subcommand.
 //!
 //! Emits one deterministic line per imported v4 operation describing the
-//! inference outcomes that are opinions rather than facts: where the rows live
-//! and what pagination contract the operation was given.
+//! inference outcomes that are opinions rather than facts: where the rows live,
+//! what pagination contract the operation was given, and which of its query
+//! parameters are trusted to anchor a dependent join.
 //!
-//! The point is diffing. Row-path and pagination inference are heuristics over
-//! vendor descriptors, so a change to either can quietly reshape a relation in
-//! a source nobody was thinking about. Running this before and after such a
-//! change turns "did anything else move?" from a question into a `diff`.
+//! The point is diffing. Row-path, pagination and lookup-key inference are all
+//! heuristics over vendor descriptors, so a change to any of them can quietly
+//! reshape a relation in a source nobody was thinking about. Running this
+//! before and after such a change turns "did anything else move?" from a
+//! question into a `diff`.
 //!
 //! Deliberately not wired into CI: it fetches multi-megabyte descriptors over
 //! the network, and vendor descriptors change under us, so a green run proves
@@ -40,14 +42,23 @@ const MAX_DESCRIPTOR_BYTES: u64 = 64 * 1024 * 1024;
 const FETCH_TIMEOUT: Duration = Duration::from_mins(2);
 
 /// Every `PaginationSpec` field the `OpenAPI` importer can populate, plus the
-/// row path.
+/// row path and the lookup-key allowlist.
 ///
 /// The narrower set this started with hid real inference changes: swapping the
 /// `page` query parameter an operation is bound to, or the response path a
 /// cursor is read from, leaves `mode` untouched and so would not show up in the
 /// diff at all. A field the importer writes but this report drops is a change
 /// the report cannot see.
-const HEADER: &str = "source,operation_id,row_path,mode,\
+///
+/// `lookup_keys` is the clearest example of that, because it moves for reasons
+/// that have nothing to do with lookup keys. The allowlist is whatever query
+/// parameters pagination did not claim, so changing which detector wins a mode
+/// hands its displaced parameters to the join planner: an operation that loses
+/// `offset_param: skip` gains `skip` as a joinable key, and a dependent join on
+/// it then attributes every row from that offset onward to one value. That is a
+/// wrong-rows bug reached entirely through a pagination edit, and without this
+/// column the report shows only the pagination half of it.
+const HEADER: &str = "source,operation_id,row_path,lookup_keys,mode,\
     page_size_param,page_size_default,page_size_max,\
     page_param,page_start,page_step,\
     cursor_param,response_cursor_path,response_cursor_header,\
@@ -84,6 +95,7 @@ struct OperationRow {
     source: String,
     operation_id: String,
     row_path: String,
+    lookup_keys: String,
     mode: String,
     page_size_param: String,
     page_size_default: String,
@@ -103,11 +115,12 @@ struct OperationRow {
 
 impl OperationRow {
     /// The fields in header order.
-    fn fields(&self) -> [&str; 18] {
+    fn fields(&self) -> [&str; 19] {
         [
             &self.source,
             &self.operation_id,
             &self.row_path,
+            &self.lookup_keys,
             &self.mode,
             &self.page_size_param,
             &self.page_size_default,
@@ -226,14 +239,23 @@ fn import_source_rows(
         .iter()
         .map(|operation| {
             let entry = metadata.get(operation.id.as_str());
-            let (row_path, pagination) = match entry {
+            // MCP operations have no lookup-key allowlist at all: the heuristic
+            // is REST-only, so their column is empty rather than "none of the
+            // inputs qualified".
+            let (row_path, lookup_keys, pagination) = match entry {
                 Some(OperationMetadata::Rest {
                     row_path,
                     pagination,
-                    ..
-                }) => (join_path(row_path), Some(pagination)),
-                Some(OperationMetadata::Mcp { row_path, .. }) => (join_path(row_path), None),
-                None => (String::new(), None),
+                    lookup_keys,
+                }) => (
+                    join_path(row_path),
+                    join_lookup_keys(lookup_keys),
+                    Some(pagination),
+                ),
+                Some(OperationMetadata::Mcp { row_path, .. }) => {
+                    (join_path(row_path), String::new(), None)
+                }
+                None => (String::new(), String::new(), None),
             };
             let page_size = pagination.and_then(|spec| spec.page_size.as_ref());
             let page_param = pagination
@@ -246,6 +268,7 @@ fn import_source_rows(
                 source: schema_name.to_owned(),
                 operation_id: operation.id.clone(),
                 row_path,
+                lookup_keys,
                 mode: pagination.map_or_else(|| "-".to_owned(), |spec| mode_name(spec.mode)),
                 page_size_param: page_size
                     .and_then(|size| size.query_param.clone())
@@ -367,6 +390,20 @@ fn join_path(path: &[String]) -> String {
     path.join(".")
 }
 
+/// Renders the lookup-key allowlist as a sorted, space-separated list.
+///
+/// Sorted because the allowlist is a set — `plan.rs` membership-tests it — but
+/// it is built by walking the operation's inputs in descriptor order, so a
+/// vendor reordering two unrelated parameters would otherwise show up as a
+/// change to every operation that declares both. Space-separated so the field
+/// needs no CSV quoting: parameter names come from descriptors and can hold a
+/// comma, but none of the sources hold one with a space.
+fn join_lookup_keys(keys: &[String]) -> String {
+    let mut sorted: Vec<&str> = keys.iter().map(String::as_str).collect();
+    sorted.sort_unstable();
+    sorted.join(" ")
+}
+
 /// Renders a pagination cursor's start or step, blank unless `param` binds it.
 ///
 /// `PaginationSpec` defaults these to `0`, so an operation with no offset
@@ -398,13 +435,16 @@ fn mode_name(mode: PaginationMode) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HEADER, OperationRow, escape_csv_field, join_path, option_number};
+    use super::{
+        HEADER, OperationRow, escape_csv_field, join_lookup_keys, join_path, option_number,
+    };
 
     fn row() -> OperationRow {
         OperationRow {
             source: "github_v4".to_owned(),
             operation_id: "issues_list".to_owned(),
             row_path: "items".to_owned(),
+            lookup_keys: "labels state".to_owned(),
             mode: "link_header".to_owned(),
             page_size_param: "per_page".to_owned(),
             page_size_default: "30".to_owned(),
@@ -447,6 +487,40 @@ mod tests {
         assert_eq!(
             field, "page",
             "rebinding the page parameter must show up in the diff even though the mode is unchanged"
+        );
+    }
+
+    #[test]
+    fn reports_the_parameters_an_operation_will_let_a_dependent_join_anchor_on() {
+        let mut row = row();
+        // What a pagination change looks like from the join planner's side: the
+        // detector that owned `skip` lost, so nothing claims it and it becomes
+        // joinable.
+        row.lookup_keys = "labels skip state".to_owned();
+        let rendered = row.render();
+        let column = HEADER
+            .split(',')
+            .position(|column| column == "lookup_keys")
+            .expect("lookup_keys is a reported column");
+        let field = rendered
+            .split(',')
+            .nth(column)
+            .expect("a row carries every header column");
+
+        assert_eq!(
+            field, "labels skip state",
+            "a paging parameter displaced into the lookup-key allowlist must be visible in the diff"
+        );
+    }
+
+    #[test]
+    fn orders_lookup_keys_so_only_membership_changes_show_up() {
+        assert_eq!(join_lookup_keys(&[]), "");
+        assert_eq!(join_lookup_keys(&["state".to_owned()]), "state");
+        assert_eq!(
+            join_lookup_keys(&["state".to_owned(), "labels".to_owned()]),
+            join_lookup_keys(&["labels".to_owned(), "state".to_owned()]),
+            "the allowlist is a set, so a descriptor reordering its parameters is not a change"
         );
     }
 

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -49,7 +49,7 @@ const FETCH_TIMEOUT: Duration = Duration::from_mins(2);
 /// the report cannot see.
 const HEADER: &str = "source,operation_id,row_path,mode,\
     page_size_param,page_size_default,page_size_max,\
-    page_param,page_start,\
+    page_param,page_start,page_step,\
     cursor_param,response_cursor_path,response_cursor_header,\
     offset_param,offset_start,offset_step,\
     next_url_header,next_url_path";
@@ -90,6 +90,7 @@ struct OperationRow {
     page_size_max: String,
     page_param: String,
     page_start: String,
+    page_step: String,
     cursor_param: String,
     response_cursor_path: String,
     response_cursor_header: String,
@@ -102,7 +103,7 @@ struct OperationRow {
 
 impl OperationRow {
     /// The fields in header order.
-    fn fields(&self) -> [&str; 17] {
+    fn fields(&self) -> [&str; 18] {
         [
             &self.source,
             &self.operation_id,
@@ -113,6 +114,7 @@ impl OperationRow {
             &self.page_size_max,
             &self.page_param,
             &self.page_start,
+            &self.page_step,
             &self.cursor_param,
             &self.response_cursor_path,
             &self.response_cursor_header,
@@ -254,6 +256,7 @@ fn import_source_rows(
                 // The start and step columns describe how their parameter is
                 // walked, so they only carry meaning when it is set.
                 page_start: option_number(pagination.map(|spec| spec.page_start), &page_param),
+                page_step: option_number(pagination.map(|spec| spec.page_step), &page_param),
                 page_param,
                 cursor_param: pagination
                     .and_then(|spec| spec.cursor_param.clone())
@@ -408,6 +411,7 @@ mod tests {
             page_size_max: "100".to_owned(),
             page_param: "page".to_owned(),
             page_start: "1".to_owned(),
+            page_step: "1".to_owned(),
             cursor_param: String::new(),
             response_cursor_path: String::new(),
             response_cursor_header: String::new(),


### PR DESCRIPTION
Row-path and pagination inference are heuristics over vendor descriptors, so a change to either can quietly reshape a relation in a source nobody was thinking about. There was no way to see that happen.

## What this adds

`v4-metadata-report` imports every v4 OpenAPI source in the catalog and emits one deterministic line per operation: where its rows live and what pagination contract it was given. Run it before and after an inference change and the blast radius is a `diff` rather than a question.

## Reading descriptors the way the app does

Descriptors are read the way `coral-app` materialization reads them -- raw bytes straight into the importer, no reference hydration, same 64 MB ceiling -- so the report reproduces what the app actually infers rather than what a hydrated variant would. `--cache-dir` makes the before/after pair fetch each descriptor once; Microsoft Graph's alone is ~38 MB.

## Scope

Deliberately not wired into CI: it fetches over the network, and vendor descriptors change under us, so a green run proves nothing about the commit that produced it. MCP surfaces are skipped -- enumerating their tools needs a live authenticated server.

Claude-Session: https://claude.ai/code/session_01Rr2wBfz6dZUWkQF58nVBrR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
