### PR TITLE
feat(spec): preserve DSL v4 operation contracts for fanout

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1866,7 +1866,7 @@ surface:
             .iter()
             .map(|column| column.name.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(column_names, ["result", "result_json"]);
+        assert_eq!(column_names, ["result", "result_json", "id"]);
     }
 
     #[test]

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -612,6 +612,7 @@ mod tests {
                 description: String::new(),
                 deprecated: false,
                 read_only: true,
+                idempotent: true,
                 naming: None,
                 inputs: pagination_inputs.clone(),
                 output: IrOperationOutput {
@@ -685,6 +686,7 @@ mod tests {
                 description: String::new(),
                 deprecated: false,
                 read_only: true,
+                idempotent: true,
                 naming: None,
                 inputs: inputs.clone(),
                 output: IrOperationOutput {
@@ -828,6 +830,7 @@ mod tests {
                 description: String::new(),
                 deprecated: false,
                 read_only: true,
+                idempotent: true,
                 naming: None,
                 inputs,
                 output: IrOperationOutput {
@@ -880,6 +883,7 @@ mod tests {
                 description: String::new(),
                 deprecated: false,
                 read_only: true,
+                idempotent: true,
                 naming: None,
                 inputs: Vec::new(),
                 output: IrOperationOutput {
@@ -919,6 +923,7 @@ mod tests {
                             required: true,
                             nullable: false,
                             description: String::new(),
+                            synthetic: false,
                         }],
                     },
                     nullable: false,
@@ -958,9 +963,38 @@ mod tests {
                 pagination: McpOperationPagination::default(),
             },
         );
-        surface.plan =
-            ValidatedSurfacePlan::new(surface.plan.semantic_ir().clone(), operation_metadata)
-                .expect("plan");
+        let mut semantic_ir = surface.plan.semantic_ir().clone();
+        let operation = semantic_ir.operations.first_mut().expect("MCP operation");
+        operation.output = IrOperationOutput {
+            cardinality: coral_spec::v4::OutputCardinality::Singleton,
+            type_ref: "envelope".to_string(),
+        };
+        semantic_ir.types.extend([
+            IrType {
+                id: "tool_result_list".to_string(),
+                shape: IrTypeShape::List {
+                    item_type_ref: "tool_result".to_string(),
+                },
+                nullable: false,
+                description: String::new(),
+            },
+            IrType {
+                id: "envelope".to_string(),
+                shape: IrTypeShape::Object {
+                    fields: vec![IrField {
+                        name: "items".to_string(),
+                        type_ref: "tool_result_list".to_string(),
+                        required: true,
+                        nullable: false,
+                        description: String::new(),
+                        synthetic: false,
+                    }],
+                },
+                nullable: false,
+                description: String::new(),
+            },
+        ]);
+        surface.plan = ValidatedSurfacePlan::new(semantic_ir, operation_metadata).expect("plan");
         surface
     }
 

--- a/crates/coral-engine/src/backends/http/request.rs
+++ b/crates/coral-engine/src/backends/http/request.rs
@@ -120,11 +120,64 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{RequestBody, build_request_body, set_path_value};
+    use super::{RequestBody, build_query_pairs, build_request_body, set_path_value};
     use crate::backends::shared::template::RenderContext;
     use coral_spec::{
-        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, RequestSpec, ValueSourceSpec,
+        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, QueryParamSpec, RequestSpec,
+        ValueSourceSpec,
     };
+
+    #[test]
+    fn build_query_pairs_omits_missing_args_but_preserves_explicit_values() {
+        let request = RequestSpec {
+            method: HttpMethod::GET,
+            path: ParsedTemplate::parse("/items").expect("template"),
+            query: vec![QueryParamSpec {
+                name: "scope".to_string(),
+                value: ValueSourceSpec::Arg {
+                    key: "scope".to_string(),
+                    default: None,
+                },
+            }],
+            body: BodySpec::default(),
+            headers: vec![],
+        };
+        let filters = HashMap::new();
+        let state = HashMap::new();
+        let resolved_inputs = BTreeMap::new();
+
+        let missing_args = HashMap::new();
+        let missing_context = RenderContext::new(&filters, &missing_args, &state, &resolved_inputs);
+        assert!(
+            build_query_pairs(&request, &missing_context)
+                .expect("query should render")
+                .is_empty()
+        );
+
+        for explicit in ["", "null"] {
+            let args = HashMap::from([("scope".to_string(), explicit.to_string())]);
+            let context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
+            assert_eq!(
+                build_query_pairs(&request, &context).expect("query should render"),
+                [("scope".to_string(), explicit.to_string())]
+            );
+        }
+
+        let literal_null = RequestSpec {
+            query: vec![QueryParamSpec {
+                name: "scope".to_string(),
+                value: ValueSourceSpec::Literal {
+                    value: serde_json::Value::Null,
+                },
+            }],
+            ..request
+        };
+        assert_eq!(
+            build_query_pairs(&literal_null, &missing_context)
+                .expect("literal null should preserve generic renderer behavior"),
+            [("scope".to_string(), String::new())]
+        );
+    }
 
     #[test]
     fn build_request_body_omits_json_body_when_no_fields_resolve() {

--- a/crates/coral-engine/src/backends/mcp/catalog.rs
+++ b/crates/coral-engine/src/backends/mcp/catalog.rs
@@ -55,5 +55,9 @@ fn tool_descriptor(tool: Tool) -> McpToolDescriptor {
             .annotations
             .as_ref()
             .and_then(|annotations| annotations.read_only_hint),
+        idempotent_hint: tool
+            .annotations
+            .as_ref()
+            .and_then(|annotations| annotations.idempotent_hint),
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -461,7 +461,7 @@ impl DeclaredDefaultValue {
     }
 }
 
-fn deserialize_declared_default<'de, D>(
+pub(crate) fn deserialize_declared_default<'de, D>(
     deserializer: D,
 ) -> std::result::Result<Option<DeclaredDefaultValue>, D::Error>
 where

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -4,6 +4,7 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::mcp::McpExecutionAttachment;
 use crate::v4::ir::rest::RestExecutionAttachment;
 use crate::v4::manifest::SurfaceType;
+use crate::{DeclaredDefaultValue, common::deserialize_declared_default};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemanticIr {
@@ -23,6 +24,12 @@ pub struct IrOperation {
     pub description: String,
     pub deprecated: bool,
     pub read_only: bool,
+    /// Whether replaying the operation with the same inputs is declared safe.
+    ///
+    /// MCP imports preserve the tool's `idempotentHint` here. REST imports
+    /// derive the property from the HTTP method.
+    #[serde(default)]
+    pub idempotent: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub naming: Option<IrOperationNaming>,
     pub inputs: Vec<IrOperationInput>,
@@ -46,7 +53,14 @@ pub struct IrOperationInput {
     pub location: IrInputLocation,
     pub required: bool,
     pub data_type: IrScalarType,
-    pub default_value: Option<String>,
+    /// A type-preserving JSON Schema default. The outer option distinguishes
+    /// an omitted `default` annotation from an explicitly authored `null`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_declared_default",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_value: Option<DeclaredDefaultValue>,
     pub description: String,
 }
 
@@ -98,6 +112,17 @@ pub struct IrField {
     pub required: bool,
     pub nullable: bool,
     pub description: String,
+    /// Whether this field was synthesized by an importer for compatibility.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub synthetic: bool,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if callbacks receive a reference"
+)]
+fn is_false(value: &bool) -> bool {
+    !value
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -164,6 +189,8 @@ pub enum IrExecutionAttachment {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::{
         HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
         IrOperationNaming, IrOperationOutput, IrScalarType, IrType, IrTypeShape, OutputCardinality,
@@ -174,6 +201,47 @@ mod tests {
     use crate::v4::ir::rest::{RestExecutionAttachment, RestResponseAttachment};
     use crate::v4::manifest::SurfaceType;
     use crate::v4::{MCP_IMPORTER_VERSION, OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
+
+    #[test]
+    fn input_defaults_distinguish_missing_from_explicit_null() {
+        let base = json!({
+            "name": "scope",
+            "location": "query",
+            "required": false,
+            "data_type": "string",
+            "description": ""
+        });
+        let absent: IrOperationInput =
+            serde_json::from_value(base.clone()).expect("input without default");
+        assert!(absent.default_value.is_none());
+        assert!(
+            serde_json::to_value(&absent)
+                .expect("serialize absent default")
+                .get("default_value")
+                .is_none()
+        );
+
+        let mut explicit_null = base;
+        explicit_null
+            .as_object_mut()
+            .expect("object")
+            .insert("default_value".to_string(), serde_json::Value::Null);
+        let explicit_null: IrOperationInput =
+            serde_json::from_value(explicit_null).expect("input with null default");
+        assert_eq!(
+            explicit_null
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&serde_json::Value::Null)
+        );
+        assert_eq!(
+            serde_json::to_value(&explicit_null)
+                .expect("serialize explicit null")
+                .get("default_value"),
+            Some(&serde_json::Value::Null)
+        );
+    }
 
     #[test]
     fn semantic_ir_yaml_uses_editor_friendly_enum_shapes() {
@@ -188,6 +256,7 @@ mod tests {
                 description: String::new(),
                 deprecated: false,
                 read_only: true,
+                idempotent: true,
                 naming: Some(IrOperationNaming {
                     group: Some("issues".to_string()),
                     operation: Some("list".to_string()),
@@ -253,6 +322,7 @@ mod tests {
                 description: String::new(),
                 deprecated: false,
                 read_only: true,
+                idempotent: true,
                 naming: None,
                 inputs: vec![IrOperationInput {
                     name: "cursor".to_string(),

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -3,12 +3,12 @@
     reason = "DSL v4 contracts are field-heavy artifact models documented in the PRD."
 )]
 
-pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
-pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v8";
-pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
-pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";
+pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 6;
+pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v4";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v9";
+pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v4";
+pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v5";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v14";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
+use serde_json::json;
+
 use super::*;
 use crate::{
     ManifestDataType, PaginationMode, PaginationSpec, SourceTableFunctionKind,
@@ -621,7 +623,7 @@ components:
         .iter()
         .map(|column| (column.name.as_str(), column.data_type))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(projection.columns.len(), 11);
+    assert_eq!(projection.columns.len(), 12);
     assert_eq!(column_types.get("id"), Some(&ManifestDataType::Float64));
     assert_eq!(
         column_types.get("content_type"),
@@ -632,6 +634,14 @@ components:
         Some(&ManifestDataType::Timestamp)
     );
     assert_eq!(column_types.get("fields"), Some(&ManifestDataType::Json));
+    assert_eq!(
+        projection
+            .columns
+            .iter()
+            .find(|column| column.name == "creator__login")
+            .map(|column| column.source_path.as_slice()),
+        Some(["creator".to_string(), "login".to_string()].as_slice())
+    );
 }
 
 #[test]
@@ -1475,10 +1485,18 @@ paths:
     let defaults = operation
         .inputs
         .iter()
-        .map(|input| (input.name.as_str(), input.default_value.as_deref()))
+        .map(|input| {
+            (
+                input.name.as_str(),
+                input
+                    .default_value
+                    .as_ref()
+                    .map(|default| default.value().clone()),
+            )
+        })
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(defaults.get("per_page"), Some(&Some("30")));
-    assert_eq!(defaults.get("archived"), Some(&Some("false")));
+    assert_eq!(defaults.get("per_page"), Some(&Some(json!(30))));
+    assert_eq!(defaults.get("archived"), Some(&Some(json!(false))));
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/operation_metadata/plan.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/plan.rs
@@ -4,7 +4,7 @@ use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
-use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
+use crate::v4::ir::{IrInputLocation, IrOperation, SemanticIr};
 use crate::v4::operation_metadata::model::{OperationMetadata, OperationMetadataCatalog};
 use crate::v4::operation_metadata::policy::{
     resolve_output_row_type_ref, rest_pagination_owned_inputs,
@@ -18,13 +18,13 @@ use crate::{PaginationSpec, Result};
 pub struct ValidatedSurfacePlan {
     semantic_ir: SemanticIr,
     operation_metadata: OperationMetadataCatalog,
-    /// Row type each REST operation yields once its row path is applied.
+    /// Row type each operation yields once its row path is applied.
     ///
     /// Resolved once, because resolving one walks the whole type catalog and a
     /// validated plan is immutable. Rebuilt on deserialization, so it stays out
     /// of the serialized form.
     #[serde(skip)]
-    rest_row_type_refs: BTreeMap<String, String>,
+    output_row_type_refs: BTreeMap<String, String>,
 }
 
 impl<'de> Deserialize<'de> for ValidatedSurfacePlan {
@@ -50,11 +50,11 @@ impl ValidatedSurfacePlan {
     ) -> Result<Self> {
         validate_semantic_ir_structure(&semantic_ir)?;
         validate_operation_metadata_structure(&semantic_ir, &operation_metadata)?;
-        let rest_row_type_refs = resolve_rest_row_type_refs(&semantic_ir, &operation_metadata);
+        let output_row_type_refs = resolve_output_row_type_refs(&semantic_ir, &operation_metadata);
         Ok(Self {
             semantic_ir,
             operation_metadata,
-            rest_row_type_refs,
+            output_row_type_refs,
         })
     }
 
@@ -88,17 +88,17 @@ impl ValidatedSurfacePlan {
     }
 
     #[must_use]
-    /// Returns the REST row type that remains after applying the operation's
+    /// Returns the row type that remains after applying the operation's
     /// row path.
     ///
     /// # Panics
     ///
-    /// Panics when the operation is absent, is not a REST operation, or the
-    /// validated-plan invariant that its row path resolves has been violated.
-    pub fn rest_output_type_ref(&self, operation_id: &str) -> &str {
-        self.rest_row_type_refs
+    /// Panics when the operation is absent or the validated-plan invariant
+    /// that its row path resolves has been violated.
+    pub fn output_row_type_ref(&self, operation_id: &str) -> &str {
+        self.output_row_type_refs
             .get(operation_id)
-            .expect("validated plan resolves a row type for every REST operation")
+            .expect("validated plan resolves a row type for every operation")
             .as_str()
     }
 
@@ -172,12 +172,12 @@ impl ValidatedSurfacePlan {
     }
 }
 
-/// Resolves every REST operation's row type against one shared type index.
+/// Resolves every operation's row type against one shared type index.
 ///
 /// Runs after structural validation, so a resolution failure cannot happen for
-/// a valid plan; skipping one leaves `rest_output_type_ref` to panic, which is
+/// a valid plan; skipping one leaves `output_row_type_ref` to panic, which is
 /// the contract it already documents.
-fn resolve_rest_row_type_refs(
+fn resolve_output_row_type_refs(
     semantic_ir: &SemanticIr,
     operation_metadata: &OperationMetadataCatalog,
 ) -> BTreeMap<String, String> {
@@ -189,7 +189,6 @@ fn resolve_rest_row_type_refs(
     semantic_ir
         .operations
         .iter()
-        .filter(|operation| matches!(operation.execution, IrExecutionAttachment::Rest(_)))
         .filter_map(|operation| {
             let row_path = operation_metadata
                 .operations

--- a/crates/coral-spec/src/v4/operation_metadata/policy.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/policy.rs
@@ -87,10 +87,13 @@ fn validate_operation_metadata(
                 pagination,
             },
         ) => {
-            // MCP output types stay opaque JSON, so an MCP row path is only
-            // checked for hygiene; the runtime resolves it against the decoded
-            // tool result.
             validate_row_path(operation, row_path)?;
+            resolve_output_row_type_ref(&operation.output, row_path, types).map_err(|error| {
+                ManifestError::validation(format!(
+                    "operation '{}' output row path is invalid: {error}",
+                    operation.id
+                ))
+            })?;
             validate_mcp_pagination(operation, pagination)
         }
         (IrExecutionAttachment::Rest(_), OperationMetadata::Mcp { .. }) => {

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -71,6 +71,7 @@ surface:
                 "properties": {"id": {"type": "string"}}
             })),
             read_only_hint: Some(true),
+            idempotent_hint: Some(true),
         }],
     };
     import_mcp_surface(v4, &v4.surface, &catalog).expect("import")
@@ -252,6 +253,30 @@ fn plan_rejects_blank_or_unresolvable_rest_row_paths() {
         error
             .to_string()
             .contains("row path must be empty when the response root is already a list"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn plan_rejects_unresolvable_mcp_row_paths() {
+    let mut imported = imported_mcp();
+    let OperationMetadata::Mcp { row_path, .. } = imported
+        .operation_metadata
+        .operations
+        .values_mut()
+        .next()
+        .expect("metadata")
+    else {
+        panic!("expected MCP metadata");
+    };
+    *row_path = vec!["id".to_string()];
+
+    let error = imported
+        .validated_plan()
+        .expect_err("an MCP row path that does not select a list must fail");
+
+    assert!(
+        error.to_string().contains("is not a list"),
         "unexpected error: {error}"
     );
 }

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1071,7 +1071,7 @@ components:
   schemas:
     LimitParameter: {type: integer, default: 25}
     ExactParameter: {type: boolean, default: false}
-    ScopeParameter: {type: [string, 'null'], default: null}
+    ScopeParameter: {type: string, nullable: true, default: null}
 paths:
   /search:
     get:
@@ -1165,11 +1165,11 @@ paths:
         - name: scope
           in: path
           required: true
-          schema: {type: [string, 'null'], default: null}
+          schema: {type: string, nullable: true, default: null}
         - name: cursor
           in: query
           required: true
-          schema: {type: [string, 'null'], default: null}
+          schema: {type: string, nullable: true, default: null}
       responses:
         '200':
           content:
@@ -1537,8 +1537,8 @@ fn generated_mcp_projection_projects_authored_top_level_raw_field() {
         .expect("authored raw field");
     assert!(!raw_field.synthetic);
 
-    let catalog =
-        generate_projection_catalog(v4, &mcp_ir.validated_plan().expect("plan")).expect("catalog");
+    let plan = mcp_ir.validated_plan().expect("plan");
+    let catalog = generate_projection_catalog(v4, &plan).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
     let raw_column = projection
         .columns
@@ -1547,6 +1547,44 @@ fn generated_mcp_projection_projects_authored_top_level_raw_field() {
         .expect("authored raw projection column");
     assert_eq!(raw_column.data_type, ManifestDataType::Utf8);
     assert_eq!(raw_column.source_path, ["raw"]);
+    validate_projection_compatibility(&plan, &catalog)
+        .expect("provider-authored raw fields must remain addressable");
+}
+
+#[test]
+fn projection_compatibility_rejects_synthetic_mcp_raw_field() {
+    let manifest = mcp_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_mcp_surface(
+        v4,
+        &v4.surface,
+        &McpToolCatalog {
+            tools: vec![McpToolDescriptor {
+                name: "get_item".to_string(),
+                title: None,
+                description: None,
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: Some(json!({
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}}
+                })),
+                read_only_hint: Some(true),
+                idempotent_hint: Some(true),
+            }],
+        },
+    )
+    .expect("MCP import");
+    let plan = ir.validated_plan().expect("plan");
+    let generated = generate_projection_catalog(v4, &plan).expect("catalog");
+    let catalog = compatibility_of_source_path(&generated, &["raw"]);
+
+    let error = validate_projection_compatibility(&plan, &catalog)
+        .expect_err("the importer-only raw field is not present in runtime rows");
+
+    assert!(
+        error.to_string().contains("reads synthetic field 'raw'"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
@@ -1774,6 +1812,96 @@ paths:
         assert_eq!(leaf.name, "repository__owner_name");
         assert_eq!(leaf.data_type, ManifestDataType::Utf8);
     }
+}
+
+#[test]
+fn nested_column_names_do_not_reuse_collision_resolved_top_level_names() {
+    let manifest = openapi_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let suffix = crate::v4::naming::stable_suffix("foo_bar");
+    let literal_name = format!("foo_bar__{suffix}");
+    let openapi = format!(
+        r"
+openapi: 3.0.3
+components:
+  schemas:
+    FooBarObject:
+      type: object
+      properties:
+        {suffix}: {{type: string}}
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    foo-bar: {{type: string}}
+                    foo_bar: {{$ref: '#/components/schemas/FooBarObject'}}
+                    {literal_name}: {{type: string}}
+"
+    );
+    let ir = import_openapi_surface(v4, &v4.surface, openapi.as_bytes()).expect("REST import");
+    let plan = ir.validated_plan().expect("plan");
+    let catalog = generate_projection_catalog(v4, &plan).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+
+    let names = projection
+        .columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names.len(),
+        projection.columns.len(),
+        "every emitted column name must be unique"
+    );
+
+    for source_path in [
+        vec!["foo-bar"],
+        vec!["foo_bar"],
+        vec![literal_name.as_str()],
+        vec!["foo_bar", suffix.as_str()],
+    ] {
+        assert!(
+            projection.columns.iter().any(|column| {
+                column
+                    .source_path
+                    .iter()
+                    .map(String::as_str)
+                    .eq(source_path.iter().copied())
+            }),
+            "missing source path {source_path:?}; columns: {:?}",
+            projection.columns
+        );
+    }
+
+    let top_level = projection
+        .columns
+        .iter()
+        .find(|column| column.source_path == ["foo_bar"])
+        .expect("collision-resolved top-level column");
+    let nested = projection
+        .columns
+        .iter()
+        .find(|column| {
+            column
+                .source_path
+                .iter()
+                .map(String::as_str)
+                .eq(["foo_bar", suffix.as_str()])
+        })
+        .expect("nested scalar column");
+    assert_ne!(top_level.name, nested.name);
+
+    validate_projection_compatibility(&plan, &catalog)
+        .expect("generated collision-safe columns must remain compatible");
 }
 
 #[test]
@@ -2210,6 +2338,32 @@ paths:
         - {name: page, in: query, schema: {type: integer, default: 1}}
         - {name: per_page, in: query, schema: {type: integer, default: 25, maximum: 100}}
         - {name: state, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {type: array, items: {type: object}}
+",
+    )
+    .expect("import");
+    (manifest, imported)
+}
+
+fn imported_defaulted_inputs_surface() -> (V4SourceManifest, ImportedSurface) {
+    let manifest = openapi_manifest().as_v4().expect("v4").clone();
+    let imported = import_openapi_surface(
+        &manifest,
+        &manifest.surface,
+        br"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: missing_default, in: query, schema: {type: string}}
+        - {name: null_default, in: query, schema: {type: string, nullable: true, default: null}}
+        - {name: value_default, in: query, schema: {type: integer, default: 7}}
       responses:
         '200':
           content:
@@ -2793,6 +2947,40 @@ fn projection_compatibility_rejects_input_missing_from_operation() {
             .contains("input 'stale' does not match a Query input named 'renamed_upstream'"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn projection_compatibility_rejects_changed_imported_defaults() {
+    let (manifest, imported) = imported_defaulted_inputs_surface();
+    let plan = imported.validated_plan().expect("plan");
+    let generated = generate_projection_catalog(&manifest, &plan).expect("projections");
+    validate_projection_compatibility(&plan, &generated)
+        .expect("an unmodified generated catalog must remain compatible");
+
+    for (wire_name, replacement) in [
+        (
+            "missing_default",
+            Some(crate::DeclaredDefaultValue::new(serde_json::Value::Null)),
+        ),
+        ("null_default", None),
+        (
+            "value_default",
+            Some(crate::DeclaredDefaultValue::new(json!(8))),
+        ),
+    ] {
+        let mut catalog = generated.clone();
+        projection_input_mut(&mut catalog, wire_name).default_value = replacement;
+
+        let error = validate_projection_compatibility(&plan, &catalog)
+            .expect_err("a projection override must not change request defaults");
+
+        assert!(
+            error.to_string().contains(&format!(
+                "input '{wire_name}' on operation 'items_list' changes the imported default_value"
+            )),
+            "unexpected error: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1048,7 +1048,7 @@ components:
 }
 
 #[test]
-fn runtime_lowering_preserves_typed_component_ref_query_defaults_including_null() {
+fn projection_metadata_preserves_typed_defaults_while_runtime_omits_null() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: demo
@@ -1079,6 +1079,16 @@ paths:
       parameters:
         - {name: query, in: query, required: true, schema: {type: string}}
         - {name: limit, in: query, schema: {$ref: '#/components/schemas/LimitParameter'}}
+        - name: component_override
+          in: query
+          schema:
+            $ref: '#/components/schemas/LimitParameter'
+            default: 50
+        - name: component_null_override
+          in: query
+          schema:
+            $ref: '#/components/schemas/LimitParameter'
+            default: null
         - {name: exact, in: query, schema: {$ref: '#/components/schemas/ExactParameter'}}
         - {name: scope, in: query, schema: {$ref: '#/components/schemas/ScopeParameter'}}
       responses:
@@ -1108,6 +1118,11 @@ paths:
         .collect::<BTreeMap<_, _>>();
     assert_eq!(defaults.get("query"), Some(&None));
     assert_eq!(defaults.get("limit"), Some(&Some(json!(25))));
+    assert_eq!(defaults.get("component_override"), Some(&Some(json!(50))));
+    assert_eq!(
+        defaults.get("component_null_override"),
+        Some(&Some(serde_json::Value::Null))
+    );
     assert_eq!(defaults.get("exact"), Some(&Some(json!(false))));
     assert_eq!(defaults.get("scope"), Some(&Some(serde_json::Value::Null)));
 
@@ -1124,11 +1139,64 @@ paths:
         })
         .collect::<BTreeMap<_, _>>();
     assert_eq!(request_defaults.get("limit"), Some(&Some(json!(25))));
-    assert_eq!(request_defaults.get("exact"), Some(&Some(json!(false))));
     assert_eq!(
-        request_defaults.get("scope"),
-        Some(&Some(serde_json::Value::Null))
+        request_defaults.get("component_override"),
+        Some(&Some(json!(50)))
     );
+    assert_eq!(request_defaults.get("component_null_override"), Some(&None));
+    assert_eq!(request_defaults.get("exact"), Some(&Some(json!(false))));
+    assert_eq!(request_defaults.get("scope"), Some(&None));
+}
+
+#[test]
+fn explicit_null_is_not_a_usable_required_rest_input_default() {
+    let manifest = openapi_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /scopes/{scope}:
+    get:
+      operationId: scopes/get
+      parameters:
+        - name: scope
+          in: path
+          required: true
+          schema: {type: [string, 'null'], default: null}
+        - name: cursor
+          in: query
+          required: true
+          schema: {type: [string, 'null'], default: null}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog =
+        generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+    let operation = ir.operations.first().expect("operation");
+    let args = projection_arg_specs(projection)
+        .into_iter()
+        .map(|arg| (arg.name, arg.required))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(args.get("scope"), Some(&true));
+    assert_eq!(args.get("cursor"), Some(&true));
+
+    let request = request_spec_for_projection(projection, operation).expect("request");
+    assert_eq!(request.path.raw(), "/scopes/{{arg.scope}}");
+    assert!(matches!(
+        request.query.first().map(|parameter| &parameter.value),
+        Some(crate::ValueSourceSpec::Arg { default: None, .. })
+    ));
 }
 
 #[test]
@@ -1705,6 +1773,103 @@ paths:
             .expect("nested scalar leaf");
         assert_eq!(leaf.name, "repository__owner_name");
         assert_eq!(leaf.data_type, ManifestDataType::Utf8);
+    }
+}
+
+#[test]
+fn generated_nested_columns_skip_numeric_object_keys() {
+    let rest_manifest = openapi_manifest();
+    let rest_v4 = rest_manifest.as_v4().expect("REST v4");
+    let rest_ir = import_openapi_surface(
+        rest_v4,
+        &rest_v4.surface,
+        r#"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  details:
+                    type: object
+                    properties:
+                      safe: {type: string}
+                      "0": {type: string}
+                      "2024":
+                        type: object
+                        properties:
+                          label: {type: string}
+"#
+        .as_bytes(),
+    )
+    .expect("REST import");
+    let rest_plan = rest_ir.validated_plan().expect("REST plan");
+    let rest_catalog = generate_projection_catalog(rest_v4, &rest_plan).expect("REST catalog");
+    validate_projection_compatibility(&rest_plan, &rest_catalog)
+        .expect("generated REST catalog should validate");
+
+    let mcp_manifest = mcp_manifest();
+    let mcp_v4 = mcp_manifest.as_v4().expect("MCP v4");
+    let mcp_ir = import_mcp_surface(
+        mcp_v4,
+        &mcp_v4.surface,
+        &McpToolCatalog {
+            tools: vec![McpToolDescriptor {
+                name: "get_item".to_string(),
+                title: None,
+                description: None,
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "details": {
+                            "type": "object",
+                            "properties": {
+                                "safe": {"type": "string"},
+                                "0": {"type": "string"},
+                                "2024": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": {"type": "string"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })),
+                read_only_hint: Some(true),
+                idempotent_hint: Some(true),
+            }],
+        },
+    )
+    .expect("MCP import");
+    let mcp_plan = mcp_ir.validated_plan().expect("MCP plan");
+    let mcp_catalog = generate_projection_catalog(mcp_v4, &mcp_plan).expect("MCP catalog");
+    validate_projection_compatibility(&mcp_plan, &mcp_catalog)
+        .expect("generated MCP catalog should validate");
+
+    for projection in [
+        rest_catalog.projections.first().expect("REST projection"),
+        mcp_catalog.projections.first().expect("MCP projection"),
+    ] {
+        assert!(
+            projection
+                .columns
+                .iter()
+                .any(|column| column.source_path == ["details", "safe"])
+        );
+        assert!(projection.columns.iter().all(|column| {
+            column
+                .source_path
+                .iter()
+                .all(|segment| segment.parse::<usize>().is_err())
+        }));
     }
 }
 
@@ -2524,9 +2689,9 @@ fn projection_compatibility_accepts_whole_row_columns_for_non_object_rows() {
     }
 }
 
-/// The generator never nests a source path, but an authored override may, and
-/// runtime follows every segment. Each case is the shape reached *before* the
-/// final segment deciding whether that segment is selectable.
+/// Generated and authored source paths may both nest, and runtime follows every
+/// segment. Each case is the shape reached *before* the final segment deciding
+/// whether that segment is selectable.
 #[test]
 fn projection_compatibility_walks_every_segment_of_a_nested_source_path() {
     let (manifest, imported) = imported_nested_row_surface();

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -874,13 +874,26 @@ paths:
         .expect("id input");
     assert_eq!(id_input.sql_exposure, SqlInputExposure::FunctionArg);
     assert!(!id_input.required);
-    assert_eq!(id_input.default_value.as_deref(), Some("public"));
+    assert_eq!(
+        id_input
+            .default_value
+            .as_ref()
+            .map(crate::DeclaredDefaultValue::value),
+        Some(&json!("public"))
+    );
 
     let id_arg = projection_arg_specs(projection)
         .into_iter()
         .find(|arg| arg.name == "id")
         .expect("id arg");
     assert!(!id_arg.required);
+    assert_eq!(
+        id_arg
+            .default
+            .as_ref()
+            .map(crate::DeclaredDefaultValue::value),
+        Some(&json!("public"))
+    );
 }
 
 #[test]
@@ -1031,6 +1044,90 @@ components:
     assert_eq!(
         namespace_request.path.raw(),
         "/namespaces/{{arg.namespace|%252E}}/items"
+    );
+}
+
+#[test]
+fn runtime_lowering_preserves_typed_component_ref_query_defaults_including_null() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+components:
+  schemas:
+    LimitParameter: {type: integer, default: 25}
+    ExactParameter: {type: boolean, default: false}
+    ScopeParameter: {type: [string, 'null'], default: null}
+paths:
+  /search:
+    get:
+      operationId: items/search
+      parameters:
+        - {name: query, in: query, required: true, schema: {type: string}}
+        - {name: limit, in: query, schema: {$ref: '#/components/schemas/LimitParameter'}}
+        - {name: exact, in: query, schema: {$ref: '#/components/schemas/ExactParameter'}}
+        - {name: scope, in: query, schema: {$ref: '#/components/schemas/ScopeParameter'}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {type: object, properties: {id: {type: string}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog =
+        generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+    let operation = ir.operations.first().expect("operation");
+
+    let defaults = projection_arg_specs(projection)
+        .into_iter()
+        .map(|arg| {
+            (
+                arg.name,
+                arg.default.map(crate::DeclaredDefaultValue::into_value),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(defaults.get("query"), Some(&None));
+    assert_eq!(defaults.get("limit"), Some(&Some(json!(25))));
+    assert_eq!(defaults.get("exact"), Some(&Some(json!(false))));
+    assert_eq!(defaults.get("scope"), Some(&Some(serde_json::Value::Null)));
+
+    let request = request_spec_for_projection(projection, operation).expect("request");
+    let request_defaults = request
+        .query
+        .iter()
+        .map(|parameter| {
+            let default = match &parameter.value {
+                crate::ValueSourceSpec::Arg { default, .. } => default.clone(),
+                other => panic!("unexpected query value source: {other:?}"),
+            };
+            (parameter.name.as_str(), default)
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(request_defaults.get("limit"), Some(&Some(json!(25))));
+    assert_eq!(request_defaults.get("exact"), Some(&Some(json!(false))));
+    assert_eq!(
+        request_defaults.get("scope"),
+        Some(&Some(serde_json::Value::Null))
     );
 }
 
@@ -1227,6 +1324,20 @@ surface:
     .expect("manifest")
 }
 
+fn openapi_manifest() -> crate::ValidatedSourceManifest {
+    parse_source_manifest_yaml(
+        r"
+name: github_rest
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.github.com
+",
+    )
+    .expect("manifest")
+}
+
 fn search_issues_mcp_catalog() -> McpToolCatalog {
     McpToolCatalog {
         tools: vec![McpToolDescriptor {
@@ -1256,6 +1367,7 @@ fn search_issues_mcp_catalog() -> McpToolCatalog {
                 }
             })),
             read_only_hint: Some(true),
+            idempotent_hint: None,
         }],
     }
 }
@@ -1315,12 +1427,154 @@ paths:
 }
 
 #[test]
-fn generated_mcp_projection_exposes_current_row_result_columns() {
+fn generated_mcp_projection_projects_authored_top_level_raw_field() {
+    let manifest = mcp_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let mcp_surface = &v4.surface;
+    let mcp_ir = import_mcp_surface(
+        v4,
+        mcp_surface,
+        &McpToolCatalog {
+            tools: vec![McpToolDescriptor {
+                name: "get_raw_item".to_string(),
+                title: None,
+                description: None,
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "raw": {"type": "string"},
+                        "id": {"type": "integer"}
+                    }
+                })),
+                read_only_hint: Some(true),
+                idempotent_hint: Some(true),
+            }],
+        },
+    )
+    .expect("MCP import");
+
+    let operation = mcp_ir.operations.first().expect("operation");
+    let row_type = mcp_ir
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type");
+    let IrTypeShape::Object { fields } = &row_type.shape else {
+        panic!("row type should be an object");
+    };
+    let raw_field = fields
+        .iter()
+        .find(|field| field.name == "raw")
+        .expect("authored raw field");
+    assert!(!raw_field.synthetic);
+
+    let catalog =
+        generate_projection_catalog(v4, &mcp_ir.validated_plan().expect("plan")).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+    let raw_column = projection
+        .columns
+        .iter()
+        .find(|column| column.name == "raw")
+        .expect("authored raw projection column");
+    assert_eq!(raw_column.data_type, ManifestDataType::Utf8);
+    assert_eq!(raw_column.source_path, ["raw"]);
+}
+
+#[test]
+fn generated_mcp_projection_exposes_structured_object_and_list_paths() {
+    let manifest = mcp_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let mcp_surface = &v4.surface;
+    let ir = import_mcp_surface(
+        v4,
+        mcp_surface,
+        &McpToolCatalog {
+            tools: vec![McpToolDescriptor {
+                name: "get_item".to_string(),
+                title: None,
+                description: None,
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "details": {
+                            "type": "object",
+                            "properties": {
+                                "owner": {"type": "string"}
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        }
+                    }
+                })),
+                read_only_hint: Some(true),
+                idempotent_hint: Some(true),
+            }],
+        },
+    )
+    .expect("MCP import");
+
+    let plan = ir.validated_plan().expect("plan");
+    assert!(
+        plan.output_row_path("get_item").is_empty(),
+        "a singleton resource must project from the response root"
+    );
+    let catalog = generate_projection_catalog(v4, &plan).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+    for (name, source_path) in [("details", ["details"]), ("tags", ["tags"])] {
+        let column = projection
+            .columns
+            .iter()
+            .find(|column| column.name == name)
+            .expect("structured column");
+        assert_eq!(column.data_type, ManifestDataType::Json);
+        assert_eq!(column.source_path, source_path);
+    }
+    assert!(projection.columns.iter().any(|column| {
+        column.name == "details__owner"
+            && column.data_type == ManifestDataType::Utf8
+            && column.source_path == ["details", "owner"]
+    }));
+    assert!(
+        projection
+            .columns
+            .iter()
+            .all(|column| column.source_path != ["raw"])
+    );
+}
+
+#[test]
+fn generated_mcp_projection_paths_are_relative_to_the_effective_row() {
     let manifest = mcp_manifest();
     let v4 = manifest.as_v4().expect("v4");
     let mcp_surface = &v4.surface;
     let mcp_ir =
         import_mcp_surface(v4, mcp_surface, &search_issues_mcp_catalog()).expect("mcp import");
+
+    let operation = mcp_ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == "search_issues")
+        .expect("operation");
+    let row_type = mcp_ir
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type");
+    let IrTypeShape::Object { fields } = &row_type.shape else {
+        panic!("row type should be an object");
+    };
+    assert!(
+        fields
+            .iter()
+            .find(|field| field.name == "raw")
+            .expect("compatibility raw field")
+            .synthetic
+    );
 
     let catalog =
         generate_projection_catalog(v4, &mcp_ir.validated_plan().expect("plan")).expect("catalog");
@@ -1349,8 +1603,227 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
                 "result_json".to_string(),
                 ManifestDataType::Json,
                 Vec::new()
-            )
+            ),
+            (
+                "id".to_string(),
+                ManifestDataType::Int64,
+                vec!["id".to_string()]
+            ),
+            (
+                "title".to_string(),
+                ManifestDataType::Utf8,
+                vec!["title".to_string()]
+            ),
         ]
+    );
+}
+
+#[test]
+fn rest_and_mcp_projections_expose_exact_nested_scalar_paths() {
+    let rest_manifest = openapi_manifest();
+    let rest_v4 = rest_manifest.as_v4().expect("REST v4");
+    let rest_ir = import_openapi_surface(
+        rest_v4,
+        &rest_v4.surface,
+        r#"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  repository:
+                    type: object
+                    properties:
+                      "owner/name": {type: string}
+"#
+        .as_bytes(),
+    )
+    .expect("REST import");
+    let rest_catalog =
+        generate_projection_catalog(rest_v4, &rest_ir.validated_plan().expect("REST plan"))
+            .expect("REST catalog");
+    let rest_projection = rest_catalog.projections.first().expect("REST projection");
+    assert!(rest_projection.columns.iter().any(|column| {
+        column.name == "repository"
+            && column.data_type == ManifestDataType::Json
+            && column.source_path == ["repository"]
+    }));
+
+    let mcp_manifest = mcp_manifest();
+    let mcp_v4 = mcp_manifest.as_v4().expect("MCP v4");
+    let mcp_ir = import_mcp_surface(
+        mcp_v4,
+        &mcp_v4.surface,
+        &McpToolCatalog {
+            tools: vec![McpToolDescriptor {
+                name: "get_item".to_string(),
+                title: None,
+                description: None,
+                input_schema: json!({"type": "object", "properties": {}}),
+                output_schema: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "object",
+                            "properties": {
+                                "owner/name": {"type": "string"}
+                            }
+                        }
+                    }
+                })),
+                read_only_hint: Some(true),
+                idempotent_hint: Some(true),
+            }],
+        },
+    )
+    .expect("MCP import");
+    let mcp_catalog =
+        generate_projection_catalog(mcp_v4, &mcp_ir.validated_plan().expect("MCP plan"))
+            .expect("MCP catalog");
+    let mcp_projection = mcp_catalog.projections.first().expect("MCP projection");
+    assert!(
+        mcp_projection
+            .columns
+            .iter()
+            .any(|column| column.name == "result_json" && column.source_path.is_empty())
+    );
+
+    for projection in [rest_projection, mcp_projection] {
+        // RFC 6901 `/repository/owner~1name` decodes to these exact raw
+        // segments. SQL-name normalization must not alter the source path.
+        let leaf = projection
+            .columns
+            .iter()
+            .find(|column| column.source_path == ["repository", "owner/name"])
+            .expect("nested scalar leaf");
+        assert_eq!(leaf.name, "repository__owner_name");
+        assert_eq!(leaf.data_type, ManifestDataType::Utf8);
+    }
+}
+
+#[test]
+fn rest_projection_exposes_nested_object_path_without_duplicating_top_level_object() {
+    let manifest = openapi_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items/{id}:
+    get:
+      operationId: items/get
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  author:
+                    type: object
+                    properties:
+                      profile:
+                        type: object
+                        properties:
+                          display_name: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("REST import");
+
+    let catalog =
+        generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+    assert_eq!(
+        projection
+            .columns
+            .iter()
+            .filter(|column| column.source_path == ["author"])
+            .count(),
+        1
+    );
+    let profile = projection
+        .columns
+        .iter()
+        .find(|column| column.source_path == ["author", "profile"])
+        .expect("nested profile object column");
+    assert_eq!(profile.name, "author__profile");
+    assert_eq!(profile.data_type, ManifestDataType::Json);
+    assert!(projection.columns.iter().any(|column| {
+        column.name == "author__profile__display_name"
+            && column.data_type == ManifestDataType::Utf8
+            && column.source_path == ["author", "profile", "display_name"]
+    }));
+}
+
+#[test]
+fn recursive_openapi_schema_projection_terminates_and_preserves_scalar_leaves() {
+    let manifest = openapi_manifest();
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        id: {type: string}
+        child: {$ref: '#/components/schemas/Node'}
+        metadata:
+          type: object
+          properties:
+            label: {type: string}
+paths:
+  /node:
+    get:
+      operationId: nodes/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Node'}
+"
+        .as_bytes(),
+    )
+    .expect("REST import");
+
+    let catalog = generate_projection_catalog(v4, &ir.validated_plan().expect("plan"))
+        .expect("projection generation");
+    let projection = catalog.projections.first().expect("projection");
+    assert!(projection.columns.iter().any(|column| {
+        column.name == "id"
+            && column.data_type == ManifestDataType::Utf8
+            && column.source_path == ["id"]
+    }));
+    assert!(projection.columns.iter().any(|column| {
+        column.name == "child__id"
+            && column.data_type == ManifestDataType::Utf8
+            && column.source_path == ["child", "id"]
+    }));
+    assert!(projection.columns.iter().any(|column| {
+        column.name == "metadata__label"
+            && column.data_type == ManifestDataType::Utf8
+            && column.source_path == ["metadata", "label"]
+    }));
+    assert!(
+        projection
+            .columns
+            .iter()
+            .all(|column| column.source_path.len() <= 3)
     );
 }
 
@@ -1393,6 +1866,7 @@ fn generated_mcp_projection_keeps_an_inferred_cursor_internal() {
                 }
             })),
             read_only_hint: Some(true),
+            idempotent_hint: None,
         }],
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
@@ -1456,6 +1930,7 @@ fn generated_mcp_projection_with_only_an_inferred_cursor_is_a_table() {
                 }
             })),
             read_only_hint: Some(true),
+            idempotent_hint: None,
         }],
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
@@ -1510,6 +1985,7 @@ fn generated_mcp_projection_snake_cases_camel_input_names() {
                 }
             })),
             read_only_hint: Some(true),
+            idempotent_hint: None,
         }],
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
@@ -1611,6 +2087,7 @@ fn imported_mcp_items_surface() -> (V4SourceManifest, ImportedSurface) {
                 }
             })),
             read_only_hint: Some(true),
+            idempotent_hint: None,
         }],
     };
     let mut imported =
@@ -2011,7 +2488,7 @@ fn projection_compatibility_rejects_field_columns_when_the_row_type_is_absent() 
         .expect("projections");
     override_row_path(&mut imported, "items_list", &["blobs"]);
     let plan = imported.validated_plan().expect("plan");
-    assert_eq!(plan.rest_output_type_ref("items_list"), "json");
+    assert_eq!(plan.output_row_type_ref("items_list"), "json");
 
     let error = validate_projection_compatibility(&plan, &catalog)
         .expect_err("field columns must not survive an opaque row path");

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -239,7 +239,12 @@ fn generated_projection_name(operation: &IrOperation, is_search: bool) -> String
 }
 
 fn projection_input_required(input: &IrOperationInput) -> bool {
-    input.required && (input.default_value.is_none() || input.location == IrInputLocation::ToolArg)
+    input.required
+        && (input.location == IrInputLocation::ToolArg
+            || input
+                .default_value
+                .as_ref()
+                .is_none_or(|default| default.value().is_null()))
 }
 
 fn rest_input_exposure(
@@ -450,6 +455,15 @@ impl ScalarLeafCollector<'_, '_> {
         description: &str,
         depth: usize,
     ) {
+        // Collector paths traverse object fields only. Runtime reserves a
+        // numeric path segment for list indexing, so a numeric object key and
+        // everything below it could never be read from the projected row.
+        if path
+            .last()
+            .is_some_and(|segment| segment.parse::<usize>().is_ok())
+        {
+            return;
+        }
         let Some(ty) = self.type_by_id.get(type_ref) else {
             return;
         };

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -20,6 +20,8 @@ use super::names::{
 };
 type TypeIndex<'a> = HashMap<&'a str, &'a IrType>;
 
+const MAX_SCALAR_LEAF_PROJECTION_DEPTH: usize = 64;
+
 pub fn generate_projection_catalog(
     manifest: &V4SourceManifest,
     plan: &ValidatedSurfacePlan,
@@ -305,10 +307,11 @@ fn projection_columns(
     operation: &IrOperation,
 ) -> Vec<ProjectionColumn> {
     if matches!(&operation.execution, IrExecutionAttachment::Mcp(_)) {
-        // MCP output schemas drive row cardinality and response extraction, but
-        // SQL columns stay opaque until Coral has stable per-tool payload
-        // normalization semantics.
-        return vec![
+        // Keep the two opaque compatibility columns while also projecting
+        // deterministic scalar leaves from an authored output schema. The
+        // original property segments remain in `source_path`, so route result
+        // pointers can resolve without relying on normalized SQL names.
+        let mut columns = vec![
             ProjectionColumn {
                 name: "result".to_string(),
                 data_type: ManifestDataType::Utf8,
@@ -326,10 +329,25 @@ fn projection_columns(
                 do_not_index: false,
             },
         ];
+        let mut names = HashSet::from(["result".to_string(), "result_json".to_string()]);
+        // The runtime applies the operation row path before it projects
+        // columns. Derive structured columns from that effective row type so
+        // their source paths are relative to the row rather than the response
+        // envelope.
+        append_scalar_leaf_columns(
+            type_by_id,
+            plan.output_row_type_ref(&operation.id),
+            &mut Vec::new(),
+            false,
+            "",
+            &mut names,
+            &mut columns,
+        );
+        return columns;
     }
     // A wrapped-list operation declares an envelope but yields the rows nested
     // inside it, so columns come from the type its row path selects.
-    let Some(row_type) = type_by_id.get(plan.rest_output_type_ref(&operation.id)) else {
+    let Some(row_type) = type_by_id.get(plan.output_row_type_ref(&operation.id)) else {
         return vec![ProjectionColumn {
             name: "value".to_string(),
             data_type: ManifestDataType::Json,
@@ -369,7 +387,172 @@ fn projection_columns(
             do_not_index: false,
         });
     }
+    // Preserve every established top-level REST column above, including JSON
+    // object columns, and add addressable scalar descendants beside them.
+    for field in fields {
+        let Some(field_type) = type_by_id.get(field.type_ref.as_str()) else {
+            continue;
+        };
+        if !matches!(field_type.shape, IrTypeShape::Object { .. }) {
+            continue;
+        }
+        append_scalar_leaf_columns(
+            type_by_id,
+            field.type_ref.as_str(),
+            &mut vec![field.name.clone()],
+            field.nullable || field_type.nullable,
+            &field.description,
+            &mut names,
+            &mut columns,
+        );
+    }
     columns
+}
+
+fn append_scalar_leaf_columns(
+    type_by_id: &TypeIndex<'_>,
+    type_ref: &str,
+    path: &mut Vec<String>,
+    inherited_nullable: bool,
+    description: &str,
+    names: &mut HashSet<String>,
+    columns: &mut Vec<ProjectionColumn>,
+) {
+    let source_paths = columns
+        .iter()
+        .filter(|column| !column.source_path.is_empty())
+        .map(|column| column.source_path.clone())
+        .collect();
+    let mut collector = ScalarLeafCollector {
+        type_by_id,
+        names,
+        columns,
+        source_paths,
+        type_stack: HashSet::new(),
+    };
+    collector.append(type_ref, path, inherited_nullable, description, 0);
+}
+
+struct ScalarLeafCollector<'a, 'ir> {
+    type_by_id: &'a TypeIndex<'ir>,
+    names: &'a mut HashSet<String>,
+    columns: &'a mut Vec<ProjectionColumn>,
+    source_paths: HashSet<Vec<String>>,
+    type_stack: HashSet<String>,
+}
+
+impl ScalarLeafCollector<'_, '_> {
+    fn append(
+        &mut self,
+        type_ref: &str,
+        path: &mut Vec<String>,
+        inherited_nullable: bool,
+        description: &str,
+        depth: usize,
+    ) {
+        let Some(ty) = self.type_by_id.get(type_ref) else {
+            return;
+        };
+        match &ty.shape {
+            IrTypeShape::Scalar(_) | IrTypeShape::Enum { .. } if !path.is_empty() => {
+                self.append_column(
+                    path,
+                    projection_data_type(ty),
+                    inherited_nullable || ty.nullable,
+                    description,
+                );
+            }
+            IrTypeShape::Object { fields } => {
+                if !path.is_empty() {
+                    self.append_column(
+                        path,
+                        ManifestDataType::Json,
+                        inherited_nullable || ty.nullable,
+                        description,
+                    );
+                }
+                if depth >= MAX_SCALAR_LEAF_PROJECTION_DEPTH
+                    || !self.type_stack.insert(ty.id.clone())
+                {
+                    return;
+                }
+                for field in fields {
+                    if path.is_empty() && field.name == "raw" && field.synthetic {
+                        continue;
+                    }
+                    path.push(field.name.clone());
+                    self.append(
+                        field.type_ref.as_str(),
+                        path,
+                        inherited_nullable || field.nullable,
+                        &field.description,
+                        depth + 1,
+                    );
+                    path.pop();
+                }
+                self.type_stack.remove(&ty.id);
+            }
+            IrTypeShape::List { .. } | IrTypeShape::Map { .. } if !path.is_empty() => {
+                self.append_column(
+                    path,
+                    ManifestDataType::Json,
+                    inherited_nullable || ty.nullable,
+                    description,
+                );
+            }
+            IrTypeShape::Scalar(_)
+            | IrTypeShape::Enum { .. }
+            | IrTypeShape::Json
+            | IrTypeShape::List { .. }
+            | IrTypeShape::Map { .. } => {}
+        }
+    }
+
+    fn append_column(
+        &mut self,
+        path: &[String],
+        data_type: ManifestDataType,
+        nullable: bool,
+        description: &str,
+    ) {
+        if !self.source_paths.insert(path.to_vec()) {
+            return;
+        }
+        let base = path
+            .iter()
+            .map(|segment| normalize_identifier(segment, "column"))
+            .collect::<Vec<_>>()
+            .join("__");
+        let name = unique_leaf_column_name(&base, path, self.names);
+        self.columns.push(ProjectionColumn {
+            name,
+            data_type,
+            source_path: path.to_vec(),
+            nullable,
+            description: description.to_string(),
+            do_not_index: false,
+        });
+    }
+}
+
+fn unique_leaf_column_name(base: &str, path: &[String], names: &mut HashSet<String>) -> String {
+    if names.insert(base.to_string()) {
+        return base.to_string();
+    }
+    let path_key = format!("{path:?}");
+    let mut attempt = 0_u32;
+    loop {
+        let suffix_key = if attempt == 0 {
+            path_key.clone()
+        } else {
+            format!("{path_key}:{attempt}")
+        };
+        let candidate = format!("{base}__{}", stable_suffix(&suffix_key));
+        if names.insert(candidate.clone()) {
+            return candidate;
+        }
+        attempt += 1;
+    }
 }
 
 fn projection_data_type(ty: &IrType) -> ManifestDataType {

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -334,20 +334,20 @@ fn projection_columns(
                 do_not_index: false,
             },
         ];
-        let mut names = HashSet::from(["result".to_string(), "result_json".to_string()]);
         // The runtime applies the operation row path before it projects
         // columns. Derive structured columns from that effective row type so
         // their source paths are relative to the row rather than the response
         // envelope.
-        append_scalar_leaf_columns(
-            type_by_id,
-            plan.output_row_type_ref(&operation.id),
-            &mut Vec::new(),
-            false,
-            "",
-            &mut names,
-            &mut columns,
-        );
+        {
+            let mut collector = ScalarLeafCollector::new(type_by_id, &mut columns);
+            collector.append(
+                plan.output_row_type_ref(&operation.id),
+                &mut Vec::new(),
+                false,
+                "",
+                0,
+            );
+        }
         return columns;
     }
     // A wrapped-list operation declares an envelope but yields the rows nested
@@ -375,11 +375,7 @@ fn projection_columns(
     let mut columns = Vec::new();
     let mut names = HashSet::new();
     for field in fields {
-        let mut name = normalize_identifier(&field.name, "column");
-        if !names.insert(name.clone()) {
-            let suffix = stable_suffix(&field.name);
-            name = format!("{name}__{suffix}");
-        }
+        let name = unique_top_level_column_name(&field.name, &mut names);
         let data_type = type_by_id
             .get(field.type_ref.as_str())
             .map_or(ManifestDataType::Json, |ty| projection_data_type(ty));
@@ -394,59 +390,75 @@ fn projection_columns(
     }
     // Preserve every established top-level REST column above, including JSON
     // object columns, and add addressable scalar descendants beside them.
-    for field in fields {
-        let Some(field_type) = type_by_id.get(field.type_ref.as_str()) else {
-            continue;
-        };
-        if !matches!(field_type.shape, IrTypeShape::Object { .. }) {
-            continue;
+    {
+        // Seed the collector once from every emitted top-level column. Besides
+        // keeping derivation linear, this reserves collision-resolved names
+        // before nested leaves choose theirs.
+        let mut collector = ScalarLeafCollector::new(type_by_id, &mut columns);
+        for field in fields {
+            let Some(field_type) = type_by_id.get(field.type_ref.as_str()) else {
+                continue;
+            };
+            if !matches!(field_type.shape, IrTypeShape::Object { .. }) {
+                continue;
+            }
+            collector.append(
+                field.type_ref.as_str(),
+                &mut vec![field.name.clone()],
+                field.nullable || field_type.nullable,
+                &field.description,
+                0,
+            );
         }
-        append_scalar_leaf_columns(
-            type_by_id,
-            field.type_ref.as_str(),
-            &mut vec![field.name.clone()],
-            field.nullable || field_type.nullable,
-            &field.description,
-            &mut names,
-            &mut columns,
-        );
     }
     columns
 }
 
-fn append_scalar_leaf_columns(
-    type_by_id: &TypeIndex<'_>,
-    type_ref: &str,
-    path: &mut Vec<String>,
-    inherited_nullable: bool,
-    description: &str,
-    names: &mut HashSet<String>,
-    columns: &mut Vec<ProjectionColumn>,
-) {
-    let source_paths = columns
-        .iter()
-        .filter(|column| !column.source_path.is_empty())
-        .map(|column| column.source_path.clone())
-        .collect();
-    let mut collector = ScalarLeafCollector {
-        type_by_id,
-        names,
-        columns,
-        source_paths,
-        type_stack: HashSet::new(),
-    };
-    collector.append(type_ref, path, inherited_nullable, description, 0);
+fn unique_top_level_column_name(field_name: &str, names: &mut HashSet<String>) -> String {
+    let base = normalize_identifier(field_name, "column");
+    if names.insert(base.clone()) {
+        return base;
+    }
+    let mut attempt = 0_u32;
+    loop {
+        let suffix_key = if attempt == 0 {
+            field_name.to_string()
+        } else {
+            format!("{field_name}:{attempt}")
+        };
+        let candidate = format!("{base}__{}", stable_suffix(&suffix_key));
+        if names.insert(candidate.clone()) {
+            return candidate;
+        }
+        attempt += 1;
+    }
 }
 
 struct ScalarLeafCollector<'a, 'ir> {
     type_by_id: &'a TypeIndex<'ir>,
-    names: &'a mut HashSet<String>,
+    names: HashSet<String>,
     columns: &'a mut Vec<ProjectionColumn>,
     source_paths: HashSet<Vec<String>>,
     type_stack: HashSet<String>,
 }
 
-impl ScalarLeafCollector<'_, '_> {
+impl<'a, 'ir> ScalarLeafCollector<'a, 'ir> {
+    fn new(type_by_id: &'a TypeIndex<'ir>, columns: &'a mut Vec<ProjectionColumn>) -> Self {
+        let names = columns.iter().map(|column| column.name.clone()).collect();
+        let source_paths = columns
+            .iter()
+            .filter(|column| !column.source_path.is_empty())
+            .map(|column| column.source_path.clone())
+            .collect();
+        ScalarLeafCollector {
+            type_by_id,
+            names,
+            columns,
+            source_paths,
+            type_stack: HashSet::new(),
+        }
+    }
+
     fn append(
         &mut self,
         type_ref: &str,
@@ -537,7 +549,7 @@ impl ScalarLeafCollector<'_, '_> {
             .map(|segment| normalize_identifier(segment, "column"))
             .collect::<Vec<_>>()
             .join("__");
-        let name = unique_leaf_column_name(&base, path, self.names);
+        let name = unique_leaf_column_name(&base, path, &mut self.names);
         self.columns.push(ProjectionColumn {
             name,
             data_type,

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::IrInputLocation;
-use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
+use crate::{
+    DeclaredDefaultValue, DetailHintSpec, ManifestDataType, SearchLimitsSpec,
+    SourceTableFunctionKind, common::deserialize_declared_default,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectionCatalog {
@@ -55,7 +58,14 @@ pub struct ProjectionInput {
     pub wire_name: String,
     pub required: bool,
     pub data_type: ManifestDataType,
-    pub default_value: Option<String>,
+    /// A type-preserving operation default. The outer option distinguishes an
+    /// omitted default from an explicitly authored JSON `null`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_declared_default",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_value: Option<DeclaredDefaultValue>,
     pub description: String,
     /// Whether this filter input is a complete exact lookup: the API returns
     /// every row matching an equality value, so dependent joins may bind to
@@ -87,11 +97,51 @@ pub struct ProjectionColumn {
 #[cfg(test)]
 mod tests {
     use super::{
-        Projection, ProjectionCatalog, ProjectionColumn, ProjectionKind, ProjectionVisibility,
-        SqlInputExposure,
+        Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,
+        ProjectionVisibility, SqlInputExposure,
     };
+    use crate::v4::ir::IrInputLocation;
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
+    use serde_json::json;
+
+    #[test]
+    fn projection_input_defaults_distinguish_missing_from_explicit_null() {
+        let base = json!({
+            "name": "scope",
+            "sql_exposure": "function_arg",
+            "source_location": "tool_arg",
+            "wire_name": "scope",
+            "required": false,
+            "data_type": "Utf8",
+            "description": ""
+        });
+        let absent: ProjectionInput =
+            serde_json::from_value(base.clone()).expect("projection input without default");
+        assert!(absent.default_value.is_none());
+
+        let mut explicit_null = base;
+        explicit_null
+            .as_object_mut()
+            .expect("object")
+            .insert("default_value".to_string(), serde_json::Value::Null);
+        let explicit_null: ProjectionInput =
+            serde_json::from_value(explicit_null).expect("projection input with null default");
+        assert_eq!(explicit_null.source_location, IrInputLocation::ToolArg);
+        assert_eq!(
+            explicit_null
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&serde_json::Value::Null)
+        );
+        assert_eq!(
+            serde_json::to_value(&explicit_null)
+                .expect("serialize explicit null")
+                .get("default_value"),
+            Some(&serde_json::Value::Null)
+        );
+    }
 
     #[test]
     fn projection_catalog_yaml_uses_editor_friendly_enum_shapes() {

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::v4::diagnostics::Diagnostic;
-use crate::v4::ir::{IrExecutionAttachment, IrOperation, OutputCardinality, SemanticIr};
+use crate::v4::ir::{
+    IrExecutionAttachment, IrInputLocation, IrOperation, OutputCardinality, SemanticIr,
+};
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, stable_suffix};
 
@@ -118,7 +120,14 @@ fn required_input_count(operation: &IrOperation) -> usize {
     operation
         .inputs
         .iter()
-        .filter(|input| input.required && input.default_value.is_none())
+        .filter(|input| {
+            input.required
+                && (input.location == IrInputLocation::ToolArg
+                    || input
+                        .default_value
+                        .as_ref()
+                        .is_none_or(|default| default.value().is_null()))
+        })
         .count()
 }
 

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -1,11 +1,9 @@
 use std::collections::HashSet;
 
-use serde_json::Value;
-
 use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation};
 use crate::{
-    ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, ParsedTemplate, RequestSpec,
-    Result, TableFunctionArgSpec,
+    ColumnSpec, DeclaredDefaultValue, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
+    ParsedTemplate, RequestSpec, Result, TableFunctionArgSpec,
 };
 
 use super::model::{Projection, SqlInputExposure};
@@ -36,7 +34,7 @@ pub fn projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArgSpec
             data_type: input.data_type,
             required: input.required,
             values: Vec::new(),
-            default: None,
+            default: input.default_value.clone(),
             bind: FunctionArgBinding {
                 arg: input.name.clone(),
             },
@@ -54,7 +52,7 @@ pub fn mcp_projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArg
             data_type: input.data_type,
             required: input.required,
             values: Vec::new(),
-            default: None,
+            default: input.default_value.clone(),
             bind: FunctionArgBinding {
                 arg: input.wire_name.clone(),
             },
@@ -118,10 +116,10 @@ pub fn request_spec_for_projection(
         if input.source_location == IrInputLocation::Path {
             let replacement = match input.sql_exposure {
                 SqlInputExposure::Filter => {
-                    path_template_token("filter", &input.name, input.default_value.as_deref())
+                    path_template_token("filter", &input.name, input.default_value.as_ref())
                 }
                 SqlInputExposure::FunctionArg => {
-                    path_template_token("arg", &input.name, input.default_value.as_deref())
+                    path_template_token("arg", &input.name, input.default_value.as_ref())
                 }
                 SqlInputExposure::Internal => continue,
             };
@@ -139,14 +137,14 @@ pub fn request_spec_for_projection(
                     default: input
                         .default_value
                         .as_ref()
-                        .map(|value| Value::String(value.clone())),
+                        .map(|value| value.value().clone()),
                 },
                 SqlInputExposure::FunctionArg => crate::ValueSourceSpec::Arg {
                     key: input.name.clone(),
                     default: input
                         .default_value
                         .as_ref()
-                        .map(|value| Value::String(value.clone())),
+                        .map(|value| value.value().clone()),
                 },
                 SqlInputExposure::Internal => return None,
             };
@@ -165,11 +163,19 @@ pub fn request_spec_for_projection(
     })
 }
 
-fn path_template_token(namespace: &str, key: &str, default: Option<&str>) -> String {
+fn path_template_token(
+    namespace: &str,
+    key: &str,
+    default: Option<&DeclaredDefaultValue>,
+) -> String {
     default.map_or_else(
         || format!("{{{{{namespace}.{key}}}}}"),
         |default| {
-            let encoded_default = encode_path_segment_default(default);
+            let rendered_default = match default.value() {
+                serde_json::Value::String(value) => value.clone(),
+                value => value.to_string(),
+            };
+            let encoded_default = encode_path_segment_default(&rendered_default);
             format!("{{{{{namespace}.{key}|{encoded_default}}}}}")
         },
     )

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -115,12 +115,16 @@ pub fn request_spec_for_projection(
     for input in &projection.inputs {
         if input.source_location == IrInputLocation::Path {
             let replacement = match input.sql_exposure {
-                SqlInputExposure::Filter => {
-                    path_template_token("filter", &input.name, input.default_value.as_ref())
-                }
-                SqlInputExposure::FunctionArg => {
-                    path_template_token("arg", &input.name, input.default_value.as_ref())
-                }
+                SqlInputExposure::Filter => path_template_token(
+                    "filter",
+                    &input.name,
+                    usable_text_default(input.default_value.as_ref()),
+                ),
+                SqlInputExposure::FunctionArg => path_template_token(
+                    "arg",
+                    &input.name,
+                    usable_text_default(input.default_value.as_ref()),
+                ),
                 SqlInputExposure::Internal => continue,
             };
             path = path.replace(&format!("{{{}}}", input.wire_name), &replacement);
@@ -134,16 +138,12 @@ pub fn request_spec_for_projection(
             let value = match input.sql_exposure {
                 SqlInputExposure::Filter => crate::ValueSourceSpec::Filter {
                     key: input.name.clone(),
-                    default: input
-                        .default_value
-                        .as_ref()
+                    default: usable_text_default(input.default_value.as_ref())
                         .map(|value| value.value().clone()),
                 },
                 SqlInputExposure::FunctionArg => crate::ValueSourceSpec::Arg {
                     key: input.name.clone(),
-                    default: input
-                        .default_value
-                        .as_ref()
+                    default: usable_text_default(input.default_value.as_ref())
                         .map(|value| value.value().clone()),
                 },
                 SqlInputExposure::Internal => return None,
@@ -161,6 +161,10 @@ pub fn request_spec_for_projection(
         body: crate::BodySpec::default(),
         headers: Vec::new(),
     })
+}
+
+fn usable_text_default(default: Option<&DeclaredDefaultValue>) -> Option<&DeclaredDefaultValue> {
+    default.filter(|default| !default.value().is_null())
 }
 
 fn path_template_token(

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -57,6 +57,12 @@ fn validate_projection_inputs(
                 projection.name, input.name, input.source_location, input.wire_name, operation.id
             )));
         };
+        if input.default_value != operation_input.default_value {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' input '{}' on operation '{}' changes the imported default_value; projection overrides cannot change operation defaults",
+                projection.name, input.name, operation.id
+            )));
+        }
 
         let pagination_owned =
             plan.pagination_owns_input(operation, &input.wire_name, input.source_location);
@@ -183,6 +189,12 @@ fn validate_projection_columns(
                 projection.name, column.name
             )));
         };
+        if field.synthetic {
+            return Err(ManifestError::validation(format!(
+                "projection '{}' column '{}' reads synthetic field '{field_name}' on rows operation '{operation_id}'; synthetic compatibility fields are not addressable response fields",
+                projection.name, column.name
+            )));
+        }
         // Generated and authored columns may both nest, and runtime follows
         // every segment it is given.
         let nested = column.source_path.get(1..).unwrap_or_default();
@@ -229,6 +241,11 @@ fn walk_source_path(
                 let Some(field) = fields.iter().find(|field| field.name == *segment) else {
                     return Err(format!("type '{type_ref}' has no field '{segment}'"));
                 };
+                if field.synthetic {
+                    return Err(format!(
+                        "field '{segment}' on type '{type_ref}' is synthetic and is not an addressable response field"
+                    ));
+                }
                 field.type_ref.as_str()
             }
             // Any key selects a map value, so only a numeric one is ruled out.

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -33,9 +33,7 @@ pub fn validate_projection_compatibility(
                 projection.name, projection.operation_id
             )));
         };
-        if matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
-            validate_projection_columns(plan, &types, projection, &operation.id)?;
-        }
+        validate_projection_columns(plan, &types, projection, &operation.id)?;
         validate_projection_inputs(plan, projection, operation)?;
     }
     Ok(())
@@ -139,7 +137,7 @@ fn validate_projection_inputs(
     Ok(())
 }
 
-/// Checks that a REST projection's columns describe the rows the effective
+/// Checks that a projection's columns describe the rows the effective
 /// operation policy actually yields.
 ///
 /// The projection catalog is a snapshot: an operation-metadata override that
@@ -153,7 +151,7 @@ fn validate_projection_columns(
     projection: &Projection,
     operation_id: &str,
 ) -> Result<()> {
-    let row_type_ref = plan.rest_output_type_ref(operation_id);
+    let row_type_ref = plan.output_row_type_ref(operation_id);
     // Only an object row type names its fields. Every other shape is projected
     // whole, as a single column with no source path — including a `json` row,
     // which the semantic IR carries no entry for at all.

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -183,8 +183,8 @@ fn validate_projection_columns(
                 projection.name, column.name
             )));
         };
-        // The generator only ever emits one segment, but an authored override
-        // may nest, and runtime follows every segment it is given.
+        // Generated and authored columns may both nest, and runtime follows
+        // every segment it is given.
         let nested = column.source_path.get(1..).unwrap_or_default();
         if let Err(reason) = walk_source_path(&field.type_ref, nested, types) {
             return Err(ManifestError::validation(format!(
@@ -203,11 +203,12 @@ fn validate_projection_columns(
 ///
 /// `get_path_value` reads a segment that parses as an integer only as an array
 /// index, never as a key, so whether a segment is numeric decides as much as the
-/// shape it lands on does. The generator can emit a numeric *first* segment, for
-/// a resource whose field really is named `0`, and those columns already resolve
-/// to null; rejecting them here would make a freshly generated catalog fail its
-/// own validation, so the rule applies only below the first segment, where
-/// nothing but an authored override can put one.
+/// shape it lands on does. Established top-level projection columns can contain
+/// a numeric *first* segment for a resource whose field really is named `0`, and
+/// those columns already resolve to null; rejecting them here would invalidate
+/// existing generated catalogs. The nested scalar-leaf generator omits numeric
+/// object keys, so the rule applies below the first segment to reject authored
+/// overrides and stale generated artifacts that runtime cannot read.
 fn walk_source_path(
     type_ref: &str,
     segments: &[String],

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -272,6 +272,22 @@ pub(crate) fn json_schema_default_to_string(value: &Value) -> String {
     }
 }
 
+pub(crate) fn merge_json_schema_properties_exact(
+    target: &mut BTreeMap<String, Value>,
+    source: BTreeMap<String, Value>,
+) -> Result<(), JsonSchemaComparisonError> {
+    for (name, property) in source {
+        if let Some(existing) = target.get(&name) {
+            if existing != &property {
+                return Err(JsonSchemaComparisonError::PropertyConflict(name));
+            }
+        } else {
+            target.insert(name, property);
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn merge_json_object_shape_annotation_insensitive(
     target: &mut JsonObjectShape,
     source: JsonObjectShape,
@@ -1114,17 +1130,6 @@ mod tests {
         assert_eq!(
             merge_json_object_shape_annotation_insensitive(&mut target, source, 0, 1),
             Err(JsonSchemaComparisonError::DepthExceeded)
-        );
-    }
-
-    #[test]
-    fn default_to_string_preserves_string_values_and_serializes_other_json() {
-        assert_eq!(json_schema_default_to_string(&json!("text")), "text");
-        assert_eq!(json_schema_default_to_string(&json!(30)), "30");
-        assert_eq!(json_schema_default_to_string(&json!(true)), "true");
-        assert_eq!(
-            json_schema_default_to_string(&json!({"enabled": true})),
-            r#"{"enabled":true}"#
         );
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -253,6 +253,18 @@ surface:
     }
 
     #[test]
+    fn normalized_mcp_catalog_omits_absent_behavior_hints() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool("search-items", None)],
+        };
+
+        let normalized = normalize_mcp_tool_catalog(&catalog).expect("normalize catalog");
+        let normalized = String::from_utf8(normalized).expect("catalog YAML");
+        assert!(!normalized.contains("read_only_hint"));
+        assert!(!normalized.contains("idempotent_hint"));
+    }
+
+    #[test]
     fn imports_input_schema_types_required_flags_and_defaults() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -165,6 +165,7 @@ surface:
             input_schema,
             output_schema,
             read_only_hint,
+            idempotent_hint: None,
         }
     }
 
@@ -233,6 +234,25 @@ surface:
     }
 
     #[test]
+    fn preserves_mcp_read_only_and_idempotent_evidence() {
+        let mut descriptor = tool("search-items", Some(true));
+        descriptor.idempotent_hint = Some(true);
+        let catalog = McpToolCatalog {
+            tools: vec![descriptor],
+        };
+
+        let normalized = normalize_mcp_tool_catalog(&catalog).expect("normalize catalog");
+        let normalized = String::from_utf8(normalized).expect("catalog YAML");
+        assert!(normalized.contains("read_only_hint: true"));
+        assert!(normalized.contains("idempotent_hint: true"));
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "search_items");
+        assert!(operation.read_only);
+        assert!(operation.idempotent);
+    }
+
+    #[test]
     fn imports_input_schema_types_required_flags_and_defaults() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(
@@ -274,7 +294,13 @@ surface:
             .find(|input| input.name == "limit")
             .expect("limit input");
         assert_eq!(limit.data_type, IrScalarType::Integer);
-        assert_eq!(limit.default_value.as_deref(), Some("10"));
+        assert_eq!(
+            limit
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&json!(10))
+        );
 
         let exact = operation
             .inputs
@@ -282,7 +308,13 @@ surface:
             .find(|input| input.name == "exact")
             .expect("exact input");
         assert_eq!(exact.data_type, IrScalarType::Boolean);
-        assert_eq!(exact.default_value.as_deref(), Some("true"));
+        assert_eq!(
+            exact
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&json!(true))
+        );
 
         let since = operation
             .inputs
@@ -462,7 +494,13 @@ surface:
             .find(|input| input.name == "limit")
             .expect("limit input");
         assert_eq!(limit.data_type, IrScalarType::Integer);
-        assert_eq!(limit.default_value.as_deref(), Some("10"));
+        assert_eq!(
+            limit
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&json!(10))
+        );
         assert_eq!(limit.description, "Page size");
     }
 
@@ -499,7 +537,13 @@ surface:
             .find(|input| input.name == "limit")
             .expect("limit input");
         assert_eq!(limit.data_type, IrScalarType::Integer);
-        assert_eq!(limit.default_value.as_deref(), Some("10"));
+        assert_eq!(
+            limit
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&json!(10))
+        );
     }
 
     #[test]
@@ -773,7 +817,13 @@ surface:
             .find(|input| input.name == "limit")
             .expect("limit input");
         assert_eq!(limit.data_type, IrScalarType::Integer);
-        assert_eq!(limit.default_value.as_deref(), Some("10"));
+        assert_eq!(
+            limit
+                .default_value
+                .as_ref()
+                .map(crate::DeclaredDefaultValue::value),
+            Some(&json!(10))
+        );
     }
 
     #[test]
@@ -944,7 +994,19 @@ surface:
             ["items"]
         );
         let wrapped_fields = row_fields(&ir, "wrapped_items_row");
-        assert_eq!(field(wrapped_fields, "items").type_ref, "mcp_json");
+        let items = field(wrapped_fields, "items");
+        let items_type = ir
+            .types
+            .iter()
+            .find(|ty| ty.id == items.type_ref)
+            .expect("items list type");
+        let IrTypeShape::List { item_type_ref } = &items_type.shape else {
+            panic!("items should remain a nested list");
+        };
+        assert_eq!(
+            field(row_fields(&ir, item_type_ref), "enabled").type_ref,
+            "mcp_boolean"
+        );
         assert!(wrapped_fields.iter().any(|field| field.name == "raw"));
 
         let get_item = operation(&ir, "get_item");
@@ -957,6 +1019,93 @@ surface:
         let generic_fields = row_fields(&ir, "no_schema_row");
         assert_eq!(field(generic_fields, "result").type_ref, "mcp_json");
         assert_eq!(field(generic_fields, "raw").type_ref, "mcp_json");
+    }
+
+    #[test]
+    fn resolves_top_level_array_ref_and_defs_item_schema() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "list-items",
+                json!({"type": "object", "properties": {}}),
+                Some(json!({
+                    "$ref": "#/$defs/ItemList",
+                    "$defs": {
+                        "ItemList": {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/Item"}
+                        },
+                        "Item": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "count": {"type": "integer"}
+                            },
+                            "required": ["id"]
+                        }
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "list_items");
+        assert_eq!(operation.output.cardinality, OutputCardinality::List);
+        let fields = row_fields(&ir, "list_items_row");
+        assert_eq!(field(fields, "id").type_ref, "mcp_string");
+        assert!(field(fields, "id").required);
+        assert_eq!(field(fields, "count").type_ref, "mcp_integer");
+        assert!(field(fields, "raw").synthetic);
+    }
+
+    #[test]
+    fn resolves_top_level_wrapped_list_ref_as_a_singleton_envelope() {
+        let catalog = McpToolCatalog {
+            tools: vec![tool_with_schemas(
+                "wrapped-items",
+                json!({"type": "object", "properties": {}}),
+                Some(json!({
+                    "$ref": "#/$defs/ItemEnvelope",
+                    "$defs": {
+                        "ItemEnvelope": {
+                            "type": "object",
+                            "properties": {
+                                "items": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/$defs/Item"}
+                                }
+                            }
+                        },
+                        "Item": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {"type": "boolean"}
+                            }
+                        }
+                    }
+                })),
+                Some(true),
+            )],
+        };
+
+        let ir = import_catalog(&catalog);
+        let operation = operation(&ir, "wrapped_items");
+        assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+        let fields = row_fields(&ir, "wrapped_items_row");
+        let items = field(fields, "items");
+        let items_type = ir
+            .types
+            .iter()
+            .find(|ty| ty.id == items.type_ref)
+            .expect("items list type");
+        let IrTypeShape::List { item_type_ref } = &items_type.shape else {
+            panic!("items should remain a nested list");
+        };
+        assert_eq!(
+            field(row_fields(&ir, item_type_ref), "enabled").type_ref,
+            "mcp_boolean"
+        );
+        assert!(field(fields, "raw").synthetic);
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -265,6 +265,22 @@ surface:
     }
 
     #[test]
+    fn normalized_mcp_catalog_preserves_explicit_false_behavior_hints() {
+        let mut descriptor = tool("search-items", Some(false));
+        descriptor.idempotent_hint = Some(false);
+        let catalog = McpToolCatalog {
+            tools: vec![descriptor],
+        };
+
+        let normalized = normalize_mcp_tool_catalog(&catalog).expect("normalize catalog");
+        let normalized: McpToolCatalog =
+            serde_yaml::from_slice(&normalized).expect("normalized catalog YAML");
+        let descriptor = normalized.tools.first().expect("normalized tool");
+        assert_eq!(descriptor.read_only_hint, Some(false));
+        assert_eq!(descriptor.idempotent_hint, Some(false));
+    }
+
+    #[test]
     fn imports_input_schema_types_required_flags_and_defaults() {
         let catalog = McpToolCatalog {
             tools: vec![tool_with_schemas(

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
+use crate::DeclaredDefaultValue;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
 use crate::v4::surfaces::json_schema::{
     JsonObjectShape, JsonSchemaComparisonError, JsonSchemaWalkError, direct_json_object_shape,
-    json_schema_default_to_string, json_schema_scalar_type,
-    merge_json_object_shape_annotation_insensitive, resolve_json_schema_ref_with_siblings,
-    with_resolved_json_schema,
+    json_schema_scalar_type, merge_json_object_shape_annotation_insensitive,
+    resolve_json_schema_ref_with_siblings, with_resolved_json_schema,
 };
 
 use super::import::McpImporter;
@@ -63,7 +63,10 @@ impl McpImporter<'_> {
                     location: IrInputLocation::ToolArg,
                     required: shape.required.contains(name.as_str()),
                     data_type,
-                    default_value: property.get("default").map(json_schema_default_to_string),
+                    default_value: property
+                        .get("default")
+                        .cloned()
+                        .map(DeclaredDefaultValue::new),
                     description: schema_description(property),
                 }
             })

--- a/crates/coral-spec/src/v4/surfaces/mcp/model.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/model.rs
@@ -14,4 +14,6 @@ pub struct McpToolDescriptor {
     pub input_schema: Value,
     pub output_schema: Option<Value>,
     pub read_only_hint: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotent_hint: Option<bool>,
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/model.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/model.rs
@@ -13,6 +13,7 @@ pub struct McpToolDescriptor {
     pub description: Option<String>,
     pub input_schema: Value,
     pub output_schema: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only_hint: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idempotent_hint: Option<bool>,

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -56,6 +56,7 @@ impl McpImporter<'_> {
                 .unwrap_or_default(),
             deprecated: false,
             read_only: tool.read_only_hint.unwrap_or(false),
+            idempotent: tool.idempotent_hint.unwrap_or(false),
             naming: None,
             inputs,
             output,

--- a/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/output_schema.rs
@@ -1,14 +1,20 @@
+use std::collections::BTreeSet;
+
 use serde_json::Value;
 
 use crate::v4::ir::{
     IrField, IrOperationOutput, IrScalarType, IrType, IrTypeShape, OutputCardinality,
 };
+use crate::v4::naming::{normalize_identifier, stable_suffix};
 use crate::v4::surfaces::json_schema::{
     json_schema_required_fields, json_schema_scalar_type, json_schema_type_contains,
+    resolve_json_schema_ref_with_siblings,
 };
 
 use super::import::McpImporter;
 use super::input_schema::schema_description;
+
+const MAX_MCP_OUTPUT_SCHEMA_DEPTH: usize = 64;
 
 impl McpImporter<'_> {
     pub(super) fn import_output(
@@ -17,22 +23,36 @@ impl McpImporter<'_> {
         output_schema: Option<&Value>,
     ) -> IrOperationOutput {
         let row_type_id = format!("{operation_id}_row");
-        let Some(schema) = output_schema else {
+        let Some(root_schema) = output_schema else {
             self.insert_generic_row_type(&row_type_id);
             return IrOperationOutput {
                 cardinality: OutputCardinality::Singleton,
                 type_ref: row_type_id,
             };
         };
-        if json_schema_type_contains(schema, "array") {
+        let mut resolving_refs = BTreeSet::new();
+        let Ok(schema) = resolve_json_schema_ref_with_siblings(
+            root_schema,
+            root_schema,
+            &mut resolving_refs,
+            0,
+            MAX_MCP_OUTPUT_SCHEMA_DEPTH,
+        ) else {
+            self.insert_generic_row_type(&row_type_id);
+            return IrOperationOutput {
+                cardinality: OutputCardinality::Singleton,
+                type_ref: row_type_id,
+            };
+        };
+        if json_schema_type_contains(&schema, "array") {
             let item_schema = schema.get("items");
-            self.insert_row_type_from_schema(&row_type_id, item_schema);
+            self.insert_row_type_from_schema(&row_type_id, item_schema, root_schema);
             return IrOperationOutput {
                 cardinality: OutputCardinality::List,
                 type_ref: row_type_id,
             };
         }
-        self.insert_row_type_from_schema(&row_type_id, Some(schema));
+        self.insert_row_type_from_schema(&row_type_id, Some(&schema), root_schema);
         IrOperationOutput {
             cardinality: OutputCardinality::Singleton,
             type_ref: row_type_id,
@@ -53,6 +73,7 @@ impl McpImporter<'_> {
                             required: false,
                             nullable: true,
                             description: String::new(),
+                            synthetic: false,
                         },
                         IrField {
                             name: "raw".to_string(),
@@ -60,6 +81,7 @@ impl McpImporter<'_> {
                             required: false,
                             nullable: true,
                             description: "Raw MCP tool payload.".to_string(),
+                            synthetic: true,
                         },
                     ],
                 },
@@ -69,50 +91,139 @@ impl McpImporter<'_> {
         );
     }
 
-    fn insert_row_type_from_schema(&mut self, type_id: &str, schema: Option<&Value>) {
+    fn insert_row_type_from_schema(
+        &mut self,
+        type_id: &str,
+        schema: Option<&Value>,
+        root_schema: &Value,
+    ) {
         let Some(schema) = schema else {
             self.insert_generic_row_type(type_id);
             return;
         };
-        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        let mut resolving_refs = BTreeSet::new();
+        let Ok(schema) = resolve_json_schema_ref_with_siblings(
+            root_schema,
+            schema,
+            &mut resolving_refs,
+            0,
+            MAX_MCP_OUTPUT_SCHEMA_DEPTH,
+        ) else {
             self.insert_generic_row_type(type_id);
             return;
+        };
+        if schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .is_none()
+        {
+            self.insert_generic_row_type(type_id);
+            return;
+        }
+        self.insert_output_type(type_id, &schema);
+        let json_type = self.ensure_type_for_scalar(IrScalarType::Json);
+        let Some(IrType {
+            shape: IrTypeShape::Object { fields },
+            ..
+        }) = self.types.get_mut(type_id)
+        else {
+            return;
+        };
+        if fields.iter().any(|field| field.name == "raw") {
+            return;
+        }
+        fields.push(IrField {
+            name: "raw".to_string(),
+            type_ref: json_type,
+            required: false,
+            nullable: true,
+            description: "Raw MCP tool payload.".to_string(),
+            synthetic: true,
+        });
+    }
+
+    fn insert_output_type(&mut self, type_id: &str, schema: &Value) -> String {
+        if self.types.contains_key(type_id) {
+            return type_id.to_string();
+        }
+        if let Some(scalar) = json_schema_scalar_type(schema) {
+            return self.ensure_type_for_scalar(scalar);
+        }
+        let nullable = schema.get("nullable").and_then(Value::as_bool) == Some(true)
+            || json_schema_type_contains(schema, "null");
+        if json_schema_type_contains(schema, "array") {
+            let item_type_ref = if let Some(items) = schema.get("items") {
+                let item_type_id = format!("{type_id}_item");
+                self.insert_output_type(&item_type_id, items)
+            } else {
+                self.ensure_type_for_scalar(IrScalarType::Json)
+            };
+            self.types.insert(
+                type_id.to_string(),
+                IrType {
+                    id: type_id.to_string(),
+                    shape: IrTypeShape::List { item_type_ref },
+                    nullable,
+                    description: schema_description(schema),
+                },
+            );
+            return type_id.to_string();
+        }
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            self.types.insert(
+                type_id.to_string(),
+                IrType {
+                    id: type_id.to_string(),
+                    shape: IrTypeShape::Json,
+                    nullable,
+                    description: schema_description(schema),
+                },
+            );
+            return type_id.to_string();
         };
         let required = schema
             .as_object()
             .map(json_schema_required_fields)
             .unwrap_or_default();
-        let mut fields = properties
+        // Reserve the type id before recursion so a recursive schema degrades
+        // to JSON instead of recursing forever.
+        self.types.insert(
+            type_id.to_string(),
+            IrType {
+                id: type_id.to_string(),
+                shape: IrTypeShape::Json,
+                nullable,
+                description: schema_description(schema),
+            },
+        );
+        let fields = properties
             .iter()
             .map(|(name, property)| {
-                let data_type = json_schema_scalar_type(property).unwrap_or(IrScalarType::Json);
+                let normalized_name = normalize_identifier(name, "field");
+                let child_type_id = format!("{type_id}_{normalized_name}_{}", stable_suffix(name));
+                let type_ref = self.insert_output_type(&child_type_id, property);
+                let is_required = required.contains(name.as_str());
+                let type_nullable = property.get("nullable").and_then(Value::as_bool) == Some(true)
+                    || json_schema_type_contains(property, "null");
                 IrField {
                     name: name.clone(),
-                    type_ref: self.ensure_type_for_scalar(data_type),
-                    required: required.contains(name.as_str()),
-                    nullable: !required.contains(name.as_str()),
+                    type_ref,
+                    required: is_required,
+                    nullable: !is_required || type_nullable,
                     description: schema_description(property),
+                    synthetic: false,
                 }
             })
             .collect::<Vec<_>>();
-        if !fields.iter().any(|field| field.name == "raw") {
-            let json_type = self.ensure_type_for_scalar(IrScalarType::Json);
-            fields.push(IrField {
-                name: "raw".to_string(),
-                type_ref: json_type,
-                required: false,
-                nullable: true,
-                description: "Raw MCP tool payload.".to_string(),
-            });
-        }
         self.types.insert(
             type_id.to_string(),
             IrType {
                 id: type_id.to_string(),
                 shape: IrTypeShape::Object { fields },
-                nullable: false,
+                nullable,
                 description: schema_description(schema),
             },
         );
+        type_id.to_string()
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/pagination.rs
@@ -109,8 +109,8 @@ fn offset_pagination_input<'a>(
         name: input.name.as_str(),
         default: input
             .default_value
-            .as_deref()
-            .and_then(|value| value.parse::<usize>().ok())
+            .as_ref()
+            .and_then(|default| json_unsigned_integer(default.value()))
             .or_else(|| schema_unsigned_integer(schema, "default"))?,
         maximum: schema_unsigned_integer(schema, "maximum"),
     })
@@ -126,7 +126,10 @@ fn schema_allows_unsigned_value(schema: &Value, value: usize) -> bool {
 }
 
 fn schema_unsigned_integer(schema: &Value, key: &str) -> Option<usize> {
-    let value = schema.get(key)?;
+    json_unsigned_integer(schema.get(key)?)
+}
+
+fn json_unsigned_integer(value: &Value) -> Option<usize> {
     value
         .as_u64()
         .and_then(|value| usize::try_from(value).ok())
@@ -136,6 +139,7 @@ fn schema_unsigned_integer(schema: &Value, key: &str) -> Option<usize> {
                 .filter(|value| *value >= 0)
                 .and_then(|value| usize::try_from(value).ok())
         })
+        .or_else(|| value.as_str()?.parse().ok())
 }
 
 fn cursor_input_name(inputs: &[IrOperationInput]) -> Option<&str> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -223,8 +223,9 @@ impl OpenApiImporter<'_> {
                     location,
                     required: parameter_is_required(parameter_obj, location),
                     data_type: scalar,
-                    default_value: resolved_schema
+                    default_value: schema
                         .get("default")
+                        .or_else(|| resolved_schema.get("default"))
                         .cloned()
                         .map(DeclaredDefaultValue::new),
                     description: parameter_obj

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -13,12 +13,11 @@ use crate::v4::lookup_keys::infer_rest_lookup_keys;
 use crate::v4::naming::normalize_identifier;
 use crate::v4::response_cursors::{StringTypeRequirement, find_response_cursor_path};
 use crate::v4::surfaces::json_schema::{
-    json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
-    json_schema_type_display,
+    json_schema_scalar_type_or_string, json_schema_type_contains, json_schema_type_display,
 };
 use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
 use crate::{
-    ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
+    DeclaredDefaultValue, ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
     v4::resolve_output_row_type_ref,
 };
 
@@ -92,6 +91,15 @@ impl OpenApiImporter<'_> {
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
             read_only: method == HttpMethod::Get,
+            idempotent: matches!(
+                method,
+                HttpMethod::Get
+                    | HttpMethod::Head
+                    | HttpMethod::Options
+                    | HttpMethod::Put
+                    | HttpMethod::Delete
+                    | HttpMethod::Trace
+            ),
             naming,
             inputs: parameters,
             output,
@@ -208,14 +216,17 @@ impl OpenApiImporter<'_> {
                     .and_then(Value::as_str)
                     .and_then(parse_parameter_location)?;
                 let schema = parameter_obj.get("schema").unwrap_or(&Value::Null);
-                let scalar =
+                let (scalar, resolved_schema) =
                     self.import_parameter_scalar(schema, &name, operation_id, diagnostics)?;
                 Some(IrOperationInput {
                     name,
                     location,
                     required: parameter_is_required(parameter_obj, location),
                     data_type: scalar,
-                    default_value: schema.get("default").map(json_schema_default_to_string),
+                    default_value: resolved_schema
+                        .get("default")
+                        .cloned()
+                        .map(DeclaredDefaultValue::new),
                     description: parameter_obj
                         .get("description")
                         .and_then(Value::as_str)
@@ -232,7 +243,7 @@ impl OpenApiImporter<'_> {
         name: &str,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> Option<IrScalarType> {
+    ) -> Option<(IrScalarType, Value)> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
         let Some(scalar) = json_schema_scalar_type_or_string(&resolved) else {
             diagnostics.push(Diagnostic::new(
@@ -244,7 +255,7 @@ impl OpenApiImporter<'_> {
             ));
             return None;
         };
-        Some(scalar)
+        Some((scalar, resolved))
     }
 
     fn import_request_body(
@@ -737,7 +748,11 @@ fn page_size_spec(input: &IrOperationInput) -> PageSizeSpec {
 }
 
 fn numeric_input_default(input: &IrOperationInput) -> Option<i64> {
-    input.default_value.as_deref()?.parse().ok()
+    let value = input.default_value.as_ref()?.value();
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+        .or_else(|| value.as_str()?.parse().ok())
 }
 
 fn name_token(value: &str) -> String {

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -380,6 +380,7 @@ impl OpenApiImporter<'_> {
                     required: required.contains(name),
                     nullable: true,
                     description: self.field_description(schema),
+                    synthetic: false,
                 }
             })
             .collect()


### PR DESCRIPTION
## TL;DR

When Coral imports a DSL v4 OpenAPI endpoint or MCP tool, it converts that external definition into Coral’s internal format. Previously, some important details could be lost during that conversion. #2009 makes those details survive all the way to runtime:

- Exact parameters, types, locations, and defaults.
- The difference between “no default” and “default is null.”
- Original operation IDs.
- MCP read-only and idempotency hints, including explicit `false`.
- Nested response paths and result shapes.

It also prevents source authors from changing the imported contract accidentally—for example, replacing an endpoint’s default `limit: 25` with `limit: 100`, or selecting a synthetic field that does not actually exist in the provider response.

Later fanout PRs can therefore safely answer: “What arguments does this endpoint need, how should we call it, and how should we interpret its response?”

It does not authorize endpoints, make them searchable, enable fanout, or make network calls. It only preserves and validates the information needed by those later layers. DSL v3 is unaffected.

## Summary

- Preserves DSL v4 imported operation contracts through semantic IR, projections, runtime registration, and materialization.
- Carries typed argument defaults without collapsing an omitted default and an explicit JSON `null`; projection overrides must preserve the imported default exactly.
- Gives OpenAPI parameter ref-site defaults precedence over referenced-schema defaults.
- Preserves the original operation ID, read-only and idempotency hints, nested source paths, importer-synthetic field metadata, and MCP structured-output and row-path metadata.
- Rejects authored projection paths that select importer-synthetic compatibility fields while keeping provider-authored fields such as `raw` addressable.
- Derives unique top-level and nested projection column names without repeatedly rebuilding source-path indexes.
- Skips nested numeric object-key paths that the runtime would interpret as array indexes, so generated catalogs remain compatible with their imported schemas.
- Omits absent MCP behavior hints from normalized catalogs while preserving explicit `true` and `false`.
- Rotates the affected schema, surface, importer, operation-metadata, and projection artifact versions so stale generated artifacts fail closed.
- Keeps this layer passive: it does not attach Universal Search authorization, resolve routes, enable fanout, or execute provider calls.

## Stack boundary

Stack 2/11. Depends on #1855; #2010 builds on this PR.

This PR establishes faithful DSL v4 runtime metadata for later route resolution. DSL v3 sources do not gain fanout metadata or compatibility behavior.

## Test plan

- `cargo test -p coral-spec` (481 passed)
- `cargo test -p coral-engine build_query_pairs_omits_missing_args_but_preserves_explicit_values --lib`
- `cargo clippy -p coral-spec -p coral-engine --all-targets --all-features -- -D warnings`
- `make schema-check`
- `make rust-checks` (2,320 passed, 5 skipped)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>