### PR TITLE
feat(spec)!: follow next-page URLs embedded in response bodies

### DIFF
--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -1136,7 +1136,7 @@ The `pagination` object controls how Coral fetches additional pages of results.
 | `mode`                        | string          | `none`  | Pagination strategy: `none`, `auto`, `cursor_query`, `cursor_body`, `page`, `offset`, `link_header`, or `next_url_body` |
 | `cursor_param`                | string          | —       | Query parameter name for the cursor (`cursor_query` mode)                                              |
 | `response_cursor_path`        | list of strings | `[]`    | JSON path in the response to the next cursor value                                                     |
-| `next_url_path`               | list of strings | `[]`    | JSON path in the response to the next page's full URL (`next_url_body` mode)                            |
+| `next_url_path`               | list of strings | `[]`    | JSON path in the response to the next page's URL (`next_url_body` mode)                                 |
 | `cursor_body_path`            | list of strings | `[]`    | JSON path in the request body for the cursor (`cursor_body` mode)                                      |
 | `page_param`                  | string          | —       | Query parameter name for the page number (`page` mode)                                                 |
 | `page_start`                  | integer         | `0`     | Starting page number                                                                                   |
@@ -1207,10 +1207,11 @@ pagination:
 ```
 
 <Note>
-  Use `next_url_body` when the response hands back a complete **URL** for the
-  next page, and `cursor_query` when it hands back a **token** you have to place
-  into a request parameter yourself. Coral requests a `next_url_body` URL exactly
-  as given, so it must stay on the same origin as the request it came from — a
+  Use `next_url_body` when the response hands back a next-page **URL**, and
+  `cursor_query` when it hands back a **token** you have to place into a request
+  parameter yourself. Both an absolute URL and a relative link such as `?page=2`
+  are accepted; Coral resolves a relative link against the request that returned
+  it. The resolved URL must stay on the same origin as that request — a
   cross-origin next link fails the query rather than following it.
 </Note>
 

--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -1133,9 +1133,10 @@ The `pagination` object controls how Coral fetches additional pages of results.
 
 | Field                         | Type            | Default | Description                                                                                            |
 | ----------------------------- | --------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `mode`                        | string          | `none`  | Pagination strategy: `none`, `auto`, `cursor_query`, `cursor_body`, `page`, `offset`, or `link_header` |
+| `mode`                        | string          | `none`  | Pagination strategy: `none`, `auto`, `cursor_query`, `cursor_body`, `page`, `offset`, `link_header`, or `next_url_body` |
 | `cursor_param`                | string          | —       | Query parameter name for the cursor (`cursor_query` mode)                                              |
 | `response_cursor_path`        | list of strings | `[]`    | JSON path in the response to the next cursor value                                                     |
+| `next_url_path`               | list of strings | `[]`    | JSON path in the response to the next page's full URL (`next_url_body` mode)                            |
 | `cursor_body_path`            | list of strings | `[]`    | JSON path in the request body for the cursor (`cursor_body` mode)                                      |
 | `page_param`                  | string          | —       | Query parameter name for the page number (`page` mode)                                                 |
 | `page_start`                  | integer         | `0`     | Starting page number                                                                                   |
@@ -1190,6 +1191,28 @@ pagination:
     max: 100
     query_param: per_page
 ```
+
+Example using a next-page URL embedded in the response body (common with OData
+APIs such as Microsoft Graph):
+
+```yaml
+pagination:
+  mode: next_url_body
+  next_url_path:
+    - "@odata.nextLink"
+  page_size:
+    default: 50
+    max: 999
+    query_param: $top
+```
+
+<Note>
+  Use `next_url_body` when the response hands back a complete **URL** for the
+  next page, and `cursor_query` when it hands back a **token** you have to place
+  into a request parameter yourself. Coral requests a `next_url_body` URL exactly
+  as given, so it must stay on the same origin as the request it came from — a
+  cross-origin next link fails the query rather than following it.
+</Note>
 
 ## Source inputs
 

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -19,7 +19,7 @@ use crate::backends::http::url::{join_url, normalize_base_url};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::response_rows::extract_rows;
 use crate::backends::shared::template::{RenderContext, render_template};
-use coral_spec::{HttpMethod, ValidatedPaginationMode};
+use coral_spec::HttpMethod;
 
 const DEFAULT_MAX_PAGES: usize = 10_000;
 
@@ -94,23 +94,21 @@ pub(super) async fn fetch_rows(
         );
         let base_url = render_template(&client.base_url, &render_context)?;
         let base_url = normalize_base_url(&base_url);
-        let following_link_header = matches!(
-            pagination.mode,
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
-        ) && state.next_url.is_some();
+        // Asked once, of the mode itself: a mode that advances by URL must
+        // both request that URL and skip rebuilding the request Coral would
+        // otherwise have made. Two independent `matches!` tests here is how a
+        // new mode silently stops after page one.
+        let follows_next_url = pagination.mode.follows_response_next_url();
+        let following_next_url = follows_next_url && state.next_url.is_some();
 
-        let url = if matches!(
-            pagination.mode,
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
-        ) && let Some(next) = state.next_url.clone()
-        {
+        let url = if let Some(next) = state.next_url.clone().filter(|_| follows_next_url) {
             next
         } else {
             let rendered_path = render_template(&active_request.path, &render_context)?;
             join_url(&base_url, &rendered_path)?
         };
 
-        let (query_pairs, body) = if following_link_header {
+        let (query_pairs, body) = if following_next_url {
             (Vec::new(), None)
         } else {
             let mut query_pairs = build_query_pairs(active_request, &render_context)?;

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -94,14 +94,20 @@ pub(super) async fn fetch_rows(
         );
         let base_url = render_template(&client.base_url, &render_context)?;
         let base_url = normalize_base_url(&base_url);
-        // Asked once, of the mode itself: a mode that advances by URL must
-        // both request that URL and skip rebuilding the request Coral would
-        // otherwise have made. Two independent `matches!` tests here is how a
-        // new mode silently stops after page one.
-        let follows_next_url = pagination.mode.follows_response_next_url();
-        let following_next_url = follows_next_url && state.next_url.is_some();
+        // Resolved once, then both decisions read that one binding: a mode
+        // that advances by URL must both request that URL and skip rebuilding
+        // the request Coral would otherwise have made. Deriving "are we
+        // following?" from the URL itself rather than re-testing the mode
+        // means the two can never disagree — and a new mode that forgets to
+        // answer `follows_response_next_url` stops after page one at both
+        // sites together, not at one of them.
+        let next_url = state
+            .next_url
+            .clone()
+            .filter(|_| pagination.mode.follows_response_next_url());
+        let following_next_url = next_url.is_some();
 
-        let url = if let Some(next) = state.next_url.clone().filter(|_| follows_next_url) {
+        let url = if let Some(next) = next_url {
             next
         } else {
             let rendered_path = render_template(&active_request.path, &render_context)?;

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -242,18 +242,35 @@ pub(super) fn advance_pagination_state(
                 .and_then(Value::as_str)
                 .map(str::trim)
                 .filter(|next| !next.is_empty());
-            match next_raw {
-                Some(next_raw) => {
-                    let base = pagination_request_url(context.request_url)?;
-                    state.next_url = Some(resolve_pagination_next_url(
-                        &base,
-                        next_raw,
-                        "next URL body value",
-                    )?);
-                    Ok(PageAdvance::Continue)
-                }
-                None => Ok(PageAdvance::Stop),
+            let Some(next_raw) = next_raw else {
+                return Ok(PageAdvance::Stop);
+            };
+            // A page that carried no rows ends the walk whatever the body
+            // claims. Unlike `page`/`offset` this cannot use
+            // `page_is_exhausted`: the server chooses the page size for a
+            // URL-following mode, so a short page is normal and only an empty
+            // one is evidence.
+            if context.rows_on_page == 0 {
+                return Ok(PageAdvance::Stop);
             }
+            let base = pagination_request_url(context.request_url)?;
+            let next = resolve_pagination_next_url(&base, next_raw, "next URL body value")?;
+            // So does a link back to the page that carried it. This mode is
+            // inferred from a property *name*, so unlike `link_header` — where
+            // the server must explicitly say `rel="next"` — the field may not
+            // be a next-page link at all: a related-resource URL the heuristic
+            // picked up, or an API that echoes the collection URL instead of
+            // omitting the link on its last page. Nothing else bounds the
+            // loop, so that would be `max_pages` credentialed requests and
+            // `max_pages` pages of duplicate rows before the query errors.
+            //
+            // From page two on `request_url` is the previous next link, so a
+            // constant link stops on its second appearance.
+            if next == context.request_url {
+                return Ok(PageAdvance::Stop);
+            }
+            state.next_url = Some(next);
+            Ok(PageAdvance::Continue)
         }
     }
 }
@@ -791,6 +808,14 @@ mod tests {
         path: &[&str],
         payload: &Value,
     ) -> datafusion::error::Result<(PageAdvance, PageState)> {
+        advance_next_url_body_with_rows(path, payload, 10)
+    }
+
+    fn advance_next_url_body_with_rows(
+        path: &[&str],
+        payload: &Value,
+        rows_on_page: usize,
+    ) -> datafusion::error::Result<(PageAdvance, PageState)> {
         let pagination = next_url_body_pagination(path);
         let mut state = PageState::default();
         let advance = advance_pagination_state(
@@ -800,7 +825,7 @@ mod tests {
                 payload,
                 response_headers: &HeaderMap::new(),
                 request_url: "https://api.example.com/v1.0/me/chats",
-                rows_on_page: 10,
+                rows_on_page,
                 page_size: Some(10),
                 source_schema: "demo",
                 table_name: "items",
@@ -851,6 +876,68 @@ mod tests {
             );
             assert!(state.next_url.is_none());
         }
+    }
+
+    #[test]
+    fn advance_next_url_body_stops_on_a_link_back_to_the_page_that_carried_it() {
+        // This mode is inferred from a property name, so the field may be a
+        // related-resource URL or a collection link an API echoes on its last
+        // page rather than omitting. Without this stop nothing bounds the
+        // loop: `max_pages` requests, all returning the same rows.
+        for next in [
+            // Absolute, exactly the request URL.
+            "https://api.example.com/v1.0/me/chats",
+            // Relative, resolving to it.
+            "chats",
+        ] {
+            let (advance, state) = advance_next_url_body_with_rows(
+                &["@odata.nextLink"],
+                &json!({ "@odata.nextLink": next }),
+                10,
+            )
+            .unwrap();
+
+            assert_eq!(
+                advance,
+                PageAdvance::Stop,
+                "a next link pointing at the current page is not progress: {next}"
+            );
+            assert!(state.next_url.is_none());
+        }
+    }
+
+    #[test]
+    fn advance_next_url_body_stops_on_an_empty_page() {
+        // A short page is normal here — the server picks the page size — but
+        // an empty one is the end of the collection whatever the body claims.
+        let (advance, state) = advance_next_url_body_with_rows(
+            &["@odata.nextLink"],
+            &json!({"@odata.nextLink": "https://api.example.com/v1.0/me/chats?$skiptoken=abc"}),
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(advance, PageAdvance::Stop);
+        assert!(state.next_url.is_none());
+    }
+
+    #[test]
+    fn advance_next_url_body_follows_a_short_page_that_still_offers_a_link() {
+        // The mirror of the empty-page stop: `page_is_exhausted` would end the
+        // walk here because 3 < 10, but the server chose that page size and
+        // has said there is more.
+        let (advance, state) = advance_next_url_body_with_rows(
+            &["@odata.nextLink"],
+            &json!({"@odata.nextLink": "https://api.example.com/v1.0/me/chats?$skiptoken=abc"}),
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(advance, PageAdvance::Continue);
+        assert_eq!(
+            state.next_url.as_deref(),
+            Some("https://api.example.com/v1.0/me/chats?$skiptoken=abc")
+        );
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -67,7 +67,11 @@ pub(super) fn apply_pagination_query_pairs(
     match &pagination.mode {
         ValidatedPaginationMode::None
         | ValidatedPaginationMode::Auto
-        | ValidatedPaginationMode::CursorBody => {}
+        | ValidatedPaginationMode::CursorBody
+        // The next URL carries the whole query the server wants repeated, so
+        // page two onwards contributes nothing here. Page one still gets the
+        // page-size parameter applied above.
+        | ValidatedPaginationMode::NextUrlBody(_) => {}
         ValidatedPaginationMode::LinkHeader => {
             if let Some(name) = &pagination.page_param {
                 params.push((name.clone(), state.page.to_string()));
@@ -226,6 +230,26 @@ pub(super) fn advance_pagination_state(
             match hints.next_url {
                 Some(next) => {
                     state.next_url = Some(next);
+                    Ok(PageAdvance::Continue)
+                }
+                None => Ok(PageAdvance::Stop),
+            }
+        }
+        ValidatedPaginationMode::NextUrlBody(next_url_body) => {
+            // Read here rather than in `extract_response_pagination_hints`,
+            // which is a header-only helper and is not given the body.
+            let next_raw = get_path_value(context.payload, next_url_body.path())
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|next| !next.is_empty());
+            match next_raw {
+                Some(next_raw) => {
+                    let base = pagination_request_url(context.request_url)?;
+                    state.next_url = Some(resolve_pagination_next_url(
+                        &base,
+                        next_raw,
+                        "next URL body value",
+                    )?);
                     Ok(PageAdvance::Continue)
                 }
                 None => Ok(PageAdvance::Stop),
@@ -395,7 +419,7 @@ fn link_param_matches(item: &str, name: &str, expected: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use reqwest::header::{HeaderMap, HeaderValue};
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     use super::{
         PageAdvance, PageAdvanceContext, PageState, advance_pagination_state,
@@ -751,5 +775,113 @@ mod tests {
         {
             assert_eq!(page_is_exhausted(rows_on_page, page_size), expected);
         }
+    }
+
+    fn next_url_body_pagination(path: &[&str]) -> coral_spec::ValidatedPagination {
+        PaginationSpec {
+            mode: PaginationMode::NextUrlBody,
+            next_url_path: path.iter().map(|segment| (*segment).to_string()).collect(),
+            ..PaginationSpec::default()
+        }
+        .validated("demo", "items")
+        .unwrap()
+    }
+
+    fn advance_next_url_body(
+        path: &[&str],
+        payload: &Value,
+    ) -> datafusion::error::Result<(PageAdvance, PageState)> {
+        let pagination = next_url_body_pagination(path);
+        let mut state = PageState::default();
+        let advance = advance_pagination_state(
+            &mut state,
+            &pagination,
+            PageAdvanceContext {
+                payload,
+                response_headers: &HeaderMap::new(),
+                request_url: "https://api.example.com/v1.0/me/chats",
+                rows_on_page: 10,
+                page_size: Some(10),
+                source_schema: "demo",
+                table_name: "items",
+            },
+        )?;
+        Ok((advance, state))
+    }
+
+    #[test]
+    fn advance_next_url_body_follows_absolute_and_relative_values() {
+        // OData nests the link under a dotted key, which is one path segment.
+        let (advance, state) = advance_next_url_body(
+            &["@odata.nextLink"],
+            &json!({"@odata.nextLink": "https://api.example.com/v1.0/me/chats?$skiptoken=abc"}),
+        )
+        .unwrap();
+        assert_eq!(advance, PageAdvance::Continue);
+        assert_eq!(
+            state.next_url.as_deref(),
+            Some("https://api.example.com/v1.0/me/chats?$skiptoken=abc")
+        );
+
+        // A bare query string resolves against the request path, matching the
+        // Link-header behaviour.
+        let (advance, state) =
+            advance_next_url_body(&["next_page_url"], &json!({"next_page_url": "?page=2"}))
+                .unwrap();
+        assert_eq!(advance, PageAdvance::Continue);
+        assert_eq!(
+            state.next_url.as_deref(),
+            Some("https://api.example.com/v1.0/me/chats?page=2")
+        );
+    }
+
+    #[test]
+    fn advance_next_url_body_stops_when_the_link_is_absent_or_blank() {
+        for payload in [
+            json!({"value": []}),
+            json!({"@odata.nextLink": ""}),
+            json!({"@odata.nextLink": "   "}),
+            json!({"@odata.nextLink": null}),
+        ] {
+            let (advance, state) = advance_next_url_body(&["@odata.nextLink"], &payload).unwrap();
+            assert_eq!(
+                advance,
+                PageAdvance::Stop,
+                "a missing next link ends the crawl: {payload}"
+            );
+            assert!(state.next_url.is_none());
+        }
+    }
+
+    #[test]
+    fn advance_next_url_body_rejects_cross_origin_values() {
+        // The URL comes from the response body, so an origin check is the only
+        // thing standing between a compromised response and an exfiltrated
+        // Authorization header.
+        let err = advance_next_url_body(
+            &["@odata.nextLink"],
+            &json!({"@odata.nextLink": "https://attacker.example/steal"}),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("pagination next URL body value must stay on origin"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn apply_pagination_query_pairs_adds_nothing_for_next_url_body() {
+        let pagination = next_url_body_pagination(&["@odata.nextLink"]);
+        let mut params = Vec::new();
+
+        apply_pagination_query_pairs(&mut params, &pagination, &PageState::default(), None)
+            .unwrap();
+
+        assert!(
+            params.is_empty(),
+            "the next URL carries the server's own query; Coral must not add to it"
+        );
     }
 }

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -245,14 +245,16 @@ pub(super) fn advance_pagination_state(
             let Some(next_raw) = next_raw else {
                 return Ok(PageAdvance::Stop);
             };
-            // A page that carried no rows ends the walk whatever the body
-            // claims. Unlike `page`/`offset` this cannot use
-            // `page_is_exhausted`: the server chooses the page size for a
-            // URL-following mode, so a short page is normal and only an empty
-            // one is evidence.
-            if context.rows_on_page == 0 {
-                return Ok(PageAdvance::Stop);
-            }
+            // Deliberately no row-count test, matching `link_header` and
+            // `next_url_header`: for a URL-following mode the link is the
+            // authority on whether more pages exist, not the size of this one.
+            // Microsoft Graph documents that "a page of results might contain
+            // zero or more results" and that a client must keep following
+            // `@odata.nextLink` until it stops being returned, so stopping on
+            // an empty page would silently truncate the collection this mode
+            // exists to read. Only `page` and `offset` can use
+            // `page_is_exhausted`, because there the client drives the offset
+            // and an empty page really is the end.
             let base = pagination_request_url(context.request_url)?;
             let next = resolve_pagination_next_url(&base, next_raw, "next URL body value")?;
             // So does a link back to the page that carried it. This mode is
@@ -907,37 +909,30 @@ mod tests {
     }
 
     #[test]
-    fn advance_next_url_body_stops_on_an_empty_page() {
-        // A short page is normal here — the server picks the page size — but
-        // an empty one is the end of the collection whatever the body claims.
-        let (advance, state) = advance_next_url_body_with_rows(
-            &["@odata.nextLink"],
-            &json!({"@odata.nextLink": "https://api.example.com/v1.0/me/chats?$skiptoken=abc"}),
-            0,
-        )
-        .unwrap();
+    fn advance_next_url_body_follows_a_link_whatever_the_page_held() {
+        // The link is the authority, not the row count. Microsoft Graph
+        // documents that "a page of results might contain zero or more
+        // results" and that a client must follow `@odata.nextLink` until it
+        // stops being returned, so an empty or short intermediate page must
+        // not end the walk — `page_is_exhausted` would end it at both 0 and 3.
+        for rows_on_page in [0, 3, 10] {
+            let (advance, state) = advance_next_url_body_with_rows(
+                &["@odata.nextLink"],
+                &json!({"@odata.nextLink": "https://api.example.com/v1.0/me/chats?$skiptoken=abc"}),
+                rows_on_page,
+            )
+            .unwrap();
 
-        assert_eq!(advance, PageAdvance::Stop);
-        assert!(state.next_url.is_none());
-    }
-
-    #[test]
-    fn advance_next_url_body_follows_a_short_page_that_still_offers_a_link() {
-        // The mirror of the empty-page stop: `page_is_exhausted` would end the
-        // walk here because 3 < 10, but the server chose that page size and
-        // has said there is more.
-        let (advance, state) = advance_next_url_body_with_rows(
-            &["@odata.nextLink"],
-            &json!({"@odata.nextLink": "https://api.example.com/v1.0/me/chats?$skiptoken=abc"}),
-            3,
-        )
-        .unwrap();
-
-        assert_eq!(advance, PageAdvance::Continue);
-        assert_eq!(
-            state.next_url.as_deref(),
-            Some("https://api.example.com/v1.0/me/chats?$skiptoken=abc")
-        );
+            assert_eq!(
+                advance,
+                PageAdvance::Continue,
+                "a declared next link outranks a {rows_on_page}-row page"
+            );
+            assert_eq!(
+                state.next_url.as_deref(),
+                Some("https://api.example.com/v1.0/me/chats?$skiptoken=abc")
+            );
+        }
     }
 
     #[test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2417,6 +2417,88 @@ async fn pagination_next_url_header() {
     assert_eq!(rows, users_rows());
 }
 
+/// The `OData` shape: the next page's URL arrives in the response body rather
+/// than a header, and the server expects it requested verbatim.
+///
+/// This is the test that catches a `next_url_body` contract whose URL is never
+/// actually followed — the artifact would still read `mode: next_url_body`, and
+/// every unit test would still pass, while the crawl silently stopped at page
+/// one. Page two is keyed on the `$skiptoken` only the body link carries.
+#[tokio::test]
+async fn pagination_next_url_body() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param_is_missing("$skiptoken"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "@odata.nextLink": "?$skiptoken=page-2",
+            "data": &rows[..2],
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("$skiptoken", "page-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[2..] })))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_next_url_body", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "next_url_body",
+        "next_url_path": ["@odata.nextLink"],
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_next_url_body.users ORDER BY id",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, users_rows());
+}
+
+/// The next URL is attacker-controllable in a way a request Coral built is not,
+/// so leaving the origin must fail loudly rather than send credentials onward.
+#[tokio::test]
+async fn pagination_next_url_body_cross_origin_surfaces_structured_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "@odata.nextLink": "https://attacker.example/steal",
+            "data": &users_rows()[..2],
+        })))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_next_url_body_evil", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "next_url_body",
+        "next_url_path": ["@odata.nextLink"],
+    });
+    let source = build_source(manifest);
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT id FROM http_next_url_body_evil.users",
+    )
+    .await
+    .expect_err("cross-origin next link should fail");
+
+    assert!(
+        error.to_string().contains("Source pagination failed"),
+        "{error}"
+    );
+}
+
 #[tokio::test]
 async fn auth_headers_sent_correctly() {
     let server = MockServer::start().await;

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -718,6 +718,14 @@ pub struct PaginationSpec {
     pub link_header_require_results: bool,
     #[serde(default)]
     pub next_url_header: Option<String>,
+    /// Path to a response-body property holding the complete URL of the next
+    /// page, as `OData`'s `@odata.nextLink` does.
+    ///
+    /// Distinct from [`Self::response_cursor_path`]: that path yields a token
+    /// to place into a request parameter, this one yields a URL to request as
+    /// it stands.
+    #[serde(default)]
+    pub next_url_path: Vec<String>,
     #[serde(default)]
     pub max_pages: Option<usize>,
 }
@@ -739,6 +747,7 @@ impl Default for PaginationSpec {
             offset_step: None,
             link_header_require_results: false,
             next_url_header: None,
+            next_url_path: Vec::new(),
             max_pages: None,
         }
     }
@@ -771,6 +780,40 @@ pub enum ValidatedPaginationMode {
     Page,
     Offset(OffsetPagination),
     LinkHeader,
+    NextUrlBody(NextUrlBodyPagination),
+}
+
+impl ValidatedPaginationMode {
+    /// Whether this mode advances by requesting a complete URL the response
+    /// supplied, rather than by mutating the request Coral built.
+    ///
+    /// The fetch loop asks this instead of testing variants, so that a mode
+    /// added later either follows its next URL or is a deliberate omission at
+    /// this one site — a `matches!` per call site would silently answer "no"
+    /// and quietly stop after page one.
+    #[must_use]
+    pub fn follows_response_next_url(&self) -> bool {
+        match self {
+            Self::LinkHeader | Self::Auto | Self::NextUrlBody(_) => true,
+            Self::None | Self::CursorQuery | Self::CursorBody | Self::Page | Self::Offset(_) => {
+                false
+            }
+        }
+    }
+}
+
+/// Validated settings for following a next-page URL out of a response body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NextUrlBodyPagination {
+    path: Vec<String>,
+}
+
+impl NextUrlBodyPagination {
+    /// Path from the response root to the property holding the next-page URL.
+    #[must_use]
+    pub fn path(&self) -> &[String] {
+        &self.path
+    }
 }
 
 /// Validated typed offset-pagination settings.
@@ -911,7 +954,34 @@ impl PaginationSpec {
                 }))
             }
             PaginationMode::LinkHeader => Ok(ValidatedPaginationMode::LinkHeader),
+            PaginationMode::NextUrlBody => self.validated_next_url_body_mode(schema, table),
         }
+    }
+
+    fn validated_next_url_body_mode(
+        &self,
+        schema: &str,
+        table: &str,
+    ) -> Result<ValidatedPaginationMode> {
+        if self.next_url_path.is_empty() {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.mode=next_url_body requires next_url_path"
+            )));
+        }
+        if self
+            .next_url_path
+            .iter()
+            .any(|segment| segment.trim().is_empty() || segment.trim() != segment)
+        {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.next_url_path segments must not be blank or padded"
+            )));
+        }
+        Ok(ValidatedPaginationMode::NextUrlBody(
+            NextUrlBodyPagination {
+                path: self.next_url_path.clone(),
+            },
+        ))
     }
 
     fn validated_page_size(&self, schema: &str, table: &str) -> Result<Option<PageSizeSpec>> {
@@ -973,6 +1043,7 @@ pub enum PaginationMode {
     Page,
     Offset,
     LinkHeader,
+    NextUrlBody,
 }
 
 /// Page-size settings shared by several pagination modes.
@@ -1532,6 +1603,55 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("demo.items pagination.next_url_header must not be empty")
+        );
+    }
+
+    #[test]
+    fn next_url_body_pagination_requires_a_usable_path() {
+        for (next_url_path, expected) in [
+            (
+                Vec::new(),
+                "demo.items pagination.mode=next_url_body requires next_url_path",
+            ),
+            (
+                vec!["  ".to_string()],
+                "demo.items pagination.next_url_path segments must not be blank or padded",
+            ),
+            (
+                vec![" @odata.nextLink".to_string()],
+                "demo.items pagination.next_url_path segments must not be blank or padded",
+            ),
+        ] {
+            let pagination = PaginationSpec {
+                mode: PaginationMode::NextUrlBody,
+                next_url_path,
+                ..PaginationSpec::default()
+            };
+
+            let err = pagination.validated("demo", "items").unwrap_err();
+            assert!(
+                err.to_string().contains(expected),
+                "expected {expected:?}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn next_url_body_pagination_carries_its_path_into_the_validated_mode() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::NextUrlBody,
+            next_url_path: vec!["@odata.nextLink".to_string()],
+            ..PaginationSpec::default()
+        };
+
+        let validated = pagination.validated("demo", "items").expect("validated");
+        let ValidatedPaginationMode::NextUrlBody(next_url_body) = &validated.mode else {
+            panic!("expected next_url_body mode, got {:?}", validated.mode);
+        };
+        assert_eq!(next_url_body.path(), ["@odata.nextLink"]);
+        assert!(
+            validated.mode.follows_response_next_url(),
+            "the fetch loop must be told to request the URL rather than rebuild the request"
         );
     }
 

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1264,7 +1264,8 @@
             "cursor_body",
             "page",
             "offset",
-            "link_header"
+            "link_header",
+            "next_url_body"
           ]
         },
         "page_size": { "$ref": "#/$defs/page_size" },
@@ -1286,6 +1287,10 @@
         "offset_step": { "type": "integer", "minimum": 1 },
         "link_header_require_results": { "type": "boolean" },
         "next_url_header": { "type": "string", "minLength": 1 },
+        "next_url_path": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
         "max_pages": { "type": "integer", "minimum": 1 }
       }
     },

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,8 +7,8 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v7";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
-pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v2";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v11";
+pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v3";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v12";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2502,6 +2502,66 @@ paths:
     );
 }
 
+/// A body next-URL outranks the input-corroborated modes, so it has to be more
+/// than a name match: the schema must declare the property a string.
+///
+/// Without that, an operation like this one got `mode: next_url_body` on the
+/// strength of the name `nextLink`. At runtime `Value::as_str` on a non-string
+/// reads `None`, `advance_pagination_state` stops, and the query returns page
+/// one — no error, no diagnostic — where the `skip`/`limit` contract the server
+/// actually declared would have fetched everything.
+#[test]
+fn importer_ignores_a_body_next_url_the_schema_does_not_declare_a_string() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: things
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /things:
+    get:
+      operationId: listThings
+      parameters:
+        - {name: skip, in: query, schema: {type: integer, default: 0}}
+        - {name: limit, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nextLink: {}
+                  data:
+                    type: array
+                    items: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let pagination = imported_rest_pagination(&ir, "listthings");
+    assert_eq!(
+        pagination.mode,
+        PaginationMode::Offset,
+        "an undeclared type is not enough to displace the contract the server declared"
+    );
+    assert_eq!(pagination.offset_param.as_deref(), Some("skip"));
+    assert!(pagination.next_url_path.is_empty());
+}
+
 /// ...but only at the response root, which is where what it unlocks applies.
 ///
 /// `find_response_cursor_path` descends into nested objects up to depth 8. A

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2306,3 +2306,141 @@ paths:
     );
     assert_eq!(operation.output.cardinality, OutputCardinality::Unknown);
 }
+
+/// A body field holding a whole next-page URL is a stronger signal than a
+/// guessed cursor parameter, so it outranks cursor-query and offset detection —
+/// but only for names that actually denote a URL.
+#[test]
+fn importer_detects_body_next_url_pagination_above_cursor_and_offset() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: nexturl
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /next-url:
+    get:
+      operationId: nextUrlList
+      parameters:
+        - {name: skip, in: query, schema: {type: integer, default: 0}}
+        - {name: limit, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_url: {type: string}
+                  data:
+                    type: array
+                    items: {type: object, properties: {id: {type: string}}}
+  /next-token:
+    get:
+      operationId: nextTokenList
+      parameters:
+        - {name: cursor, in: query, schema: {type: string}}
+        - {name: limit, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_cursor: {type: string}
+                  data:
+                    type: array
+                    items: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let next_url = imported_rest_pagination(&ir, "nexturllist");
+    assert_eq!(next_url.mode, PaginationMode::NextUrlBody);
+    assert_eq!(next_url.next_url_path, ["next_page_url"]);
+    assert_eq!(
+        next_url
+            .page_size
+            .as_ref()
+            .and_then(|size| size.query_param.as_deref()),
+        Some("limit"),
+        "page one still asks for a page size; later pages inherit it from the URL"
+    );
+    assert!(
+        next_url.offset_param.is_none(),
+        "a whole next URL must beat offset detection, which would drive `skip` the server may reject"
+    );
+    assert_eq!(imported_row_path(&ir, "nexturllist"), ["data"]);
+
+    // `next_cursor` is a token, not a URL: it belongs in the request parameter
+    // that expects it, so it must keep falling through to cursor-query.
+    let next_token = imported_rest_pagination(&ir, "nexttokenlist");
+    assert_eq!(next_token.mode, PaginationMode::CursorQuery);
+    assert_eq!(next_token.cursor_param.as_deref(), Some("cursor"));
+    assert!(next_token.next_url_path.is_empty());
+}
+
+/// A declared `Link` header is cheaper and more standard than reading the body,
+/// so it stays ahead of body next-URL detection.
+#[test]
+fn importer_prefers_a_declared_link_header_over_a_body_next_url() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: linkfirst
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /both:
+    get:
+      operationId: bothList
+      parameters:
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_link: {type: string}
+                  data:
+                    type: array
+                    items: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let pagination = imported_rest_pagination(&ir, "bothlist");
+    assert_eq!(pagination.mode, PaginationMode::LinkHeader);
+    assert!(pagination.next_url_path.is_empty());
+}

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2002,7 +2002,7 @@ components:
 
 /// Row-path inference asks the pagination detectors whether an operation is
 /// paginated rather than predicting their answer, so a contract binding any
-/// request input is envelope evidence — one case per way `binds_pagination_input`
+/// request input is envelope evidence — one case per way `signals_page_envelope`
 /// can be satisfied. Predicting the answer used to deadlock the two inferences:
 /// no row path because an alias was unknown, and no pagination because the gate
 /// needs a row path. `skip`/`take` and `$skip`/`$top` are the aliases that
@@ -2125,7 +2125,7 @@ components:
         ("cursorlist", PaginationMode::CursorQuery),
         ("pagelist", PaginationMode::Page),
         // Link-header detection is tried first, so this reaches
-        // `binds_pagination_input` by a different route than `pagelist` does —
+        // `signals_page_envelope` by a different route than `pagelist` does —
         // and it is the shape most real paginated endpoints use.
         ("linkheaderlist", PaginationMode::LinkHeader),
     ] {
@@ -2443,4 +2443,61 @@ paths:
     let pagination = imported_rest_pagination(&ir, "bothlist");
     assert_eq!(pagination.mode, PaginationMode::LinkHeader);
     assert!(pagination.next_url_path.is_empty());
+}
+
+/// A next-page URL in the response body is envelope evidence in its own right.
+///
+/// Graph is the shape that needs it: `{"@odata.nextLink": ..., "value": [...]}`
+/// on an operation that declares no `$top`. The response names no conventional
+/// row property and carries no metadata sibling the lexicon recognizes, so
+/// without the next-URL path there is nothing to unwrap `value` on — and a
+/// contract only survives once the response reads as a list, so the pagination
+/// would have been discarded along with the row path.
+#[test]
+fn importer_treats_a_body_next_url_as_envelope_evidence_without_page_inputs() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: odata
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://graph.microsoft.com/v1.0
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  '@odata.nextLink': {type: string}
+                  value:
+                    type: array
+                    items: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    assert_eq!(imported_row_path(&ir, "listusers"), ["value"]);
+    let pagination = imported_rest_pagination(&ir, "listusers");
+    assert_eq!(pagination.mode, PaginationMode::NextUrlBody);
+    assert_eq!(pagination.next_url_path, ["@odata.nextLink"]);
+    assert!(
+        pagination.page_size.is_none(),
+        "nothing declares a page size here; the next URL carries the paging state"
+    );
 }

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2501,3 +2501,66 @@ paths:
         "nothing declares a page size here; the next URL carries the paging state"
     );
 }
+
+/// ...but only at the response root, which is where what it unlocks applies.
+///
+/// `find_response_cursor_path` descends into nested objects up to depth 8. A
+/// singleton resource that happens to carry a nested link — every pre-existing
+/// detector was immune to this, because each needed a bound request input —
+/// would otherwise reach the sole-array fallback and have its one incidental
+/// array promoted to the whole relation.
+#[test]
+fn importer_ignores_a_body_next_url_nested_below_the_response_root() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: tracks
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /tracks/{id}:
+    get:
+      operationId: getTrack
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: string}
+                  tags:
+                    type: array
+                    items: {type: string}
+                  links:
+                    type: object
+                    properties:
+                      next_href: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    assert!(
+        imported_row_path(&ir, "gettrack").is_empty(),
+        "the track is the resource; its tags are one of its fields, not the relation"
+    );
+    assert_eq!(
+        imported_rest_pagination(&ir, "gettrack").mode,
+        PaginationMode::None,
+        "a contract only survives once the response reads as a list"
+    );
+}

--- a/crates/coral-spec/src/v4/operation_metadata/model.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/model.rs
@@ -104,6 +104,7 @@ pub(super) fn rest_pagination_is_canonical_none(pagination: &PaginationSpec) -> 
         && pagination.offset_step.is_none()
         && !pagination.link_header_require_results
         && pagination.next_url_header.is_none()
+        && pagination.next_url_path.is_empty()
         && pagination.max_pages.is_none()
 }
 

--- a/crates/coral-spec/src/v4/operation_metadata/policy.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/policy.rs
@@ -177,6 +177,7 @@ fn validate_rest_pagination(
     for path in [
         pagination.cursor_body_path.as_slice(),
         pagination.response_cursor_path.as_slice(),
+        pagination.next_url_path.as_slice(),
         pagination
             .page_size
             .as_ref()

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -178,8 +178,16 @@ fn declares_only_string(schema: &Value) -> bool {
     match schema.get("type") {
         Some(Value::String(value)) => value == "string",
         Some(Value::Array(values)) => {
-            let mut permitted = values.iter().filter_map(Value::as_str);
-            let all_readable = permitted.all(|value| value == "string" || value == "null");
+            // Every member must be one of the two readable names, and a member
+            // that is not even a string counts against that. Filtering
+            // non-strings out first would discard the evidence: `["string", 1]`
+            // is not a JSON Schema type union, and reading it as one lets a
+            // malformed descriptor buy the mode. `json_schema_type_contains`
+            // still has to confirm one member *is* `string`, because `all` is
+            // vacuously true on `[]` and `["null"]` alone declares no URL.
+            let all_readable = values
+                .iter()
+                .all(|value| matches!(value.as_str(), Some("string" | "null")));
             all_readable && json_schema_type_contains(schema, "string")
         }
         _ => false,
@@ -385,6 +393,27 @@ mod tests {
 
         assert_eq!(find_declared(&no_string, &no_string, TOKENS), None);
         assert_eq!(find_untyped(&no_string, &no_string, TOKENS), None);
+
+        // A member that is not even a type name means the descriptor is
+        // malformed, not that it declared a string. Skipping it would let
+        // `["string", 1]` read as a clean string-only union and buy the mode.
+        let malformed = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"type": ["string", 1]}},
+        });
+
+        assert_eq!(find_declared(&malformed, &malformed, TOKENS), None);
+
+        // `null` alone declares no URL, and an empty union declares nothing —
+        // neither is vacuously acceptable.
+        for values in [json!(["null"]), json!([])] {
+            let schema = json!({
+                "type": "object",
+                "properties": {"next_cursor": {"type": values}},
+            });
+
+            assert_eq!(find_declared(&schema, &schema, TOKENS), None);
+        }
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -1,10 +1,19 @@
-//! Ref-aware discovery of the response property that carries a continuation
-//! token.
+//! Ref-aware discovery of the response property that carries the next page —
+//! either a continuation token or a whole next-page URL.
 //!
-//! Both surfaces ask the same question of a response schema: which property
-//! holds the cursor for the next page? They ask it of different vocabularies —
-//! `OpenAPI` accepts a wider set of names than MCP — so the lexicon is a
-//! parameter, but the walk itself is shared.
+//! Three callers ask the same question of a response schema: which property
+//! carries the next page? They ask it of different vocabularies — `OpenAPI`
+//! accepts a wider set of cursor names than MCP, and body next-URL detection
+//! has its own narrower lexicon — so the lexicon is a parameter, but the walk
+//! itself is shared.
+//!
+//! What each caller does with the answer differs enough to matter here. Cursor
+//! detection still has to find a request parameter to put the token in before
+//! it commits to a contract, so a false positive costs nothing. Body next-URL
+//! detection has no such second signal: the name is the whole case, and a
+//! property that turns out not to hold a string means the query silently
+//! returns its first page. That is what [`StringTypeRequirement`] exists for —
+//! do not relax it back to one shared rule.
 //!
 //! The walk resolves `$ref` because the responses it now runs against are page
 //! envelopes, and an envelope's `meta`/`pageInfo` sibling is routinely a
@@ -25,18 +34,43 @@ use crate::v4::surfaces::json_schema::{
 const MAX_DEPTH: usize = 8;
 
 /// Returns the path from the response root to the property holding the
-/// continuation token, or `None` when no property matches `cursor_tokens`.
+/// next page, or `None` when no property matches `name_tokens`.
 ///
 /// Names are matched after collapsing case and separators, so `nextCursor`,
 /// `next_cursor`, and `next-cursor` all match the token `nextcursor`.
 pub(in crate::v4) fn find_response_cursor_path(
     root: &Value,
     schema: &Value,
-    cursor_tokens: &[&str],
+    name_tokens: &[&str],
+    string_type: StringTypeRequirement,
 ) -> Option<Vec<String>> {
-    cursor_path(root, schema, cursor_tokens, &mut BTreeSet::new(), 0)
-        .ok()
-        .flatten()
+    cursor_path(
+        root,
+        schema,
+        name_tokens,
+        string_type,
+        &mut BTreeSet::new(),
+        0,
+    )
+    .ok()
+    .flatten()
+}
+
+/// How much a name match has to be corroborated by the declared type.
+///
+/// The walk matches on property *names*, which is a guess. This says how much
+/// the schema has to agree before the guess is accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::v4) enum StringTypeRequirement {
+    /// Accept a property that declares no type. For cursor detection, where a
+    /// matching request parameter still has to be found before anything is
+    /// committed, and descriptors routinely leave envelope metadata untyped.
+    Untyped,
+    /// Require a declared `string`. For body next-URL detection, which has no
+    /// second signal: a property that is not a string reads back as `None` at
+    /// runtime, `advance_pagination_state` stops, and the query returns page
+    /// one with no error and no diagnostic.
+    Declared,
 }
 
 /// Prefers a cursor on the level being walked before descending, so a nested
@@ -44,7 +78,8 @@ pub(in crate::v4) fn find_response_cursor_path(
 fn cursor_path<'a>(
     root: &'a Value,
     schema: &'a Value,
-    cursor_tokens: &[&str],
+    name_tokens: &[&str],
+    string_type: StringTypeRequirement,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
 ) -> Result<Option<Vec<String>>, JsonSchemaWalkError<'a>> {
@@ -59,8 +94,14 @@ fn cursor_path<'a>(
                 return Ok(None);
             };
             for (name, property) in properties {
-                if cursor_tokens.contains(&normalized_name(name).as_str())
-                    && property_allows_string(root, property, resolving_refs, next_depth)
+                if name_tokens.contains(&normalized_name(name).as_str())
+                    && property_holds_string(
+                        root,
+                        property,
+                        string_type,
+                        resolving_refs,
+                        next_depth,
+                    )
                 {
                     return Ok(Some(vec![name.clone()]));
                 }
@@ -69,9 +110,14 @@ fn cursor_path<'a>(
                 if !property_is_object(root, property, resolving_refs, next_depth) {
                     continue;
                 }
-                if let Some(mut path) =
-                    cursor_path(root, property, cursor_tokens, resolving_refs, next_depth)?
-                {
+                if let Some(mut path) = cursor_path(
+                    root,
+                    property,
+                    name_tokens,
+                    string_type,
+                    resolving_refs,
+                    next_depth,
+                )? {
                     path.insert(0, name.clone());
                     return Ok(Some(path));
                 }
@@ -81,12 +127,17 @@ fn cursor_path<'a>(
     )
 }
 
-/// A conventionally named property is accepted unless it declares a type that
-/// rules a token out. An unresolvable or cyclic reference declares nothing, so
-/// it cannot rule anything out either.
-fn property_allows_string(
+/// Whether a conventionally named property carries a string, to the standard
+/// `string_type` asks for.
+///
+/// An unresolvable or cyclic reference declares nothing. Under
+/// [`StringTypeRequirement::Untyped`] that cannot rule a token out, so the
+/// property is kept; under [`StringTypeRequirement::Declared`] it is precisely
+/// the absent declaration the caller insists on, so it is rejected.
+fn property_holds_string(
     root: &Value,
     schema: &Value,
+    string_type: StringTypeRequirement,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
 ) -> bool {
@@ -97,10 +148,14 @@ fn property_allows_string(
         depth,
         MAX_DEPTH,
         |resolved, _, _| {
-            Ok(json_schema_type_contains(resolved, "string") || resolved.get("type").is_none())
+            let declares_string = json_schema_type_contains(resolved, "string");
+            Ok(match string_type {
+                StringTypeRequirement::Declared => declares_string,
+                StringTypeRequirement::Untyped => declares_string || resolved.get("type").is_none(),
+            })
         },
     )
-    .unwrap_or(true)
+    .unwrap_or(string_type == StringTypeRequirement::Untyped)
 }
 
 /// Descent is the opposite case: a property that cannot be resolved into an
@@ -131,11 +186,22 @@ fn normalized_name(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use serde_json::{Value, json};
 
-    use super::find_response_cursor_path;
+    use super::{StringTypeRequirement, find_response_cursor_path};
 
     const TOKENS: &[&str] = &["nextcursor", "nextpagetoken", "nexttoken", "endcursor"];
+
+    /// The cursor-detection standard: a name match is enough unless the schema
+    /// declares a type that rules it out.
+    fn find_untyped(root: &Value, schema: &Value, tokens: &[&str]) -> Option<Vec<String>> {
+        find_response_cursor_path(root, schema, tokens, StringTypeRequirement::Untyped)
+    }
+
+    /// The body-next-URL standard: the schema has to say `string`.
+    fn find_declared(root: &Value, schema: &Value, tokens: &[&str]) -> Option<Vec<String>> {
+        find_response_cursor_path(root, schema, tokens, StringTypeRequirement::Declared)
+    }
 
     #[test]
     fn finds_a_cursor_declared_on_the_response_root() {
@@ -148,7 +214,7 @@ mod tests {
         });
 
         assert_eq!(
-            find_response_cursor_path(&schema, &schema, TOKENS),
+            find_untyped(&schema, &schema, TOKENS),
             Some(vec!["next_cursor".to_string()])
         );
     }
@@ -170,7 +236,7 @@ mod tests {
         });
 
         assert_eq!(
-            find_response_cursor_path(&schema, &schema, TOKENS),
+            find_untyped(&schema, &schema, TOKENS),
             Some(vec!["meta".to_string(), "nextCursor".to_string()])
         );
     }
@@ -187,7 +253,7 @@ mod tests {
         });
 
         assert_eq!(
-            find_response_cursor_path(&schema, &schema, TOKENS),
+            find_untyped(&schema, &schema, TOKENS),
             Some(vec!["next_token".to_string()])
         );
     }
@@ -204,7 +270,7 @@ mod tests {
         });
 
         assert_eq!(
-            find_response_cursor_path(&root, &json!({"$ref": "#/$defs/Page"}), TOKENS),
+            find_untyped(&root, &json!({"$ref": "#/$defs/Page"}), TOKENS),
             Some(vec!["end_cursor".to_string()])
         );
     }
@@ -217,7 +283,57 @@ mod tests {
             "$defs": {"Count": {"type": "integer"}},
         });
 
-        assert_eq!(find_response_cursor_path(&schema, &schema, TOKENS), None);
+        assert_eq!(find_untyped(&schema, &schema, TOKENS), None);
+    }
+
+    #[test]
+    fn the_two_standards_disagree_only_about_an_undeclared_type() {
+        let untyped = json!({
+            "type": "object",
+            "properties": {"next_cursor": {}},
+        });
+
+        assert_eq!(
+            find_untyped(&untyped, &untyped, TOKENS),
+            Some(vec!["next_cursor".to_string()]),
+            "cursor detection still needs a matching request parameter, so a \
+             name match on an untyped property costs nothing"
+        );
+        assert_eq!(
+            find_declared(&untyped, &untyped, TOKENS),
+            None,
+            "body next-URL detection commits on the name alone, and a property \
+             that is not a string stops pagination silently after page one"
+        );
+
+        // A declared string satisfies both, which is why Graph keeps working:
+        // `@odata.nextLink` is declared `{type: string, nullable: true}`.
+        let declared = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"type": ["string", "null"]}},
+        });
+        for found in [
+            find_untyped(&declared, &declared, TOKENS),
+            find_declared(&declared, &declared, TOKENS),
+        ] {
+            assert_eq!(found, Some(vec!["next_cursor".to_string()]));
+        }
+    }
+
+    #[test]
+    fn a_reference_that_declares_nothing_fails_the_declared_standard() {
+        // An unresolvable ref cannot rule a token out, but neither can it be
+        // the declaration the strict caller insists on.
+        let schema = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"$ref": "#/$defs/Missing"}},
+        });
+
+        assert_eq!(
+            find_untyped(&schema, &schema, TOKENS),
+            Some(vec!["next_cursor".to_string()])
+        );
+        assert_eq!(find_declared(&schema, &schema, TOKENS), None);
     }
 
     #[test]
@@ -233,6 +349,6 @@ mod tests {
             },
         });
 
-        assert_eq!(find_response_cursor_path(&schema, &schema, TOKENS), None);
+        assert_eq!(find_untyped(&schema, &schema, TOKENS), None);
     }
 }

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -66,10 +66,12 @@ pub(in crate::v4) enum StringTypeRequirement {
     /// matching request parameter still has to be found before anything is
     /// committed, and descriptors routinely leave envelope metadata untyped.
     Untyped,
-    /// Require a declared `string`. For body next-URL detection, which has no
-    /// second signal: a property that is not a string reads back as `None` at
-    /// runtime, `advance_pagination_state` stops, and the query returns page
-    /// one with no error and no diagnostic.
+    /// Require a declared `string`, or a union of `string` and `null` and
+    /// nothing else. For body next-URL detection, which has no second signal:
+    /// a property that is not a string reads back as `None` at runtime,
+    /// `advance_pagination_state` stops, and the query returns page one with no
+    /// error and no diagnostic. A union that merely *permits* a string is not
+    /// enough — the response can still carry the other variant.
     Declared,
 }
 
@@ -148,14 +150,40 @@ fn property_holds_string(
         depth,
         MAX_DEPTH,
         |resolved, _, _| {
-            let declares_string = json_schema_type_contains(resolved, "string");
             Ok(match string_type {
-                StringTypeRequirement::Declared => declares_string,
-                StringTypeRequirement::Untyped => declares_string || resolved.get("type").is_none(),
+                StringTypeRequirement::Declared => declares_only_string(resolved),
+                StringTypeRequirement::Untyped => {
+                    json_schema_type_contains(resolved, "string") || resolved.get("type").is_none()
+                }
             })
         },
     )
     .unwrap_or(string_type == StringTypeRequirement::Untyped)
+}
+
+/// Whether every type the schema permits is one the runtime can read as a URL.
+///
+/// `json_schema_type_contains` would be too weak here: it asks whether `string`
+/// is *among* the permitted types, so a union like `["string", "integer"]`
+/// passes. That union is exactly the shape the strict requirement exists to
+/// reject — a response carrying the integer variant reads back as `None` and
+/// stops pagination after page one, which is the silent failure, not a louder
+/// version of it.
+///
+/// `null` is the one companion allowed, because that is how a descriptor says
+/// "absent on the last page" — Graph's `@odata.nextLink` is declared
+/// `{type: string, nullable: true}` — and the runtime already treats an absent
+/// or empty link as the end of the collection.
+fn declares_only_string(schema: &Value) -> bool {
+    match schema.get("type") {
+        Some(Value::String(value)) => value == "string",
+        Some(Value::Array(values)) => {
+            let mut permitted = values.iter().filter_map(Value::as_str);
+            let all_readable = permitted.all(|value| value == "string" || value == "null");
+            all_readable && json_schema_type_contains(schema, "string")
+        }
+        _ => false,
+    }
 }
 
 /// Descent is the opposite case: a property that cannot be resolved into an
@@ -318,6 +346,45 @@ mod tests {
         ] {
             assert_eq!(found, Some(vec!["next_cursor".to_string()]));
         }
+    }
+
+    #[test]
+    fn the_declared_standard_rejects_a_union_that_permits_a_non_string() {
+        // Merely permitting a string is not enough: a response carrying the
+        // other variant reads back as `None` and stops after page one, which
+        // is the silent failure the strict standard exists to prevent.
+        let union = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"type": ["string", "integer"]}},
+        });
+
+        assert_eq!(
+            find_untyped(&union, &union, TOKENS),
+            Some(vec!["next_cursor".to_string()])
+        );
+        assert_eq!(find_declared(&union, &union, TOKENS), None);
+
+        // `null` is the one companion allowed, because that is how a
+        // descriptor says "absent on the last page", and the runtime already
+        // treats an absent link as the end.
+        let nullable = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"type": ["string", "null"]}},
+        });
+
+        assert_eq!(
+            find_declared(&nullable, &nullable, TOKENS),
+            Some(vec!["next_cursor".to_string()])
+        );
+
+        // A union with no string at all fails both standards.
+        let no_string = json!({
+            "type": "object",
+            "properties": {"next_cursor": {"type": ["integer", "null"]}},
+        });
+
+        assert_eq!(find_declared(&no_string, &no_string, TOKENS), None);
+        assert_eq!(find_untyped(&no_string, &no_string, TOKENS), None);
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 use crate::v4::ir::{IrOperationInput, IrOperationOutput, IrScalarType, OutputCardinality};
-use crate::v4::response_cursors::find_response_cursor_path;
+use crate::v4::response_cursors::{StringTypeRequirement, find_response_cursor_path};
 
 /// Pagination contracts a tool's arguments and output schema describe, before
 /// any decision about whether its result is read as a list.
@@ -46,8 +46,12 @@ fn infer_mcp_pagination(
     // A tool's output schema is its own reference root, so `$defs` entries
     // resolve against the schema itself.
     let output_schema = output_schema?;
-    let response_cursor_path =
-        find_response_cursor_path(output_schema, output_schema, RESPONSE_CURSOR_TOKENS)?;
+    let response_cursor_path = find_response_cursor_path(
+        output_schema,
+        output_schema,
+        RESPONSE_CURSOR_TOKENS,
+        StringTypeRequirement::Untyped,
+    )?;
     Some(McpPaginationSpec {
         cursor_arg: cursor_arg.to_string(),
         response_cursor_path,

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -371,12 +371,24 @@ fn detect_pagination_contract(
 /// envelope.
 ///
 /// Two signals qualify. Binding a request input — a cursor, offset, page, or
-/// page-size parameter — says the caller can ask for another page. A response
-/// path holding a whole next-page URL says the response hands one back
-/// unprompted; that path comes out of this operation's own response schema, so
-/// it is evidence about this response rather than about the API at large. Graph
-/// needs the second signal: `{"@odata.nextLink": ..., "value": [...]}` on an
-/// operation that declares no `$top` binds nothing at all.
+/// page-size parameter — says the caller can ask for another page. A next-page
+/// URL *at the response root* says the response hands one back unprompted; that
+/// path comes out of this operation's own response schema, so it is evidence
+/// about this response rather than about the API at large. Graph needs the
+/// second signal: `{"@odata.nextLink": ..., "value": [...]}` on an operation
+/// that declares no `$top` binds nothing at all.
+///
+/// Root-only is the whole point of the length test. `find_response_cursor_path`
+/// descends into nested objects up to depth 8, but what this unlocks —
+/// `accept_fallback` in `infer_wrapped_list_row_path` — applies at the root, so
+/// deep evidence would answer a question it was not asked. A singleton
+/// `GET /tracks/{id}` returning `{id, tags: [...], links: {next_href}}` matches
+/// `nexthref` two levels down; counting that would fire the sole-array fallback
+/// and promote `tags` to the whole relation, discarding the declared resource.
+/// Both shapes this exists for — `@odata.nextLink` and Stripe's
+/// `next_page_url` — sit at the root as single segments, and a legitimate
+/// `{data, meta: {next_url}}` still qualifies through `meta` in the
+/// metadata-object lexicon.
 ///
 /// A bare `Link` header is neither. It reads no input, and providers declare
 /// that header on singleton resources too — GitHub does, on
@@ -388,7 +400,7 @@ fn signals_page_envelope(contract: &PaginationSpec) -> bool {
         || contract.offset_param.is_some()
         || contract.page_param.is_some()
         || contract.page_size.is_some()
-        || !contract.next_url_path.is_empty()
+        || contract.next_url_path.len() == 1
 }
 
 fn detect_link_header_pagination(

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -11,7 +11,7 @@ use crate::v4::ir::{
 };
 use crate::v4::lookup_keys::infer_rest_lookup_keys;
 use crate::v4::naming::normalize_identifier;
-use crate::v4::response_cursors::find_response_cursor_path;
+use crate::v4::response_cursors::{StringTypeRequirement, find_response_cursor_path};
 use crate::v4::surfaces::json_schema::{
     json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
     json_schema_type_display,
@@ -428,8 +428,19 @@ fn detect_link_header_pagination(
 ///
 /// Ranked above cursor-query and offset detection because a whole URL is
 /// unambiguous: there is no guessing which request parameter a token belongs
-/// in, and no risk of driving the endpoint with a parameter it rejects. It
-/// stays below `Link` header detection, which is a declared, cheaper signal.
+/// in, and no risk of driving the endpoint with a parameter it rejects. Graph
+/// declares `$skip` on collections that reject it at runtime, so that ordering
+/// is load-bearing, not a preference. It stays below `Link` header detection,
+/// which is a declared, cheaper signal.
+///
+/// Outranking the input-corroborated modes is what makes
+/// [`StringTypeRequirement::Declared`] necessary. Every other detector has a
+/// second signal — a matching cursor, offset or page parameter — so a name-only
+/// false positive costs them nothing. This one commits on the name alone, and
+/// if the property does not hold a string `Value::as_str` reads `None` at
+/// runtime, pagination stops, and the query returns page one with no error and
+/// no diagnostic, where offset pagination would have fetched everything.
+/// Requiring the descriptor to declare `string` is the second signal.
 fn detect_next_url_body_pagination(
     document: &Value,
     inputs: &[IrOperationInput],
@@ -455,8 +466,12 @@ fn detect_next_url_body_pagination(
         "nexthref",
     ];
 
-    let next_url_path =
-        find_response_cursor_path(document, &context.schema, RESPONSE_NEXT_URL_BODY_TOKENS)?;
+    let next_url_path = find_response_cursor_path(
+        document,
+        &context.schema,
+        RESPONSE_NEXT_URL_BODY_TOKENS,
+        StringTypeRequirement::Declared,
+    )?;
     Some(PaginationSpec {
         mode: PaginationMode::NextUrlBody,
         page_size: detect_page_size(inputs),
@@ -513,9 +528,16 @@ fn detect_cursor_query_pagination(
     // The pagination context holds the response schema with only its own `$ref`
     // resolved, so the document is still needed to see inside a referenced
     // metadata sibling.
-    let response_cursor_path =
-        find_response_cursor_path(document, &context.schema, RESPONSE_CURSOR_TOKENS)
-            .unwrap_or_default();
+    // Permissive about the declared type, unlike body next-URL detection: this
+    // detector has already found a cursor query parameter to corroborate the
+    // name, and descriptors routinely leave envelope metadata untyped.
+    let response_cursor_path = find_response_cursor_path(
+        document,
+        &context.schema,
+        RESPONSE_CURSOR_TOKENS,
+        StringTypeRequirement::Untyped,
+    )
+    .unwrap_or_default();
     let response_cursor_header = response_cursor_header(context);
     if response_cursor_path.is_empty() && response_cursor_header.is_none() {
         return None;

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -361,6 +361,7 @@ fn detect_pagination_contract(
     context: &OpenApiResponsePaginationContext,
 ) -> Option<PaginationSpec> {
     detect_link_header_pagination(inputs, context)
+        .or_else(|| detect_next_url_body_pagination(document, inputs, context))
         .or_else(|| detect_cursor_query_pagination(document, inputs, context))
         .or_else(|| detect_offset_pagination(inputs))
         .or_else(|| detect_page_pagination(inputs))
@@ -396,6 +397,48 @@ fn detect_link_header_pagination(
         page_param: page_input.map(|input| input.name.clone()),
         page_start: page_input.and_then(numeric_input_default).unwrap_or(1),
         next_url_header,
+        ..PaginationSpec::default()
+    })
+}
+
+/// Detects a response body that hands back the complete URL of the next page,
+/// as `OData` does with `@odata.nextLink`.
+///
+/// Ranked above cursor-query and offset detection because a whole URL is
+/// unambiguous: there is no guessing which request parameter a token belongs
+/// in, and no risk of driving the endpoint with a parameter it rejects. It
+/// stays below `Link` header detection, which is a declared, cheaper signal.
+fn detect_next_url_body_pagination(
+    document: &Value,
+    inputs: &[IrOperationInput],
+    context: &OpenApiResponsePaginationContext,
+) -> Option<PaginationSpec> {
+    /// Response property names that carry a whole URL rather than a token.
+    ///
+    /// Deliberately narrower than `RESPONSE_NEXT_URL_HEADER_TOKENS`, which
+    /// accepts bare `next`/`nextpage`. A *header* called `Next` is nearly
+    /// always a URL; a *body field* called `next` is very often a continuation
+    /// token, and those must keep falling through to cursor-query detection so
+    /// they end up in the request parameter that expects them. Resist
+    /// harmonising the two lists.
+    const RESPONSE_NEXT_URL_BODY_TOKENS: &[&str] = &[
+        "odatanextlink",
+        "nextlink",
+        "nexturl",
+        "nexturi",
+        "nextpageurl",
+        "nextpageuri",
+        "nextpagelink",
+        "nextpagehref",
+        "nexthref",
+    ];
+
+    let next_url_path =
+        find_response_cursor_path(document, &context.schema, RESPONSE_NEXT_URL_BODY_TOKENS)?;
+    Some(PaginationSpec {
+        mode: PaginationMode::NextUrlBody,
+        page_size: detect_page_size(inputs),
+        next_url_path,
         ..PaginationSpec::default()
     })
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -53,7 +53,7 @@ impl OpenApiImporter<'_> {
         let contract = detect_pagination_contract(self.document, &parameters, &pagination_context);
         let row_path = self.infer_row_path(
             raw_operation_id.unwrap_or(&operation_id),
-            contract.as_ref().is_some_and(binds_pagination_input),
+            contract.as_ref().is_some_and(signals_page_envelope),
             &pagination_context,
             &output,
         );
@@ -367,18 +367,28 @@ fn detect_pagination_contract(
         .or_else(|| detect_page_pagination(inputs))
 }
 
-/// Whether a detected contract binds any request input.
+/// Whether a detected contract is evidence that the response is a page
+/// envelope.
 ///
-/// Only this narrower question is envelope evidence. `Link` header detection
-/// reads no input at all, and providers declare that header on singleton
-/// resources too — GitHub does, on `GET /orgs/{org}/actions/hosted-runners/{id}`
-/// among others. Treating a bare header as evidence would promote a resource's
-/// incidental array, such as that runner's `public_ips`, to the whole relation.
-fn binds_pagination_input(contract: &PaginationSpec) -> bool {
+/// Two signals qualify. Binding a request input — a cursor, offset, page, or
+/// page-size parameter — says the caller can ask for another page. A response
+/// path holding a whole next-page URL says the response hands one back
+/// unprompted; that path comes out of this operation's own response schema, so
+/// it is evidence about this response rather than about the API at large. Graph
+/// needs the second signal: `{"@odata.nextLink": ..., "value": [...]}` on an
+/// operation that declares no `$top` binds nothing at all.
+///
+/// A bare `Link` header is neither. It reads no input, and providers declare
+/// that header on singleton resources too — GitHub does, on
+/// `GET /orgs/{org}/actions/hosted-runners/{id}` among others. Treating it as
+/// evidence would promote a resource's incidental array, such as that runner's
+/// `public_ips`, to the whole relation.
+fn signals_page_envelope(contract: &PaginationSpec) -> bool {
     contract.cursor_param.is_some()
         || contract.offset_param.is_some()
         || contract.page_param.is_some()
         || contract.page_size.is_some()
+        || !contract.next_url_path.is_empty()
 }
 
 fn detect_link_header_pagination(

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -301,11 +301,9 @@ fn import_source_rows(
                 next_url_header: pagination
                     .and_then(|spec| spec.next_url_header.clone())
                     .unwrap_or_default(),
-                // Always empty today: no pagination contract reads a next URL
-                // out of the response body yet. The column exists so the
-                // baseline captured before that lands has the same shape as the
-                // reports compared against it.
-                next_url_path: String::new(),
+                next_url_path: pagination
+                    .map(|spec| join_path(&spec.next_url_path))
+                    .unwrap_or_default(),
             }
         })
         .collect())
@@ -429,6 +427,7 @@ fn mode_name(mode: PaginationMode) -> String {
         PaginationMode::Page => "page",
         PaginationMode::Offset => "offset",
         PaginationMode::LinkHeader => "link_header",
+        PaginationMode::NextUrlBody => "next_url_body",
     }
     .to_owned()
 }


### PR DESCRIPTION
OData APIs paginate by returning the complete URL of the next page in the response body -- Microsoft Graph's `@odata.nextLink` -- and no pagination mode could express that. `next_url_header` reads response headers only, and `cursor_query` needs a request parameter to place a token into, but there is no token here: there is a whole URL, and the server expects it requested as it stands.

## The new mode

`next_url_body` reads that URL from a declared response path and requests it verbatim, reusing the same-origin check the Link-header path already applies. That check matters more here than it does for a header, because the URL now comes out of the response body, so a compromised response must not be able to redirect a credentialed request off-origin.

Both absolute URLs and relative links are accepted. A relative link is resolved against the request URL that returned it -- `?page=2` resolves against the current path -- and only then checked for origin.

## How it ranks against the other detectors

Inference ranks it above cursor-query and offset detection. A whole URL is unambiguous -- there is no guessing which parameter a token belongs in, and no risk of driving an endpoint with a parameter it rejects. Graph declares `$skip` on collections that reject it at runtime, so that ordering is load-bearing rather than a preference. It stays below `Link` header detection, which is declared and cheaper.

Outranking the input-corroborated modes is also why this detector alone requires the descriptor to declare the property a `string`. Every other detector has a second signal -- a matching cursor, offset or page parameter -- so a name-only false positive costs them nothing. This one commits on the name alone, and the shared schema walk otherwise accepts a property that declares no type at all. If the property turns out not to hold a string, `Value::as_str` reads `None` at runtime, pagination stops, and the query returns page one with no error and no diagnostic, where offset pagination would have fetched everything.

The body name lexicon is deliberately narrower than the header one: a header called `Next` is nearly always a URL, while a body field called `next` is very often a token, and tokens must keep falling through to cursor-query.

## What counts as a page envelope

A next-page URL at the response root is now evidence that the response is an envelope, independently of whether the operation binds a page input. Graph needs that: `{"@odata.nextLink": ..., "value": [...]}` on an operation with no `$top` binds nothing at all, so without it there is nothing to unwrap `value` on -- and a contract only survives once the response reads as a list, so the pagination would have been discarded along with the row path.

Root-only, deliberately. The walk descends into nested objects up to depth 8, but what this unlocks applies at the response root, so deep evidence would answer a question it was not asked. A singleton `GET /tracks/{id}` returning `{id, tags: [...], links: {next_href}}` would otherwise have `tags` promoted to the whole relation and the declared resource discarded.

## Making the fetch loop exhaustive

The fetch loop resolves the next URL once and derives whether it is following one from that single binding, rather than testing the mode at two call sites. Neither site was an exhaustive match, so a mode added later would have built cleanly, reported `next_url_body` in its artifact, and silently stopped after page one. `pagination_next_url_body` is the test that catches exactly that, and it fails without the change.

## Bounding the walk

Unlike `link_header`, where the server must explicitly emit `rel="next"`, this mode is inferred from a property *name*, so the field may not be a next-page link at all -- a related-resource URL the heuristic picked up, or an API that echoes the collection URL instead of omitting the link on its last page. Two stops bound it: a link resolving to the request URL that carried it is not progress, and an empty page ends the walk whatever the body claims. Without them either shape meant `max_pages` credentialed requests and `max_pages` pages of duplicate rows before the query finally errored.

## Breaking change

`OPERATION_METADATA_GENERATOR_VERSION` moves `operation-metadata-v2` -> `operation-metadata-v3` and `PROJECTION_GENERATOR_VERSION` moves `derive-read-v11` -> `derive-read-v12`.

Both bumps invalidate existing materializations, which are regenerated on next import. Anyone holding an `operation-metadata.yaml` or a projection override copied from the previous generator versions will get the "override was copied from generator version ... but this Coral build expects ..." warning until they re-copy it.

## Impact

Measured with `cargo run -p xtask -- v4-metadata-report` (#1996) across all 20,673 operations in the six importable v4 sources, diffed against this stack's base.

**5 Stripe v2 operations** change, all in the same direction -- they return `next_page_url` and were previously reporting `mode: none` with no row path, so each returned a single envelope row:

| Operation | Row path | Mode | `limit` |
| --- | --- | --- | --- |
| `getv2commerceproductcatalogimports` | `""` -> `data` | `none` -> `next_url_body` | lookup key -> `page_size_param` |
| `getv2coreaccounts` | `""` -> `data` | `none` -> `next_url_body` | lookup key -> `page_size_param` |
| `getv2coreaccountsaccountidpersons` | `""` -> `data` | `none` -> `next_url_body` | lookup key -> `page_size_param` |
| `getv2coreeventdestinations` | `""` -> `data` | `none` -> `next_url_body` | lookup key -> `page_size_param` |
| `getv2coreevents` | `""` -> `data` | `none` -> `next_url_body` | lookup key -> `page_size_param` |

Nothing else in the catalog moves. The envelope-evidence widening does not reach Microsoft Graph here: its collection responses are `allOf`-composed, and nothing folds that until #1998, so all 16,702 Graph operations still report `mode: none` at this head.

The `limit` column above is the reason #1996 grew a `lookup_keys` column in this stack. The allowlist is whatever query parameters pagination did not claim, so a pagination edit that changes which detector wins hands its displaced parameters to the dependent-join planner -- and that half of the diff was previously invisible.

Claude-Session: https://claude.ai/code/session_01Rr2wBfz6dZUWkQF58nVBrR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
