### PR TITLE
feat: expose sources used by functions

### DIFF
--- a/apps/reef/app/routes/functions.server.test.ts
+++ b/apps/reef/app/routes/functions.server.test.ts
@@ -32,6 +32,7 @@ describe('functions route mapping', () => {
             { dataType: 'Int64', name: 'number', nullable: false },
             { dataType: 'Utf8', name: 'title', nullable: true },
           ],
+          sourceNames: ['github', 'slack'],
           sqlBody: 'select * from github.pull_requests',
           tableFunction: create(FunctionTableFunctionPublishSchema, {
             name: 'review_queue',
@@ -54,7 +55,7 @@ describe('functions route mapping', () => {
         { dataType: 'Int64', name: 'number', nullable: false },
         { dataType: 'Utf8', name: 'title', nullable: true },
       ],
-      sources: [],
+      sources: ['github', 'slack'],
     })
   })
 

--- a/apps/reef/app/routes/functions.tsx
+++ b/apps/reef/app/routes/functions.tsx
@@ -78,6 +78,6 @@ export function toFunctionDetails(fn: Function): FunctionDetailsProps | null {
       name,
       nullable,
     })),
-    sources: [],
+    sources: ready.sourceNames,
   }
 }

--- a/apps/reef/app/views/functions/functions-index.test.tsx
+++ b/apps/reef/app/views/functions/functions-index.test.tsx
@@ -10,7 +10,7 @@ const reviewQueue = {
   name: 'review_queue',
   namespace: 'engineering',
   resultColumns: [{ dataType: 'Int64', name: 'number', nullable: false }],
-  sources: [],
+  sources: ['github'],
 }
 
 function renderFunctions(
@@ -43,7 +43,7 @@ describe('FunctionsIndex', () => {
           name: 'recent_incidents',
           namespace: 'operations',
           resultColumns: [{ dataType: 'Utf8', name: 'id', nullable: false }],
-          sources: [],
+          sources: ['pagerduty'],
         },
       ],
       loadError: null,
@@ -63,6 +63,7 @@ describe('FunctionsIndex', () => {
     await expect.element(screen.getByText('Pull requests waiting for review.')).toBeVisible()
     await expect.element(screen.getByText('owner')).toBeVisible()
     await expect.element(screen.getByText('number')).toBeVisible()
+    await expect.element(screen.getByText('github')).toBeVisible()
 
     await screen.getByRole('button', { name: /operations/ }).click()
     await expect
@@ -74,6 +75,8 @@ describe('FunctionsIndex', () => {
 
     await expect.element(screen.getByText('Recently opened incidents.')).toBeVisible()
     await expect.element(screen.getByRole('heading', { name: 'recent_incidents' })).toBeVisible()
+    await expect.element(screen.getByText('pagerduty')).toBeVisible()
+    await expect.element(screen.getByText('github')).not.toBeInTheDocument()
 
     await screen.getByRole('button', { name: /operations/ }).click()
     await expect

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -38,6 +38,8 @@ message FunctionRuntimeReady {
   repeated TableFunctionResultColumn result_columns = 4;
   // Executable SQL body parsed from the installed artifact.
   string sql_body = 5;
+  // Canonical installed sources referenced by the planned function SQL.
+  repeated string source_names = 6;
 }
 
 // Validation failure for an installed function that is not currently queryable.

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -47,7 +47,7 @@ pub(crate) struct FunctionListing {
 }
 
 pub(crate) enum FunctionRuntimeStatus {
-    Ready(UdfRuntimeDefinition),
+    Ready(Box<UdfRuntimeDefinition>),
     Invalid(String),
 }
 
@@ -60,7 +60,7 @@ enum FunctionCandidate {
     Listing(FunctionListing),
     Pending {
         name: FunctionName,
-        definition: UdfRuntimeDefinition,
+        definition: Box<UdfRuntimeDefinition>,
     },
 }
 
@@ -209,7 +209,7 @@ impl FunctionManager {
         let mut definitions = Vec::new();
         for listing in listings {
             match listing.runtime {
-                FunctionRuntimeStatus::Ready(definition) => definitions.push(definition),
+                FunctionRuntimeStatus::Ready(definition) => definitions.push(*definition),
                 FunctionRuntimeStatus::Invalid(error) => tracing::warn!(
                     function = %listing.name,
                     detail = %error,
@@ -261,14 +261,14 @@ impl FunctionManager {
             }
             candidates.push(FunctionCandidate::Pending {
                 name: artifact.name,
-                definition: runtime_function,
+                definition: Box::new(runtime_function),
             });
         }
 
         let pending = candidates
             .iter()
             .filter_map(|candidate| match candidate {
-                FunctionCandidate::Pending { definition, .. } => Some(definition.clone()),
+                FunctionCandidate::Pending { definition, .. } => Some(definition.as_ref().clone()),
                 FunctionCandidate::Listing(_) => None,
             })
             .collect::<Vec<_>>();
@@ -426,7 +426,7 @@ fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, 
 fn ready_listing(name: FunctionName, definition: UdfRuntimeDefinition) -> FunctionListing {
     FunctionListing {
         name,
-        runtime: FunctionRuntimeStatus::Ready(definition),
+        runtime: FunctionRuntimeStatus::Ready(Box::new(definition)),
     }
 }
 

--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -69,6 +69,7 @@ fn apply_signatures(
             let signature = signature.map_err(|error| runtime_validation_error(&error))?;
             function.arguments = signature.arguments;
             function.result_columns = signature.result_columns;
+            function.source_names = signature.source_names;
             Ok(function)
         })
         .collect()
@@ -86,6 +87,7 @@ pub(crate) fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRunt
         implementation: runtime_implementation(spec.implementation()),
         publish: runtime_publish(spec),
         result_columns: Vec::new(),
+        source_names: Vec::new(),
     }
 }
 

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -100,7 +100,7 @@ impl FunctionServiceApi for FunctionService {
 fn function_listing_to_proto(workspace_name: &WorkspaceName, listing: FunctionListing) -> Function {
     match listing.runtime {
         FunctionRuntimeStatus::Ready(definition) => {
-            runtime_function_to_proto(workspace_name, definition)
+            runtime_function_to_proto(workspace_name, *definition)
         }
         FunctionRuntimeStatus::Invalid(reason) => Function {
             name: listing.name.to_string(),
@@ -147,6 +147,7 @@ fn runtime_function_to_proto(
                 })
                 .collect(),
             sql_body,
+            source_names: function.source_names,
         })),
     }
 }

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -199,6 +199,7 @@ tables:
                 },
             },
             result_columns: Vec::new(),
+            source_names: Vec::new(),
         }
     }
 

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{
 use coral_client::default_workspace;
 use tonic::Request;
 
-use crate::harness::GrpcHarness;
+use crate::harness::{GrpcHarness, fixture_manifest_yaml};
 
 fn workspace(name: &str) -> Workspace {
     Workspace {
@@ -58,6 +58,7 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         panic!("expected runtime-ready function");
     };
     assert_eq!(ready.sql_body, sql_body);
+    assert!(ready.source_names.is_empty());
     assert_eq!(
         ready.table_function.expect("table function").guide,
         "Use this function to echo a typed value."
@@ -89,6 +90,7 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         panic!("expected listed runtime-ready function");
     };
     assert_eq!(ready.sql_body, sql_body);
+    assert!(ready.source_names.is_empty());
 
     harness
         .function_client()
@@ -109,6 +111,49 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         .into_inner()
         .functions;
     assert!(remaining.is_empty());
+}
+
+#[tokio::test]
+async fn function_sources_are_returned_when_added_and_listed() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let added = harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            workspace: Some(default_workspace()),
+            sql: function_sql(r#"select "sessionId" as session_id from local_messages.messages"#),
+        }))
+        .await
+        .expect("add function")
+        .into_inner()
+        .function
+        .expect("added function");
+    let Some(function::Runtime::Ready(ready)) = added.runtime else {
+        panic!("expected runtime-ready function");
+    };
+    assert_eq!(ready.source_names, ["local_messages"]);
+
+    let listed = harness
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list functions")
+        .into_inner()
+        .functions;
+    let listed = listed.into_iter().next().expect("listed function");
+    let Some(function::Runtime::Ready(ready)) = listed.runtime else {
+        panic!("expected listed runtime-ready function");
+    };
+    assert_eq!(ready.source_names, ["local_messages"]);
 }
 
 #[tokio::test]

--- a/crates/coral-engine/src/contracts/udfs.rs
+++ b/crates/coral-engine/src/contracts/udfs.rs
@@ -9,6 +9,8 @@ pub struct UdfRuntimeSignature {
     pub arguments: Vec<UdfRuntimeArgument>,
     /// Columns returned by the UDF SQL body.
     pub result_columns: Vec<UdfRuntimeResultColumn>,
+    /// Canonical installed source names referenced by the UDF SQL body.
+    pub source_names: Vec<String>,
 }
 
 /// One SQL UDF body to validate before runtime registration.
@@ -44,6 +46,8 @@ pub struct UdfRuntimeDefinition {
     pub publish: UdfRuntimePublish,
     /// Columns inferred by planning the UDF SQL body.
     pub result_columns: Vec<UdfRuntimeResultColumn>,
+    /// Canonical installed source names referenced by the UDF SQL body.
+    pub source_names: Vec<String>,
 }
 
 /// One typed UDF argument.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -73,6 +73,7 @@ pub(crate) struct InferredSqlSignature {
     pub(crate) parameter_fields: HashMap<String, Option<FieldRef>>,
     pub(crate) declared_parameter_types: HashMap<String, ManifestDataType>,
     pub(crate) planned_schema: Arc<arrow::datatypes::Schema>,
+    pub(crate) source_names: Vec<String>,
 }
 
 pub(crate) struct PreparedSql {
@@ -740,11 +741,24 @@ impl QueryRuntimeAdapter {
             &mut declared_parameter_types,
         )
         .map_err(plan_error)?;
+        let source_names = self
+            .resolve_query_resources(df.logical_plan())
+            .map_err(plan_error)?
+            .sources()
+            .iter()
+            .filter(|source_name| {
+                self.schema_to_source
+                    .values()
+                    .any(|installed_name| installed_name == *source_name)
+            })
+            .cloned()
+            .collect();
 
         Ok(InferredSqlSignature {
             parameter_fields,
             declared_parameter_types,
             planned_schema: Arc::new(df.logical_plan().schema().as_arrow().clone()),
+            source_names,
         })
     }
 
@@ -1568,6 +1582,7 @@ mod tests {
                     data_type: DataType::Int64,
                     nullable: false,
                 }],
+                source_names: Vec::new(),
             }])
             .await
             .expect("late UDF install");

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -63,6 +63,7 @@ pub(crate) async fn infer_udf_signature(
     Ok(UdfRuntimeSignature {
         arguments,
         result_columns: result_columns(signature.planned_schema.as_ref()),
+        source_names: signature.source_names,
     })
 }
 
@@ -504,6 +505,7 @@ mod tests {
                 },
             },
             result_columns: Vec::new(),
+            source_names: vec!["github".to_string()],
         }
     }
 

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -7,9 +8,9 @@ use arrow::record_batch::RecordBatch;
 use coral_engine::{
     CoralQuery, CoreError, EngineExtensions, QueryExecutionProvenance, QueryParameterValue,
     QueryParameters, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
-    QueryRuntimeContext, StatusCode, UdfRuntimeArgument, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    QueryRuntimeContext, QuerySource, RuntimeSourcePackage, StatusCode, UdfRuntimeArgument,
+    UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
+    UdfRuntimeSignature, UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
 };
 use coral_spec::ManifestDataType;
 use serde_json::{Value, json};
@@ -240,6 +241,7 @@ fn min_id_udf(source_name: &str) -> UdfRuntimeDefinition {
         },
         publish: udf_publish("min_id_events"),
         result_columns: vec![udf_result_column("id", DataType::Int64)],
+        source_names: vec![source_name.to_string()],
     }
 }
 
@@ -301,6 +303,7 @@ fn published_limited_events_udf(source_name: &str) -> UdfRuntimeDefinition {
         },
         publish: udf_publish("limited_events"),
         result_columns: vec![udf_result_column("id", DataType::Int64)],
+        source_names: vec![source_name.to_string()],
     }
 }
 
@@ -338,6 +341,7 @@ fn review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
         },
         publish: udf_publish("review_queue"),
         result_columns: Vec::new(),
+        source_names: vec![source_name.to_string()],
     }
 }
 
@@ -444,6 +448,7 @@ async fn infer_udf_signature_uses_source_function_schema_with_parameters() {
             ("since", ManifestDataType::Timestamp),
         ]
     );
+    assert_eq!(signature.source_names, ["signature_param_search"]);
 
     let columns = column_types(&signature);
     assert!(matches!(
@@ -474,6 +479,7 @@ async fn infer_udf_signature_uses_explicit_cast_for_argument_type() {
         panic!("expected label result column");
     };
     assert!(matches!(column_type, DataType::Utf8 | DataType::Utf8View));
+    assert!(signature.source_names.is_empty());
 }
 
 #[tokio::test]
@@ -522,7 +528,74 @@ async fn infer_udf_signature_uses_column_comparison_for_argument_type() {
         column_types(&signature).as_slice(),
         [("id", DataType::Int64)]
     ));
+    assert_eq!(signature.source_names, ["schema_udf_events"]);
     assert_eq!(observer.calls(), 0);
+}
+
+#[tokio::test]
+async fn infer_udf_signature_maps_component_schema_to_canonical_source_name() {
+    let (_temp, component_source) = events_source("github_rest");
+    let source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "github".to_string(),
+            authored_version: None,
+            description: String::new(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: None,
+            components: component_source.components().to_vec(),
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("composite runtime source");
+
+    let signature = CoralQuery::infer_udf_signature(
+        &[source],
+        test_runtime(),
+        udf_sql("github_events", "select id from github_rest.events"),
+    )
+    .await
+    .expect("udf signature inference should resolve the installed source name");
+
+    assert_eq!(signature.source_names, ["github"]);
+}
+
+#[tokio::test]
+async fn infer_udf_signature_sorts_and_deduplicates_source_names() {
+    let (_zeta_temp, zeta_source) = events_source("zeta_events");
+    let (_alpha_temp, alpha_source) = events_source("alpha_events");
+
+    let signature = CoralQuery::infer_udf_signature(
+        &[zeta_source, alpha_source],
+        test_runtime(),
+        udf_sql(
+            "combined_events",
+            "select id from zeta_events.events \
+             union all select id from alpha_events.events \
+             union all select id from zeta_events.events",
+        ),
+    )
+    .await
+    .expect("udf signature inference should collect every source once");
+
+    assert_eq!(signature.source_names, ["alpha_events", "zeta_events"]);
+}
+
+#[tokio::test]
+async fn infer_udf_signature_excludes_system_catalog_tables() {
+    let signature = CoralQuery::infer_udf_signature(
+        &[],
+        test_runtime(),
+        udf_sql(
+            "catalog_tables",
+            "select schema_name, table_name from coral.tables",
+        ),
+    )
+    .await
+    .expect("system catalog query should plan");
+
+    assert!(signature.source_names.is_empty());
 }
 
 #[tokio::test]
@@ -656,6 +729,7 @@ async fn published_udf_table_function_coerces_arguments_in_the_expanded_body() {
         },
         publish: udf_publish("format_id"),
         result_columns: vec![udf_result_column("formatted_id", DataType::Utf8View)],
+        source_names: Vec::new(),
     };
     let runtime = CoralQuery::prepare(&[], test_runtime())
         .await


### PR DESCRIPTION
## Summary

Says on the tin. It'd be cool to exposes a list of all the sources a saved function touches, so we can show them in the UI and e.g. enable filtering too

## Test plan

UI now shows sources.

<img width="845" height="180" alt="image" src="https://github.com/user-attachments/assets/80666b20-2705-4819-9e0a-0bfe444b80d2" />
