### PR TITLE
perf(app): cache OIDC provider discovery documents

### DIFF
--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -25,6 +25,8 @@ const DEFAULT_BIND_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCAL
 const DEFAULT_SIGNING_KEY_ENV: &str = "CORAL_SESSION_SIGNING_KEY";
 const DEFAULT_TOKEN_TTL: Duration = Duration::from_hours(720);
 const MAX_TOKEN_TTL: Duration = Duration::from_hours(24 * 365);
+const DEFAULT_DISCOVERY_CACHE_TTL: Duration = Duration::from_mins(5);
+const MAX_DISCOVERY_CACHE_TTL: Duration = Duration::from_hours(1);
 const CONFLICTING_KEY_SOURCES: &str = "configure only one of signing_key_env or signing_key_file";
 
 /// Validated settings for the top-level `[auth]` configuration section.
@@ -323,6 +325,11 @@ struct OidcProviderSettings {
     display_name_claim: String,
     auth_params: BTreeMap<String, String>,
     required_claims: BTreeMap<String, Value>,
+    /// How long a validated discovery document stays reusable.
+    ///
+    /// Unset means [`DEFAULT_DISCOVERY_CACHE_TTL`]. Zero disables caching, at
+    /// the cost of one outbound discovery request per authorization request.
+    discovery_cache_ttl_seconds: Option<u64>,
 }
 
 impl OidcProviderSettings {
@@ -433,6 +440,15 @@ impl OidcProviderSettings {
                 )));
             }
         }
+        if self
+            .discovery_cache_ttl_seconds
+            .is_some_and(|ttl| ttl > MAX_DISCOVERY_CACHE_TTL.as_secs())
+        {
+            return Err(invalid_provider(format!(
+                "discovery_cache_ttl_seconds must not exceed {}",
+                MAX_DISCOVERY_CACHE_TTL.as_secs()
+            )));
+        }
         Ok(())
     }
 
@@ -477,6 +493,9 @@ impl OidcProviderSettings {
             display_name_claim: self.display_name_claim,
             auth_params: self.auth_params,
             required_claims: self.required_claims,
+            discovery_cache_ttl: self
+                .discovery_cache_ttl_seconds
+                .map_or(DEFAULT_DISCOVERY_CACHE_TTL, Duration::from_secs),
             client_secret,
         })
     }
@@ -502,12 +521,21 @@ pub(super) struct ResolvedOidcProvider {
     pub(super) display_name_claim: String,
     pub(super) auth_params: BTreeMap<String, String>,
     pub(super) required_claims: BTreeMap<String, Value>,
+    discovery_cache_ttl: Duration,
     client_secret: ProviderSecret,
 }
 
 impl ResolvedOidcProvider {
     pub(super) fn client_secret(&self) -> &str {
         self.client_secret.as_str()
+    }
+
+    /// How long a validated discovery document may be reused.
+    ///
+    /// A zero duration disables caching: every authorization request then makes
+    /// its own discovery call to the provider.
+    pub(super) fn discovery_cache_ttl(&self) -> Duration {
+        self.discovery_cache_ttl
     }
 }
 
@@ -862,9 +890,24 @@ mod tests {
         assert_eq!(provider.scopes, ["openid", "email", "profile"]);
         assert_eq!(provider.principal_claim, "sub");
         assert_eq!(provider.display_name_claim, "email");
+        assert_eq!(provider.discovery_cache_ttl(), DEFAULT_DISCOVERY_CACHE_TTL);
         let debug = format!("{provider:?}");
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("inline-secret"));
+    }
+
+    #[test]
+    fn honors_a_configured_discovery_cache_ttl() {
+        for seconds in [0, 30, MAX_DISCOVERY_CACHE_TTL.as_secs()] {
+            let raw = valid("").replace(
+                "client_id = 'upstream-client'",
+                &format!("client_id = 'upstream-client'\ndiscovery_cache_ttl_seconds = {seconds}"),
+            );
+            assert_eq!(
+                resolved(&raw).provider().discovery_cache_ttl(),
+                Duration::from_secs(seconds)
+            );
+        }
     }
 
     #[test]
@@ -1083,6 +1126,16 @@ mod tests {
                     "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['openid', 'two scopes']",
                 ),
                 "scopes must contain valid OAuth scope tokens",
+            ),
+            (
+                valid("").replace(
+                    "client_id = 'upstream-client'",
+                    &format!(
+                        "client_id = 'upstream-client'\ndiscovery_cache_ttl_seconds = {}",
+                        MAX_DISCOVERY_CACHE_TTL.as_secs() + 1
+                    ),
+                ),
+                "discovery_cache_ttl_seconds must not exceed",
             ),
             (
                 valid("").replace(

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -327,8 +327,9 @@ struct OidcProviderSettings {
     required_claims: BTreeMap<String, Value>,
     /// How long a validated discovery document stays reusable.
     ///
-    /// Unset means [`DEFAULT_DISCOVERY_CACHE_TTL`]. Zero disables caching, at
-    /// the cost of one outbound discovery request per authorization request.
+    /// Unset means [`DEFAULT_DISCOVERY_CACHE_TTL`]. Zero keeps no document, at
+    /// the cost of an outbound discovery request per authorization request that
+    /// cannot join one already in flight.
     discovery_cache_ttl_seconds: Option<u64>,
 }
 
@@ -532,8 +533,9 @@ impl ResolvedOidcProvider {
 
     /// How long a validated discovery document may be reused.
     ///
-    /// A zero duration disables caching: every authorization request then makes
-    /// its own discovery call to the provider.
+    /// A zero duration keeps no document between requests, so an authorization
+    /// request then makes its own discovery call unless it can join one already
+    /// in flight.
     pub(super) fn discovery_cache_ttl(&self) -> Duration {
         self.discovery_cache_ttl
     }

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -19,6 +19,8 @@
 
 #![cfg_attr(not(test), expect(dead_code, reason = "wired by OAuth descendants"))]
 
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use base64::Engine as _;
@@ -28,6 +30,8 @@ use ring::rand::{SecureRandom as _, SystemRandom};
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::Instant;
 use url::Url;
 use zeroize::Zeroizing;
 
@@ -67,6 +71,7 @@ const RESERVED_TOKEN_PARAMS: &[&str] = &[
 pub(super) struct OidcProviderClient {
     http: reqwest::Client,
     random: SystemRandom,
+    discovery: Arc<DiscoveryCache>,
 }
 
 /// An authorization URL and the per-login values that must outlive it.
@@ -159,6 +164,7 @@ impl OidcProviderClient {
         Ok(Self {
             http,
             random: SystemRandom::new(),
+            discovery: Arc::new(DiscoveryCache::default()),
         })
     }
 
@@ -279,8 +285,37 @@ impl OidcProviderClient {
         identity.map_err(|_error| OidcProviderClientError::IdTokenValidation)
     }
 
-    /// Fetches and validates the provider's discovery document.
+    /// Returns the provider's validated discovery document, reusing a cached
+    /// copy while one is live.
+    ///
+    /// Only successes are cached, so a provider outage never outlives itself:
+    /// a failed discovery leaves the previous entry expired and the next call
+    /// retries. Concurrent misses are collapsed behind a single refresh, so a
+    /// burst of authorization requests makes one outbound call rather than one
+    /// per request.
     async fn discover(
+        &self,
+        provider: &ResolvedOidcProvider,
+    ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
+        let ttl = provider.discovery_cache_ttl();
+        if let Some(cached) = self.discovery.get(&provider.issuer).await {
+            return Ok(cached);
+        }
+        let _refresh = self.discovery.refresh.lock().await;
+        // Another task may have populated the entry while this one waited for
+        // the refresh lock.
+        if let Some(cached) = self.discovery.get(&provider.issuer).await {
+            return Ok(cached);
+        }
+        let discovery = self.fetch_discovery(provider).await?;
+        self.discovery
+            .insert(&provider.issuer, &discovery, ttl)
+            .await;
+        Ok(discovery)
+    }
+
+    /// Fetches and validates the provider's discovery document.
+    async fn fetch_discovery(
         &self,
         provider: &ResolvedOidcProvider,
     ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
@@ -341,12 +376,66 @@ impl OidcProviderClient {
     }
 }
 
-/// A discovery document that passed every check in [`OidcProviderClient::discover`].
+/// A discovery document that passed every check in
+/// [`OidcProviderClient::fetch_discovery`].
+///
+/// Only a validated document is cached, so a copy handed back by
+/// [`OidcProviderClient::discover`] carries the same guarantees as a freshly
+/// fetched one.
+#[derive(Clone)]
 struct ValidatedDiscovery {
     authorization_endpoint: EndpointUrl<Discovered>,
     token_endpoint: EndpointUrl<Discovered>,
     jwks_uri: EndpointUrl<Discovered>,
     signing_algorithms: Vec<String>,
+}
+
+/// Live discovery documents, keyed by the configured issuer they were fetched
+/// for.
+///
+/// The key space is the set of configured providers, so the map is bounded by
+/// configuration rather than by request traffic. `refresh` serializes cache
+/// misses: it is held across the outbound call so that concurrent misses
+/// produce one request, not one per caller.
+#[derive(Default)]
+struct DiscoveryCache {
+    entries: RwLock<HashMap<String, CachedDiscovery>>,
+    refresh: Mutex<()>,
+}
+
+struct CachedDiscovery {
+    discovery: ValidatedDiscovery,
+    expires_at: Instant,
+}
+
+impl DiscoveryCache {
+    async fn get(&self, issuer: &str) -> Option<ValidatedDiscovery> {
+        let now = Instant::now();
+        self.entries
+            .read()
+            .await
+            .get(issuer)
+            .filter(|entry| entry.expires_at > now)
+            .map(|entry| entry.discovery.clone())
+    }
+
+    /// Stores `discovery` for `ttl`, dropping it when the deadline cannot be
+    /// represented or has already passed.
+    ///
+    /// A zero `ttl` therefore disables caching without a separate code path.
+    async fn insert(&self, issuer: &str, discovery: &ValidatedDiscovery, ttl: Duration) {
+        let now = Instant::now();
+        let Some(expires_at) = now.checked_add(ttl).filter(|deadline| *deadline > now) else {
+            return;
+        };
+        self.entries.write().await.insert(
+            issuer.to_string(),
+            CachedDiscovery {
+                discovery: discovery.clone(),
+                expires_at,
+            },
+        );
+    }
 }
 
 /// The fields this module reads from a provider's discovery document.
@@ -476,6 +565,10 @@ mod tests {
     const CLIENT_SECRET: &str = "client-secret-must-not-leak";
 
     fn provider(issuer: &str) -> ResolvedOidcProvider {
+        provider_with(issuer, "")
+    }
+
+    fn provider_with(issuer: &str, extra: &str) -> ResolvedOidcProvider {
         let settings = AuthSettings::from_toml(&format!(
             "[auth]
              [auth.session]
@@ -487,6 +580,7 @@ mod tests {
              client_secret = '{CLIENT_SECRET}'
              redirect_uri = 'http://localhost/auth/oidc/callback'
              scopes = ['openid', 'email']
+             {extra}
              [auth.provider.auth_params]
              prompt = 'login'"
         ))
@@ -615,6 +709,153 @@ mod tests {
         assert_eq!(query.get("nonce"), Some(&request.nonce));
         let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(request.code_verifier.as_bytes()));
         assert_eq!(query.get("code_challenge"), Some(&expected));
+    }
+
+    async fn discovery_requests(server: &MockServer) -> usize {
+        server
+            .received_requests()
+            .await
+            .expect("requests")
+            .iter()
+            .filter(|request| {
+                request
+                    .url
+                    .path()
+                    .ends_with("/.well-known/openid-configuration")
+            })
+            .count()
+    }
+
+    async fn mount_valid_discovery(server: &MockServer, issuer: &str) {
+        mount_discovery(
+            server,
+            "/tenant/.well-known/openid-configuration",
+            valid_document(server, issuer).to_string(),
+        )
+        .await;
+    }
+
+    fn validated_discovery() -> ValidatedDiscovery {
+        let issuer =
+            EndpointUrl::<Configured>::parse("https://accounts.example.test").expect("issuer");
+        let endpoint = |label, path: &str| {
+            discovered_endpoint(
+                label,
+                &format!("https://accounts.example.test{path}"),
+                &issuer,
+            )
+            .expect(label)
+        };
+        ValidatedDiscovery {
+            authorization_endpoint: endpoint("authorization_endpoint", "/authorize"),
+            token_endpoint: endpoint("token_endpoint", "/token"),
+            jwks_uri: endpoint("jwks_uri", "/jwks"),
+            signing_algorithms: vec!["RS256".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn discovery_is_reused_across_authorization_requests() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        mount_valid_discovery(&server, &issuer).await;
+        let client = OidcProviderClient::new().expect("client");
+        let provider = provider(&issuer);
+
+        for _ in 0..3 {
+            client
+                .authorization_request(&provider)
+                .await
+                .expect("authorization request");
+        }
+        assert_eq!(discovery_requests(&server).await, 1);
+    }
+
+    /// Expiry is checked against the cache directly: `start_paused` auto-advances
+    /// while a real socket read is pending, which would trip the client's own
+    /// request timeout in an end-to-end test.
+    #[tokio::test(start_paused = true)]
+    async fn cached_discovery_is_dropped_once_its_ttl_expires() {
+        let cache = DiscoveryCache::default();
+        let issuer = "https://accounts.example.test";
+        let ttl = Duration::from_mins(5);
+        cache.insert(issuer, &validated_discovery(), ttl).await;
+        assert!(cache.get("https://other.example.test").await.is_none());
+
+        tokio::time::advance(Duration::from_mins(4)).await;
+        assert!(cache.get(issuer).await.is_some(), "expired before its TTL");
+
+        tokio::time::advance(Duration::from_mins(2)).await;
+        assert!(cache.get(issuer).await.is_none(), "outlived its TTL");
+    }
+
+    /// A cached failure would turn a provider blip into an outage lasting a
+    /// whole TTL, so only successes are stored.
+    #[tokio::test]
+    async fn discovery_failures_are_never_cached() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        Mock::given(method("GET"))
+            .and(path("/tenant/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let client = OidcProviderClient::new().expect("client");
+        let provider = provider(&issuer);
+        let Err(error) = client.authorization_request(&provider).await else {
+            panic!("expected the provider outage to fail discovery");
+        };
+        assert_eq!(error, OidcProviderClientError::Discovery);
+
+        server.reset().await;
+        mount_valid_discovery(&server, &issuer).await;
+        client
+            .authorization_request(&provider)
+            .await
+            .expect("recovers without waiting out a TTL");
+    }
+
+    /// The cache exists so that a burst of authorization requests cannot be
+    /// amplified into a burst of provider requests.
+    #[tokio::test]
+    async fn concurrent_discovery_misses_collapse_into_one_request() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        mount_valid_discovery(&server, &issuer).await;
+        let client = OidcProviderClient::new().expect("client");
+        let provider = provider(&issuer);
+
+        let requests = (0..16)
+            .map(|_index| {
+                let client = client.clone();
+                let provider = provider.clone();
+                tokio::spawn(async move { client.authorization_request(&provider).await })
+            })
+            .collect::<Vec<_>>();
+        for request in requests {
+            request
+                .await
+                .expect("join")
+                .expect("concurrent authorization request");
+        }
+        assert_eq!(discovery_requests(&server).await, 1);
+    }
+
+    #[tokio::test]
+    async fn zero_discovery_cache_ttl_disables_reuse() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        mount_valid_discovery(&server, &issuer).await;
+        let client = OidcProviderClient::new().expect("client");
+        let provider = provider_with(&issuer, "discovery_cache_ttl_seconds = 0");
+
+        for _ in 0..2 {
+            client
+                .authorization_request(&provider)
+                .await
+                .expect("authorization request");
+        }
+        assert_eq!(discovery_requests(&server).await, 2);
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -738,18 +738,19 @@ mod tests {
     fn validated_discovery() -> ValidatedDiscovery {
         let issuer =
             EndpointUrl::<Configured>::parse("https://accounts.example.test").expect("issuer");
-        let endpoint = |label, path: &str| {
+        let endpoint = |endpoint: DiscoveredEndpoint, path: &str| {
+            let label = endpoint.label();
             discovered_endpoint(
-                label,
+                endpoint,
                 &format!("https://accounts.example.test{path}"),
                 &issuer,
             )
             .expect(label)
         };
         ValidatedDiscovery {
-            authorization_endpoint: endpoint("authorization_endpoint", "/authorize"),
-            token_endpoint: endpoint("token_endpoint", "/token"),
-            jwks_uri: endpoint("jwks_uri", "/jwks"),
+            authorization_endpoint: endpoint(DiscoveredEndpoint::Authorization, "/authorize"),
+            token_endpoint: endpoint(DiscoveredEndpoint::Token, "/token"),
+            jwks_uri: endpoint(DiscoveredEndpoint::Jwks, "/jwks"),
             signing_algorithms: vec!["RS256".to_string()],
         }
     }

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -20,7 +20,7 @@
 #![cfg_attr(not(test), expect(dead_code, reason = "wired by OAuth descendants"))]
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
 use base64::Engine as _;
@@ -30,7 +30,7 @@ use ring::rand::{SecureRandom as _, SystemRandom};
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{RwLock, broadcast};
 use tokio::time::Instant;
 use url::Url;
 use zeroize::Zeroizing;
@@ -290,28 +290,42 @@ impl OidcProviderClient {
     ///
     /// Only successes are cached, so a provider outage never outlives itself:
     /// a failed discovery leaves the previous entry expired and the next call
-    /// retries. Concurrent misses are collapsed behind a single refresh, so a
-    /// burst of authorization requests makes one outbound call rather than one
-    /// per request.
+    /// retries. A caller that misses while another caller's fetch is already
+    /// running joins that fetch rather than starting its own, so a burst of
+    /// authorization requests makes one outbound call and every caller in the
+    /// burst finishes on its result — including when that result is a failure,
+    /// which is what keeps an outage from charging each caller in turn for its
+    /// own [`REQUEST_TIMEOUT`].
     async fn discover(
         &self,
         provider: &ResolvedOidcProvider,
     ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
         let ttl = provider.discovery_cache_ttl();
-        if let Some(cached) = self.discovery.get(&provider.issuer).await {
-            return Ok(cached);
+        loop {
+            if let Some(cached) = self.discovery.get(&provider.issuer).await {
+                return Ok(cached);
+            }
+            match self.discovery.join(&provider.issuer) {
+                Flight::Lead(mut flight) => {
+                    let outcome = self.fetch_discovery(provider).await;
+                    if let Ok(discovery) = &outcome {
+                        self.discovery
+                            .insert(&provider.issuer, discovery, ttl)
+                            .await;
+                    }
+                    flight.publish(&outcome);
+                    return outcome;
+                }
+                Flight::Follow(mut flight) => {
+                    if let Ok(outcome) = flight.recv().await {
+                        return outcome;
+                    }
+                    // The leader went away without publishing, which is what a
+                    // cancelled request looks like, so no outcome is coming.
+                    // Looping finds that flight retired and leads the retry.
+                }
+            }
         }
-        let _refresh = self.discovery.refresh.lock().await;
-        // Another task may have populated the entry while this one waited for
-        // the refresh lock.
-        if let Some(cached) = self.discovery.get(&provider.issuer).await {
-            return Ok(cached);
-        }
-        let discovery = self.fetch_discovery(provider).await?;
-        self.discovery
-            .insert(&provider.issuer, &discovery, ttl)
-            .await;
-        Ok(discovery)
     }
 
     /// Fetches and validates the provider's discovery document.
@@ -390,17 +404,28 @@ struct ValidatedDiscovery {
     signing_algorithms: Vec<String>,
 }
 
+/// The result of one discovery fetch, as handed to every caller that joined it.
+type DiscoveryOutcome = Result<ValidatedDiscovery, OidcProviderClientError>;
+
 /// Live discovery documents, keyed by the configured issuer they were fetched
 /// for.
 ///
-/// The key space is the set of configured providers, so the map is bounded by
-/// configuration rather than by request traffic. `refresh` serializes cache
-/// misses: it is held across the outbound call so that concurrent misses
-/// produce one request, not one per caller.
+/// The key space is the set of configured providers, so `entries` is bounded by
+/// configuration rather than by request traffic. `inflight` holds the fetches
+/// running right now, one per issuer, and is what gives the cache single-flight
+/// semantics: the first caller to miss performs the outbound request and every
+/// caller that misses while it runs waits on that one result. No lock is held
+/// across the fetch, so callers waiting on one issuer never delay another, and
+/// a fetch that resolves to a failure ends the whole burst at once instead of
+/// releasing it one retry at a time.
+///
+/// `inflight` is a synchronous mutex because [`FlightLead`] releases its entry
+/// from `Drop`, which cannot await. Every critical section is a map operation
+/// and at most a channel send, so no guard ever spans an `await`.
 #[derive(Default)]
 struct DiscoveryCache {
     entries: RwLock<HashMap<String, CachedDiscovery>>,
-    refresh: Mutex<()>,
+    inflight: Mutex<HashMap<String, broadcast::Sender<DiscoveryOutcome>>>,
 }
 
 struct CachedDiscovery {
@@ -435,6 +460,85 @@ impl DiscoveryCache {
                 expires_at,
             },
         );
+    }
+
+    /// Joins the fetch already running for `issuer`, or starts one.
+    ///
+    /// The caller that starts it gets [`Flight::Lead`] and owes an outcome to
+    /// everyone else; a caller that arrives while it runs gets
+    /// [`Flight::Follow`] and waits for that outcome instead of fetching.
+    fn join(&self, issuer: &str) -> Flight<'_> {
+        let mut inflight = self.inflight();
+        if let Some(sender) = inflight.get(issuer) {
+            return Flight::Follow(sender.subscribe());
+        }
+        // One outcome is ever published per flight, and every follower attaches
+        // before it is sent, so a single slot is all the channel needs.
+        let (sender, _initial_receiver) = broadcast::channel(1);
+        inflight.insert(issuer.to_string(), sender.clone());
+        drop(inflight);
+        Flight::Lead(FlightLead {
+            cache: self,
+            issuer: issuer.to_string(),
+            sender,
+            retired: false,
+        })
+    }
+
+    /// Locks the in-flight map, recovering a poisoned guard.
+    ///
+    /// The map holds nothing but channel senders, so a panic while it was held
+    /// cannot leave a broken invariant behind, and the alternative — panicking
+    /// inside [`FlightLead::drop`] — would abort the process.
+    fn inflight(&self) -> MutexGuard<'_, HashMap<String, broadcast::Sender<DiscoveryOutcome>>> {
+        self.inflight.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// A caller's part in the fetch for one issuer, as decided by
+/// [`DiscoveryCache::join`].
+enum Flight<'cache> {
+    /// This caller performs the fetch and publishes its outcome.
+    Lead(FlightLead<'cache>),
+    /// Another caller is already fetching; this one waits for that outcome.
+    Follow(broadcast::Receiver<DiscoveryOutcome>),
+}
+
+/// The right to perform one discovery fetch, and the obligation to hand its
+/// outcome to everyone waiting on it.
+///
+/// Dropping without publishing — which is what a cancelled request does —
+/// retires the flight, so the next caller starts a fresh one rather than
+/// waiting on a fetch that will never finish.
+struct FlightLead<'cache> {
+    cache: &'cache DiscoveryCache,
+    issuer: String,
+    sender: broadcast::Sender<DiscoveryOutcome>,
+    retired: bool,
+}
+
+impl FlightLead<'_> {
+    /// Retires the flight and hands `outcome` to every caller that joined it.
+    fn publish(&mut self, outcome: &DiscoveryOutcome) {
+        self.retire();
+        // Every follower subscribed before the flight was retired, so all of
+        // them are still attached. Leading alone is the ordinary case, and a
+        // send with nobody listening is not a failure.
+        let _followers = self.sender.send(outcome.clone());
+    }
+
+    /// Drops the flight from the cache so that the next miss starts a new one.
+    fn retire(&mut self) {
+        if !self.retired {
+            self.retired = true;
+            self.cache.inflight().remove(&self.issuer);
+        }
+    }
+}
+
+impl Drop for FlightLead<'_> {
+    fn drop(&mut self) {
+        self.retire();
     }
 }
 
@@ -551,6 +655,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use serde_json::{Value, json};
+    use tokio::sync::Barrier;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -816,6 +921,46 @@ mod tests {
             .expect("recovers without waiting out a TTL");
     }
 
+    /// How long a mounted discovery response is held open, so that every caller
+    /// in a burst reaches the cache while the first one's request is still
+    /// running. Only the tests that turn reuse off need it: with reuse on, a
+    /// late caller finds the stored document instead.
+    const BURST_WINDOW: Duration = Duration::from_millis(250);
+
+    /// Mounts a discovery response that stays open for [`BURST_WINDOW`].
+    async fn mount_held_open(server: &MockServer, response: ResponseTemplate) {
+        Mock::given(method("GET"))
+            .and(path("/tenant/.well-known/openid-configuration"))
+            .respond_with(response.set_delay(BURST_WINDOW))
+            .mount(server)
+            .await;
+    }
+
+    /// Runs `count` authorization requests that all start together.
+    async fn authorization_burst(
+        client: &OidcProviderClient,
+        provider: &ResolvedOidcProvider,
+        count: usize,
+    ) -> Vec<Result<OidcAuthorizationRequest, OidcProviderClientError>> {
+        let barrier = Arc::new(Barrier::new(count));
+        let requests = (0..count)
+            .map(|_index| {
+                let client = client.clone();
+                let provider = provider.clone();
+                let barrier = Arc::clone(&barrier);
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    client.authorization_request(&provider).await
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut outcomes = Vec::with_capacity(count);
+        for request in requests {
+            outcomes.push(request.await.expect("join"));
+        }
+        outcomes
+    }
+
     /// The cache exists so that a burst of authorization requests cannot be
     /// amplified into a burst of provider requests.
     #[tokio::test]
@@ -826,18 +971,8 @@ mod tests {
         let client = OidcProviderClient::new().expect("client");
         let provider = provider(&issuer);
 
-        let requests = (0..16)
-            .map(|_index| {
-                let client = client.clone();
-                let provider = provider.clone();
-                tokio::spawn(async move { client.authorization_request(&provider).await })
-            })
-            .collect::<Vec<_>>();
-        for request in requests {
-            request
-                .await
-                .expect("join")
-                .expect("concurrent authorization request");
+        for outcome in authorization_burst(&client, &provider, 16).await {
+            outcome.expect("concurrent authorization request");
         }
         assert_eq!(discovery_requests(&server).await, 1);
     }
@@ -857,6 +992,102 @@ mod tests {
                 .expect("authorization request");
         }
         assert_eq!(discovery_requests(&server).await, 2);
+    }
+
+    /// Nothing is cached to release a burst that failed, so the fetch itself has
+    /// to be what the burst shares. Otherwise each caller waits out the one
+    /// ahead of it, and an unreachable provider turns into a queue whose tail
+    /// waits a multiple of [`REQUEST_TIMEOUT`].
+    #[tokio::test]
+    async fn concurrent_discovery_failures_collapse_into_one_request() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        mount_held_open(&server, ResponseTemplate::new(500)).await;
+        let client = OidcProviderClient::new().expect("client");
+        let provider = provider(&issuer);
+
+        for outcome in authorization_burst(&client, &provider, 16).await {
+            let Err(error) = outcome else {
+                panic!("expected the provider outage to fail discovery");
+            };
+            assert_eq!(error, OidcProviderClientError::Discovery);
+        }
+        assert_eq!(discovery_requests(&server).await, 1);
+    }
+
+    /// Turning reuse off must not turn discovery into a queue: callers still
+    /// share a fetch that is already running, they just keep no document once
+    /// it finishes.
+    #[tokio::test]
+    async fn zero_discovery_cache_ttl_still_shares_one_in_flight_request() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        mount_held_open(
+            &server,
+            ResponseTemplate::new(200).set_body_bytes(valid_document(&server, &issuer).to_string()),
+        )
+        .await;
+        let client = OidcProviderClient::new().expect("client");
+        let provider = provider_with(&issuer, "discovery_cache_ttl_seconds = 0");
+
+        for outcome in authorization_burst(&client, &provider, 16).await {
+            outcome.expect("concurrent authorization request");
+        }
+        assert_eq!(discovery_requests(&server).await, 1);
+    }
+
+    #[tokio::test]
+    async fn a_published_flight_reaches_every_follower() {
+        let cache = DiscoveryCache::default();
+        let issuer = "https://accounts.example.test";
+        let Flight::Lead(mut lead) = cache.join(issuer) else {
+            panic!("the first caller leads its own flight");
+        };
+        let followers = (0..3)
+            .map(|_index| match cache.join(issuer) {
+                Flight::Follow(follower) => follower,
+                Flight::Lead(_) => panic!("a caller arriving mid-flight follows it"),
+            })
+            .collect::<Vec<_>>();
+
+        lead.publish(&Err(OidcProviderClientError::Discovery));
+
+        for mut follower in followers {
+            let Err(error) = follower.recv().await.expect("published outcome") else {
+                panic!("the published outcome was a failure");
+            };
+            assert_eq!(error, OidcProviderClientError::Discovery);
+        }
+        assert!(
+            matches!(cache.join(issuer), Flight::Lead(_)),
+            "a finished flight still holds later callers"
+        );
+    }
+
+    /// A cancelled request drops its lead mid-fetch. Its followers have to be
+    /// released rather than left waiting on an outcome nobody will publish, and
+    /// the flight has to be retired rather than left for callers to join.
+    #[tokio::test]
+    async fn a_cancelled_flight_lead_releases_its_followers() {
+        let cache = DiscoveryCache::default();
+        let issuer = "https://accounts.example.test";
+        let Flight::Lead(lead) = cache.join(issuer) else {
+            panic!("the first caller leads its own flight");
+        };
+        let Flight::Follow(mut follower) = cache.join(issuer) else {
+            panic!("a caller arriving mid-flight follows it");
+        };
+
+        drop(lead);
+
+        assert!(
+            follower.recv().await.is_err(),
+            "a follower is still waiting on a flight that will never publish"
+        );
+        assert!(
+            matches!(cache.join(issuer), Flight::Lead(_)),
+            "an abandoned flight still holds later callers"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Stack context

**Whole stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

**This part of the stack:** PR #1655 completes the authorization endpoint by requiring a Client ID Metadata Document, which makes `client_id` something any caller can supply. This PR removes the outbound cost that then sits behind every such request.

**This PR:** Caches the provider's OIDC discovery document.

## Intent

`GET /oauth/authorize` fetched the provider's discovery document on every request, before writing anything to the authorization-session store. Once a client identity is obtainable — which is exactly what CIMD makes possible — an unauthenticated caller can turn each inbound request into an outbound request to the configured IdP, and every real login pays that round trip too.

Discovery documents are stable and designed to be cached, so refetching them per request buys nothing.

## What it enables

- Reuses a validated discovery document for a configurable TTL, defaulting to five minutes.
- Caches only successes, so a provider blip never outlives itself: a failed discovery leaves nothing behind and the next request retries immediately.
- Collapses concurrent misses behind a single refresh, so a burst of authorization requests produces one outbound call rather than one per request.
- Keys entries by configured issuer, bounding the cache by configuration rather than by request traffic.

A zero TTL disables reuse, which keeps an escape hatch for operators who need a provider endpoint change to take effect at once.

## Usage examples

Caching is on by default and needs no configuration. To tune the window:

```toml
[auth.provider]
issuer = "https://accounts.example.com"
client_id = "coral-server"
redirect_uri = "https://coral.example.com/auth/oidc/callback"
# Reuse a discovery document for 15 minutes instead of the default 5.
discovery_cache_ttl_seconds = 900
```

To disable caching entirely, so that every authorization request performs its own discovery:

```toml
[auth.provider]
discovery_cache_ttl_seconds = 0
```

Values above one hour are rejected at config-parse time, so a stale provider endpoint cannot outlive a plausible rotation window.
