### PR TITLE
feat(spec)!: read allOf-composed responses as page envelopes

### DIFF
--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -5,7 +5,7 @@
 
 pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v7";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v8";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
 pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,8 +7,8 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v7";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
-pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v3";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v12";
+pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 
 use super::*;
 use crate::{
@@ -1231,6 +1232,198 @@ components:
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.message.contains("allOf property")),
+        "{:?}",
+        operation.diagnostics
+    );
+    assert_eq!(operation.output.type_ref, "json");
+}
+
+/// A branch may be an alias — `{$ref: Alias}` where `Alias` is itself
+/// `{$ref: Base}` — which one hop of resolution leaves still holding a `$ref`,
+/// with nothing to contribute.
+///
+/// Inference resolves chains, so a branch dropped here would make a row path it
+/// found look absent from the imported type, and `infer_row_path` would discard
+/// the path.
+#[test]
+fn importer_folds_all_of_branches_through_alias_refs() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: aliased_all_of
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Page'}
+components:
+  schemas:
+    Base:
+      type: object
+      properties:
+        next_cursor: {type: string}
+    Alias: {$ref: '#/components/schemas/Base'}
+    Page:
+      type: object
+      allOf:
+        - {$ref: '#/components/schemas/Alias'}
+        - type: object
+          properties:
+            items:
+              type: array
+              items: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let operation = ir.operations.first().expect("operation");
+    let row_type = ir
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type");
+    let IrTypeShape::Object { fields } = &row_type.shape else {
+        panic!("the composed page should import as an object: {row_type:?}");
+    };
+    let names = fields
+        .iter()
+        .map(|field| field.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        names.contains(&"next_cursor"),
+        "the aliased base contributes its properties: {names:?}"
+    );
+    assert!(names.contains(&"items"), "{names:?}");
+}
+
+/// The fold tracks the refs it is resolving, so a self-referential branch is
+/// named as a cycle rather than recursing until the depth cap stops it.
+#[test]
+fn importer_reports_a_cyclic_all_of_branch() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: cyclic_all_of
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Loop'}
+components:
+  schemas:
+    Loop:
+      type: object
+      allOf:
+        - {$ref: '#/components/schemas/Loop'}
+"
+        .as_bytes(),
+    )
+    .expect("a cyclic allOf imports with diagnostics rather than recursing");
+
+    let operation = ir.operations.first().expect("operation");
+    assert!(
+        operation
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("cyclic")),
+        "the diagnostic must name the cycle, not a depth ceiling: {:?}",
+        operation.diagnostics
+    );
+    assert_eq!(operation.output.type_ref, "json");
+}
+
+/// Composition past the cap reports its own ceiling. Reusing the property
+/// comparison error sent whoever read it to a constant eight times larger.
+#[test]
+fn importer_reports_all_of_composition_past_the_depth_cap() {
+    let mut schemas = String::from(
+        r"
+components:
+  schemas:
+    Deep0:
+      type: object
+      properties:
+        id: {type: string}
+",
+    );
+    for level in 1..=12 {
+        writeln!(
+            schemas,
+            "    Deep{level}:\n      type: object\n      allOf:\n        - {{$ref: '#/components/schemas/Deep{}'}}",
+            level - 1
+        )
+        .expect("writing to a String cannot fail");
+    }
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: deep_all_of
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let document = format!(
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {{$ref: '#/components/schemas/Deep12'}}
+{schemas}"
+    );
+    let ir = import_openapi_surface(v4, &v4.surface, document.as_bytes()).expect("import");
+
+    let operation = ir.operations.first().expect("operation");
+    assert!(
+        operation
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("nests past")),
         "{:?}",
         operation.diagnostics
     );

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2710,3 +2710,248 @@ components:
         "Graph rejects $skip on several collections; the next link is the only contract that works"
     );
 }
+
+/// Graph nests its envelope bases: a delta collection response composes
+/// `BaseDeltaFunctionResponse`, which is itself an `allOf` over
+/// `BaseCollectionPaginationCountResponse`. Row-path inference folds that whole
+/// tree, so type import has to fold it too — otherwise the imported type is
+/// missing the properties the inferred path names and the path is discarded.
+#[test]
+fn importer_folds_nested_all_of_envelope_bases() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: graph
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://graph.microsoft.com/v1.0
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /me/chats/delta:
+    get:
+      operationId: me.chats.delta
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatDeltaCollectionResponse'
+components:
+  schemas:
+    BaseCollectionPaginationCountResponse:
+      type: object
+      properties:
+        '@odata.count': {type: integer, format: int64, nullable: true}
+        '@odata.nextLink': {type: string, nullable: true}
+    BaseDeltaFunctionResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseCollectionPaginationCountResponse'
+        - type: object
+          properties:
+            '@odata.deltaLink': {type: string, nullable: true}
+    microsoft.graph.chat:
+      type: object
+      properties:
+        id: {type: string}
+    microsoft.graph.chatDeltaCollectionResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseDeltaFunctionResponse'
+        - type: object
+          properties:
+            value:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.chat'
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    assert_eq!(imported_row_path(&ir, "me_chats_delta"), ["value"]);
+
+    let pagination = imported_rest_pagination(&ir, "me_chats_delta");
+    assert_eq!(pagination.mode, PaginationMode::NextUrlBody);
+    assert_eq!(pagination.next_url_path, ["@odata.nextLink"]);
+
+    // The nested base contributes `@odata.count`/`@odata.nextLink` and the
+    // intermediate one `@odata.deltaLink`. Folding only the immediate branches
+    // kept `value` alone.
+    let IrTypeShape::Object { fields } = &ir
+        .semantic_ir
+        .types
+        .iter()
+        .find(|ty| ty.id == "me_chats_delta_row")
+        .expect("response type")
+        .shape
+    else {
+        panic!("expected an object response type");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(
+        names,
+        [
+            "@odata.count",
+            "@odata.deltaLink",
+            "@odata.nextLink",
+            "value"
+        ]
+    );
+}
+
+/// `properties` declared alongside `allOf` are as much part of the schema as
+/// the branches are.
+///
+/// Row-path inference reads both, so before type import did too, the inferred
+/// `value` path was rejected as absent from the imported type and the whole
+/// collection collapsed to a single JSON row.
+#[test]
+fn importer_keeps_properties_declared_beside_all_of() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: graph
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://graph.microsoft.com/v1.0
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /me/chats:
+    get:
+      operationId: me.listChats
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatCollectionResponse'
+components:
+  schemas:
+    BaseCollectionPaginationCountResponse:
+      type: object
+      properties:
+        '@odata.count': {type: integer, format: int64, nullable: true}
+        '@odata.nextLink': {type: string, nullable: true}
+    microsoft.graph.chat:
+      type: object
+      properties:
+        id: {type: string}
+    microsoft.graph.chatCollectionResponse:
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/microsoft.graph.chat'
+      allOf:
+        - $ref: '#/components/schemas/BaseCollectionPaginationCountResponse'
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    assert_eq!(imported_row_path(&ir, "me_listchats"), ["value"]);
+}
+
+/// A subtype re-declaring an inherited property to pin an annotation is not a
+/// conflict.
+///
+/// Every Graph type re-declares the `@odata.type` discriminator with its own
+/// `default`. Comparing declarations byte-for-byte reads that as two branches
+/// disagreeing and discards the whole type, which costs every column rather
+/// than the one property — so the comparison is on validation semantics, and
+/// [`importer_warns_for_openapi_all_of_property_conflicts`] still holds for branches
+/// that genuinely disagree.
+#[test]
+fn importer_accepts_annotation_only_redeclaration_across_all_of_levels() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: graph
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://graph.microsoft.com/v1.0
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /me/drive:
+    get:
+      operationId: me.getDrive
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.drive'
+components:
+  schemas:
+    microsoft.graph.entity:
+      type: object
+      properties:
+        id: {type: string}
+        '@odata.type': {type: string}
+    microsoft.graph.baseItem:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.entity'
+        - type: object
+          properties:
+            name: {type: string}
+            webUrl: {type: string}
+    microsoft.graph.drive:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/microsoft.graph.baseItem'
+        - type: object
+          properties:
+            driveType: {type: string}
+            '@odata.type': {type: string, default: '#microsoft.graph.drive'}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let IrTypeShape::Object { fields } = &ir
+        .semantic_ir
+        .types
+        .iter()
+        .find(|ty| ty.id == "me_getdrive_row")
+        .expect("drive response type")
+        .shape
+    else {
+        panic!("a conflict would have left the type as opaque JSON");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["@odata.type", "driveType", "id", "name", "webUrl"],
+        "the inherited columns must survive two levels of composition"
+    );
+}

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2904,6 +2904,90 @@ components:
     );
 }
 
+/// The fixture above declares only `$top` and `$skip`, which is not what a real
+/// Graph collection looks like: they also declare a boolean `$count`.
+///
+/// `find_numeric_query_input` picks the first candidate-named input and only
+/// then filters by type, so `$count` is chosen and rejected and `$top` is never
+/// reached — page-size detection finds nothing. Pinning it here so the
+/// follow-up that fixes the ordering has an assertion to flip; pagination
+/// itself is unaffected, since the next link carries the paging state and Coral
+/// just accepts Graph's server-side default page size.
+#[test]
+fn importer_misses_the_page_size_a_boolean_count_parameter_masks() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: graph
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://graph.microsoft.com/v1.0
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /me/chats:
+    get:
+      operationId: me.listChats
+      parameters:
+        - {name: $top, in: query, schema: {type: integer}}
+        - {name: $skip, in: query, schema: {type: integer}}
+        - {name: $count, in: query, schema: {type: boolean}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatCollectionResponse'
+components:
+  schemas:
+    BaseCollectionPaginationCountResponse:
+      title: Base collection pagination and count responses
+      type: object
+      properties:
+        '@odata.count': {type: integer, format: int64, nullable: true}
+        '@odata.nextLink': {type: string, nullable: true}
+    microsoft.graph.chat:
+      type: object
+      properties:
+        id: {type: string}
+        topic: {type: string}
+    microsoft.graph.chatCollectionResponse:
+      title: Collection of chat
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseCollectionPaginationCountResponse'
+        - type: object
+          properties:
+            value:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.chat'
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    // The collection still reads as a paginated row table — only the page size
+    // is lost.
+    assert_eq!(imported_row_path(&ir, "me_listchats"), ["value"]);
+    let pagination = imported_rest_pagination(&ir, "me_listchats");
+    assert_eq!(pagination.mode, PaginationMode::NextUrlBody);
+    assert_eq!(pagination.next_url_path, ["@odata.nextLink"]);
+    assert!(
+        pagination.page_size.is_none(),
+        "boolean $count sorts ahead of $top and masks it; flip this when \
+         find_numeric_query_input filters by type before choosing"
+    );
+}
+
 /// Graph nests its envelope bases: a delta collection response composes
 /// `BaseDeltaFunctionResponse`, which is itself an `allOf` over
 /// `BaseCollectionPaginationCountResponse`. Row-path inference folds that whole

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2624,3 +2624,89 @@ paths:
         "a contract only survives once the response reads as a list"
     );
 }
+
+/// End to end on the Microsoft Graph shape: an `allOf` envelope of a shared
+/// pagination base and a `value` array, with `$top`/`$skip` both declared.
+///
+/// The `offset_param` assertion is the regression guard for the ordering
+/// constraint. Graph declares `$skip` on collections that reject it at runtime,
+/// so if body next-URL detection ever stopped winning, these tables would go
+/// from returning one page to returning an error.
+#[test]
+fn importer_reads_odata_collections_as_paginated_row_tables() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: graph
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://graph.microsoft.com/v1.0
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /me/chats:
+    get:
+      operationId: me.listChats
+      parameters:
+        - {name: $top, in: query, schema: {type: integer}}
+        - {name: $skip, in: query, schema: {type: integer}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/microsoft.graph.chatCollectionResponse'
+components:
+  schemas:
+    BaseCollectionPaginationCountResponse:
+      title: Base collection pagination and count responses
+      type: object
+      properties:
+        '@odata.count': {type: integer, format: int64, nullable: true}
+        '@odata.nextLink': {type: string, nullable: true}
+    microsoft.graph.chat:
+      type: object
+      properties:
+        id: {type: string}
+        topic: {type: string}
+    microsoft.graph.chatCollectionResponse:
+      title: Collection of chat
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseCollectionPaginationCountResponse'
+        - type: object
+          properties:
+            value:
+              type: array
+              items:
+                $ref: '#/components/schemas/microsoft.graph.chat'
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    assert_eq!(imported_row_path(&ir, "me_listchats"), ["value"]);
+
+    let pagination = imported_rest_pagination(&ir, "me_listchats");
+    assert_eq!(pagination.mode, PaginationMode::NextUrlBody);
+    assert_eq!(pagination.next_url_path, ["@odata.nextLink"]);
+    assert_eq!(
+        pagination
+            .page_size
+            .as_ref()
+            .and_then(|size| size.query_param.as_deref()),
+        Some("$top")
+    );
+    assert!(
+        pagination.offset_param.is_none(),
+        "Graph rejects $skip on several collections; the next link is the only contract that works"
+    );
+}

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -104,17 +104,21 @@ fn cursor_path<'a>(
             else {
                 return Ok(None);
             };
-            for (name, property) in &view.properties {
-                if name_tokens.contains(&normalized_name(name).as_str())
-                    && property_holds_string(
-                        root,
-                        property,
-                        string_type,
-                        resolving_refs,
-                        next_depth,
-                    )
-                {
-                    return Ok(Some(vec![name.clone()]));
+            // Tokens outside, so a response declaring two of them picks by
+            // `name_tokens` order rather than by property name.
+            for token in name_tokens {
+                for (name, property) in &view.properties {
+                    if normalized_name(name) == *token
+                        && property_holds_string(
+                            root,
+                            property,
+                            string_type,
+                            resolving_refs,
+                            next_depth,
+                        )
+                    {
+                        return Ok(Some(vec![name.clone()]));
+                    }
                 }
             }
             for (name, property) in &view.properties {
@@ -450,6 +454,32 @@ mod tests {
             Some(vec!["next_cursor".to_string()])
         );
         assert_eq!(find_declared(&schema, &schema, TOKENS), None);
+    }
+
+    /// Callers rank their lexicons — `odatanextlink` ahead of `nexthref`,
+    /// `nextcursor` ahead of `endcursor` — so the rank has to beat the
+    /// alphabetical order of the property names.
+    #[test]
+    fn prefers_the_earlier_token_over_the_earlier_property_name() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "end_cursor": {"type": "string"},
+                "next_cursor": {"type": "string"},
+            },
+        });
+
+        assert_eq!(
+            find_untyped(&schema, &schema, &["nextcursor", "endcursor"]),
+            Some(vec!["next_cursor".to_string()])
+        );
+
+        // Reversing the list reverses the answer: the ranking is the decision,
+        // not the spelling.
+        assert_eq!(
+            find_untyped(&schema, &schema, &["endcursor", "nextcursor"]),
+            Some(vec!["end_cursor".to_string()])
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -28,7 +28,8 @@ use std::collections::BTreeSet;
 use serde_json::Value;
 
 use crate::v4::surfaces::json_schema::{
-    JsonSchemaWalkError, json_schema_type_contains, with_resolved_json_schema,
+    JsonSchemaWalkError, json_schema_type_contains, merged_all_of_object_view,
+    with_resolved_json_schema,
 };
 
 const MAX_DEPTH: usize = 8;
@@ -92,10 +93,18 @@ fn cursor_path<'a>(
         depth,
         MAX_DEPTH,
         |resolved, resolving_refs, next_depth| {
-            let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
+            // Folding `allOf` keeps this walk agreeing with wrapped-list
+            // inference: an envelope assembled from a shared pagination base
+            // declares its cursor on a branch, not on the schema itself. If one
+            // half of the decision could see through composition and the other
+            // could not, an operation would be presented as a paginated table
+            // that silently stops after its first page.
+            let Some(view) =
+                merged_all_of_object_view(root, resolved, resolving_refs, next_depth, MAX_DEPTH)
+            else {
                 return Ok(None);
             };
-            for (name, property) in properties {
+            for (name, property) in &view.properties {
                 if name_tokens.contains(&normalized_name(name).as_str())
                     && property_holds_string(
                         root,
@@ -108,10 +117,14 @@ fn cursor_path<'a>(
                     return Ok(Some(vec![name.clone()]));
                 }
             }
-            for (name, property) in properties {
+            for (name, property) in &view.properties {
                 if !property_is_object(root, property, resolving_refs, next_depth) {
                     continue;
                 }
+                // A branch that cannot be walked — unresolvable, cyclic, too
+                // deep — declares no cursor, which is not a reason to abandon
+                // its siblings. This matches how `property_holds_string` and
+                // `property_is_object` already treat the same failures.
                 if let Some(mut path) = cursor_path(
                     root,
                     property,
@@ -119,7 +132,10 @@ fn cursor_path<'a>(
                     string_type,
                     resolving_refs,
                     next_depth,
-                )? {
+                )
+                .ok()
+                .flatten()
+                {
                     path.insert(0, name.clone());
                     return Ok(Some(path));
                 }
@@ -208,7 +224,11 @@ fn property_is_object(
         resolving_refs,
         depth,
         MAX_DEPTH,
-        |resolved, _, _| Ok(json_schema_type_contains(resolved, "object")),
+        |resolved, resolving_refs, next_depth| {
+            Ok(json_schema_type_contains(resolved, "object")
+                || merged_all_of_object_view(root, resolved, resolving_refs, next_depth, MAX_DEPTH)
+                    .is_some_and(|view| view.declares_type("object")))
+        },
     )
     .unwrap_or(false)
 }
@@ -446,5 +466,43 @@ mod tests {
         });
 
         assert_eq!(find_untyped(&schema, &schema, TOKENS), None);
+    }
+
+    /// The cursor walk and wrapped-list inference must agree about composed
+    /// envelopes. If only one of them could see through `allOf`, an operation
+    /// would be presented as a paginated table that stops after page one.
+    #[test]
+    fn finds_a_cursor_through_an_all_of_envelope() {
+        let schema = json!({
+            "$ref": "#/components/schemas/Page",
+            "components": {
+                "schemas": {
+                    "PaginationBase": {
+                        "type": "object",
+                        "properties": {"@odata.nextLink": {"type": "string"}},
+                    },
+                    "Page": {
+                        "type": "object",
+                        "allOf": [
+                            {"$ref": "#/components/schemas/PaginationBase"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"type": "array", "items": {"type": "object"}},
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        });
+
+        // The strict standard, because this is the body next-URL lexicon: an
+        // `allOf` branch still has to declare the property a string, and
+        // Graph's base does.
+        assert_eq!(
+            find_declared(&schema, &schema, &["odatanextlink"]),
+            Some(vec!["@odata.nextLink".to_string()])
+        );
     }
 }

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -229,9 +229,20 @@ fn property_is_object(
         depth,
         MAX_DEPTH,
         |resolved, resolving_refs, next_depth| {
-            Ok(json_schema_type_contains(resolved, "object")
-                || merged_all_of_object_view(root, resolved, resolving_refs, next_depth, MAX_DEPTH)
-                    .is_some_and(|view| view.declares_type("object")))
+            if json_schema_type_contains(resolved, "object") {
+                return Ok(true);
+            }
+            // Without `allOf` the merge has only this schema to collect, so it
+            // could only re-derive the answer above. Skipping it matters here
+            // because this runs for every property on every walked level, and
+            // building the view clones the properties of each one.
+            if resolved.get("allOf").is_none() {
+                return Ok(false);
+            }
+            Ok(
+                merged_all_of_object_view(root, resolved, resolving_refs, next_depth, MAX_DEPTH)
+                    .is_some_and(|view| view.declares_type("object")),
+            )
         },
     )
     .unwrap_or(false)

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -316,6 +316,149 @@ pub(crate) fn json_schema_scalar_type_or_string(schema: &Value) -> Option<IrScal
     json_schema_scalar_type_with_default(schema, Some("string"))
 }
 
+/// A schema's properties and declared types after folding its `allOf` branches
+/// together.
+#[derive(Debug, Default)]
+pub(crate) struct MergedObjectView {
+    /// Every `type` any branch declares. Usually one entry; an empty set means
+    /// no branch declared a type at all.
+    pub(crate) declared_types: BTreeSet<String>,
+    pub(crate) properties: BTreeMap<String, Value>,
+}
+
+impl MergedObjectView {
+    pub(crate) fn declares_type(&self, expected: &str) -> bool {
+        self.declared_types.contains(expected)
+    }
+}
+
+/// Folds a schema's `allOf` branches into one view of its properties.
+///
+/// Inference passes that ask shape questions of a response — is this a page
+/// envelope, does it carry a cursor — cannot answer them through a composed
+/// schema without this: the properties live on the branches, not the schema.
+/// `OData` collection responses are the motivating case, being uniformly
+/// `type: object` plus an `allOf` of a shared pagination base and the rows.
+///
+/// Only `allOf` is folded. `anyOf`, `oneOf`, and `not` describe alternation and
+/// negation rather than intersection, so there is no single property map to
+/// answer questions against, and this returns `None` for them — which is what
+/// the callers did for all composition before.
+///
+/// Returns `None` when the schema is not object-like, so callers can keep
+/// treating "not an object" and "cannot be read as an envelope" alike.
+///
+/// On duplicate property names the first branch wins, and no conflict is
+/// reported. This answers a heuristic question, so an annotation-only
+/// disagreement between branches must not discard the whole envelope. Type
+/// import has the opposite need and keeps its own exact merge.
+pub(crate) fn merged_all_of_object_view<'a>(
+    root: &'a Value,
+    schema: &'a Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+) -> Option<MergedObjectView> {
+    let mut view = MergedObjectView::default();
+    let mut alternation = false;
+    collect_all_of_branches(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        max_depth,
+        &mut view,
+        &mut alternation,
+    );
+    if alternation {
+        return None;
+    }
+
+    // An explicit `type: object` on any branch settles it. Failing that, a
+    // schema that declares no type at all but does declare properties is an
+    // object by convention, which is how JSON Schema is usually written.
+    let object_like = view.declares_type("object")
+        || (view.declared_types.is_empty() && !view.properties.is_empty());
+    object_like.then_some(view)
+}
+
+/// Walks the schema and its `allOf` members, accumulating types and properties.
+///
+/// An unresolvable, cyclic, or too-deep branch contributes nothing rather than
+/// abandoning the merge: its siblings may still describe the envelope. An
+/// alternation anywhere is different — it makes the whole merge meaningless, so
+/// it is recorded and the caller discards the view.
+fn collect_all_of_branches(
+    root: &Value,
+    schema: &Value,
+    resolving_refs: &mut BTreeSet<String>,
+    depth: usize,
+    max_depth: usize,
+    view: &mut MergedObjectView,
+    alternation: &mut bool,
+) {
+    // Discarded on purpose: a branch that cannot be walked contributes nothing,
+    // and its siblings still can.
+    let _unwalkable_branch = with_resolved_json_schema(
+        root,
+        schema,
+        resolving_refs,
+        depth,
+        max_depth,
+        |resolved, resolving_refs, next_depth| {
+            if schema_uses_alternation(resolved) {
+                *alternation = true;
+                return Ok(());
+            }
+            match resolved.get("type") {
+                Some(Value::String(value)) => {
+                    view.declared_types.insert(value.clone());
+                }
+                Some(Value::Array(values)) => {
+                    view.declared_types.extend(
+                        values
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToString::to_string),
+                    );
+                }
+                _ => {}
+            }
+            if let Some(properties) = resolved.get("properties").and_then(Value::as_object) {
+                for (name, property) in properties {
+                    view.properties
+                        .entry(name.clone())
+                        .or_insert_with(|| property.clone());
+                }
+            }
+            for branch in resolved
+                .get("allOf")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                collect_all_of_branches(
+                    root,
+                    branch,
+                    resolving_refs,
+                    next_depth,
+                    max_depth,
+                    view,
+                    alternation,
+                );
+            }
+            Ok(())
+        },
+    );
+}
+
+/// Whether the schema describes a choice between shapes rather than one shape.
+pub(crate) fn schema_uses_alternation(schema: &Value) -> bool {
+    ["anyOf", "oneOf", "not"]
+        .iter()
+        .any(|keyword| schema.get(*keyword).is_some())
+}
+
 pub(crate) fn json_schema_type_contains(schema: &Value, expected: &str) -> bool {
     match schema.get("type") {
         Some(Value::String(value)) => value == expected,

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -272,22 +272,6 @@ pub(crate) fn json_schema_default_to_string(value: &Value) -> String {
     }
 }
 
-pub(crate) fn merge_json_schema_properties_exact(
-    target: &mut BTreeMap<String, Value>,
-    source: BTreeMap<String, Value>,
-) -> Result<(), JsonSchemaComparisonError> {
-    for (name, property) in source {
-        if let Some(existing) = target.get(&name) {
-            if existing != &property {
-                return Err(JsonSchemaComparisonError::PropertyConflict(name));
-            }
-        } else {
-            target.insert(name, property);
-        }
-    }
-    Ok(())
-}
-
 pub(crate) fn merge_json_object_shape_annotation_insensitive(
     target: &mut JsonObjectShape,
     source: JsonObjectShape,
@@ -867,31 +851,6 @@ mod tests {
             Some("integer")
         );
         assert!(resolving_refs.is_empty());
-    }
-
-    #[test]
-    fn exact_property_merge_reports_conflict() {
-        let mut target = direct_json_object_shape(&json!({
-            "type": "object",
-            "properties": {
-                "query": {"type": "string"}
-            }
-        }))
-        .properties;
-        let source = direct_json_object_shape(&json!({
-            "type": "object",
-            "properties": {
-                "query": {"type": "integer"}
-            }
-        }))
-        .properties;
-
-        assert_eq!(
-            merge_json_schema_properties_exact(&mut target, source),
-            Err(JsonSchemaComparisonError::PropertyConflict(
-                "query".to_string()
-            ))
-        );
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -358,12 +358,19 @@ pub(crate) fn merged_all_of_object_view<'a>(
         return None;
     }
 
-    // An explicit `type: object` on any branch settles it. Failing that, a
-    // schema that declares no type at all but does declare properties is an
-    // object by convention, which is how JSON Schema is usually written.
-    let object_like = view.declares_type("object")
-        || (view.declared_types.is_empty() && !view.properties.is_empty());
-    object_like.then_some(view)
+    // Some branch has to declare `type: object`. Declaring `properties` is not
+    // enough on its own: in JSON Schema `properties` constrains an instance
+    // only if it happens to be an object, and asserts nothing about whether it
+    // is one — `{properties: {...}}` validates a string quite happily. Reading
+    // that constraint as an assertion would promote schemas the author never
+    // said were objects, and the expensive failure of this walk is a *wrong*
+    // envelope, which silently discards the declared resource.
+    //
+    // Nothing in the ingested catalog would gain from the looser rule: every
+    // typeless response root across the six v4 sources is `allOf`, `anyOf`, or
+    // `oneOf`, never a bare property bag. Revisit if a real spec turns up where
+    // it would help.
+    view.declares_type("object").then_some(view)
 }
 
 /// Walks the schema and its `allOf` members, accumulating types and properties.

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -335,7 +335,9 @@ impl MergedObjectView {
 /// On duplicate property names the first branch wins, and no conflict is
 /// reported. This answers a heuristic question, so an annotation-only
 /// disagreement between branches must not discard the whole envelope. Type
-/// import has the opposite need and keeps its own exact merge.
+/// import has the opposite need and folds through
+/// [`merge_json_object_shape_annotation_insensitive`], which reports a genuine
+/// disagreement rather than resolving it by branch order.
 pub(crate) fn merged_all_of_object_view<'a>(
     root: &'a Value,
     schema: &'a Value,

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -41,7 +41,7 @@ pub(super) struct OpenApiImporter<'a> {
     pub(super) diagnostics: Vec<Diagnostic>,
 }
 
-enum RefDiagnosticContext<'a> {
+pub(super) enum RefDiagnosticContext<'a> {
     Operation { path: &'a str, method_name: &'a str },
     OperationId(&'a str),
 }
@@ -142,7 +142,10 @@ impl<'a> OpenApiImporter<'a> {
         }
     }
 
-    fn ref_error_diagnostic(error: RefError<'_>, context: &RefDiagnosticContext<'_>) -> Diagnostic {
+    pub(super) fn ref_error_diagnostic(
+        error: RefError<'_>,
+        context: &RefDiagnosticContext<'_>,
+    ) -> Diagnostic {
         let message = match error {
             RefError::External(reference) => {
                 format!(

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use serde_json::Value;
 
@@ -6,11 +6,31 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
-    JsonSchemaComparisonError, direct_json_object_shape, json_schema_required_fields,
-    json_schema_scalar_type, merge_json_schema_properties_exact,
+    JsonObjectShape, JsonSchemaComparisonError, direct_json_object_shape,
+    json_schema_required_fields, json_schema_scalar_type,
+    merge_json_object_shape_annotation_insensitive,
 };
 
 use super::import::OpenApiImporter;
+
+/// Ceiling on nested `allOf` composition, matching the depth the inference
+/// passes walk to. A cyclic `$ref` chain — `A: {allOf: [$ref A]}` — is a schema
+/// this recursion would otherwise follow forever.
+const MAX_ALL_OF_DEPTH: usize = 8;
+
+/// Ceiling on the walk that compares two declarations of the same property.
+/// Separate from [`MAX_ALL_OF_DEPTH`], which bounds composition nesting: this
+/// one bounds the property schema itself, and exceeding it discards the whole
+/// type. Matches the MCP importer's ceiling for the same comparison.
+const MAX_PROPERTY_COMPARISON_DEPTH: usize = 64;
+
+/// Why folding a schema's `allOf` tree stopped.
+enum AllOfMergeError {
+    /// A branch could not be resolved. `resolve_ref` has already recorded a
+    /// diagnostic for it.
+    UnresolvedRef,
+    Comparison(JsonSchemaComparisonError),
+}
 
 impl OpenApiImporter<'_> {
     #[expect(
@@ -50,32 +70,42 @@ impl OpenApiImporter<'_> {
                 description: description.clone(),
             },
         );
-        let shape = if let Some(all_of) = resolved.get("allOf").and_then(Value::as_array) {
-            let mut merged = BTreeMap::new();
-            for item in all_of {
-                let item = self.resolve_ref(item, operation_id, diagnostics)?;
-                let properties = direct_json_object_shape(&item).properties;
-                match merge_json_schema_properties_exact(&mut merged, properties) {
-                    Ok(()) => {}
-                    Err(JsonSchemaComparisonError::PropertyConflict(property)) => {
-                        diagnostics.push(Diagnostic::new(
-                            format!("allOf property '{property}' conflicts in operation '{operation_id}'"),
-                            Some(operation_id.to_string()),
-                        ));
-                        return None;
-                    }
-                    Err(JsonSchemaComparisonError::DepthExceeded) => {
-                        diagnostics.push(Diagnostic::new(
-                            format!("allOf schema exceeds maximum comparison depth in operation '{operation_id}'"),
-                            Some(operation_id.to_string()),
-                        ));
-                        return None;
-                    }
+        let shape = if resolved.get("allOf").and_then(Value::as_array).is_some() {
+            let mut merged = JsonObjectShape::default();
+            match self.merge_all_of_properties(&resolved, &mut merged, operation_id, 0, diagnostics)
+            {
+                Ok(()) => {}
+                // `resolve_ref` has already reported the branch it could not
+                // reach.
+                Err(AllOfMergeError::UnresolvedRef) => return None,
+                Err(AllOfMergeError::Comparison(JsonSchemaComparisonError::PropertyConflict(
+                    property,
+                ))) => {
+                    diagnostics.push(Diagnostic::new(
+                        format!(
+                            "allOf property '{property}' conflicts in operation '{operation_id}'"
+                        ),
+                        Some(operation_id.to_string()),
+                    ));
+                    return None;
+                }
+                Err(AllOfMergeError::Comparison(JsonSchemaComparisonError::DepthExceeded)) => {
+                    diagnostics.push(Diagnostic::new(
+                        format!(
+                            "allOf schema exceeds maximum comparison depth in operation '{operation_id}'"
+                        ),
+                        Some(operation_id.to_string()),
+                    ));
+                    return None;
                 }
             }
             IrTypeShape::Object {
+                // The merged `required` set is deliberately dropped, as it was
+                // before this folded the whole tree: honouring it here would
+                // flip the nullability of every field of every composed type,
+                // which is a change for its own commit.
                 fields: self.import_object_fields(
-                    merged.iter(),
+                    merged.properties.iter(),
                     &BTreeSet::new(),
                     &type_id,
                     operation_id,
@@ -148,6 +178,69 @@ impl OpenApiImporter<'_> {
             },
         );
         Some(type_id)
+    }
+
+    /// Folds a schema's own properties together with those of every `allOf`
+    /// branch, recursively.
+    ///
+    /// Providers compose envelopes out of already-composed bases: a Graph delta
+    /// collection response is an `allOf` over `BaseDeltaFunctionResponse`, which
+    /// is itself an `allOf` over `BaseCollectionPaginationCountResponse`.
+    /// Merging only the immediate branches drops everything the nested ones
+    /// declare, which does two things. It silently loses fields from the
+    /// imported type, and — because row-path inference folds the whole tree —
+    /// it makes a path inference found in a nested branch look absent here, so
+    /// `infer_row_path` discards it and the relation collapses to a single JSON
+    /// row.
+    ///
+    /// A schema's own `properties` are merged alongside its branches for the
+    /// same reason: `{type: object, properties: {...}, allOf: [...]}` is legal,
+    /// and reading only the branches drops the properties declared in place.
+    ///
+    /// Deliberately not `merged_all_of_object_view`, which answers heuristic
+    /// shape questions and lets the first branch win on a duplicate property.
+    /// Type import has the opposite need: a genuine disagreement between
+    /// branches must still be reported rather than resolved by ordering.
+    ///
+    /// Properties are compared on validation semantics, not raw equality. A
+    /// derived type routinely re-declares an inherited property to narrow an
+    /// annotation — every Graph subtype re-declares the `@odata.type`
+    /// discriminator with its own `default` — and folding the full chain under
+    /// exact equality would read those as conflicts and discard the type
+    /// entirely. A property that genuinely disagrees about type or constraints
+    /// is still a conflict.
+    fn merge_all_of_properties(
+        &self,
+        schema: &Value,
+        merged: &mut JsonObjectShape,
+        operation_id: &str,
+        depth: usize,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Result<(), AllOfMergeError> {
+        if depth > MAX_ALL_OF_DEPTH {
+            return Err(AllOfMergeError::Comparison(
+                JsonSchemaComparisonError::DepthExceeded,
+            ));
+        }
+        merge_json_object_shape_annotation_insensitive(
+            merged,
+            direct_json_object_shape(schema),
+            0,
+            MAX_PROPERTY_COMPARISON_DEPTH,
+        )
+        .map_err(AllOfMergeError::Comparison)?;
+        for branch in schema
+            .get("allOf")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let branch = self
+                .resolve_ref(branch, operation_id, diagnostics)
+                .ok_or(AllOfMergeError::UnresolvedRef)?;
+            self.merge_all_of_properties(&branch, merged, operation_id, depth + 1, diagnostics)?;
+        }
+        Ok(())
     }
 
     fn import_object_fields<'a>(

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -6,16 +6,21 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
-    JsonObjectShape, JsonSchemaComparisonError, direct_json_object_shape,
-    json_schema_required_fields, json_schema_scalar_type,
-    merge_json_object_shape_annotation_insensitive,
+    JsonObjectShape, JsonSchemaComparisonError, JsonSchemaWalkError, RefError,
+    direct_json_object_shape, json_schema_required_fields, json_schema_scalar_type,
+    merge_json_object_shape_annotation_insensitive, with_resolved_json_schema,
 };
 
-use super::import::OpenApiImporter;
+use super::import::{OpenApiImporter, RefDiagnosticContext};
 
-/// Ceiling on nested `allOf` composition, matching the depth the inference
-/// passes walk to. A cyclic `$ref` chain — `A: {allOf: [$ref A]}` — is a schema
-/// this recursion would otherwise follow forever.
+/// Ceiling on the `allOf` fold, matching the budget the inference passes walk
+/// to. Spent on composition nesting and `$ref` hops alike, because the fold
+/// resolves branches through the same shared walk — so both halves stop at the
+/// same schema rather than one seeing a tree the other cannot.
+///
+/// Not the cycle guard: the walk tracks the refs it is resolving, so
+/// `A: {allOf: [$ref A]}` is reported as a cycle rather than recursing until
+/// this stops it.
 const MAX_ALL_OF_DEPTH: usize = 8;
 
 /// Ceiling on the walk that compares two declarations of the same property.
@@ -26,9 +31,17 @@ const MAX_PROPERTY_COMPARISON_DEPTH: usize = 64;
 
 /// Why folding a schema's `allOf` tree stopped.
 enum AllOfMergeError {
-    /// A branch could not be resolved. `resolve_ref` has already recorded a
-    /// diagnostic for it.
+    /// A branch could not be resolved. A diagnostic naming it has already been
+    /// recorded.
     UnresolvedRef,
+    /// A branch references itself, directly or through a chain.
+    RefCycle(String),
+    /// Composition nests past [`MAX_ALL_OF_DEPTH`]. Distinct from
+    /// [`JsonSchemaComparisonError::DepthExceeded`], which is the much larger
+    /// ceiling on one property's own schema: reporting them with the same
+    /// wording sends whoever is debugging a deeply composed spec to the wrong
+    /// constant.
+    CompositionTooDeep,
     Comparison(JsonSchemaComparisonError),
 }
 
@@ -72,12 +85,35 @@ impl OpenApiImporter<'_> {
         );
         let shape = if resolved.get("allOf").and_then(Value::as_array).is_some() {
             let mut merged = JsonObjectShape::default();
-            match self.merge_all_of_properties(&resolved, &mut merged, operation_id, 0, diagnostics)
-            {
+            match self.merge_all_of_properties(
+                &resolved,
+                &mut merged,
+                operation_id,
+                &mut BTreeSet::new(),
+                0,
+                diagnostics,
+            ) {
                 Ok(()) => {}
-                // `resolve_ref` has already reported the branch it could not
-                // reach.
+                // The walk has already reported the branch it could not reach.
                 Err(AllOfMergeError::UnresolvedRef) => return None,
+                Err(AllOfMergeError::RefCycle(reference)) => {
+                    diagnostics.push(Diagnostic::new(
+                        format!(
+                            "allOf branch '{reference}' is cyclic in operation '{operation_id}'"
+                        ),
+                        Some(operation_id.to_string()),
+                    ));
+                    return None;
+                }
+                Err(AllOfMergeError::CompositionTooDeep) => {
+                    diagnostics.push(Diagnostic::new(
+                        format!(
+                            "allOf composition nests past {MAX_ALL_OF_DEPTH} levels in operation '{operation_id}'"
+                        ),
+                        Some(operation_id.to_string()),
+                    ));
+                    return None;
+                }
                 Err(AllOfMergeError::Comparison(JsonSchemaComparisonError::PropertyConflict(
                     property,
                 ))) => {
@@ -209,38 +245,115 @@ impl OpenApiImporter<'_> {
     /// exact equality would read those as conflicts and discard the type
     /// entirely. A property that genuinely disagrees about type or constraints
     /// is still a conflict.
+    /// Folds a schema's `allOf` chain into `merged`, resolving each branch
+    /// through the shared walk.
+    ///
+    /// `resolve_ref` follows exactly one hop, so an alias branch — `{$ref:
+    /// Alias}` where `Alias` is itself `{$ref: Base}` — came back still holding
+    /// a `$ref`, with no `properties` and no `allOf` to contribute. It was
+    /// dropped silently. Inference resolves chains, so it could find a row path
+    /// behind an alias that the imported type lacked, and `infer_row_path`
+    /// would then discard the path and collapse the collection to one JSON row
+    /// — the failure this whole pass exists to remove. Both halves have to fold
+    /// the same tree.
+    ///
+    /// The walk also tracks the refs it is resolving, so a self-referential
+    /// branch is reported as a cycle instead of recursing until the depth cap
+    /// stops it. That cap is now a shared budget: it bounds composition nesting
+    /// and `$ref` hops together, matching how the inference walk spends it.
     fn merge_all_of_properties(
         &self,
         schema: &Value,
         merged: &mut JsonObjectShape,
         operation_id: &str,
+        resolving_refs: &mut BTreeSet<String>,
         depth: usize,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Result<(), AllOfMergeError> {
-        if depth > MAX_ALL_OF_DEPTH {
-            return Err(AllOfMergeError::Comparison(
-                JsonSchemaComparisonError::DepthExceeded,
-            ));
+        let walked = with_resolved_json_schema(
+            self.document,
+            schema,
+            resolving_refs,
+            depth,
+            MAX_ALL_OF_DEPTH,
+            |resolved, resolving_refs, next_depth| {
+                // The merge's own failures ride inside `T`: the walk fixes the
+                // error type as `JsonSchemaWalkError`, and a property conflict
+                // has to stay distinguishable from a ref that would not resolve.
+                Ok(self.merge_resolved_all_of_properties(
+                    resolved,
+                    merged,
+                    operation_id,
+                    resolving_refs,
+                    next_depth,
+                    diagnostics,
+                ))
+            },
+        );
+        match walked {
+            Ok(merge_result) => merge_result,
+            // Converted rather than propagated: the walk error borrows from the
+            // schema it walked, and the top-level caller passes a local.
+            Err(error) => Err(Self::all_of_walk_error(error, operation_id, diagnostics)),
         }
+    }
+
+    /// The per-level half of [`Self::merge_all_of_properties`], after the walk
+    /// has resolved this branch to a concrete schema.
+    fn merge_resolved_all_of_properties(
+        &self,
+        resolved: &Value,
+        merged: &mut JsonObjectShape,
+        operation_id: &str,
+        resolving_refs: &mut BTreeSet<String>,
+        depth: usize,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Result<(), AllOfMergeError> {
         merge_json_object_shape_annotation_insensitive(
             merged,
-            direct_json_object_shape(schema),
+            direct_json_object_shape(resolved),
             0,
             MAX_PROPERTY_COMPARISON_DEPTH,
         )
         .map_err(AllOfMergeError::Comparison)?;
-        for branch in schema
+        for branch in resolved
             .get("allOf")
             .and_then(Value::as_array)
             .into_iter()
             .flatten()
         {
-            let branch = self
-                .resolve_ref(branch, operation_id, diagnostics)
-                .ok_or(AllOfMergeError::UnresolvedRef)?;
-            self.merge_all_of_properties(&branch, merged, operation_id, depth + 1, diagnostics)?;
+            self.merge_all_of_properties(
+                branch,
+                merged,
+                operation_id,
+                resolving_refs,
+                depth,
+                diagnostics,
+            )?;
         }
         Ok(())
+    }
+
+    /// Records the diagnostic a failed branch walk deserves and reduces it to a
+    /// lifetime-free error.
+    fn all_of_walk_error(
+        error: JsonSchemaWalkError<'_>,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> AllOfMergeError {
+        let ref_error = match error {
+            JsonSchemaWalkError::ExternalRef(reference) => RefError::External(reference),
+            JsonSchemaWalkError::RefNotFound(reference) => RefError::NotFound(reference),
+            JsonSchemaWalkError::RefCycle(reference) => {
+                return AllOfMergeError::RefCycle(reference.to_string());
+            }
+            JsonSchemaWalkError::DepthExceeded => return AllOfMergeError::CompositionTooDeep,
+        };
+        diagnostics.push(OpenApiImporter::ref_error_diagnostic(
+            ref_error,
+            &RefDiagnosticContext::OperationId(operation_id),
+        ));
+        AllOfMergeError::UnresolvedRef
     }
 
     fn import_object_fields<'a>(

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -191,10 +191,13 @@ fn candidate_row_path<'a>(
             // such as `results.data` are worth finding, an unrestricted walk of
             // every resource child is not.
             for name in PREFERRED_ROW_PROPERTIES {
-                // A branch that cannot be walked — unresolvable, cyclic, too
-                // deep — holds no rows, which is not a reason to abandon the
-                // other candidate names. `schema_has_type` already treats the
-                // same failures this way.
+                // The error cannot propagate: `JsonSchemaWalkError` borrows
+                // from the schema it walked, and these properties belong to
+                // the merged view rather than the document, so `?` would hand
+                // back a reference to a local. Skipping is sound in itself — a
+                // branch that cannot be walked holds no rows — but it leaves
+                // the sole-array fallback below reachable for an envelope
+                // whose preferred branch is an unresolvable `$ref`.
                 if let Some(property) = properties.get(*name)
                     && let Some(mut path) = candidate_row_path(
                         root,

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -268,9 +268,11 @@ fn is_metadata_name(name: &str) -> bool {
 /// An unresolvable or cyclic property simply does not declare the type asked
 /// about; it must not abandon inference for its siblings.
 ///
-/// `allOf` branches count, so a property assembled from a base and an extension
-/// still declares its type. An alternation does not: a property that is one of
-/// several shapes has no single type to check against.
+/// `allOf` branches count for `object`, so a property assembled from a base and
+/// an extension still reads as one. Other types do not: the merged view is
+/// object-only, so a composed `array` or `string` still has to declare its type
+/// outright. An alternation never counts — a property that is one of several
+/// shapes has no single type to check against.
 fn schema_has_type(
     root: &Value,
     schema: &Value,

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -14,13 +14,20 @@
 //! envelope (see [`has_envelope_evidence`]). A missed envelope leaves a JSON
 //! column the user can still unnest; a wrong envelope silently discards the
 //! declared resource.
+//!
+//! `allOf` is folded before any of this runs, because providers routinely
+//! assemble an envelope from a shared pagination base and a rows branch rather
+//! than declaring it whole — every `OData` collection response is written that
+//! way. `anyOf`, `oneOf`, and `not` are still refused: they describe a choice
+//! between shapes, and there is no single property map to ask questions of.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use crate::v4::surfaces::json_schema::{
-    JsonSchemaWalkError, json_schema_type_contains, with_resolved_json_schema,
+    JsonSchemaWalkError, json_schema_type_contains, merged_all_of_object_view,
+    schema_uses_alternation, with_resolved_json_schema,
 };
 
 const MAX_DEPTH: usize = 8;
@@ -51,6 +58,13 @@ const METADATA_STRING_NAMES: &[&str] = &[
     "nexttoken",
     "nexturl",
     "nextlink",
+    // OData spells its annotations `@odata.nextLink`, which normalizes with the
+    // prefix intact. Listed explicitly rather than stripping `@odata.` in
+    // `normalized_name`, because that function also decides which arrays are
+    // *excluded* as metadata — stripping there would silently reclassify every
+    // `@odata.*` property in every source.
+    "odatanextlink",
+    "odatadeltalink",
     "endcursor",
     "continuationtoken",
     "scrollid",
@@ -63,6 +77,7 @@ const METADATA_INTEGER_NAMES: &[&str] = &[
     "totalsize",
     "totalitems",
     "resultcount",
+    "odatacount",
     "page",
     "pages",
     "pagecount",
@@ -147,17 +162,19 @@ fn candidate_row_path<'a>(
         depth,
         MAX_DEPTH,
         |resolved, resolving_refs, next_depth| {
-            // Composed schemas describe a merge Coral does not model here, so
-            // their properties cannot be read as a complete envelope.
-            if schema_uses_composition(resolved) {
-                return Ok(None);
-            }
-            if !json_schema_type_contains(resolved, "object") {
-                return Ok(None);
-            }
-            let Some(properties) = resolved.get("properties").and_then(Value::as_object) else {
+            // `allOf` is folded in, so an envelope assembled from a shared
+            // pagination base and a rows branch reads as one object. `anyOf`,
+            // `oneOf`, and `not` still bail: they describe a choice of shapes,
+            // not one shape.
+            let Some(view) =
+                merged_all_of_object_view(root, resolved, resolving_refs, next_depth, MAX_DEPTH)
+            else {
                 return Ok(None);
             };
+            let properties = &view.properties;
+            if properties.is_empty() {
+                return Ok(None);
+            }
             let evidence = has_envelope_evidence(root, properties, resolving_refs, next_depth);
             let accept_preferred = paginated_operation || inherited_evidence || evidence;
             let accept_fallback = paginated_operation || evidence;
@@ -174,6 +191,10 @@ fn candidate_row_path<'a>(
             // such as `results.data` are worth finding, an unrestricted walk of
             // every resource child is not.
             for name in PREFERRED_ROW_PROPERTIES {
+                // A branch that cannot be walked — unresolvable, cyclic, too
+                // deep — holds no rows, which is not a reason to abandon the
+                // other candidate names. `schema_has_type` already treats the
+                // same failures this way.
                 if let Some(property) = properties.get(*name)
                     && let Some(mut path) = candidate_row_path(
                         root,
@@ -182,7 +203,9 @@ fn candidate_row_path<'a>(
                         inherited_evidence || evidence,
                         resolving_refs,
                         next_depth,
-                    )?
+                    )
+                    .ok()
+                    .flatten()
                 {
                     path.insert(0, (*name).to_string());
                     return Ok(Some(path));
@@ -214,7 +237,7 @@ fn candidate_row_path<'a>(
 /// `has_more` boolean or a `next_cursor` string on a plain resource.
 fn has_envelope_evidence(
     root: &Value,
-    properties: &Map<String, Value>,
+    properties: &BTreeMap<String, Value>,
     resolving_refs: &mut BTreeSet<String>,
     depth: usize,
 ) -> bool {
@@ -239,14 +262,12 @@ fn is_metadata_name(name: &str) -> bool {
         .any(|(names, _)| names.contains(&normalized.as_str()))
 }
 
-fn schema_uses_composition(schema: &Value) -> bool {
-    ["allOf", "anyOf", "oneOf", "not"]
-        .iter()
-        .any(|keyword| schema.get(*keyword).is_some())
-}
-
 /// An unresolvable or cyclic property simply does not declare the type asked
 /// about; it must not abandon inference for its siblings.
+///
+/// `allOf` branches count, so a property assembled from a base and an extension
+/// still declares its type. An alternation does not: a property that is one of
+/// several shapes has no single type to check against.
 fn schema_has_type(
     root: &Value,
     schema: &Value,
@@ -260,8 +281,20 @@ fn schema_has_type(
         resolving_refs,
         depth,
         MAX_DEPTH,
-        |resolved, _, _| {
-            Ok(!schema_uses_composition(resolved) && json_schema_type_contains(resolved, expected))
+        |resolved, resolving_refs, next_depth| {
+            if schema_uses_alternation(resolved) {
+                return Ok(false);
+            }
+            if json_schema_type_contains(resolved, expected) {
+                return Ok(true);
+            }
+            if resolved.get("allOf").is_none() {
+                return Ok(false);
+            }
+            Ok(
+                merged_all_of_object_view(root, resolved, resolving_refs, next_depth, MAX_DEPTH)
+                    .is_some_and(|view| view.declares_type(expected)),
+            )
         },
     )
     .unwrap_or(false)
@@ -502,7 +535,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_composed_schemas() {
+    fn merges_all_of_branches_into_one_envelope() {
         let schema = json!({
             "allOf": [{
                 "type": "object",
@@ -512,6 +545,128 @@ mod tests {
                 },
             }],
         });
+
+        assert_eq!(row_path(&schema, false), ["items"]);
+    }
+
+    #[test]
+    fn ignores_alternation_schemas() {
+        // `anyOf`/`oneOf`/`not` describe a choice of shapes, so there is no one
+        // property map to read as an envelope.
+        for keyword in ["anyOf", "oneOf"] {
+            let schema = json!({
+                keyword: [{
+                    "type": "object",
+                    "properties": {
+                        "total_count": {"type": "integer"},
+                        "items": {"type": "array", "items": {"type": "object"}},
+                    },
+                }],
+            });
+
+            assert!(
+                row_path(&schema, false).is_empty(),
+                "{keyword} must not be read as an envelope"
+            );
+        }
+
+        let negated = json!({
+            "type": "object",
+            "not": {"type": "string"},
+            "properties": {
+                "total_count": {"type": "integer"},
+                "items": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+        assert!(row_path(&negated, false).is_empty());
+    }
+
+    /// The Microsoft Graph shape, and every other `OData` collection response:
+    /// a shared pagination base merged with a branch declaring the rows, with
+    /// the annotations that make it recognizable spelled `@odata.*`.
+    #[test]
+    fn selects_rows_through_an_odata_collection_envelope() {
+        let schema = json!({
+            "$ref": "#/components/schemas/ChatCollectionResponse",
+            "components": {
+                "schemas": {
+                    "BaseCollectionPaginationCountResponse": {
+                        "type": "object",
+                        "properties": {
+                            "@odata.count": {"type": "integer", "format": "int64"},
+                            "@odata.nextLink": {"type": "string"},
+                        },
+                    },
+                    "ChatCollectionResponse": {
+                        "title": "Collection of chat",
+                        "type": "object",
+                        "allOf": [
+                            {"$ref": "#/components/schemas/BaseCollectionPaginationCountResponse"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "array",
+                                        "items": {"type": "object"},
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        });
+
+        assert_eq!(
+            row_path(&schema, false),
+            ["value"],
+            "the OData annotations are the envelope evidence; no pagination contract is needed"
+        );
+    }
+
+    #[test]
+    fn odata_annotations_count_as_envelope_evidence_without_composition() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "@odata.count": {"type": "integer"},
+                "@odata.nextLink": {"type": "string"},
+                "value": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+
+        assert_eq!(row_path(&schema, false), ["value"]);
+    }
+
+    #[test]
+    fn ignores_an_all_of_branch_that_cycles() {
+        let schema = json!({
+            "$ref": "#/components/schemas/Node",
+            "components": {
+                "schemas": {
+                    "Node": {
+                        "type": "object",
+                        "allOf": [{"$ref": "#/components/schemas/Node"}],
+                    },
+                },
+            },
+        });
+
+        assert!(row_path(&schema, false).is_empty());
+    }
+
+    #[test]
+    fn ignores_all_of_branches_nested_past_the_depth_cap() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "has_more": {"type": "boolean"},
+                "data": {"type": "array", "items": {"type": "object"}},
+            },
+        });
+        for _ in 0..super::MAX_DEPTH {
+            schema = json!({"type": "object", "allOf": [schema]});
+        }
 
         assert!(row_path(&schema, false).is_empty());
     }

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -724,4 +724,22 @@ mod tests {
 
         assert!(row_path(&schema, false).is_empty());
     }
+
+    /// Declaring `properties` is not a claim to be an object. In JSON Schema
+    /// `properties` constrains an instance only if it happens to be one, so
+    /// `{properties: {...}}` validates a string quite happily — treating it as
+    /// an envelope would promote a shape the author never asserted.
+    ///
+    /// Deliberate and load-bearing: the sole-array fallback below would make
+    /// `warnings` the whole relation, discarding the declared resource.
+    #[test]
+    fn refuses_a_response_that_declares_properties_without_a_type() {
+        let schema = json!({
+            "properties": {
+                "warnings": {"type": "array", "items": {"type": "string"}},
+            },
+        });
+
+        assert!(row_path(&schema, false).is_empty());
+    }
 }


### PR DESCRIPTION
Providers routinely assemble a collection response from a shared pagination base and a branch declaring the rows, rather than declaring it whole. Every OData collection response is written that way, so all 16,702 Microsoft Graph operations were refused by envelope detection: the properties live on the allOf branches, and the walk only looked at the schema itself. Each collection surfaced as a single row holding `odata_count`, `odata_nextlink`, and a JSON `value` blob.

## Folding allOf for inference

`merged_all_of_object_view` folds allOf branches into one property map, shared by wrapped-list inference and cursor discovery so both halves of the decision see the same shape -- if only one could, an operation would be presented as a paginated table that stops after page one.

Only allOf is folded. anyOf, oneOf, and not describe a choice of shapes, not one shape, so there is no single property map to ask questions of and they are still refused. Duplicate names take the first branch and report no conflict: this answers a heuristic question, and an annotation-only disagreement between branches must not discard a whole envelope.

What still has to be declared is the object itself. Folding replaces the response walk's explicit `type: object` check with the merged view's own object test, and that test asks the same question -- some branch must say `type: object`. Declaring `properties` alone is not enough: in JSON Schema `properties` constrains an instance only if it happens to be an object and asserts nothing about whether it is one, so `{properties: {...}}` validates a string quite happily. Reading that as an assertion would let a singleton `{properties: {warnings: [...]}}` reach the sole-array fallback and have `warnings` promoted to the whole relation, which `resolve_output_row_type_ref` cannot catch because type import defaults typeless schemas to object as well.

So the widening here is exactly `allOf` visibility, not a looser notion of what an object is.

## The @odata annotation lexicon

Folding alone is not enough. `normalized_name` keeps the annotation prefix, so `@odata.count` and `@odata.nextLink` normalize to `odatacount` and `odatanextlink` and matched nothing in the metadata lexicon, leaving a three-property envelope with no evidence. They are added explicitly rather than by stripping `@odata.` in `normalized_name`, because that function also decides which arrays are *excluded* as metadata -- stripping there would silently reclassify every `@odata.*` property in every source.

## Folding allOf for type import

Type import had to follow, and did not: it merged only the immediate branches and ignored properties declared alongside allOf. The two halves then disagreed, and a path inference found in a nested branch looked absent from the imported type, so `infer_row_path` discarded it and the collection collapsed to a single JSON row again. Nested branches also lost their fields outright -- `microsoft.graph.drive` reaches `id`, `name`, and `webUrl` through `baseItem` and `entity`, and shipped without those columns.

Folding the full chain forces the property comparison to be annotation-insensitive. Every Graph subtype re-declares the `@odata.type` discriminator with its own `default`, which byte-for-byte equality reads as two branches disagreeing: 1,618 Graph operations lost their response type entirely before the comparison moved to validation semantics, which is a worse outcome than the missing columns it set out to fix. Branches that genuinely disagree about type or constraints are still conflicts.

## Impact

2,592 Graph operations become paginated row tables, and none lands on offset pagination -- which matters, because Graph declares `$skip` on collections that reject it at runtime. Verified against the live v1.0 description: the other six v4 sources are byte-identical, and `v4-metadata-report` does not move by a line across the type-import change either.

Keeping the declared-object requirement costs nothing measurable: every typeless success-response root across the six ingested specs is `allOf` (3,242), `anyOf` (705), or `oneOf` (8), and not one is a bare property bag, so refusing the typeless case moves 0 of 20,673 operations. Worth revisiting if a real spec turns up where accepting it would help.

## Follow-ups

Pre-existing and out of scope: `find_numeric_query_input` selects the first candidate-named query input and only then filters by type, so Graph's boolean `$count` masks its integer `$top` and page-size detection finds nothing. Pagination is unaffected -- Coral just accepts Graph's server-side default page size, and `top` stays a user-facing filter rather than becoming pagination-owned.

The `required` set merged across allOf branches is still dropped, exactly as it was before type import folded the whole tree. Honouring it would flip the nullability of every field of every composed type, which deserves its own commit.

Claude-Session: https://claude.ai/code/session_01Rr2wBfz6dZUWkQF58nVBrR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
