### PR TITLE
fix(desktop): coordinate shutdown with update installation

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -31,10 +31,12 @@
         "react-router": "7.17.0",
         "react-toastify": "11.1.0",
         "react-truncate-markup": "5.1.2",
+        "semver": "7.8.4",
         "tinykeys": "4.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.2",
+        "@types/semver": "7.7.1",
         "electron": "^42.3.3",
         "electron-builder": "^26.15.2",
         "electron-vite": "^5.0.0",
@@ -2027,6 +2029,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -6644,7 +6653,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,10 +52,12 @@
     "react-router": "7.17.0",
     "react-toastify": "11.1.0",
     "react-truncate-markup": "5.1.2",
+    "semver": "7.8.4",
     "tinykeys": "4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.2",
+    "@types/semver": "7.7.1",
     "electron": "^42.3.3",
     "electron-builder": "^26.15.2",
     "electron-vite": "^5.0.0",

--- a/apps/desktop/src/main/auto-update-core.test.ts
+++ b/apps/desktop/src/main/auto-update-core.test.ts
@@ -21,6 +21,7 @@ function createFakeUpdater() {
       return fake
     },
     checkForUpdates: vi.fn(async (): Promise<UpdateCheckResultLike | null> => null),
+    quitAndInstall: vi.fn(),
     emit(event: string, ...args: unknown[]) {
       for (const listener of listeners.get(event) ?? []) listener(...args)
     },
@@ -54,6 +55,9 @@ function createDeps(updater: UpdaterLike): DesktopUpdaterDeps & {
     showNotification: (title, body) => {
       notifications.push({ title, body })
     },
+    recordUpdateIntent: vi.fn(),
+    clearUpdateIntent: vi.fn(),
+    onInstallFailure: vi.fn(),
     notifications,
     infoDialogs,
     errorDialogs,
@@ -97,11 +101,11 @@ afterEach(() => {
 })
 
 describe('install', () => {
-  it('configures auto download and install-on-quit', () => {
+  it('configures auto download without automatic install-on-quit', () => {
     const updater = createFakeUpdater()
     createDesktopUpdater(createDeps(updater)).install()
     expect(updater.autoDownload).toBe(true)
-    expect(updater.autoInstallOnAppQuit).toBe(true)
+    expect(updater.autoInstallOnAppQuit).toBe(false)
   })
 
   it('checks shortly after startup and again every interval', async () => {
@@ -130,8 +134,88 @@ describe('install', () => {
   })
 })
 
+describe('explicit install hand-off', () => {
+  it('waits for the local update payload and hands off only once', async () => {
+    const events: string[] = []
+    const updater = createFakeUpdater()
+    const download = deferredPromise()
+    vi.mocked(updater.checkForUpdates).mockResolvedValue(
+      availableUpdate('1.2.4', download.promise),
+    )
+    const deps = createDeps(updater)
+    vi.mocked(deps.recordUpdateIntent).mockImplementation((version) => {
+      events.push(`intent:write:${version}`)
+    })
+    updater.quitAndInstall.mockImplementation(() => {
+      events.push('updater:quitAndInstall')
+    })
+    const desktopUpdater = createDesktopUpdater(deps)
+    desktopUpdater.install()
+
+    const check = desktopUpdater.check({ interactive: false })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(desktopUpdater.quitAndInstall()).toBe(false)
+    expect(deps.recordUpdateIntent).not.toHaveBeenCalled()
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+
+    download.resolve()
+    await check
+    expect(desktopUpdater.quitAndInstall()).toBe(true)
+    expect(desktopUpdater.quitAndInstall()).toBe(true)
+    expect(updater.quitAndInstall).toHaveBeenCalledOnce()
+    expect(events).toEqual(['intent:write:1.2.4', 'updater:quitAndInstall'])
+  })
+
+  it('clears intent before finishing quit on an updater failure', async () => {
+    const events: string[] = []
+    const updater = createFakeUpdater()
+    vi.mocked(updater.checkForUpdates).mockResolvedValue(availableUpdate())
+    const deps = createDeps(updater)
+    vi.mocked(deps.clearUpdateIntent).mockImplementation(() => {
+      events.push('intent:clear')
+    })
+    vi.mocked(deps.onInstallFailure).mockImplementation(() => {
+      events.push('app:quit')
+    })
+    const desktopUpdater = createDesktopUpdater(deps)
+    desktopUpdater.install()
+    await desktopUpdater.check({ interactive: false })
+    expect(desktopUpdater.quitAndInstall()).toBe(true)
+
+    updater.emit('error', new Error('ShipIt hand-off failed'))
+
+    expect(events).toEqual(['intent:clear', 'app:quit'])
+  })
+
+  it('does not start installation when the intent marker cannot be written', async () => {
+    const updater = createFakeUpdater()
+    vi.mocked(updater.checkForUpdates).mockResolvedValue(availableUpdate())
+    const deps = createDeps(updater)
+    vi.mocked(deps.recordUpdateIntent).mockImplementation(() => {
+      throw new Error('disk full')
+    })
+    const desktopUpdater = createDesktopUpdater(deps)
+    desktopUpdater.install()
+    await desktopUpdater.check({ interactive: false })
+
+    expect(desktopUpdater.quitAndInstall()).toBe(false)
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('does not treat an updater error before hand-off as an install failure', () => {
+    const updater = createFakeUpdater()
+    const deps = createDeps(updater)
+    createDesktopUpdater(deps).install()
+
+    updater.emit('error', new Error('background check failed'))
+
+    expect(deps.clearUpdateIntent).not.toHaveBeenCalled()
+    expect(deps.onInstallFailure).not.toHaveBeenCalled()
+  })
+})
+
 describe('download completion notifications', () => {
-  it('waits for the download handoff promise instead of the earlier event', async () => {
+  it('waits for the local proxy promise instead of the earlier event', async () => {
     const updater = createFakeUpdater()
     const download = deferredPromise()
     vi.mocked(updater.checkForUpdates).mockResolvedValue(
@@ -155,7 +239,7 @@ describe('download completion notifications', () => {
     })
   })
 
-  it('notifies once when overlapping checks share a download promise', async () => {
+  it('serializes overlapping checks and notifies once', async () => {
     const updater = createFakeUpdater()
     const download = deferredPromise()
     vi.mocked(updater.checkForUpdates).mockResolvedValue(
@@ -170,27 +254,12 @@ describe('download completion notifications', () => {
     download.resolve()
     await Promise.all([firstCheck, secondCheck])
 
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce()
     expect(deps.notifications).toEqual([
       {
         title: 'Coral update ready',
         body: 'Coral 1.2.4 will install when you quit the app.',
       },
-    ])
-  })
-
-  it('notifies again when a newer version is staged', async () => {
-    const updater = createFakeUpdater()
-    vi.mocked(updater.checkForUpdates)
-      .mockResolvedValueOnce(availableUpdate('1.2.4'))
-      .mockResolvedValueOnce(availableUpdate('1.2.5'))
-    const deps = createDeps(updater)
-    const desktopUpdater = createDesktopUpdater(deps)
-
-    await desktopUpdater.check({ interactive: false })
-    await desktopUpdater.check({ interactive: false })
-    expect(deps.notifications.map((n) => n.body)).toEqual([
-      'Coral 1.2.4 will install when you quit the app.',
-      'Coral 1.2.5 will install when you quit the app.',
     ])
   })
 })
@@ -210,11 +279,46 @@ describe('interactive checks', () => {
     ])
   })
 
-  it('reports the downloading version when an update is available', async () => {
+  it('reuses an in-flight background result', async () => {
     const updater = createFakeUpdater()
-    vi.mocked(updater.checkForUpdates).mockResolvedValue(availableUpdate())
+    const feed = deferredPromise()
+    vi.mocked(updater.checkForUpdates)
+      .mockImplementationOnce(async () => {
+        await feed.promise
+        return {
+          isUpdateAvailable: false,
+          updateInfo: { version: '1.2.3' },
+        }
+      })
+      .mockRejectedValueOnce(new Error('transient second request failure'))
     const deps = createDeps(updater)
-    await createDesktopUpdater(deps).check({ interactive: true })
+    const desktopUpdater = createDesktopUpdater(deps)
+
+    const background = desktopUpdater.check({ interactive: false })
+    const interactive = desktopUpdater.check({ interactive: true })
+    feed.resolve()
+    await Promise.all([background, interactive])
+
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce()
+    expect(deps.infoDialogs).toEqual([
+      { message: 'Coral is up to date', detail: 'You are running Coral 1.2.3.' },
+    ])
+    expect(deps.errorDialogs).toHaveLength(0)
+  })
+
+  it('shows a background result before its download completes', async () => {
+    const updater = createFakeUpdater()
+    const download = deferredPromise()
+    vi.mocked(updater.checkForUpdates).mockResolvedValue(
+      availableUpdate('1.2.4', download.promise),
+    )
+    const deps = createDeps(updater)
+    const desktopUpdater = createDesktopUpdater(deps)
+
+    const background = desktopUpdater.check({ interactive: false })
+    await vi.advanceTimersByTimeAsync(0)
+    const interactive = desktopUpdater.check({ interactive: true })
+    await vi.advanceTimersByTimeAsync(0)
 
     expect(deps.infoDialogs).toEqual([
       {
@@ -223,6 +327,32 @@ describe('interactive checks', () => {
           'You will be notified when the update is ready. It will install after Coral quits.',
       },
     ])
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce()
+
+    download.resolve()
+    await Promise.all([background, interactive])
+  })
+
+  it('reports the downloading version when an update is available', async () => {
+    const updater = createFakeUpdater()
+    const download = deferredPromise()
+    vi.mocked(updater.checkForUpdates).mockResolvedValue(
+      availableUpdate('1.2.4', download.promise),
+    )
+    const deps = createDeps(updater)
+    const check = createDesktopUpdater(deps).check({ interactive: true })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(deps.infoDialogs).toEqual([
+      {
+        message: 'Coral 1.2.4 is downloading',
+        detail:
+          'You will be notified when the update is ready. It will install after Coral quits.',
+      },
+    ])
+
+    download.resolve()
+    await check
   })
 
   it('reports the update as ready (not downloading) once it has been staged', async () => {
@@ -240,6 +370,7 @@ describe('interactive checks', () => {
         detail: 'The update will install when you quit Coral.',
       },
     ])
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce()
     // The staged-version notification must not fire a second time.
     expect(deps.notifications).toHaveLength(1)
   })

--- a/apps/desktop/src/main/auto-update-core.ts
+++ b/apps/desktop/src/main/auto-update-core.ts
@@ -6,7 +6,7 @@
 export const STARTUP_UPDATE_CHECK_DELAY_MS = 5000
 // Long-running desktop sessions would otherwise only see new releases after a
 // restart; re-check periodically so a release ships to open apps too. The
-// downloaded update still installs on quit.
+// downloaded update is handed to the installer explicitly after app teardown.
 export const PERIODIC_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
 
 interface UpdateInfoLike {
@@ -33,6 +33,7 @@ export interface UpdaterLike {
   on(event: 'update-downloaded', listener: (info: UpdateInfoLike) => void): unknown
   on(event: 'error', listener: (error: Error) => void): unknown
   checkForUpdates(): Promise<UpdateCheckResultLike | null>
+  quitAndInstall(): void
 }
 
 export interface DesktopUpdaterDeps {
@@ -41,11 +42,15 @@ export interface DesktopUpdaterDeps {
   showInfoDialog: (message: string, detail: string) => Promise<void>
   showErrorDialog: (message: string, detail: string) => Promise<void>
   showNotification: (title: string, body: string) => void
+  recordUpdateIntent: (targetVersion: string) => void
+  clearUpdateIntent: () => void
+  onInstallFailure: (error: Error) => void
 }
 
 export interface DesktopUpdater {
   install: () => void
   check: (options: { interactive: boolean }) => Promise<void>
+  quitAndInstall: () => boolean
 }
 
 function errorMessage(error: unknown): string {
@@ -56,12 +61,25 @@ function errorMessage(error: unknown): string {
 export function createDesktopUpdater(deps: DesktopUpdaterDeps): DesktopUpdater {
   const { updater } = deps
   let installed = false
-  // The version whose download promise completed successfully. On macOS,
-  // electron-updater emits `update-downloaded` before Squirrel has fetched the
-  // archive from its local proxy; the promise resolves after that handoff.
-  // Only the latter is safe to describe as ready for install-on-quit.
+  let installing = false
+  // With automatic install disabled on macOS, the promise resolves once the
+  // complete archive is available through electron-updater's local proxy.
+  // Explicit quitAndInstall() starts the subsequent Squirrel hand-off.
   let readyVersion: string | null = null
-  const trackedDownloads = new WeakMap<Promise<unknown>, Promise<DownloadOutcome>>()
+  let activeCheck:
+    | {
+        result: Promise<CheckOutcome>
+        completion: Promise<void>
+      }
+    | null = null
+
+  function clearInstallIntent(): void {
+    try {
+      deps.clearUpdateIntent()
+    } catch (error) {
+      console.error(`[coral-updater] failed to clear update intent: ${errorMessage(error)}`)
+    }
+  }
 
   function installListeners(): void {
     updater.on('checking-for-update', () => {
@@ -81,6 +99,18 @@ export function createDesktopUpdater(deps: DesktopUpdaterDeps): DesktopUpdater {
     })
     updater.on('error', (error) => {
       console.error(`[coral-updater] updater error: ${errorMessage(error)}`)
+      if (!installing) return
+
+      installing = false
+      readyVersion = null
+      clearInstallIntent()
+      try {
+        deps.onInstallFailure(error)
+      } catch (failureError) {
+        console.error(
+          `[coral-updater] install failure handler failed: ${errorMessage(failureError)}`,
+        )
+      }
     })
   }
 
@@ -122,14 +152,8 @@ export function createDesktopUpdater(deps: DesktopUpdaterDeps): DesktopUpdater {
     const downloadPromise = result.downloadPromise
     if (!downloadPromise) return null
 
-    const existing = trackedDownloads.get(downloadPromise)
-    if (existing) return existing
-
-    // electron-updater returns the same in-flight download promise to
-    // overlapping checks. Track it once so every caller observes failures but
-    // one completed version produces one notification.
     const version = result.updateInfo.version
-    const outcome = downloadPromise.then<DownloadOutcome, DownloadOutcome>(
+    return downloadPromise.then<DownloadOutcome, DownloadOutcome>(
       () => {
         if (readyVersion !== version) {
           readyVersion = version
@@ -149,8 +173,6 @@ export function createDesktopUpdater(deps: DesktopUpdaterDeps): DesktopUpdater {
         return { ok: false, error }
       },
     )
-    trackedDownloads.set(downloadPromise, outcome)
-    return outcome
   }
 
   function install(): void {
@@ -158,45 +180,112 @@ export function createDesktopUpdater(deps: DesktopUpdaterDeps): DesktopUpdater {
 
     installed = true
     updater.autoDownload = true
-    updater.autoInstallOnAppQuit = true
+    updater.autoInstallOnAppQuit = false
     installListeners()
 
     setTimeout(() => {
       void check({ interactive: false })
     }, STARTUP_UPDATE_CHECK_DELAY_MS)
-    // The check and download layers each reuse their own in-flight promise;
-    // trackDownload() also observes a shared download only once.
     setInterval(() => {
       void check({ interactive: false })
     }, PERIODIC_UPDATE_CHECK_INTERVAL_MS)
   }
 
-  async function check({ interactive }: { interactive: boolean }): Promise<void> {
+  async function performCheck(): Promise<CheckOutcome> {
     let result: UpdateCheckResultLike | null
     try {
       result = await updater.checkForUpdates()
     } catch (error) {
       console.error(`[coral-updater] update check failed: ${errorMessage(error)}`)
+      return { ok: false, error }
+    }
+
+    // Attach before exposing the result. The download starts inside
+    // checkForUpdates() and can fail while an interactive dialog is open;
+    // attaching now prevents an unhandled rejection.
+    const download = result?.isUpdateAvailable ? trackDownload(result) : null
+    return { ok: true, result, download }
+  }
+
+  async function observeCheck(
+    resultPromise: Promise<CheckOutcome>,
+    { interactive }: { interactive: boolean },
+  ): Promise<void> {
+    const result = await resultPromise
+    if (!result.ok) {
       if (interactive) {
-        await deps.showErrorDialog('Update check failed', errorMessage(error))
+        await deps.showErrorDialog('Update check failed', errorMessage(result.error))
       }
       return
     }
 
-    // Attach to the auto-download before opening an interactive dialog. The
-    // download starts inside checkForUpdates() and can fail while that dialog
-    // is still open; attaching now prevents an unhandled rejection.
-    const download = result?.isUpdateAvailable ? trackDownload(result) : null
-    if (interactive) await showManualResult(result)
-    if (!download) return
+    if (interactive) await showManualResult(result.result)
+    if (!result.download) return
 
-    const outcome = await download
-    if (!outcome.ok && interactive) {
-      await deps.showErrorDialog('Update download failed', errorMessage(outcome.error))
+    const download = await result.download
+    if (!download.ok && interactive) {
+      await deps.showErrorDialog('Update download failed', errorMessage(download.error))
     }
   }
 
-  return { check, install }
+  function check({ interactive }: { interactive: boolean }): Promise<void> {
+    // MacUpdater owns one local proxy for the staged ZIP. Serialize the whole
+    // check and download, then stop checking once ready, so no later operation
+    // can replace that proxy while Squirrel fetches from it.
+    if (readyVersion) {
+      return interactive
+        ? deps.showInfoDialog(
+            `Coral ${readyVersion} is ready`,
+            'The update will install when you quit Coral.',
+          )
+        : Promise.resolve()
+    }
+
+    if (activeCheck) {
+      return interactive
+        ? observeCheck(activeCheck.result, { interactive: true })
+        : activeCheck.completion
+    }
+
+    const result = performCheck()
+    const completion = observeCheck(result, { interactive }).finally(() => {
+      if (activeCheck?.completion === completion) activeCheck = null
+    })
+    activeCheck = { result, completion }
+    return completion
+  }
+
+  function quitAndInstall(): boolean {
+    if (installing) return true
+    if (!readyVersion) return false
+
+    try {
+      deps.recordUpdateIntent(readyVersion)
+    } catch (error) {
+      console.error(`[coral-updater] failed to record update intent: ${errorMessage(error)}`)
+      return false
+    }
+
+    installing = true
+    try {
+      updater.quitAndInstall()
+      return true
+    } catch (error) {
+      installing = false
+      clearInstallIntent()
+      console.error(`[coral-updater] explicit install failed: ${errorMessage(error)}`)
+      return false
+    }
+  }
+
+  return { check, install, quitAndInstall }
 }
 
 type DownloadOutcome = { ok: true } | { ok: false; error: unknown }
+type CheckOutcome =
+  | { ok: false; error: unknown }
+  | {
+      ok: true
+      result: UpdateCheckResultLike | null
+      download: Promise<DownloadOutcome> | null
+    }

--- a/apps/desktop/src/main/auto-update.ts
+++ b/apps/desktop/src/main/auto-update.ts
@@ -1,11 +1,19 @@
-import { Notification, app, dialog } from 'electron'
+import { Notification, app, autoUpdater as nativeAutoUpdater, dialog } from 'electron'
 import { createRequire } from 'node:module'
+import { join } from 'node:path'
 import type { AppUpdater } from 'electron-updater'
 
 import { createDesktopUpdater, type DesktopUpdater } from './auto-update-core'
+import {
+  clearUpdateIntent,
+  discardUpdateIntent,
+  shouldExitForUpdateIntent,
+  writeUpdateIntent,
+} from './update-intent'
 
 const require = createRequire(import.meta.url)
 const RELEASE_UPDATER_BUNDLE_MARKER = '[coral-updater] release updater enabled'
+const UPDATE_INTENT_FILENAME = 'update-intent.json'
 
 // Baked in at build time by electron.vite.config.ts (true only when
 // CORAL_DESKTOP_RELEASE=1). `typeof` guard keeps it safe if the define is ever
@@ -23,6 +31,11 @@ export function desktopUpdatesSupported(): boolean {
 }
 
 let updater: DesktopUpdater | null = null
+let installFailureHandler = () => app.exit(0)
+
+function updateIntentPath(): string {
+  return join(app.getPath('userData'), UPDATE_INTENT_FILENAME)
+}
 
 function desktopUpdater(): DesktopUpdater {
   if (!updater) {
@@ -39,15 +52,48 @@ function desktopUpdater(): DesktopUpdater {
       showNotification: (title, body) => {
         new Notification({ title, body }).show()
       },
+      recordUpdateIntent: (targetVersion) => {
+        writeUpdateIntent(updateIntentPath(), targetVersion)
+      },
+      clearUpdateIntent: () => {
+        clearUpdateIntent(updateIntentPath())
+      },
+      // Core clears the marker before this callback; the lifecycle handler then
+      // allows a normal quit from the already-stopped state.
+      onInstallFailure: () => installFailureHandler(),
     })
   }
   return updater
 }
 
-export function installAutoUpdater(): void {
+export function shouldExitForPendingDesktopUpdate(): boolean {
+  if (!desktopUpdatesSupported()) return false
+  return shouldExitForUpdateIntent(updateIntentPath(), app.getVersion())
+}
+
+export function clearPendingDesktopUpdateIntent(): void {
   if (!desktopUpdatesSupported()) return
+  discardUpdateIntent(updateIntentPath())
+}
+
+export function installAutoUpdater({
+  allowUpdateQuit,
+  onInstallFailure,
+}: {
+  allowUpdateQuit: () => void
+  onInstallFailure: () => void
+}): void {
+  if (!desktopUpdatesSupported()) return
+
+  installFailureHandler = onInstallFailure
+  nativeAutoUpdater.once('before-quit-for-update', allowUpdateQuit)
   console.info(RELEASE_UPDATER_BUNDLE_MARKER)
   desktopUpdater().install()
+}
+
+export function quitAndInstallDesktopUpdate(): boolean {
+  if (!desktopUpdatesSupported()) return false
+  return desktopUpdater().quitAndInstall()
 }
 
 export async function checkForDesktopUpdates({

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,15 +14,21 @@ import {
   registerAppSchemePrivileges,
 } from './app-renderer'
 import { killAllTrackedChildren, startCoralSidecar, type CoralSidecar } from './sidecar'
-import { checkForDesktopUpdates, desktopUpdatesSupported, installAutoUpdater } from './auto-update'
+import {
+  checkForDesktopUpdates,
+  clearPendingDesktopUpdateIntent,
+  desktopUpdatesSupported,
+  installAutoUpdater,
+  quitAndInstallDesktopUpdate,
+  shouldExitForPendingDesktopUpdate,
+} from './auto-update'
+import { createShutdownCoordinator } from './shutdown'
 
 const SHUTDOWN_TIMEOUT_MS = 6000
 
 let mainWindow: BrowserWindow | null = null
 let sidecar: CoralSidecar | null = null
 let sidecarPromise: Promise<CoralSidecar> | null = null
-let quitting = false
-let stopping = false
 
 function currentDir(): string {
   return dirname(fileURLToPath(import.meta.url))
@@ -189,7 +195,7 @@ function isTrustedNavigation(
 
 function ensureSidecar(): Promise<CoralSidecar> {
   // Don't spawn a fresh child once teardown has begun — it would outlive quit.
-  if (stopping || quitting) {
+  if (shutdownCoordinator.isShuttingDown()) {
     return Promise.reject(new Error('Coral is shutting down.'))
   }
   if (sidecarPromise) return sidecarPromise
@@ -200,7 +206,7 @@ function ensureSidecar(): Promise<CoralSidecar> {
     started.child.once('exit', (code, signal) => {
       if (sidecar === started) sidecar = null
       if (sidecarPromise === promise) sidecarPromise = null
-      if (!stopping && !quitting) {
+      if (!shutdownCoordinator.isShuttingDown()) {
         console.error(`[coral-sidecar] exited unexpectedly (code=${code}, signal=${signal})`)
       }
     })
@@ -239,6 +245,12 @@ async function stopServices(): Promise<void> {
   // has already reaped them.
   killAllTrackedChildren()
 }
+
+const shutdownCoordinator = createShutdownCoordinator({
+  stopServices,
+  installReadyUpdate: quitAndInstallDesktopUpdate,
+  quit: () => app.quit(),
+})
 
 function registerIpcHandlers() {
   ipcMain.handle('coral:list-mcp-clients', () => mcpClients())
@@ -301,52 +313,68 @@ function installMenu() {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
-// Must run before the app `ready` event.
-registerAppSchemePrivileges()
+function startApplication(): void {
+  const gotLock = app.requestSingleInstanceLock()
+  if (!gotLock) {
+    app.quit()
+    return
+  }
 
-const gotLock = app.requestSingleInstanceLock()
-if (!gotLock) {
-  app.quit()
-} else {
+  // The marker may have appeared while this process waited for the lock. An
+  // old binary that won the race must release it without clearing the marker.
+  if (shouldExitForPendingDesktopUpdate()) {
+    console.info('[coral-updater] update installation is still in progress; exiting')
+    app.releaseSingleInstanceLock()
+    app.exit(0)
+    return
+  }
+
+  // Keep the hand-off marker visible until the updated binary owns the lock.
+  clearPendingDesktopUpdateIntent()
+
+  // Must run before the app `ready` event.
+  registerAppSchemePrivileges()
+
   app.on('second-instance', () => {
+    if (shutdownCoordinator.isShuttingDown()) return
     if (!mainWindow) return
     if (mainWindow.isMinimized()) mainWindow.restore()
     mainWindow.focus()
   })
+
+  app.on('before-quit', shutdownCoordinator.beforeQuit)
+
+  app.whenReady().then(() => {
+    if (shutdownCoordinator.isShuttingDown()) return
+
+    updatePlatformIcon()
+    nativeTheme.on('updated', updatePlatformIcon)
+    registerIpcHandlers()
+    installMenu()
+    installAutoUpdater({
+      allowUpdateQuit: shutdownCoordinator.allowQuit,
+      onInstallFailure: shutdownCoordinator.quitAfterUpdateFailure,
+    })
+    registerAppProtocol(() => ensureSidecar().then((started) => started.url))
+    void ensureSidecar().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`[coral-sidecar] failed to start during boot: ${message}`)
+    })
+    mainWindow = createMainWindow()
+  })
+
+  app.on('activate', () => {
+    if (shutdownCoordinator.isShuttingDown()) return
+    if (BrowserWindow.getAllWindows().length === 0) mainWindow = createMainWindow()
+  })
 }
 
-app.whenReady().then(() => {
-  updatePlatformIcon()
-  nativeTheme.on('updated', updatePlatformIcon)
-  registerIpcHandlers()
-  installMenu()
-  installAutoUpdater()
-  registerAppProtocol(() => ensureSidecar().then((started) => started.url))
-  void ensureSidecar().catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error(`[coral-sidecar] failed to start during boot: ${message}`)
-  })
-  mainWindow = createMainWindow()
-})
-
-app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) mainWindow = createMainWindow()
-})
-
-app.on('before-quit', (event) => {
-  if (quitting) return
-  // Teardown already in flight (e.g. a second Cmd-Q): block the quit until it
-  // finishes so the spawned sidecar child is never orphaned.
-  if (stopping) {
-    event.preventDefault()
-    return
-  }
-  if (!sidecar && !sidecarPromise) return
-
-  stopping = true
-  event.preventDefault()
-  void stopServices().finally(() => {
-    quitting = true
-    app.quit()
-  })
-})
+// Evaluate the hand-off marker before taking the single-instance lock. A
+// rapidly reopened old binary exits independently instead of waking the
+// instance that is still handing its update to ShipIt.
+if (shouldExitForPendingDesktopUpdate()) {
+  console.info('[coral-updater] update installation is still in progress; exiting')
+  app.exit(0)
+} else {
+  startApplication()
+}

--- a/apps/desktop/src/main/shutdown.test.ts
+++ b/apps/desktop/src/main/shutdown.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createShutdownCoordinator } from './shutdown'
+
+function deferredPromise(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function quitEvent() {
+  return { preventDefault: vi.fn() }
+}
+
+describe('shutdown coordinator', () => {
+  it('finishes service shutdown before recording and handing off an update', async () => {
+    const events: string[] = []
+    const stopped = deferredPromise()
+    const coordinator = createShutdownCoordinator({
+      stopServices: () => {
+        events.push('sidecar:stop:start')
+        return stopped.promise.then(() => {
+          events.push('sidecar:stop:end')
+        })
+      },
+      installReadyUpdate: () => {
+        events.push('intent:write:1.2.4')
+        events.push('updater:quitAndInstall')
+        return true
+      },
+      quit: () => {
+        events.push('app:quit')
+      },
+    })
+    const event = quitEvent()
+
+    coordinator.beforeQuit(event)
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(events).toEqual(['sidecar:stop:start'])
+
+    stopped.resolve()
+    await stopped.promise
+    await Promise.resolve()
+    expect(events).toEqual([
+      'sidecar:stop:start',
+      'sidecar:stop:end',
+      'intent:write:1.2.4',
+      'updater:quitAndInstall',
+    ])
+  })
+
+  it('suppresses duplicate quit requests while services are stopping', async () => {
+    const stopped = deferredPromise()
+    const stopServices = vi.fn(() => stopped.promise)
+    const installReadyUpdate = vi.fn(() => false)
+    const quit = vi.fn()
+    const coordinator = createShutdownCoordinator({
+      stopServices,
+      installReadyUpdate,
+      quit,
+    })
+    const firstEvent = quitEvent()
+    const secondEvent = quitEvent()
+
+    coordinator.beforeQuit(firstEvent)
+    coordinator.beforeQuit(secondEvent)
+
+    expect(firstEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(secondEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(stopServices).toHaveBeenCalledOnce()
+    expect(installReadyUpdate).not.toHaveBeenCalled()
+
+    stopped.resolve()
+    await stopped.promise
+    await Promise.resolve()
+    expect(quit).toHaveBeenCalledOnce()
+  })
+
+  it('blocks manual quits during hand-off until Electron begins its update quit', async () => {
+    const coordinator = createShutdownCoordinator({
+      stopServices: async () => {},
+      installReadyUpdate: () => true,
+      quit: vi.fn(),
+    })
+
+    coordinator.beforeQuit(quitEvent())
+    await Promise.resolve()
+
+    const manualQuitEvent = quitEvent()
+    coordinator.beforeQuit(manualQuitEvent)
+    expect(manualQuitEvent.preventDefault).toHaveBeenCalledOnce()
+
+    coordinator.allowQuit()
+    const updateQuitEvent = quitEvent()
+    coordinator.beforeQuit(updateQuitEvent)
+    expect(updateQuitEvent.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('allows an ordinary quit after the updater hand-off fails', async () => {
+    const quit = vi.fn()
+    const coordinator = createShutdownCoordinator({
+      stopServices: async () => {},
+      installReadyUpdate: () => true,
+      quit,
+    })
+
+    coordinator.beforeQuit(quitEvent())
+    await Promise.resolve()
+    coordinator.quitAfterUpdateFailure()
+
+    expect(quit).toHaveBeenCalledOnce()
+    const failureQuitEvent = quitEvent()
+    coordinator.beforeQuit(failureQuitEvent)
+    expect(failureQuitEvent.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('still checks for a ready update when there are no active services', async () => {
+    const installReadyUpdate = vi.fn(() => true)
+    const quit = vi.fn()
+    const coordinator = createShutdownCoordinator({
+      stopServices: async () => {},
+      installReadyUpdate,
+      quit,
+    })
+
+    coordinator.beforeQuit(quitEvent())
+    await Promise.resolve()
+
+    expect(installReadyUpdate).toHaveBeenCalledOnce()
+    expect(quit).not.toHaveBeenCalled()
+  })
+
+  it('falls back to an ordinary quit when no update is ready', async () => {
+    const quit = vi.fn()
+    const coordinator = createShutdownCoordinator({
+      stopServices: async () => {},
+      installReadyUpdate: () => false,
+      quit,
+    })
+
+    coordinator.beforeQuit(quitEvent())
+    await Promise.resolve()
+
+    expect(quit).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/main/shutdown.ts
+++ b/apps/desktop/src/main/shutdown.ts
@@ -1,0 +1,66 @@
+export interface BeforeQuitEventLike {
+  preventDefault: () => void
+}
+
+export interface ShutdownCoordinatorDeps {
+  stopServices: () => Promise<void>
+  installReadyUpdate: () => boolean
+  quit: () => void
+}
+
+export interface ShutdownCoordinator {
+  allowQuit: () => void
+  beforeQuit: (event: BeforeQuitEventLike) => void
+  isShuttingDown: () => boolean
+  quitAfterUpdateFailure: () => void
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+export function createShutdownCoordinator(
+  deps: ShutdownCoordinatorDeps,
+): ShutdownCoordinator {
+  let shutdownStarted = false
+  let quitAllowed = false
+
+  function quitNormally(): void {
+    quitAllowed = true
+    deps.quit()
+  }
+
+  function finishShutdown(): void {
+    try {
+      if (deps.installReadyUpdate()) return
+    } catch (error) {
+      console.error(`[coral-desktop] update hand-off failed: ${errorMessage(error)}`)
+    }
+    quitNormally()
+  }
+
+  function beforeQuit(event: BeforeQuitEventLike): void {
+    if (quitAllowed) return
+
+    event.preventDefault()
+    if (shutdownStarted) return
+    shutdownStarted = true
+
+    void deps.stopServices().then(finishShutdown, (error: unknown) => {
+      console.error(`[coral-desktop] service shutdown failed: ${errorMessage(error)}`)
+      quitNormally()
+    })
+  }
+
+  return {
+    // Keep manual quits blocked while Squirrel fetches from the in-process
+    // proxy. Electron calls this immediately before its update-driven quit.
+    allowQuit: () => {
+      quitAllowed = true
+    },
+    beforeQuit,
+    isShuttingDown: () => shutdownStarted,
+    quitAfterUpdateFailure: quitNormally,
+  }
+}

--- a/apps/desktop/src/main/update-intent.test.ts
+++ b/apps/desktop/src/main/update-intent.test.ts
@@ -1,0 +1,88 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  UPDATE_INTENT_TTL_MS,
+  clearUpdateIntent,
+  shouldExitForUpdateIntent,
+  writeUpdateIntent,
+} from './update-intent'
+
+const NOW = 1_800_000_000_000
+
+let temporaryDirectory: string
+let markerPath: string
+
+beforeEach(() => {
+  temporaryDirectory = mkdtempSync(join(tmpdir(), 'coral-update-intent-'))
+  markerPath = join(temporaryDirectory, 'update-intent.json')
+})
+
+afterEach(() => {
+  rmSync(temporaryDirectory, { force: true, recursive: true })
+})
+
+function writeMarker(targetVersion = '1.2.4', createdAt = NOW): void {
+  writeFileSync(markerPath, JSON.stringify({ targetVersion, createdAt }))
+}
+
+describe('update intent', () => {
+  it('writes the target version and creation time', () => {
+    writeUpdateIntent(markerPath, '1.2.4', NOW)
+
+    expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual({
+      targetVersion: '1.2.4',
+      createdAt: NOW,
+    })
+  })
+
+  it('keeps a fresh marker and exits an older rapidly reopened app', () => {
+    writeMarker()
+
+    expect(shouldExitForUpdateIntent(markerPath, '1.2.3', NOW + 1000)).toBe(true)
+    expect(readFileSync(markerPath, 'utf8')).toBe(
+      JSON.stringify({ targetVersion: '1.2.4', createdAt: NOW }),
+    )
+  })
+
+  it('detects a marker written while an old app waits for the lock', () => {
+    expect(shouldExitForUpdateIntent(markerPath, '1.2.3', NOW)).toBe(false)
+
+    writeMarker()
+
+    expect(shouldExitForUpdateIntent(markerPath, '1.2.3', NOW + 1000)).toBe(true)
+    expect(existsSync(markerPath)).toBe(true)
+  })
+
+  it('keeps the marker until the target version owns the app lock', () => {
+    writeMarker()
+
+    expect(shouldExitForUpdateIntent(markerPath, '1.2.4', NOW + 1000)).toBe(false)
+    expect(existsSync(markerPath)).toBe(true)
+
+    clearUpdateIntent(markerPath)
+    expect(existsSync(markerPath)).toBe(false)
+  })
+
+  it('clears a stale marker instead of locking out an older app', () => {
+    writeMarker('1.2.4', NOW - UPDATE_INTENT_TTL_MS - 1)
+
+    expect(shouldExitForUpdateIntent(markerPath, '1.2.3', NOW)).toBe(false)
+    expect(existsSync(markerPath)).toBe(false)
+  })
+
+  it('fails open and clears a malformed marker', () => {
+    writeFileSync(markerPath, 'not json')
+
+    expect(shouldExitForUpdateIntent(markerPath, '1.2.3', NOW)).toBe(false)
+    expect(existsSync(markerPath)).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/update-intent.ts
+++ b/apps/desktop/src/main/update-intent.ts
@@ -1,0 +1,112 @@
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname } from 'node:path'
+import { gte, valid } from 'semver'
+
+export const UPDATE_INTENT_TTL_MS = 10 * 60 * 1000
+
+interface UpdateIntent {
+  targetVersion: string
+  createdAt: number
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function isMissingFile(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  )
+}
+
+export function writeUpdateIntent(
+  filePath: string,
+  targetVersion: string,
+  now = Date.now(),
+): void {
+  if (!valid(targetVersion)) {
+    throw new Error(`Invalid update target version: ${targetVersion}`)
+  }
+  mkdirSync(dirname(filePath), { recursive: true })
+  const temporaryPath = `${filePath}.${process.pid}.tmp`
+  try {
+    writeFileSync(
+      temporaryPath,
+      JSON.stringify({ targetVersion, createdAt: now } satisfies UpdateIntent),
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    renameSync(temporaryPath, filePath)
+  } catch (error) {
+    try {
+      rmSync(temporaryPath, { force: true })
+    } catch {
+      // Preserve the original write failure.
+    }
+    throw error
+  }
+}
+
+export function clearUpdateIntent(filePath: string): void {
+  rmSync(filePath, { force: true })
+}
+
+export function discardUpdateIntent(filePath: string): void {
+  try {
+    clearUpdateIntent(filePath)
+  } catch (error) {
+    console.error(`[coral-updater] failed to clear update intent: ${errorMessage(error)}`)
+  }
+}
+
+function parseUpdateIntent(value: string): UpdateIntent | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+
+  const { targetVersion, createdAt } = parsed as Partial<UpdateIntent>
+  if (typeof targetVersion !== 'string' || !valid(targetVersion)) return null
+  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt)) return null
+  return { targetVersion, createdAt }
+}
+
+export function shouldExitForUpdateIntent(
+  filePath: string,
+  currentVersion: string,
+  now = Date.now(),
+): boolean {
+  let serialized: string | null
+  try {
+    serialized = readFileSync(filePath, 'utf8')
+  } catch (error) {
+    if (isMissingFile(error)) return false
+    console.error(`[coral-updater] failed to read update intent: ${errorMessage(error)}`)
+    return false
+  }
+
+  const intent = parseUpdateIntent(serialized)
+  const age = intent ? now - intent.createdAt : Number.NaN
+  if (
+    !intent ||
+    age < 0 ||
+    age > UPDATE_INTENT_TTL_MS ||
+    !valid(currentVersion)
+  ) {
+    discardUpdateIntent(filePath)
+    return false
+  }
+
+  return !gte(currentVersion, intent.targetVersion)
+}


### PR DESCRIPTION
## Summary

When trying to update my app, I noticed an issue.
I clicked download update, when it finished, clicked quit. Then reopened it. It reopened immediately, and the update hadn't been done.
Turns out that's because I was too hastily in reopening the app.

This shouldn't be on the user though, to was for X amount of time. We should just improve the update flow; this is what this PR is doing
