### PR TITLE
feat(search): expose passive fanout metadata in catalogs

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -86,46 +86,11 @@ message TableSummary {
   string catalog_name = 7;
 }
 
-// An exact JSON value carried through protobuf without text encoding.
-message JsonValue {
-  // Exactly one JSON kind.
-  oneof kind {
-    // Explicit JSON null.
-    JsonNull null_value = 1;
-    // JSON boolean.
-    bool bool_value = 2;
-    // JSON integer represented as a signed 64-bit value.
-    int64 int64_value = 3 [jstype = JS_STRING];
-    // JSON integer represented as an unsigned 64-bit value.
-    uint64 uint64_value = 4 [jstype = JS_STRING];
-    // JSON non-integer number.
-    double double_value = 5;
-    // JSON string.
-    string string_value = 6;
-    // JSON array.
-    JsonArray array_value = 7;
-    // JSON object.
-    JsonObject object_value = 8;
-  }
-}
-
-// Explicit JSON null.
-message JsonNull {}
-
-// JSON array.
-message JsonArray {
-  // Values in array order.
-  repeated JsonValue values = 1;
-}
-
-// JSON object.
-message JsonObject {
-  // Object fields keyed by property name.
-  map<string, JsonValue> fields = 1;
-}
-
 // An argument accepted by a query-visible table function.
 message TableFunctionArgument {
+  reserved 5;
+  reserved "default_value", "default_json";
+
   // Argument name as used in a named SQL function call.
   string name = 1;
   // Whether callers must provide this argument.
@@ -134,9 +99,6 @@ message TableFunctionArgument {
   repeated string values = 3;
   // Argument type in source-manifest spelling.
   string data_type = 4;
-  // Authored typed default. Absence means no default; a present `null_value`
-  // means the source explicitly authored JSON null.
-  JsonValue default_value = 5;
 }
 
 // A result column returned by a query-visible table function.

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -94,6 +94,11 @@ message TableFunctionArgument {
   bool required = 2;
   // Allowed values, if the source declares an enum-like value set.
   repeated string values = 3;
+  // Argument type in source-manifest spelling.
+  string data_type = 4;
+  // Authored typed default encoded as JSON. Presence distinguishes no default
+  // from an explicit JSON null.
+  optional string default_json = 5;
 }
 
 // A result column returned by a query-visible table function.
@@ -128,6 +133,43 @@ message SearchLimits {
   uint32 max_calls_per_query = 3;
 }
 
+// How a passive Universal Search authorization was selected.
+enum UniversalSearchAuthorizationOrigin {
+  // No origin was supplied.
+  UNIVERSAL_SEARCH_AUTHORIZATION_ORIGIN_UNSPECIFIED = 0;
+  // The source authored an explicit Universal Search route.
+  UNIVERSAL_SEARCH_AUTHORIZATION_ORIGIN_EXPLICIT = 1;
+  // Coral selected the route through canonical inference.
+  UNIVERSAL_SEARCH_AUTHORIZATION_ORIGIN_INFERRED = 2;
+}
+
+// Passive authorization decision for one provider-native search route.
+enum UniversalSearchAuthorizationDecision {
+  // No decision was supplied.
+  UNIVERSAL_SEARCH_AUTHORIZATION_DECISION_UNSPECIFIED = 0;
+  // The route is eligible if the independent runtime feature is enabled.
+  UNIVERSAL_SEARCH_AUTHORIZATION_DECISION_ELIGIBLE = 1;
+  // The source explicitly denied execution of the route.
+  UNIVERSAL_SEARCH_AUTHORIZATION_DECISION_DENIED = 2;
+}
+
+// Passive source authorization attached to one query-visible table function.
+// This metadata does not represent effective execution state.
+message UniversalSearchAuthorization {
+  // Canonical installed source identity, separate from the SQL schema.
+  string source_name = 1;
+  // Stable source-authored route id. Absent for inferred routes.
+  optional string route_id = 2;
+  // How the route was selected.
+  UniversalSearchAuthorizationOrigin origin = 3;
+  // Whether the route is eligible or explicitly denied.
+  UniversalSearchAuthorizationDecision decision = 4;
+  // Query-visible argument receiving the Universal Search query, when present.
+  optional string query_argument = 5;
+  // Original DSL v4 operation identity.
+  string operation_id = 6;
+}
+
 // A query-visible table function in one workspace.
 message TableFunction {
   // Workspace whose query catalog makes this function visible.
@@ -148,6 +190,8 @@ message TableFunction {
   SearchLimits search_limits = 8;
   // User-facing query guidance.
   string guide = 9;
+  // Passive source authorization for provider-native Universal Search.
+  UniversalSearchAuthorization universal_search = 10;
 }
 
 // Catalog item kind filter for unified discovery.

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -86,6 +86,44 @@ message TableSummary {
   string catalog_name = 7;
 }
 
+// An exact JSON value carried through protobuf without text encoding.
+message JsonValue {
+  // Exactly one JSON kind.
+  oneof kind {
+    // Explicit JSON null.
+    JsonNull null_value = 1;
+    // JSON boolean.
+    bool bool_value = 2;
+    // JSON integer represented as a signed 64-bit value.
+    int64 int64_value = 3 [jstype = JS_STRING];
+    // JSON integer represented as an unsigned 64-bit value.
+    uint64 uint64_value = 4 [jstype = JS_STRING];
+    // JSON non-integer number.
+    double double_value = 5;
+    // JSON string.
+    string string_value = 6;
+    // JSON array.
+    JsonArray array_value = 7;
+    // JSON object.
+    JsonObject object_value = 8;
+  }
+}
+
+// Explicit JSON null.
+message JsonNull {}
+
+// JSON array.
+message JsonArray {
+  // Values in array order.
+  repeated JsonValue values = 1;
+}
+
+// JSON object.
+message JsonObject {
+  // Object fields keyed by property name.
+  map<string, JsonValue> fields = 1;
+}
+
 // An argument accepted by a query-visible table function.
 message TableFunctionArgument {
   // Argument name as used in a named SQL function call.
@@ -96,9 +134,9 @@ message TableFunctionArgument {
   repeated string values = 3;
   // Argument type in source-manifest spelling.
   string data_type = 4;
-  // Authored typed default encoded as JSON. Presence distinguishes no default
-  // from an explicit JSON null.
-  optional string default_json = 5;
+  // Authored typed default. Absence means no default; a present `null_value`
+  // means the source explicitly authored JSON null.
+  JsonValue default_value = 5;
 }
 
 // A result column returned by a query-visible table function.

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeMap;
 
 use coral_engine::{
     CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
+    TableFunctionResultColumnInfo, TableInfo, UniversalSearchAuthorizationDecision,
+    UniversalSearchAuthorizationInfo, UniversalSearchAuthorizationOrigin,
 };
 use coral_spec::SourceTableFunctionKind;
 use sha2::{Digest as _, Sha256};
@@ -14,7 +15,7 @@ use crate::search::catalog::sqlite_index::{
 };
 use crate::search::result::{SearchFieldRole, SearchSurfaceKind};
 
-const CATALOG_SEARCH_SNAPSHOT_VERSION: &str = "catalog-search-snapshot-v3";
+const CATALOG_SEARCH_SNAPSHOT_VERSION: &str = "catalog-search-snapshot-v4";
 
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogSearchSnapshot {
@@ -492,10 +493,12 @@ fn catalog_snapshot_fingerprint(
         for argument in arguments {
             update_hash(&mut hasher, "argument");
             update_hash(&mut hasher, &argument.name);
+            update_hash(&mut hasher, &argument.data_type);
             update_hash_bool(&mut hasher, argument.required);
             for value in &argument.values {
                 update_hash(&mut hasher, value);
             }
+            update_optional_hash(&mut hasher, argument.default_json.as_deref());
         }
         let mut result_columns = function.result_columns.iter().collect::<Vec<_>>();
         result_columns.sort_by(|left, right| left.name.cmp(&right.name));
@@ -506,9 +509,51 @@ fn catalog_snapshot_fingerprint(
             update_hash_bool(&mut hasher, column.nullable);
             update_hash(&mut hasher, &column.description);
         }
+        update_universal_search_hash(&mut hasher, function.universal_search.as_ref());
     }
 
     format!("{:x}", hasher.finalize())
+}
+
+fn update_universal_search_hash(
+    hasher: &mut Sha256,
+    authorization: Option<&UniversalSearchAuthorizationInfo>,
+) {
+    let Some(authorization) = authorization else {
+        update_hash(hasher, "universal_search_absent");
+        return;
+    };
+    update_hash(hasher, "universal_search");
+    update_hash(hasher, &authorization.source_name);
+    update_optional_hash(hasher, authorization.route_id.as_deref());
+    update_hash(
+        hasher,
+        match authorization.origin {
+            UniversalSearchAuthorizationOrigin::Unspecified => "unspecified",
+            UniversalSearchAuthorizationOrigin::Explicit => "explicit",
+            UniversalSearchAuthorizationOrigin::Inferred => "inferred",
+        },
+    );
+    update_hash(
+        hasher,
+        match authorization.decision {
+            UniversalSearchAuthorizationDecision::Unspecified => "unspecified",
+            UniversalSearchAuthorizationDecision::Eligible => "eligible",
+            UniversalSearchAuthorizationDecision::Denied => "denied",
+        },
+    );
+    update_optional_hash(hasher, authorization.query_argument.as_deref());
+    update_hash(hasher, &authorization.operation_id);
+}
+
+fn update_optional_hash(hasher: &mut Sha256, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            update_hash(hasher, "some");
+            update_hash(hasher, value);
+        }
+        None => update_hash(hasher, "none"),
+    }
 }
 
 fn update_column_hash(hasher: &mut Sha256, column: &ColumnInfo) {
@@ -535,7 +580,12 @@ fn update_hash(hasher: &mut Sha256, value: &str) {
 mod tests {
     use std::collections::BTreeMap;
 
-    use coral_engine::{CatalogInfo, TableInfo};
+    use coral_engine::{
+        CatalogInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableInfo,
+        UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationInfo,
+        UniversalSearchAuthorizationOrigin,
+    };
+    use coral_spec::SourceTableFunctionKind;
 
     use super::{CatalogDocumentKind, CatalogSearchSnapshot};
 
@@ -591,6 +641,28 @@ mod tests {
             && doc.field_name == "title"));
     }
 
+    #[test]
+    fn snapshot_fingerprint_tracks_typed_defaults_and_passive_authorization() {
+        let without_default =
+            CatalogSearchSnapshot::from_catalog(&catalog_with_function(None, None));
+        let explicit_null =
+            CatalogSearchSnapshot::from_catalog(&catalog_with_function(Some("null"), None));
+        let authorized = CatalogSearchSnapshot::from_catalog(&catalog_with_function(
+            Some("null"),
+            Some(UniversalSearchAuthorizationInfo {
+                source_name: "installed_fixture".to_string(),
+                route_id: Some("primary".to_string()),
+                origin: UniversalSearchAuthorizationOrigin::Explicit,
+                decision: UniversalSearchAuthorizationDecision::Eligible,
+                query_argument: Some("query".to_string()),
+                operation_id: "search".to_string(),
+            }),
+        ));
+
+        assert_ne!(without_default.fingerprint, explicit_null.fingerprint);
+        assert_ne!(explicit_null.fingerprint, authorized.fingerprint);
+    }
+
     fn catalog_with_table(table_name: &str) -> CatalogInfo {
         CatalogInfo {
             tables: vec![TableInfo {
@@ -612,6 +684,33 @@ mod tests {
                 required_filters: Vec::new(),
             }],
             table_functions: Vec::new(),
+        }
+    }
+
+    fn catalog_with_function(
+        default_json: Option<&str>,
+        universal_search: Option<UniversalSearchAuthorizationInfo>,
+    ) -> CatalogInfo {
+        CatalogInfo {
+            tables: Vec::new(),
+            table_functions: vec![TableFunctionInfo {
+                schema_name: "fixture_schema".to_string(),
+                function_name: "search".to_string(),
+                description: String::new(),
+                guide: String::new(),
+                require_guide_read: false,
+                arguments: vec![TableFunctionArgumentInfo {
+                    name: "query".to_string(),
+                    data_type: "Utf8".to_string(),
+                    required: true,
+                    values: Vec::new(),
+                    default_json: default_json.map(str::to_string),
+                }],
+                result_columns: Vec::new(),
+                kind: SourceTableFunctionKind::Search,
+                search_limits: None,
+                universal_search,
+            }],
         }
     }
 }

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -4,8 +4,7 @@ use std::collections::BTreeMap;
 
 use coral_engine::{
     CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo, UniversalSearchAuthorizationDecision,
-    UniversalSearchAuthorizationInfo, UniversalSearchAuthorizationOrigin,
+    TableFunctionResultColumnInfo, TableInfo, UniversalSearchAuthorizationInfo,
 };
 use coral_spec::SourceTableFunctionKind;
 use sha2::{Digest as _, Sha256};
@@ -526,22 +525,8 @@ fn update_universal_search_hash(
     update_hash(hasher, "universal_search");
     update_hash(hasher, &authorization.source_name);
     update_optional_hash(hasher, authorization.route_id.as_deref());
-    update_hash(
-        hasher,
-        match authorization.origin {
-            UniversalSearchAuthorizationOrigin::Unspecified => "unspecified",
-            UniversalSearchAuthorizationOrigin::Explicit => "explicit",
-            UniversalSearchAuthorizationOrigin::Inferred => "inferred",
-        },
-    );
-    update_hash(
-        hasher,
-        match authorization.decision {
-            UniversalSearchAuthorizationDecision::Unspecified => "unspecified",
-            UniversalSearchAuthorizationDecision::Eligible => "eligible",
-            UniversalSearchAuthorizationDecision::Denied => "denied",
-        },
-    );
+    update_hash(hasher, authorization.origin.as_str());
+    update_hash(hasher, authorization.decision.as_str());
     update_optional_hash(hasher, authorization.query_argument.as_deref());
     update_hash(hasher, &authorization.operation_id);
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -10,13 +10,15 @@ use coral_api::{
     v1::{
         CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
         ColumnSearchResult as ProtoColumnSearchResult,
-        DescribeTableResponse as ProtoDescribeTableResponse, PaginationResponse, QueryTestFailure,
-        QueryTestResult, QueryTestSuccess, SearchLimits, Source, Table, TableFunction,
-        TableFunctionArgument, TableFunctionKind, TableFunctionResultColumn, TableSummary,
+        DescribeTableResponse as ProtoDescribeTableResponse, JsonArray, JsonNull, JsonObject,
+        JsonValue as ProtoJsonValue, PaginationResponse, QueryTestFailure, QueryTestResult,
+        QueryTestSuccess, SearchLimits, Source, Table, TableFunction, TableFunctionArgument,
+        TableFunctionKind, TableFunctionResultColumn, TableSummary,
         UniversalSearchAuthorization as ProtoUniversalSearchAuthorization,
         UniversalSearchAuthorizationDecision as ProtoUniversalSearchAuthorizationDecision,
         UniversalSearchAuthorizationOrigin as ProtoUniversalSearchAuthorizationOrigin,
-        ValidateSourceResponse, Workspace, catalog_item, query_test_result,
+        ValidateSourceResponse, Workspace, catalog_item, json_value as proto_json_value,
+        query_test_result,
     },
 };
 use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
@@ -460,7 +462,11 @@ pub(crate) fn table_function_to_proto(
                 required: argument.required,
                 values: argument.values,
                 data_type: argument.data_type,
-                default_json: argument.default_json,
+                default_value: argument.default_json.map(|default_json| {
+                    let value = serde_json::from_str(&default_json)
+                        .expect("catalog argument defaults contain valid JSON");
+                    json_value_to_proto(value)
+                }),
             })
             .collect(),
         result_columns: function
@@ -481,6 +487,39 @@ pub(crate) fn table_function_to_proto(
             .as_ref()
             .map(universal_search_authorization_to_proto),
     }
+}
+
+fn json_value_to_proto(value: serde_json::Value) -> ProtoJsonValue {
+    use proto_json_value::Kind;
+
+    let kind = match value {
+        serde_json::Value::Null => Kind::NullValue(JsonNull {}),
+        serde_json::Value::Bool(value) => Kind::BoolValue(value),
+        serde_json::Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                Kind::Int64Value(value)
+            } else if let Some(value) = value.as_u64() {
+                Kind::Uint64Value(value)
+            } else {
+                Kind::DoubleValue(
+                    value
+                        .as_f64()
+                        .expect("serde_json numbers are signed, unsigned, or finite floats"),
+                )
+            }
+        }
+        serde_json::Value::String(value) => Kind::StringValue(value),
+        serde_json::Value::Array(values) => Kind::ArrayValue(JsonArray {
+            values: values.into_iter().map(json_value_to_proto).collect(),
+        }),
+        serde_json::Value::Object(fields) => Kind::ObjectValue(JsonObject {
+            fields: fields
+                .into_iter()
+                .map(|(key, value)| (key, json_value_to_proto(value)))
+                .collect(),
+        }),
+    };
+    ProtoJsonValue { kind: Some(kind) }
 }
 
 fn universal_search_authorization_to_proto(
@@ -650,10 +689,10 @@ mod tests {
         CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY, CORAL_TASK_ID_METADATA_KEY,
         grpc_response_status_code,
         v1::{
-            QueryTestFailure, SearchLimits, TableFunction, TableFunctionArgument,
-            TableFunctionResultColumn, UniversalSearchAuthorization,
+            JsonValue as ProtoJsonValue, QueryTestFailure, SearchLimits, TableFunction,
+            TableFunctionArgument, TableFunctionResultColumn, UniversalSearchAuthorization,
             UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationOrigin, Workspace,
-            query_test_result,
+            json_value as proto_json_value, query_test_result,
         },
     };
     use opentelemetry::Value;
@@ -666,9 +705,10 @@ mod tests {
 
     use super::{
         GRPC_REQUEST_ERROR_MESSAGE, GrpcMethodMetadata, GrpcServerMethod, annotate_request_context,
-        grpc_method, grpc_span_for_metadata, instrument_grpc, principal_provider_status,
-        query_status, query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
-        table_to_proto, workspace_name_from_proto, workspace_to_proto,
+        grpc_method, grpc_span_for_metadata, instrument_grpc, json_value_to_proto,
+        principal_provider_status, query_status, query_test_result_to_proto,
+        table_function_to_proto, table_summary_to_proto, table_to_proto, workspace_name_from_proto,
+        workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::identity::PrincipalProviderError;
@@ -1090,7 +1130,13 @@ mod tests {
         assert!(proto.arguments[0].required);
         assert!(proto.arguments[0].values.is_empty());
         assert_eq!(proto.arguments[0].data_type, "Json");
-        assert_eq!(proto.arguments[0].default_json.as_deref(), Some("null"));
+        assert!(matches!(
+            proto.arguments[0]
+                .default_value
+                .as_ref()
+                .and_then(|value| value.kind.as_ref()),
+            Some(proto_json_value::Kind::NullValue(_))
+        ));
         let authorization = proto.universal_search.expect("authorization");
         assert_eq!(authorization.source_name, "installed_demo");
         assert_eq!(authorization.route_id.as_deref(), Some("primary"));
@@ -1146,7 +1192,7 @@ mod tests {
                 required: legacy.arguments[0].required,
                 values: legacy.arguments[0].values.clone(),
                 data_type: "Utf8".to_string(),
-                default_json: Some("\"lexical\"".to_string()),
+                default_value: Some(json_value_to_proto(serde_json::json!("lexical"))),
             }],
             result_columns: legacy.result_columns.clone(),
             kind: legacy.kind,
@@ -1188,8 +1234,87 @@ mod tests {
         assert_eq!(decoded_by_current.kind, current.kind);
         assert_eq!(decoded_by_current.search_limits, current.search_limits);
         assert!(decoded_by_current.arguments[0].data_type.is_empty());
-        assert!(decoded_by_current.arguments[0].default_json.is_none());
+        assert!(decoded_by_current.arguments[0].default_value.is_none());
         assert!(decoded_by_current.universal_search.is_none());
+    }
+
+    #[test]
+    fn json_value_to_proto_preserves_json_types_and_integer_precision() {
+        let value = json_value_to_proto(serde_json::json!({
+            "null": null,
+            "bool": false,
+            "signed": -9_007_199_254_740_993_i64,
+            "large_integer": 9_007_199_254_740_993_u64,
+            "unsigned": u64::MAX,
+            "double": 0.75,
+            "integral_double": 1.0,
+            "string": "recent",
+            "array": [1, "two"],
+            "object": {"nested": true}
+        }));
+        let decoded = ProtoJsonValue::decode(value.encode_to_vec().as_slice())
+            .expect("structured JSON protobuf round trip");
+        assert_eq!(decoded, value);
+        let Some(proto_json_value::Kind::ObjectValue(object)) = decoded.kind else {
+            panic!("expected JSON object");
+        };
+
+        assert!(matches!(
+            json_kind(&object.fields["null"]),
+            proto_json_value::Kind::NullValue(_)
+        ));
+        assert_eq!(
+            json_kind(&object.fields["bool"]),
+            &proto_json_value::Kind::BoolValue(false)
+        );
+        assert_eq!(
+            json_kind(&object.fields["signed"]),
+            &proto_json_value::Kind::Int64Value(-9_007_199_254_740_993)
+        );
+        assert_eq!(
+            json_kind(&object.fields["large_integer"]),
+            &proto_json_value::Kind::Int64Value(9_007_199_254_740_993)
+        );
+        assert_eq!(
+            json_kind(&object.fields["unsigned"]),
+            &proto_json_value::Kind::Uint64Value(u64::MAX)
+        );
+        assert_eq!(
+            json_kind(&object.fields["double"]),
+            &proto_json_value::Kind::DoubleValue(0.75)
+        );
+        assert_eq!(
+            json_kind(&object.fields["integral_double"]),
+            &proto_json_value::Kind::DoubleValue(1.0)
+        );
+        assert_eq!(
+            json_kind(&object.fields["string"]),
+            &proto_json_value::Kind::StringValue("recent".to_string())
+        );
+        let proto_json_value::Kind::ArrayValue(array) = json_kind(&object.fields["array"]) else {
+            panic!("expected nested JSON array");
+        };
+        assert_eq!(array.values.len(), 2);
+        assert_eq!(
+            json_kind(&array.values[0]),
+            &proto_json_value::Kind::Int64Value(1)
+        );
+        assert_eq!(
+            json_kind(&array.values[1]),
+            &proto_json_value::Kind::StringValue("two".to_string())
+        );
+        let proto_json_value::Kind::ObjectValue(nested) = json_kind(&object.fields["object"])
+        else {
+            panic!("expected nested JSON object");
+        };
+        assert_eq!(
+            json_kind(&nested.fields["nested"]),
+            &proto_json_value::Kind::BoolValue(true)
+        );
+    }
+
+    fn json_kind(value: &ProtoJsonValue) -> &proto_json_value::Kind {
+        value.kind.as_ref().expect("JSON value kind")
     }
 
     #[test]

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -10,15 +10,13 @@ use coral_api::{
     v1::{
         CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
         ColumnSearchResult as ProtoColumnSearchResult,
-        DescribeTableResponse as ProtoDescribeTableResponse, JsonArray, JsonNull, JsonObject,
-        JsonValue as ProtoJsonValue, PaginationResponse, QueryTestFailure, QueryTestResult,
-        QueryTestSuccess, SearchLimits, Source, Table, TableFunction, TableFunctionArgument,
-        TableFunctionKind, TableFunctionResultColumn, TableSummary,
+        DescribeTableResponse as ProtoDescribeTableResponse, PaginationResponse, QueryTestFailure,
+        QueryTestResult, QueryTestSuccess, SearchLimits, Source, Table, TableFunction,
+        TableFunctionArgument, TableFunctionKind, TableFunctionResultColumn, TableSummary,
         UniversalSearchAuthorization as ProtoUniversalSearchAuthorization,
         UniversalSearchAuthorizationDecision as ProtoUniversalSearchAuthorizationDecision,
         UniversalSearchAuthorizationOrigin as ProtoUniversalSearchAuthorizationOrigin,
-        ValidateSourceResponse, Workspace, catalog_item, json_value as proto_json_value,
-        query_test_result,
+        ValidateSourceResponse, Workspace, catalog_item, query_test_result,
     },
 };
 use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
@@ -462,11 +460,6 @@ pub(crate) fn table_function_to_proto(
                 required: argument.required,
                 values: argument.values,
                 data_type: argument.data_type,
-                default_value: argument.default_json.map(|default_json| {
-                    let value = serde_json::from_str(&default_json)
-                        .expect("catalog argument defaults contain valid JSON");
-                    json_value_to_proto(value)
-                }),
             })
             .collect(),
         result_columns: function
@@ -487,39 +480,6 @@ pub(crate) fn table_function_to_proto(
             .as_ref()
             .map(universal_search_authorization_to_proto),
     }
-}
-
-fn json_value_to_proto(value: serde_json::Value) -> ProtoJsonValue {
-    use proto_json_value::Kind;
-
-    let kind = match value {
-        serde_json::Value::Null => Kind::NullValue(JsonNull {}),
-        serde_json::Value::Bool(value) => Kind::BoolValue(value),
-        serde_json::Value::Number(value) => {
-            if let Some(value) = value.as_i64() {
-                Kind::Int64Value(value)
-            } else if let Some(value) = value.as_u64() {
-                Kind::Uint64Value(value)
-            } else {
-                Kind::DoubleValue(
-                    value
-                        .as_f64()
-                        .expect("serde_json numbers are signed, unsigned, or finite floats"),
-                )
-            }
-        }
-        serde_json::Value::String(value) => Kind::StringValue(value),
-        serde_json::Value::Array(values) => Kind::ArrayValue(JsonArray {
-            values: values.into_iter().map(json_value_to_proto).collect(),
-        }),
-        serde_json::Value::Object(fields) => Kind::ObjectValue(JsonObject {
-            fields: fields
-                .into_iter()
-                .map(|(key, value)| (key, json_value_to_proto(value)))
-                .collect(),
-        }),
-    };
-    ProtoJsonValue { kind: Some(kind) }
 }
 
 fn universal_search_authorization_to_proto(
@@ -689,10 +649,10 @@ mod tests {
         CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY, CORAL_TASK_ID_METADATA_KEY,
         grpc_response_status_code,
         v1::{
-            JsonValue as ProtoJsonValue, QueryTestFailure, SearchLimits, TableFunction,
-            TableFunctionArgument, TableFunctionResultColumn, UniversalSearchAuthorization,
+            QueryTestFailure, SearchLimits, TableFunction, TableFunctionArgument,
+            TableFunctionResultColumn, UniversalSearchAuthorization,
             UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationOrigin, Workspace,
-            json_value as proto_json_value, query_test_result,
+            query_test_result,
         },
     };
     use opentelemetry::Value;
@@ -705,10 +665,9 @@ mod tests {
 
     use super::{
         GRPC_REQUEST_ERROR_MESSAGE, GrpcMethodMetadata, GrpcServerMethod, annotate_request_context,
-        grpc_method, grpc_span_for_metadata, instrument_grpc, json_value_to_proto,
-        principal_provider_status, query_status, query_test_result_to_proto,
-        table_function_to_proto, table_summary_to_proto, table_to_proto, workspace_name_from_proto,
-        workspace_to_proto,
+        grpc_method, grpc_span_for_metadata, instrument_grpc, principal_provider_status,
+        query_status, query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
+        table_to_proto, workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::identity::PrincipalProviderError;
@@ -1130,13 +1089,6 @@ mod tests {
         assert!(proto.arguments[0].required);
         assert!(proto.arguments[0].values.is_empty());
         assert_eq!(proto.arguments[0].data_type, "Json");
-        assert!(matches!(
-            proto.arguments[0]
-                .default_value
-                .as_ref()
-                .and_then(|value| value.kind.as_ref()),
-            Some(proto_json_value::Kind::NullValue(_))
-        ));
         let authorization = proto.universal_search.expect("authorization");
         assert_eq!(authorization.source_name, "installed_demo");
         assert_eq!(authorization.route_id.as_deref(), Some("primary"));
@@ -1192,7 +1144,6 @@ mod tests {
                 required: legacy.arguments[0].required,
                 values: legacy.arguments[0].values.clone(),
                 data_type: "Utf8".to_string(),
-                default_value: Some(json_value_to_proto(serde_json::json!("lexical"))),
             }],
             result_columns: legacy.result_columns.clone(),
             kind: legacy.kind,
@@ -1234,87 +1185,7 @@ mod tests {
         assert_eq!(decoded_by_current.kind, current.kind);
         assert_eq!(decoded_by_current.search_limits, current.search_limits);
         assert!(decoded_by_current.arguments[0].data_type.is_empty());
-        assert!(decoded_by_current.arguments[0].default_value.is_none());
         assert!(decoded_by_current.universal_search.is_none());
-    }
-
-    #[test]
-    fn json_value_to_proto_preserves_json_types_and_integer_precision() {
-        let value = json_value_to_proto(serde_json::json!({
-            "null": null,
-            "bool": false,
-            "signed": -9_007_199_254_740_993_i64,
-            "large_integer": 9_007_199_254_740_993_u64,
-            "unsigned": u64::MAX,
-            "double": 0.75,
-            "integral_double": 1.0,
-            "string": "recent",
-            "array": [1, "two"],
-            "object": {"nested": true}
-        }));
-        let decoded = ProtoJsonValue::decode(value.encode_to_vec().as_slice())
-            .expect("structured JSON protobuf round trip");
-        assert_eq!(decoded, value);
-        let Some(proto_json_value::Kind::ObjectValue(object)) = decoded.kind else {
-            panic!("expected JSON object");
-        };
-
-        assert!(matches!(
-            json_kind(&object.fields["null"]),
-            proto_json_value::Kind::NullValue(_)
-        ));
-        assert_eq!(
-            json_kind(&object.fields["bool"]),
-            &proto_json_value::Kind::BoolValue(false)
-        );
-        assert_eq!(
-            json_kind(&object.fields["signed"]),
-            &proto_json_value::Kind::Int64Value(-9_007_199_254_740_993)
-        );
-        assert_eq!(
-            json_kind(&object.fields["large_integer"]),
-            &proto_json_value::Kind::Int64Value(9_007_199_254_740_993)
-        );
-        assert_eq!(
-            json_kind(&object.fields["unsigned"]),
-            &proto_json_value::Kind::Uint64Value(u64::MAX)
-        );
-        assert_eq!(
-            json_kind(&object.fields["double"]),
-            &proto_json_value::Kind::DoubleValue(0.75)
-        );
-        assert_eq!(
-            json_kind(&object.fields["integral_double"]),
-            &proto_json_value::Kind::DoubleValue(1.0)
-        );
-        assert_eq!(
-            json_kind(&object.fields["string"]),
-            &proto_json_value::Kind::StringValue("recent".to_string())
-        );
-        let proto_json_value::Kind::ArrayValue(array) = json_kind(&object.fields["array"]) else {
-            panic!("expected nested JSON array");
-        };
-        assert_eq!(array.values.len(), 2);
-        assert_eq!(
-            json_kind(&array.values[0]),
-            &proto_json_value::Kind::Int64Value(1)
-        );
-        assert_eq!(
-            json_kind(&array.values[1]),
-            &proto_json_value::Kind::StringValue("two".to_string())
-        );
-        let proto_json_value::Kind::ObjectValue(nested) = json_kind(&object.fields["object"])
-        else {
-            panic!("expected nested JSON object");
-        };
-        assert_eq!(
-            json_kind(&nested.fields["nested"]),
-            &proto_json_value::Kind::BoolValue(true)
-        );
-    }
-
-    fn json_kind(value: &ProtoJsonValue) -> &proto_json_value::Kind {
-        value.kind.as_ref().expect("JSON value kind")
     }
 
     #[test]

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -490,9 +490,6 @@ fn universal_search_authorization_to_proto(
         source_name: authorization.source_name.clone(),
         route_id: authorization.route_id.clone(),
         origin: match authorization.origin {
-            coral_engine::UniversalSearchAuthorizationOrigin::Unspecified => {
-                ProtoUniversalSearchAuthorizationOrigin::Unspecified
-            }
             coral_engine::UniversalSearchAuthorizationOrigin::Explicit => {
                 ProtoUniversalSearchAuthorizationOrigin::Explicit
             }
@@ -501,9 +498,6 @@ fn universal_search_authorization_to_proto(
             }
         } as i32,
         decision: match authorization.decision {
-            coral_engine::UniversalSearchAuthorizationDecision::Unspecified => {
-                ProtoUniversalSearchAuthorizationDecision::Unspecified
-            }
             coral_engine::UniversalSearchAuthorizationDecision::Eligible => {
                 ProtoUniversalSearchAuthorizationDecision::Eligible
             }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -13,6 +13,9 @@ use coral_api::{
         DescribeTableResponse as ProtoDescribeTableResponse, PaginationResponse, QueryTestFailure,
         QueryTestResult, QueryTestSuccess, SearchLimits, Source, Table, TableFunction,
         TableFunctionArgument, TableFunctionKind, TableFunctionResultColumn, TableSummary,
+        UniversalSearchAuthorization as ProtoUniversalSearchAuthorization,
+        UniversalSearchAuthorizationDecision as ProtoUniversalSearchAuthorizationDecision,
+        UniversalSearchAuthorizationOrigin as ProtoUniversalSearchAuthorizationOrigin,
         ValidateSourceResponse, Workspace, catalog_item, query_test_result,
     },
 };
@@ -456,6 +459,8 @@ pub(crate) fn table_function_to_proto(
                 name: argument.name,
                 required: argument.required,
                 values: argument.values,
+                data_type: argument.data_type,
+                default_json: argument.default_json,
             })
             .collect(),
         result_columns: function
@@ -471,6 +476,43 @@ pub(crate) fn table_function_to_proto(
         kind: table_function_kind_to_proto(function.kind) as i32,
         search_limits: function.search_limits.as_ref().map(search_limits_to_proto),
         guide: function.guide,
+        universal_search: function
+            .universal_search
+            .as_ref()
+            .map(universal_search_authorization_to_proto),
+    }
+}
+
+fn universal_search_authorization_to_proto(
+    authorization: &coral_engine::UniversalSearchAuthorizationInfo,
+) -> ProtoUniversalSearchAuthorization {
+    ProtoUniversalSearchAuthorization {
+        source_name: authorization.source_name.clone(),
+        route_id: authorization.route_id.clone(),
+        origin: match authorization.origin {
+            coral_engine::UniversalSearchAuthorizationOrigin::Unspecified => {
+                ProtoUniversalSearchAuthorizationOrigin::Unspecified
+            }
+            coral_engine::UniversalSearchAuthorizationOrigin::Explicit => {
+                ProtoUniversalSearchAuthorizationOrigin::Explicit
+            }
+            coral_engine::UniversalSearchAuthorizationOrigin::Inferred => {
+                ProtoUniversalSearchAuthorizationOrigin::Inferred
+            }
+        } as i32,
+        decision: match authorization.decision {
+            coral_engine::UniversalSearchAuthorizationDecision::Unspecified => {
+                ProtoUniversalSearchAuthorizationDecision::Unspecified
+            }
+            coral_engine::UniversalSearchAuthorizationDecision::Eligible => {
+                ProtoUniversalSearchAuthorizationDecision::Eligible
+            }
+            coral_engine::UniversalSearchAuthorizationDecision::Denied => {
+                ProtoUniversalSearchAuthorizationDecision::Denied
+            }
+        } as i32,
+        query_argument: authorization.query_argument.clone(),
+        operation_id: authorization.operation_id.clone(),
     }
 }
 
@@ -613,11 +655,17 @@ mod tests {
     use coral_api::{
         CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY, CORAL_TASK_ID_METADATA_KEY,
         grpc_response_status_code,
-        v1::{QueryTestFailure, Workspace, query_test_result},
+        v1::{
+            QueryTestFailure, SearchLimits, TableFunction, TableFunctionArgument,
+            TableFunctionResultColumn, UniversalSearchAuthorization,
+            UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationOrigin, Workspace,
+            query_test_result,
+        },
     };
     use opentelemetry::Value;
     use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
     use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+    use prost::Message;
     use tonic::{Code, Request, Status};
     use tonic_types::{ErrorDetail, StatusExt as _};
     use tracing_subscriber::layer::SubscriberExt as _;
@@ -634,9 +682,41 @@ mod tests {
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
-        TableInfo,
+        TableInfo, UniversalSearchAuthorizationDecision as EngineAuthorizationDecision,
+        UniversalSearchAuthorizationInfo,
+        UniversalSearchAuthorizationOrigin as EngineAuthorizationOrigin,
     };
     use coral_spec::SourceTableFunctionKind;
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacyTableFunctionArgument {
+        #[prost(string, tag = "1")]
+        name: String,
+        #[prost(bool, tag = "2")]
+        required: bool,
+        #[prost(string, repeated, tag = "3")]
+        values: Vec<String>,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacyTableFunction {
+        #[prost(message, optional, tag = "1")]
+        workspace: Option<Workspace>,
+        #[prost(string, tag = "2")]
+        schema_name: String,
+        #[prost(string, tag = "3")]
+        name: String,
+        #[prost(string, tag = "4")]
+        description: String,
+        #[prost(message, repeated, tag = "5")]
+        arguments: Vec<LegacyTableFunctionArgument>,
+        #[prost(message, repeated, tag = "6")]
+        result_columns: Vec<TableFunctionResultColumn>,
+        #[prost(int32, tag = "7")]
+        kind: i32,
+        #[prost(message, optional, tag = "8")]
+        search_limits: Option<SearchLimits>,
+    }
 
     #[test]
     fn query_status_maps_app_errors() {
@@ -986,12 +1066,22 @@ mod tests {
             require_guide_read: true,
             arguments: vec![coral_engine::TableFunctionArgumentInfo {
                 name: "payload".to_string(),
+                data_type: "Json".to_string(),
                 required: true,
                 values: Vec::new(),
+                default_json: Some("null".to_string()),
             }],
             result_columns: Vec::new(),
             kind: SourceTableFunctionKind::Search,
             search_limits: None,
+            universal_search: Some(UniversalSearchAuthorizationInfo {
+                source_name: "installed_demo".to_string(),
+                route_id: Some("primary".to_string()),
+                origin: EngineAuthorizationOrigin::Explicit,
+                decision: EngineAuthorizationDecision::Eligible,
+                query_argument: Some("payload".to_string()),
+                operation_id: "search".to_string(),
+            }),
         };
 
         let proto = table_function_to_proto(&workspace_name, function);
@@ -1005,6 +1095,107 @@ mod tests {
         assert_eq!(proto.arguments[0].name, "payload");
         assert!(proto.arguments[0].required);
         assert!(proto.arguments[0].values.is_empty());
+        assert_eq!(proto.arguments[0].data_type, "Json");
+        assert_eq!(proto.arguments[0].default_json.as_deref(), Some("null"));
+        let authorization = proto.universal_search.expect("authorization");
+        assert_eq!(authorization.source_name, "installed_demo");
+        assert_eq!(authorization.route_id.as_deref(), Some("primary"));
+        assert_eq!(
+            UniversalSearchAuthorizationOrigin::try_from(authorization.origin)
+                .expect("authorization origin"),
+            UniversalSearchAuthorizationOrigin::Explicit
+        );
+        assert_eq!(
+            UniversalSearchAuthorizationDecision::try_from(authorization.decision)
+                .expect("authorization decision"),
+            UniversalSearchAuthorizationDecision::Eligible
+        );
+        assert_eq!(authorization.query_argument.as_deref(), Some("payload"));
+        assert_eq!(authorization.operation_id, "search");
+    }
+
+    #[test]
+    fn table_function_proto_is_wire_compatible_with_legacy_clients() {
+        let legacy = LegacyTableFunction {
+            workspace: Some(Workspace {
+                name: "default".to_string(),
+            }),
+            schema_name: "demo".to_string(),
+            name: "search".to_string(),
+            description: "Search demo records".to_string(),
+            arguments: vec![LegacyTableFunctionArgument {
+                name: "mode".to_string(),
+                required: true,
+                values: vec!["lexical".to_string(), "semantic".to_string()],
+            }],
+            result_columns: vec![TableFunctionResultColumn {
+                name: "title".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+                description: "Result title".to_string(),
+            }],
+            kind: 2,
+            search_limits: Some(SearchLimits {
+                default_top_k: 10,
+                max_top_k: 25,
+                max_calls_per_query: 2,
+            }),
+        };
+        let current = TableFunction {
+            workspace: legacy.workspace.clone(),
+            schema_name: legacy.schema_name.clone(),
+            name: legacy.name.clone(),
+            description: legacy.description.clone(),
+            guide: String::new(),
+            arguments: vec![TableFunctionArgument {
+                name: legacy.arguments[0].name.clone(),
+                required: legacy.arguments[0].required,
+                values: legacy.arguments[0].values.clone(),
+                data_type: "Utf8".to_string(),
+                default_json: Some("\"lexical\"".to_string()),
+            }],
+            result_columns: legacy.result_columns.clone(),
+            kind: legacy.kind,
+            search_limits: legacy.search_limits,
+            universal_search: Some(UniversalSearchAuthorization {
+                source_name: "installed_demo".to_string(),
+                route_id: Some("primary".to_string()),
+                origin: UniversalSearchAuthorizationOrigin::Explicit as i32,
+                decision: UniversalSearchAuthorizationDecision::Eligible as i32,
+                query_argument: Some("mode".to_string()),
+                operation_id: "search".to_string(),
+            }),
+        };
+
+        let decoded_by_legacy =
+            LegacyTableFunction::decode(current.encode_to_vec().as_slice()).expect("legacy decode");
+        assert_eq!(decoded_by_legacy, legacy);
+
+        let decoded_by_current =
+            TableFunction::decode(legacy.encode_to_vec().as_slice()).expect("current decode");
+        assert_eq!(decoded_by_current.workspace, current.workspace);
+        assert_eq!(decoded_by_current.schema_name, current.schema_name);
+        assert_eq!(decoded_by_current.name, current.name);
+        assert_eq!(decoded_by_current.description, current.description);
+        assert_eq!(decoded_by_current.arguments.len(), 1);
+        assert_eq!(
+            decoded_by_current.arguments[0].name,
+            current.arguments[0].name
+        );
+        assert_eq!(
+            decoded_by_current.arguments[0].required,
+            current.arguments[0].required
+        );
+        assert_eq!(
+            decoded_by_current.arguments[0].values,
+            current.arguments[0].values
+        );
+        assert_eq!(decoded_by_current.result_columns, current.result_columns);
+        assert_eq!(decoded_by_current.kind, current.kind);
+        assert_eq!(decoded_by_current.search_limits, current.search_limits);
+        assert!(decoded_by_current.arguments[0].data_type.is_empty());
+        assert!(decoded_by_current.arguments[0].default_json.is_none());
+        assert!(decoded_by_current.universal_search.is_none());
     }
 
     #[test]

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -375,6 +375,7 @@ fn mock_validate_response() -> ValidateSourceResponse {
             result_columns: Vec::new(),
             kind: 0,
             search_limits: None,
+            universal_search: None,
         }],
         query_tests: Vec::new(),
     }

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use coral_spec::{
-    ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY, FilterSpec, ManifestDataType, ManifestInputKind,
-    ManifestInputSpec, SearchLimitsSpec, SourceBackend, SourceTableFunctionKind,
-    SourceTableFunctionSpec, TableCommon,
+    ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY, DeclaredDefaultValue, FilterSpec,
+    ManifestDataType, ManifestInputKind, ManifestInputSpec, SearchLimitsSpec, SourceBackend,
+    SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::CatalogProvider;
@@ -88,6 +88,7 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
     pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
     pub(crate) search_limits: Option<SearchLimitsSpec>,
+    pub(crate) universal_search: Option<crate::UniversalSearchAuthorizationInfo>,
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +106,7 @@ pub(crate) struct RegisteredTableFunctionArgument {
     pub(crate) data_type: ManifestDataType,
     pub(crate) required: bool,
     pub(crate) values: Vec<String>,
+    pub(crate) default: Option<DeclaredDefaultValue>,
 }
 
 #[derive(Debug, Clone)]
@@ -410,6 +412,7 @@ pub(crate) fn build_registered_table_function(
             data_type: arg.data_type,
             required: arg.required,
             values: arg.values.clone(),
+            default: arg.default.clone(),
         })
         .collect::<Vec<_>>();
     let result_columns = registered_columns_from_specs(&function.columns, &[])
@@ -433,6 +436,7 @@ pub(crate) fn build_registered_table_function(
         arguments,
         result_columns,
         search_limits: function.search_limits.clone(),
+        universal_search: None,
     }
 }
 

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::{
     BoundRequestIdentityHttpAuthenticator, QueryRuntimeContext, QuerySource, RequestAuthenticator,
-    SourceInputResolver, SourceObservationPublisher,
+    SourceInputResolver, SourceObservationPublisher, UniversalSearchAuthorizationInfo,
 };
 use async_trait::async_trait;
 use coral_spec::{
@@ -88,7 +88,7 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
     pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
     pub(crate) search_limits: Option<SearchLimitsSpec>,
-    pub(crate) universal_search: Option<crate::UniversalSearchAuthorizationInfo>,
+    pub(crate) universal_search: Option<UniversalSearchAuthorizationInfo>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -65,10 +65,56 @@ pub struct DescribeTableInfo {
 pub struct TableFunctionArgumentInfo {
     /// Argument name as used in a named SQL function call.
     pub name: String,
+    /// Argument type in source-manifest spelling.
+    pub data_type: String,
     /// Whether callers must provide this argument.
     pub required: bool,
     /// Allowed values, if the source declares an enum-like value set.
     pub values: Vec<String>,
+    /// Authored typed default encoded as JSON, or `None` when no default was declared.
+    pub default_json: Option<String>,
+}
+
+/// How a passive Universal Search authorization was selected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UniversalSearchAuthorizationOrigin {
+    /// No origin was supplied.
+    Unspecified,
+    /// The source authored an explicit Universal Search route.
+    Explicit,
+    /// Coral selected the route through canonical inference.
+    Inferred,
+}
+
+/// Passive authorization decision for one source table function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UniversalSearchAuthorizationDecision {
+    /// No decision was supplied.
+    Unspecified,
+    /// The route is eligible if the independent runtime feature is enabled.
+    Eligible,
+    /// The source explicitly denied execution of the route.
+    Denied,
+}
+
+/// Passive Universal Search authorization attached to one query-visible function.
+///
+/// This metadata does not enable execution. The app owns policy resolution and
+/// the independent runtime feature gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UniversalSearchAuthorizationInfo {
+    /// Canonical installed source identity, separate from the SQL schema.
+    pub source_name: String,
+    /// Stable source-authored route id, when the route was explicit.
+    pub route_id: Option<String>,
+    /// Whether the route was explicitly authored or canonically inferred.
+    pub origin: UniversalSearchAuthorizationOrigin,
+    /// Passive eligibility or explicit-denial decision.
+    pub decision: UniversalSearchAuthorizationDecision,
+    /// Query-visible argument receiving the Universal Search query, when present.
+    pub query_argument: Option<String>,
+    /// Original DSL v4 operation identity.
+    pub operation_id: String,
 }
 
 /// Describes one result column returned by a table function.
@@ -105,4 +151,6 @@ pub struct TableFunctionInfo {
     pub kind: SourceTableFunctionKind,
     /// Provider search limit metadata, when declared by the source.
     pub search_limits: Option<SearchLimitsSpec>,
+    /// Passive Universal Search authorization, when one resolves to this function.
+    pub universal_search: Option<UniversalSearchAuthorizationInfo>,
 }

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -78,23 +78,41 @@ pub struct TableFunctionArgumentInfo {
 /// How a passive Universal Search authorization was selected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UniversalSearchAuthorizationOrigin {
-    /// No origin was supplied.
-    Unspecified,
     /// The source authored an explicit Universal Search route.
     Explicit,
     /// Coral selected the route through canonical inference.
     Inferred,
 }
 
+impl UniversalSearchAuthorizationOrigin {
+    /// Returns the stable catalog spelling of this origin.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::Inferred => "inferred",
+        }
+    }
+}
+
 /// Passive authorization decision for one source table function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UniversalSearchAuthorizationDecision {
-    /// No decision was supplied.
-    Unspecified,
     /// The route is eligible if the independent runtime feature is enabled.
     Eligible,
     /// The source explicitly denied execution of the route.
     Denied,
+}
+
+impl UniversalSearchAuthorizationDecision {
+    /// Returns the stable catalog spelling of this decision.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Eligible => "eligible",
+            Self::Denied => "denied",
+        }
+    }
 }
 
 /// Passive Universal Search authorization attached to one query-visible function.

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -8,7 +8,8 @@ mod udfs;
 
 pub use catalog::{
     CatalogInfo, ColumnInfo, DescribeTableInfo, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
+    TableFunctionResultColumnInfo, TableInfo, UniversalSearchAuthorizationDecision,
+    UniversalSearchAuthorizationInfo, UniversalSearchAuthorizationOrigin,
 };
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -851,6 +851,7 @@ mod tests {
             result_columns: vec![],
             kind: coral_spec::SourceTableFunctionKind::Table,
             search_limits: None,
+            universal_search: None,
         }
     }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -88,7 +88,8 @@ pub use contracts::{
     StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
     TableFunctionResultColumnInfo, TableInfo, UdfRuntimeArgument, UdfRuntimeDefinition,
     UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish, UniversalSearchAuthorizationDecision,
+    UniversalSearchAuthorizationInfo, UniversalSearchAuthorizationOrigin,
 };
 pub use runtime::normalize_catalog_name;
 

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -16,8 +16,7 @@ use crate::backends::{RegisteredSource, SourceQualifiedName};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
-    TableInfo, UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationInfo,
-    UniversalSearchAuthorizationOrigin,
+    TableInfo, UniversalSearchAuthorizationInfo,
 };
 
 /// Schema name for source metadata tables such as `coral.tables`.
@@ -227,16 +226,8 @@ impl<'a> From<&'a UniversalSearchAuthorizationInfo> for UniversalSearchAuthoriza
         Self {
             source_name: &authorization.source_name,
             route_id: authorization.route_id.as_deref(),
-            origin: match authorization.origin {
-                UniversalSearchAuthorizationOrigin::Unspecified => "unspecified",
-                UniversalSearchAuthorizationOrigin::Explicit => "explicit",
-                UniversalSearchAuthorizationOrigin::Inferred => "inferred",
-            },
-            decision: match authorization.decision {
-                UniversalSearchAuthorizationDecision::Unspecified => "unspecified",
-                UniversalSearchAuthorizationDecision::Eligible => "eligible",
-                UniversalSearchAuthorizationDecision::Denied => "denied",
-            },
+            origin: authorization.origin.as_str(),
+            decision: authorization.decision.as_str(),
             query_argument: authorization.query_argument.as_deref(),
             operation_id: &authorization.operation_id,
         }
@@ -1244,8 +1235,54 @@ mod tests {
 
     use crate::backends::common::test_support::StubSourceFunctionFactory;
     use crate::backends::{RegisteredSource, RegisteredTableFunction, SourceQualifiedName};
+    use crate::{
+        UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationInfo,
+        UniversalSearchAuthorizationOrigin,
+    };
 
-    use super::collect_table_functions;
+    use super::{collect_table_functions, universal_search_json};
+
+    #[test]
+    fn universal_search_json_serializes_the_public_catalog_shape() {
+        let explicit = UniversalSearchAuthorizationInfo {
+            source_name: "installed_demo".to_string(),
+            route_id: Some("primary".to_string()),
+            origin: UniversalSearchAuthorizationOrigin::Explicit,
+            decision: UniversalSearchAuthorizationDecision::Eligible,
+            query_argument: Some("query".to_string()),
+            operation_id: "issues/search".to_string(),
+        };
+        assert_eq!(
+            universal_search_json(Some(&explicit))
+                .expect("authorization JSON")
+                .expect("present authorization"),
+            r#"{"source_name":"installed_demo","route_id":"primary","origin":"explicit","decision":"eligible","query_argument":"query","operation_id":"issues/search"}"#
+        );
+
+        let inferred = UniversalSearchAuthorizationInfo {
+            route_id: None,
+            origin: UniversalSearchAuthorizationOrigin::Inferred,
+            ..explicit.clone()
+        };
+        assert_eq!(
+            universal_search_json(Some(&inferred))
+                .expect("authorization JSON")
+                .expect("present authorization"),
+            r#"{"source_name":"installed_demo","origin":"inferred","decision":"eligible","query_argument":"query","operation_id":"issues/search"}"#
+        );
+
+        let denied = UniversalSearchAuthorizationInfo {
+            decision: UniversalSearchAuthorizationDecision::Denied,
+            query_argument: None,
+            ..explicit
+        };
+        assert_eq!(
+            universal_search_json(Some(&denied))
+                .expect("authorization JSON")
+                .expect("present authorization"),
+            r#"{"source_name":"installed_demo","route_id":"primary","origin":"explicit","decision":"denied","operation_id":"issues/search"}"#
+        );
+    }
 
     #[test]
     fn collect_table_functions_preserves_registered_function_schema() {

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -10,12 +10,14 @@ use datafusion::datasource::MemTable;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
+use serde_json::Value;
 
 use crate::backends::{RegisteredSource, SourceQualifiedName};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
-    TableInfo,
+    TableInfo, UniversalSearchAuthorizationDecision, UniversalSearchAuthorizationInfo,
+    UniversalSearchAuthorizationOrigin,
 };
 
 /// Schema name for source metadata tables such as `coral.tables`.
@@ -33,13 +35,16 @@ pub(crate) struct CatalogTableFunction {
     pub(crate) result_columns: Vec<CatalogTableFunctionResultColumn>,
     pub(crate) kind: SourceTableFunctionKind,
     pub(crate) search_limits: Option<SearchLimitsSpec>,
+    pub(crate) universal_search: Option<UniversalSearchAuthorizationInfo>,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogTableFunctionArgument {
     pub(crate) name: String,
+    pub(crate) data_type: String,
     pub(crate) required: bool,
     pub(crate) values: Vec<String>,
+    pub(crate) default: Option<Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -103,6 +108,7 @@ fn build_table_functions_table(
         Field::new("kind", DataType::Utf8, false),
         Field::new("search_limits_json", DataType::Utf8, true),
         Field::new("guide", DataType::Utf8, false),
+        Field::new("universal_search_json", DataType::Utf8, true),
     ]));
 
     let rows = catalog_table_functions(active_sources, catalog_only_table_functions);
@@ -119,6 +125,10 @@ fn build_table_functions_table(
         .iter()
         .map(|row| search_limits_json(row.search_limits.as_ref()))
         .collect::<Result<Vec<_>>>()?;
+    let universal_search_json = rows
+        .iter()
+        .map(|row| universal_search_json(row.universal_search.as_ref()))
+        .collect::<Result<Vec<_>>>()?;
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -131,6 +141,7 @@ fn build_table_functions_table(
             utf8_column(rows.iter().map(|row| Some(row.kind.as_str()))),
             utf8_column(search_limits_json.iter().map(|value| value.as_deref())),
             utf8_column(rows.iter().map(|row| Some(row.guide.as_str()))),
+            utf8_column(universal_search_json.iter().map(|value| value.as_deref())),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -168,16 +179,66 @@ fn search_limits_json(limits: Option<&SearchLimitsSpec>) -> Result<Option<String
 #[derive(Serialize)]
 struct TableFunctionArgumentJson<'a> {
     name: &'a str,
+    #[serde(rename = "type")]
+    data_type: &'a str,
     required: bool,
     values: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default: Option<&'a Value>,
 }
 
 impl<'a> From<&'a CatalogTableFunctionArgument> for TableFunctionArgumentJson<'a> {
     fn from(argument: &'a CatalogTableFunctionArgument) -> Self {
         Self {
             name: &argument.name,
+            data_type: &argument.data_type,
             required: argument.required,
             values: &argument.values,
+            default: argument.default.as_ref(),
+        }
+    }
+}
+
+fn universal_search_json(
+    authorization: Option<&UniversalSearchAuthorizationInfo>,
+) -> Result<Option<String>> {
+    authorization
+        .map(|authorization| {
+            serde_json::to_string(&UniversalSearchAuthorizationJson::from(authorization))
+                .map_err(|error| DataFusionError::External(Box::new(error)))
+        })
+        .transpose()
+}
+
+#[derive(Serialize)]
+struct UniversalSearchAuthorizationJson<'a> {
+    source_name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route_id: Option<&'a str>,
+    origin: &'static str,
+    decision: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    query_argument: Option<&'a str>,
+    operation_id: &'a str,
+}
+
+impl<'a> From<&'a UniversalSearchAuthorizationInfo> for UniversalSearchAuthorizationJson<'a> {
+    fn from(authorization: &'a UniversalSearchAuthorizationInfo) -> Self {
+        Self {
+            source_name: &authorization.source_name,
+            route_id: authorization.route_id.as_deref(),
+            origin: match authorization.origin {
+                UniversalSearchAuthorizationOrigin::Unspecified => "unspecified",
+                UniversalSearchAuthorizationOrigin::Explicit => "explicit",
+                UniversalSearchAuthorizationOrigin::Inferred => "inferred",
+            },
+            decision: match authorization.decision {
+                UniversalSearchAuthorizationDecision::Unspecified => "unspecified",
+                UniversalSearchAuthorizationDecision::Eligible => "eligible",
+                UniversalSearchAuthorizationDecision::Denied => "denied",
+            },
+            query_argument: authorization.query_argument.as_deref(),
+            operation_id: &authorization.operation_id,
         }
     }
 }
@@ -491,6 +552,12 @@ const TABLE_FUNCTIONS_COLUMNS: &[SystemColumnDefinition] = &[
         nullable: false,
         description: "User-facing query guidance for the table function.",
     },
+    SystemColumnDefinition {
+        name: "universal_search_json",
+        data_type: "Utf8",
+        nullable: true,
+        description: "Passive Universal Search authorization metadata when the function resolves to a source route.",
+    },
 ];
 
 const SYSTEM_TABLE_DEFINITIONS: &[SystemTableDefinition] = &[
@@ -619,8 +686,12 @@ pub(crate) fn collect_table_functions(
                 .into_iter()
                 .map(|argument| TableFunctionArgumentInfo {
                     name: argument.name,
+                    data_type: argument.data_type,
                     required: argument.required,
                     values: argument.values,
+                    default_json: argument
+                        .default
+                        .map(|value| serde_json::to_string(&value).expect("JSON value serializes")),
                 })
                 .collect(),
             result_columns: function
@@ -635,6 +706,7 @@ pub(crate) fn collect_table_functions(
                 .collect(),
             kind: function.kind,
             search_limits: function.search_limits,
+            universal_search: function.universal_search,
         })
         .collect()
 }
@@ -660,8 +732,13 @@ fn catalog_table_functions(
                         .iter()
                         .map(|argument| CatalogTableFunctionArgument {
                             name: argument.name.clone(),
+                            data_type: argument.data_type.as_manifest_str().to_string(),
                             required: argument.required,
                             values: argument.values.clone(),
+                            default: argument
+                                .default
+                                .as_ref()
+                                .map(|default| default.value().clone()),
                         })
                         .collect(),
                     result_columns: function
@@ -676,6 +753,7 @@ fn catalog_table_functions(
                         .collect(),
                     kind: function.kind,
                     search_limits: function.search_limits.clone(),
+                    universal_search: function.universal_search.clone(),
                 })
         })
         .chain(catalog_only_table_functions.iter().cloned())
@@ -1186,6 +1264,7 @@ mod tests {
                     arguments: Vec::new(),
                     result_columns: Vec::new(),
                     search_limits: None,
+                    universal_search: None,
                 }],
                 inputs: Vec::new(),
             }],

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -381,6 +381,7 @@ mod tests {
             result_columns: vec![],
             kind: coral_spec::SourceTableFunctionKind::Table,
             search_limits: None,
+            universal_search: None,
         }
     }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -1479,6 +1479,7 @@ mod tests {
                 result_columns: Vec::new(),
                 kind: coral_spec::SourceTableFunctionKind::Table,
                 search_limits: None,
+                universal_search: None,
             }],
             failures: Vec::new(),
             name_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -170,8 +170,10 @@ fn catalog_table_function(
             .iter()
             .map(|argument| CatalogTableFunctionArgument {
                 name: argument.name.clone(),
+                data_type: argument.data_type.as_manifest_str().to_string(),
                 required: true,
                 values: Vec::new(),
+                default: None,
             })
             .collect(),
         result_columns: udf
@@ -185,6 +187,7 @@ fn catalog_table_function(
             })
             .collect(),
         search_limits: None,
+        universal_search: None,
     }
 }
 

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -429,7 +429,11 @@ fn http_manifest_with_function() -> Value {
     })
 }
 
-fn build_v4_runtime_source_with_function() -> QuerySource {
+fn build_materialized_v4_runtime_source_with_function() -> QuerySource {
+    // coral-engine consumes the backend-ready runtime component produced by
+    // DSL v4 materialization, not the authored DSL v4 manifest. Start from the
+    // validated HTTP component fixture, mark that generated component as v4,
+    // and attach the typed defaults that materialization preserves.
     let parsed = parse_source_manifest_value(http_manifest_with_function())
         .expect("base HTTP manifest should parse");
     let mut runtime_manifest = parsed.as_http().expect("HTTP manifest").clone();
@@ -515,7 +519,7 @@ fn jsonl_manifest_with_inputs(dir: &std::path::Path) -> Value {
 
 #[tokio::test]
 async fn coral_table_functions_lists_source_functions() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -539,8 +543,8 @@ async fn coral_table_functions_lists_source_functions() {
         serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
         json!([
             { "name": "q", "type": "Utf8", "required": true, "values": [] },
-            { "name": "mode", "type": "Utf8", "required": false, "values": ["lexical", "semantic", "hybrid"], "default": "lexical" },
-            { "name": "metadata", "type": "Json", "required": false, "values": [], "default": null },
+            { "name": "mode", "type": "Utf8", "required": false, "values": ["lexical", "semantic", "hybrid"] },
+            { "name": "metadata", "type": "Json", "required": false, "values": [] },
             { "name": "since", "type": "Timestamp", "required": false, "values": [] }
         ])
     );
@@ -564,8 +568,35 @@ async fn coral_table_functions_lists_source_functions() {
 }
 
 #[tokio::test]
+async fn coral_table_functions_preserves_materialized_v4_typed_defaults() {
+    let sources = vec![build_materialized_v4_runtime_source_with_function()];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT arguments_json FROM coral.table_functions \
+             WHERE schema_name = 'searchy' AND function_name = 'search_issues'",
+        )
+        .await
+        .expect("table function catalog query should succeed"),
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        serde_json::from_str::<Value>(rows[0]["arguments_json"].as_str().unwrap()).unwrap(),
+        json!([
+            { "name": "q", "type": "Utf8", "required": true, "values": [] },
+            { "name": "mode", "type": "Utf8", "required": false, "values": ["lexical", "semantic", "hybrid"], "default": "lexical" },
+            { "name": "metadata", "type": "Json", "required": false, "values": [], "default": null },
+            { "name": "since", "type": "Timestamp", "required": false, "values": [] }
+        ])
+    );
+}
+
+#[tokio::test]
 async fn table_function_used_as_table_returns_guided_error() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     for sql in [
         "DESCRIBE searchy.search_issues",
@@ -627,7 +658,7 @@ async fn describe_table_keeps_datafusion_shape() {
 
 #[tokio::test]
 async fn describe_select_from_table_function_keeps_datafusion_shape() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let execution = CoralQuery::execute_sql(
         &sources,
@@ -649,7 +680,7 @@ async fn describe_select_from_table_function_keeps_datafusion_shape() {
 
 #[tokio::test]
 async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinals() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let table_functions = CoralQuery::execute_sql(
         &sources,
@@ -710,7 +741,7 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
 
 #[tokio::test]
 async fn coral_tables_exposes_search_limits() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -736,7 +767,7 @@ async fn coral_tables_exposes_search_limits() {
 
 #[tokio::test]
 async fn coral_filters_lists_filter_metadata() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -765,7 +796,7 @@ async fn coral_filters_lists_filter_metadata() {
 
 #[tokio::test]
 async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -792,7 +823,7 @@ async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
 
 #[tokio::test]
 async fn list_catalog_matches_table_function_metadata() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_materialized_v4_runtime_source_with_function()];
 
     let catalog = CoralQuery::list_catalog(&sources, test_runtime(), None, Some("searchy"))
         .await
@@ -826,7 +857,7 @@ async fn list_catalog_matches_table_function_metadata() {
 
 #[tokio::test]
 async fn list_catalog_collects_tables_and_functions_together() {
-    let sources = vec![build_v4_runtime_source_with_function()];
+    let sources = vec![build_source(http_manifest_with_function())];
 
     let catalog = CoralQuery::list_catalog(&sources, test_runtime(), None, Some("searchy"))
         .await

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -6,7 +6,10 @@
 
 use std::collections::BTreeMap;
 
-use coral_engine::{CoralQuery, CoreError, QuerySource, TableInfo};
+use coral_engine::{
+    CoralQuery, CoreError, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage, TableInfo,
+};
+use coral_spec::{DeclaredDefaultValue, parse_source_manifest_value};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -395,9 +398,6 @@ fn http_manifest_with_function() -> Value {
                     "values": ["lexical", "semantic", "hybrid"],
                     "bind": { "arg": "search_type" }
                 },
-                // OpenAPI v4 generation does not produce Json HTTP function args.
-                // This fixture verifies typed args still register and list even
-                // though public catalog metadata does not expose arg types yet.
                 {
                     "name": "metadata",
                     "type": "Json",
@@ -427,6 +427,44 @@ fn http_manifest_with_function() -> Value {
             ]
         }]
     })
+}
+
+fn build_v4_runtime_source_with_function() -> QuerySource {
+    let parsed = parse_source_manifest_value(http_manifest_with_function())
+        .expect("base HTTP manifest should parse");
+    let mut runtime_manifest = parsed.as_http().expect("HTTP manifest").clone();
+    runtime_manifest.common.dsl_version = 4;
+    let function = runtime_manifest
+        .functions
+        .first_mut()
+        .expect("search function");
+    function
+        .args
+        .iter_mut()
+        .find(|argument| argument.name == "mode")
+        .expect("mode argument")
+        .default = Some(DeclaredDefaultValue::new(json!("lexical")));
+    function
+        .args
+        .iter_mut()
+        .find(|argument| argument.name == "metadata")
+        .expect("metadata argument")
+        .default = Some(DeclaredDefaultValue::new(Value::Null));
+
+    QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: parsed.schema_name().to_string(),
+            authored_version: None,
+            description: parsed.description().to_string(),
+            declared_inputs: parsed.declared_inputs().to_vec(),
+            test_queries: parsed.test_queries().to_vec(),
+            identity_requirements: None,
+            components: vec![RuntimeSourceComponent::Http(runtime_manifest)],
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("DSL v4 runtime source should assemble")
 }
 
 fn build_demo_source(variables: &[(&str, &str)], secrets: &[(&str, &str)]) -> QuerySource {
@@ -477,13 +515,13 @@ fn jsonl_manifest_with_inputs(dir: &std::path::Path) -> Value {
 
 #[tokio::test]
 async fn coral_table_functions_lists_source_functions() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
             test_runtime(),
-            "SELECT schema_name, function_name, kind, description, arguments_json, result_columns_json, search_limits_json, guide \
+            "SELECT schema_name, function_name, kind, description, arguments_json, result_columns_json, search_limits_json, guide, universal_search_json \
              FROM coral.table_functions WHERE schema_name = 'searchy'",
         )
         .await
@@ -500,12 +538,13 @@ async fn coral_table_functions_lists_source_functions() {
     assert_eq!(
         serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
         json!([
-            { "name": "q", "required": true, "values": [] },
-            { "name": "mode", "required": false, "values": ["lexical", "semantic", "hybrid"] },
-            { "name": "metadata", "required": false, "values": [] },
-            { "name": "since", "required": false, "values": [] }
+            { "name": "q", "type": "Utf8", "required": true, "values": [] },
+            { "name": "mode", "type": "Utf8", "required": false, "values": ["lexical", "semantic", "hybrid"], "default": "lexical" },
+            { "name": "metadata", "type": "Json", "required": false, "values": [], "default": null },
+            { "name": "since", "type": "Timestamp", "required": false, "values": [] }
         ])
     );
+    assert!(row["universal_search_json"].is_null());
     assert_eq!(
         serde_json::from_str::<Value>(row["result_columns_json"].as_str().unwrap()).unwrap(),
         json!([
@@ -526,7 +565,7 @@ async fn coral_table_functions_lists_source_functions() {
 
 #[tokio::test]
 async fn table_function_used_as_table_returns_guided_error() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     for sql in [
         "DESCRIBE searchy.search_issues",
@@ -588,7 +627,7 @@ async fn describe_table_keeps_datafusion_shape() {
 
 #[tokio::test]
 async fn describe_select_from_table_function_keeps_datafusion_shape() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let execution = CoralQuery::execute_sql(
         &sources,
@@ -610,7 +649,7 @@ async fn describe_select_from_table_function_keeps_datafusion_shape() {
 
 #[tokio::test]
 async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinals() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let table_functions = CoralQuery::execute_sql(
         &sources,
@@ -634,6 +673,7 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
             "kind",
             "search_limits_json",
             "guide",
+            "universal_search_json",
         ]
     );
 
@@ -670,7 +710,7 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
 
 #[tokio::test]
 async fn coral_tables_exposes_search_limits() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -696,7 +736,7 @@ async fn coral_tables_exposes_search_limits() {
 
 #[tokio::test]
 async fn coral_filters_lists_filter_metadata() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -725,7 +765,7 @@ async fn coral_filters_lists_filter_metadata() {
 
 #[tokio::test]
 async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
@@ -752,7 +792,7 @@ async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
 
 #[tokio::test]
 async fn list_catalog_matches_table_function_metadata() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let catalog = CoralQuery::list_catalog(&sources, test_runtime(), None, Some("searchy"))
         .await
@@ -767,12 +807,16 @@ async fn list_catalog_matches_table_function_metadata() {
     assert_eq!(function.guide, "Prefer this function for issue lookup.");
     assert_eq!(function.arguments.len(), 4);
     assert_eq!(function.arguments[0].name, "q");
+    assert_eq!(function.arguments[0].data_type, "Utf8");
+    assert!(function.arguments[0].default_json.is_none());
     assert!(function.arguments[0].required);
     assert_eq!(
         function.arguments[1].values,
         ["lexical", "semantic", "hybrid"]
     );
     assert_eq!(function.arguments[2].name, "metadata");
+    assert_eq!(function.arguments[2].data_type, "Json");
+    assert_eq!(function.arguments[2].default_json.as_deref(), Some("null"));
     assert_eq!(function.arguments[3].name, "since");
     assert_eq!(function.result_columns.len(), 3);
     assert_eq!(function.result_columns[0].name, "id");
@@ -782,7 +826,7 @@ async fn list_catalog_matches_table_function_metadata() {
 
 #[tokio::test]
 async fn list_catalog_collects_tables_and_functions_together() {
-    let sources = vec![build_source(http_manifest_with_function())];
+    let sources = vec![build_v4_runtime_source_with_function()];
 
     let catalog = CoralQuery::list_catalog(&sources, test_runtime(), None, Some("searchy"))
         .await


### PR DESCRIPTION
## TL;DR

This PR carries passive DSL v4 Universal Search authorization through the runtime and catalog layers so later code can resolve provider-native search routes safely.

For an authorized table function, the catalog can describe:

- The canonical installed source and original DSL v4 operation.
- The optional authored route ID.
- Whether authorization was explicit or inferred.
- Whether the route is eligible or explicitly denied.
- The query-visible argument that receives the search query.
- The declared type of each function argument.

This layer is passive. It does not resolve routes, enable fanout, or call providers. PR #1856 owns route resolution.

## What changed

- Carries passive Universal Search authorization from generated DSL v4 runtime metadata into engine catalog contracts, SQL catalog rows, catalog snapshots, and protobuf table-function metadata.
- Keeps installed source identity separate from the SQL schema and function locator.
- Adds stable authorization origin and decision spellings while retaining the required protobuf zero values.
- Adds `TableFunctionArgument.data_type` to the protobuf catalog.
- Keeps authored argument defaults internal to source materialization and engine/app catalog contracts. Argument defaults are **not exposed in protobuf**.
- Reserves protobuf field 5 and the historical `default_value` and `default_json` names so defaults cannot be added back accidentally.
- Includes argument types, internal defaults, and authorization metadata in catalog fingerprints so stale snapshots are invalidated.
- Adds `universal_search_json` to `coral.table_functions` for passive SQL-visible inspection.
- Keeps DSL v3 functions as ordinary catalog entries with no Universal Search authorization.

## Protobuf contract

`TableFunctionArgument` exposes only the argument name, requiredness, allowed values, and declared data type. It does not contain JSON text, a dynamic JSON value message, or any other default-value representation.

The new protobuf fields are additive, and the transport tests verify that older clients can decode current table-function payloads and current clients can decode legacy payloads.

## Stack boundary

Stack 3/11. Depends on #2009; #1856 builds on this PR.

This PR stops at passive metadata transport. It does not attach executable routes or change provider-call behavior.

## Validation

Local validation:

- `cargo fmt --check`
- `cargo test -p coral-api`
- `cargo test -p coral-app transport::tests:: --lib` (19 passed)
- `cargo clippy -p coral-api -p coral-app --all-targets --all-features -- -D warnings`
- `make lint-proto`
- `cargo test -p coral-app sources::universal_search::tests --lib` on the cumulative top branch (24 passed, including typed array, object, and null defaults remaining internal)

Required CI on head `f3d9ed92` passed, including Rust checks, protobuf lint, performance regression, Reef checks, UI build/tests, and Windows Rust smoke.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>