### PR TITLE
feat(reef): add desktop update indicator

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -615,11 +615,7 @@ describe('Architectural Tests', () => {
         'async function rendererEntryUrl()',
         'function urlOrigin',
       )
-      const readyHandler = sourceSection(
-        desktopIndex,
-        'app.whenReady().then',
-        "app.on('before-quit'",
-      )
+      const readyHandler = sourceSection(desktopIndex, 'app.whenReady().then', "app.on('activate'")
       const responseHandler = sourceSection(
         appRenderer,
         'async function reactRouterResponse',

--- a/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.css.ts
+++ b/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.css.ts
@@ -1,0 +1,80 @@
+import { style } from '@vanilla-extract/css'
+import { recipe } from '@vanilla-extract/recipes'
+
+import { breakpoints } from '@/styles/theme.css'
+import { animation, theme } from '@/wax/theme/theme.css'
+
+const MOBILE_QUERY = `screen and (max-width: ${breakpoints.mobile})`
+
+const collapsedGeometry = {
+  gap: 0,
+  justifyContent: 'center',
+  minHeight: '34px',
+  padding: 0,
+  width: '34px',
+} as const
+
+export const indicator = recipe({
+  base: {
+    '@media': {
+      [MOBILE_QUERY]: collapsedGeometry,
+    },
+    alignItems: 'center',
+    border: '1px solid',
+    borderRadius: '8px',
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexShrink: 0,
+    gap: '8px',
+    marginBlockStart: '12px',
+    minHeight: '48px',
+    minWidth: 0,
+    overflow: 'hidden',
+    paddingBlock: '7px',
+    paddingInline: '8px',
+    transition: animation.colorTransition,
+    width: '100%',
+  },
+  defaultVariants: {
+    isMinimized: false,
+    status: 'available',
+  },
+  variants: {
+    isMinimized: {
+      false: {},
+      true: collapsedGeometry,
+    },
+    status: {
+      available: {
+        background: theme.pill.blue.background,
+        borderColor: theme.pill.blue.stroke,
+        color: theme.pill.blue.color,
+      },
+      downloading: {
+        background: theme.pill.blue.background,
+        borderColor: theme.pill.blue.stroke,
+        color: theme.pill.blue.color,
+      },
+      ready: {
+        background: theme.pill.green.background,
+        borderColor: theme.pill.green.stroke,
+        color: theme.pill.green.color,
+      },
+    },
+  },
+})
+
+export const icon = style({
+  flexShrink: 0,
+})
+
+export const copy = style({
+  '@media': {
+    [MOBILE_QUERY]: {
+      display: 'none',
+    },
+  },
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+})

--- a/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.stories.tsx
+++ b/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { theme } from '@/wax/theme/theme.css'
+
+import { DesktopUpdateIndicator } from './desktop-update-indicator'
+
+const meta = {
+  args: {
+    isMinimized: false,
+    state: { status: 'available', version: '0.9.0' },
+  },
+  component: DesktopUpdateIndicator,
+  parameters: { layout: 'centered' },
+  render: (args) => (
+    <div
+      style={{
+        background: theme.surface.main,
+        boxSizing: 'border-box',
+        padding: 12,
+        width: args.isMinimized ? 58 : 180,
+      }}
+    >
+      <DesktopUpdateIndicator {...args} />
+    </div>
+  ),
+  tags: ['autodocs'],
+  title: 'Components/DesktopUpdateIndicator',
+} satisfies Meta<typeof DesktopUpdateIndicator>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Available: Story = {}
+
+export const Downloading: Story = {
+  args: {
+    state: { status: 'downloading', version: '0.9.0' },
+  },
+}
+
+export const Ready: Story = {
+  args: {
+    state: { status: 'ready', version: '0.9.0' },
+  },
+}
+
+export const Minimized: Story = {
+  args: {
+    isMinimized: true,
+    state: { status: 'ready', version: '0.9.0' },
+  },
+}

--- a/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.test.tsx
+++ b/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { DesktopUpdateIndicator } from './desktop-update-indicator'
+import type { DesktopUpdateIndicatorState } from './desktop-update-indicator'
+
+describe('DesktopUpdateIndicator', () => {
+  it.each([
+    [
+      { status: 'available', version: '0.9.0' },
+      'Update available',
+      'Coral 0.9.0',
+      'Coral 0.9.0 is available and will download automatically.',
+    ],
+    [
+      { status: 'downloading', version: '0.9.0' },
+      'Downloading',
+      'Coral 0.9.0',
+      'Coral 0.9.0 is downloading.',
+    ],
+    [
+      { status: 'ready', version: '0.9.0' },
+      'Update ready',
+      'Restart to install',
+      'Coral 0.9.0 is ready. Restart to install.',
+    ],
+  ] as const)('presents the %s state', async (state, title, detail, accessibleLabel) => {
+    const screen = await render(
+      <DesktopUpdateIndicator
+        isMinimized={false}
+        state={state satisfies DesktopUpdateIndicatorState}
+      />,
+    )
+
+    await expect.element(screen.getByText(title)).toBeVisible()
+    await expect.element(screen.getByText(detail)).toBeVisible()
+    await expect
+      .element(screen.getByRole('status', { name: accessibleLabel }))
+      .not.toHaveAttribute('tabindex')
+  })
+
+  it('keeps the minimized indicator keyboard accessible and explains it in a tooltip', async () => {
+    const accessibleLabel = 'Coral 0.9.0 is ready. Restart to install.'
+    const screen = await render(
+      <DesktopUpdateIndicator isMinimized state={{ status: 'ready', version: '0.9.0' }} />,
+    )
+    const indicator = screen.getByRole('status', { name: accessibleLabel })
+
+    await expect.element(indicator).toHaveAttribute('tabindex', '0')
+    await expect.element(screen.getByText('Update ready')).not.toBeInTheDocument()
+    await expect.element(screen.getByText('Restart to install')).not.toBeInTheDocument()
+    await indicator.hover()
+    await expect
+      .poll(() => document.querySelector('[data-base-ui-portal]')?.textContent)
+      .toContain(accessibleLabel)
+  })
+})

--- a/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.tsx
+++ b/apps/reef/app/components/desktop-update-indicator/desktop-update-indicator.tsx
@@ -1,0 +1,87 @@
+import classNames from 'classnames'
+
+import { animations } from '@/wax/animations'
+import { Icon } from '@/wax/components/icon'
+import type { IconName } from '@/wax/components/icon'
+import { Tooltip } from '@/wax/components/tooltip'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './desktop-update-indicator.css'
+
+export type DesktopUpdateIndicatorState =
+  | { status: 'available'; version: string }
+  | { status: 'downloading'; version: string }
+  | { status: 'ready'; version: string }
+
+interface DesktopUpdateIndicatorProps {
+  isMinimized: boolean
+  state: DesktopUpdateIndicatorState
+}
+
+const PRESENTATION: Record<
+  DesktopUpdateIndicatorState['status'],
+  { icon: IconName; title: string }
+> = {
+  available: {
+    icon: 'Download',
+    title: 'Update available',
+  },
+  downloading: {
+    icon: 'RefreshCw',
+    title: 'Downloading',
+  },
+  ready: {
+    icon: 'CircleCheck',
+    title: 'Update ready',
+  },
+}
+
+export function DesktopUpdateIndicator({ isMinimized, state }: DesktopUpdateIndicatorProps) {
+  const presentation = PRESENTATION[state.status]
+  const accessibleLabel = updateAccessibleLabel(state)
+  const indicator = (
+    <div
+      aria-atomic="true"
+      aria-label={accessibleLabel}
+      className={styles.indicator({ isMinimized, status: state.status })}
+      role="status"
+      tabIndex={isMinimized ? 0 : undefined}
+    >
+      <Icon
+        className={classNames(styles.icon, {
+          [animations.spinAnimation]: state.status === 'downloading',
+        })}
+        color="inherit"
+        name={presentation.icon}
+        size="18"
+      />
+      {!isMinimized && (
+        <div className={styles.copy}>
+          <Typography.BodySmallStrong truncate>{presentation.title}</Typography.BodySmallStrong>
+          <Typography.BodySmall truncate>
+            {state.status === 'ready' ? 'Restart to install' : `Coral ${state.version}`}
+          </Typography.BodySmall>
+        </div>
+      )}
+    </div>
+  )
+
+  if (!isMinimized) return indicator
+
+  return (
+    <Tooltip content={accessibleLabel} side="right">
+      {indicator}
+    </Tooltip>
+  )
+}
+
+function updateAccessibleLabel(state: DesktopUpdateIndicatorState): string {
+  switch (state.status) {
+    case 'available':
+      return `Coral ${state.version} is available and will download automatically.`
+    case 'downloading':
+      return `Coral ${state.version} is downloading.`
+    case 'ready':
+      return `Coral ${state.version} is ready. Restart to install.`
+  }
+}

--- a/apps/reef/app/components/desktop-update-indicator/index.ts
+++ b/apps/reef/app/components/desktop-update-indicator/index.ts
@@ -1,0 +1,4 @@
+export {
+  DesktopUpdateIndicator,
+  type DesktopUpdateIndicatorState,
+} from './desktop-update-indicator'


### PR DESCRIPTION
## Summary

Currently, there's no indication on the UI about newer version of Coral; we should show it though!
In this PR, I'm adding the component, in the next one, I'll wire it up.

## Test plan

<img width="286" height="229" alt="image" src="https://github.com/user-attachments/assets/79975390-53a6-436c-a160-43d9c466e7ba" />
<img width="245" height="153" alt="image" src="https://github.com/user-attachments/assets/dcd7dcd2-cb76-4a06-9e34-0f9bbd61d5ed" />
<img width="227" height="143" alt="image" src="https://github.com/user-attachments/assets/645aefda-7beb-4c88-87c7-f78abdab2751" />

When collapsed, show only the icon

<img width="86" height="113" alt="image" src="https://github.com/user-attachments/assets/92f218e2-0b2f-443e-9836-bdbad5178382" />