### PR TITLE
feat(openapi-forge): parse Slack docs pages and infer response schemas

### DIFF
--- a/tools/openapi-forge/src/adapters/slack/docs.ts
+++ b/tools/openapi-forge/src/adapters/slack/docs.ts
@@ -1,0 +1,256 @@
+/**
+ * Parsing Slack's method reference pages.
+ *
+ * Each page is served as markdown at `<page>.md`, and the layout is regular
+ * across all 310 of them:
+ *
+ * ```
+ * ## Facts
+ * **Description**<one line>
+ * **Method Access**
+ * ```GET https://slack.com/api/conversations.list```
+ * **Scopes**  Bot token: [`channels:read`](…)  User token: …
+ * **Rate Limits**[Tier 2: 20+ per minute](…)
+ *
+ * ## Arguments
+ * ### Required arguments
+ * **`channel`**`string`Required
+ * <description>
+ * _Default:_ `…`
+ * _Example:_ `…`
+ * ```
+ *
+ * This is the only source for an operation's HTTP verb, argument names, which
+ * of them are required, their defaults, and their descriptions. Response shapes
+ * come from the recorded samples instead — the pages describe responses only by
+ * example.
+ */
+
+import type { HttpMethod, Parameter, ScalarType, Scopes } from '../../core/model.ts'
+
+/** Everything one reference page states about its operation. */
+export interface DocsFacts {
+  /** The method in the casing the request line uses, e.g. `conversations.list`. */
+  method: string
+  /** Path relative to the server URL, e.g. `/conversations.list`. */
+  path: string
+  httpMethod: HttpMethod
+  description: string
+  scopes: Scopes
+  /** The tier label Slack publishes, e.g. `Tier 2: 20+ per minute`. */
+  rateLimitTier?: string
+  parameters: Parameter[]
+  warnings: string[]
+}
+
+/**
+ * `token` is documented as a required argument on every method, but Coral sends
+ * credentials as a manifest-configured header. Emitting it as a query parameter
+ * would put a required, unfillable argument on every generated relation.
+ */
+const AUTH_PARAMETER = 'token'
+
+const SOURCE_LINE = /^Source:\s*(\S+)/m
+const DESCRIPTION = /^\*\*Description\*\*(.*)$/m
+const REQUEST_LINE = /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(https?:\/\/\S+)$/m
+const RATE_LIMIT = /^\*\*Rate Limits\*\*\[([^\]]+)]/m
+const SCOPE_LINK = /\[`([^`]+)`]\(\/reference\/scopes\//g
+const ARGUMENT_HEADING = /^\*\*`([^`]+)`\*\*`([^`]+)`(Required|Optional)$/gm
+const DEFAULT_VALUE = /^_Default:_\s*`?([^`\n]*)`?$/m
+const EXAMPLE_VALUE = /^_Example:_\s*`?([^`\n]*)`?$/m
+
+const SCALAR_TYPES: Record<string, ScalarType> = {
+  string: 'string',
+  boolean: 'boolean',
+  number: 'number',
+  integer: 'integer',
+}
+
+export class DocsParseError extends Error {}
+
+export function parseDocsPage(markdown: string, serverUrl: string): DocsFacts {
+  const request = REQUEST_LINE.exec(markdown)
+  if (request === null) {
+    throw new DocsParseError('no HTTP request line found under "Method Access"')
+  }
+  const httpMethod = request[1]?.toLowerCase() as HttpMethod
+  const url = request[2] ?? ''
+  if (!url.startsWith(serverUrl)) {
+    throw new DocsParseError(
+      `request URL '${url}' is not under the configured server '${serverUrl}'`,
+    )
+  }
+  const path = url.slice(serverUrl.length)
+  const method = path.replace(/^\//, '')
+
+  const warnings: string[] = []
+  const { parameters, warnings: argumentWarnings } = parseArguments(markdown)
+  warnings.push(...argumentWarnings)
+
+  const rateLimitTier = RATE_LIMIT.exec(markdown)?.[1]
+  return {
+    method,
+    path,
+    httpMethod,
+    description: cleanText(DESCRIPTION.exec(markdown)?.[1] ?? ''),
+    scopes: parseScopes(markdown),
+    ...(rateLimitTier === undefined ? {} : { rateLimitTier }),
+    parameters,
+    warnings,
+  }
+}
+
+/** The canonical documentation URL, recorded for provenance. */
+export function parseSourceUrl(markdown: string): string | undefined {
+  return SOURCE_LINE.exec(markdown)?.[1]
+}
+
+/**
+ * Bot and user scopes.
+ *
+ * Both lists live under a single `**Scopes**` heading, separated by `Bot
+ * token:` and `User token:` labels, so the section is split on those labels
+ * rather than parsed as structure.
+ */
+function parseScopes(markdown: string): Scopes {
+  const section = sliceBetween(markdown, '**Scopes**', '**Content types**')
+  if (section === undefined) {
+    return { bot: [], user: [] }
+  }
+  const userIndex = section.indexOf('User token:')
+  const botPart = userIndex === -1 ? section : section.slice(0, userIndex)
+  const userPart = userIndex === -1 ? '' : section.slice(userIndex)
+  return { bot: scopeNames(botPart), user: scopeNames(userPart) }
+}
+
+function scopeNames(text: string): string[] {
+  const names = new Set<string>()
+  for (const match of text.matchAll(SCOPE_LINK)) {
+    if (match[1] !== undefined) {
+      names.add(match[1])
+    }
+  }
+  return [...names].toSorted((left, right) => left.localeCompare(right))
+}
+
+function parseArguments(markdown: string): { parameters: Parameter[]; warnings: string[] } {
+  const section = sliceBetween(markdown, '## Arguments', '\n## ')
+  const parameters: Parameter[] = []
+  const warnings: string[] = []
+  if (section === undefined) {
+    return { parameters, warnings }
+  }
+
+  // Requiredness is stated on each argument heading, so the Required/Optional
+  // subheadings carry no information the headings do not already have.
+  const headings = [...section.matchAll(ARGUMENT_HEADING)]
+  for (const [index, heading] of headings.entries()) {
+    const name = heading[1]
+    const declaredType = heading[2]
+    const required = heading[3] === 'Required'
+    if (name === undefined || declaredType === undefined) {
+      continue
+    }
+    if (name === AUTH_PARAMETER) {
+      continue
+    }
+
+    const start = (heading.index ?? 0) + heading[0].length
+    const end = headings[index + 1]?.index ?? section.length
+    const body = section.slice(start, end)
+
+    const type = SCALAR_TYPES[declaredType]
+    if (type === undefined) {
+      // Coral drops non-scalar parameters anyway, so emitting one would only
+      // add a column of noise to the descriptor.
+      warnings.push(`argument '${name}' has unsupported type '${declaredType}'; omitted`)
+      continue
+    }
+
+    const defaultValue = coerce(DEFAULT_VALUE.exec(body)?.[1], type)
+    const exampleValue = coerce(EXAMPLE_VALUE.exec(body)?.[1], type)
+    parameters.push({
+      name,
+      in: 'query',
+      required,
+      description: parseArgumentDescription(body),
+      schema: { kind: 'scalar', type },
+      ...(defaultValue === undefined ? {} : { default: defaultValue }),
+      ...(exampleValue === undefined ? {} : { example: exampleValue }),
+    })
+  }
+
+  return {
+    parameters: parameters.toSorted((left, right) => left.name.localeCompare(right.name)),
+    warnings,
+  }
+}
+
+/**
+ * The first prose paragraph after an argument heading.
+ *
+ * Boolean arguments render a stray `0` line between the description and the
+ * `_Default:_` line, so paragraphs are filtered rather than counted.
+ */
+function parseArgumentDescription(body: string): string {
+  for (const paragraph of body.split(/\n\s*\n/)) {
+    const text = paragraph.trim()
+    if (text === '' || text.startsWith('_Default:_') || text.startsWith('_Example:_')) {
+      continue
+    }
+    if (/^[\d.]+$/.test(text)) {
+      continue
+    }
+    return cleanText(text)
+  }
+  return ''
+}
+
+/**
+ * Read a documented literal as the type its argument declares.
+ *
+ * Slack writes every default as text, so `false` on a boolean and `100` on a
+ * number both arrive as strings. Typing them matters: Coral derives a page-size
+ * maximum from the declared default, and a string there would be ignored.
+ */
+function coerce(raw: string | undefined, type: ScalarType): string | number | boolean | undefined {
+  const value = raw?.trim()
+  if (value === undefined || value === '') {
+    return undefined
+  }
+  if (type === 'boolean') {
+    if (value === 'true' || value === 'false') {
+      return value === 'true'
+    }
+    return undefined
+  }
+  if (type === 'number' || type === 'integer') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return value
+}
+
+/**
+ * Flatten documentation prose into one line of plain text.
+ *
+ * Descriptions land in the SQL catalog, where a relative markdown link is worse
+ * than useless — it renders as a path to nowhere — so links keep their label
+ * and drop their target.
+ */
+function cleanText(text: string): string {
+  return text
+    .replace(/\[([^\]]*)]\([^)]*\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function sliceBetween(text: string, start: string, end: string): string | undefined {
+  const from = text.indexOf(start)
+  if (from === -1) {
+    return undefined
+  }
+  const rest = text.slice(from + start.length)
+  const to = rest.indexOf(end)
+  return to === -1 ? rest : rest.slice(0, to)
+}

--- a/tools/openapi-forge/src/core/infer.ts
+++ b/tools/openapi-forge/src/core/infer.ts
@@ -1,0 +1,128 @@
+/**
+ * Inferring schemas from recorded response samples.
+ *
+ * Providers rarely describe their response bodies in a machine-readable way,
+ * but many record real responses — for tests, for SDK type generation, or as
+ * documentation examples. Those samples are the most accurate description of a
+ * response available, so the schema is read off them.
+ *
+ * Inference is deliberately shallow. Coral turns only a row object's *direct*
+ * properties into typed SQL columns; anything nested becomes a single JSON
+ * column regardless of how precisely it was described. Describing three levels
+ * is therefore enough to type every column that exists, and describing more
+ * would add bytes to the descriptor that nothing reads.
+ */
+
+import type { ObjectNode, SchemaNode, ScalarType } from './model.ts'
+
+/**
+ * Levels of nesting described.
+ *
+ * Three is what a wrapped list needs: the envelope, the row array, and the row
+ * object's own properties. A property of a row is described as a bare object or
+ * array, which is exactly how Coral treats it.
+ */
+export const DEFAULT_SCHEMA_DEPTH = 3
+
+const UNKNOWN: SchemaNode = { kind: 'unknown' }
+
+export function inferSchema(sample: unknown, maxDepth: number = DEFAULT_SCHEMA_DEPTH): SchemaNode {
+  return inferAt(sample, 0, maxDepth)
+}
+
+function inferAt(sample: unknown, depth: number, maxDepth: number): SchemaNode {
+  if (Array.isArray(sample)) {
+    if (depth >= maxDepth) {
+      return { kind: 'array', items: UNKNOWN }
+    }
+    // Samples list variants of the same thing, so the item schema is the
+    // union of what every element declares rather than the first element's.
+    const items = sample
+      .map((element) => inferAt(element, depth + 1, maxDepth))
+      .reduce<SchemaNode | undefined>(
+        (left, right) => (left === undefined ? right : unify(left, right)),
+        undefined,
+      )
+    return { kind: 'array', items: items ?? UNKNOWN }
+  }
+
+  if (sample !== null && typeof sample === 'object') {
+    if (depth >= maxDepth) {
+      return { kind: 'object', properties: {} }
+    }
+    const properties: Record<string, SchemaNode> = {}
+    for (const [key, value] of Object.entries(sample)) {
+      properties[key] = inferAt(value, depth + 1, maxDepth)
+    }
+    return { kind: 'object', properties }
+  }
+
+  return inferScalar(sample)
+}
+
+function inferScalar(sample: unknown): SchemaNode {
+  switch (typeof sample) {
+    case 'string':
+      return { kind: 'scalar', type: 'string' }
+    case 'boolean':
+      return { kind: 'scalar', type: 'boolean' }
+    case 'number':
+      // A count typed as a float would be a worse answer than a float typed as
+      // a count: the former is wrong for every row, the latter for values the
+      // sample never showed. Overlays correct the second case.
+      return { kind: 'scalar', type: Number.isInteger(sample) ? 'integer' : 'number' }
+    default:
+      // `null` says a field exists but not what it holds.
+      return UNKNOWN
+  }
+}
+
+/**
+ * Merge two schemas for the same position.
+ *
+ * Disagreement collapses to `unknown` rather than picking a winner. A field
+ * seen as a string in one variant and an object in another has no scalar type,
+ * and asserting one would produce a column that fails on real data.
+ */
+export function unify(left: SchemaNode, right: SchemaNode): SchemaNode {
+  if (left.kind === 'unknown') {
+    return right
+  }
+  if (right.kind === 'unknown') {
+    return left
+  }
+
+  if (left.kind === 'scalar' && right.kind === 'scalar') {
+    if (left.type === right.type) {
+      return left
+    }
+    // Integers are a subset of numbers, so this pair has a real answer.
+    if (isNumeric(left.type) && isNumeric(right.type)) {
+      return { kind: 'scalar', type: 'number' }
+    }
+    return UNKNOWN
+  }
+
+  if (left.kind === 'object' && right.kind === 'object') {
+    return unifyObjects(left, right)
+  }
+
+  if (left.kind === 'array' && right.kind === 'array') {
+    return { kind: 'array', items: unify(left.items, right.items) }
+  }
+
+  return UNKNOWN
+}
+
+function unifyObjects(left: ObjectNode, right: ObjectNode): ObjectNode {
+  const properties: Record<string, SchemaNode> = { ...left.properties }
+  for (const [key, schema] of Object.entries(right.properties)) {
+    const existing = properties[key]
+    properties[key] = existing === undefined ? schema : unify(existing, schema)
+  }
+  return { kind: 'object', properties }
+}
+
+function isNumeric(type: ScalarType): boolean {
+  return type === 'integer' || type === 'number'
+}

--- a/tools/openapi-forge/test/docs.test.ts
+++ b/tools/openapi-forge/test/docs.test.ts
@@ -1,0 +1,140 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { DocsParseError, parseDocsPage, parseSourceUrl } from '../src/adapters/slack/docs.ts'
+import { apiDir } from '../src/core/config.ts'
+
+const SERVER_URL = 'https://slack.com/api'
+const DOCS_DIR = join(apiDir('slack'), 'snapshot', 'docs')
+
+async function page(slug: string): Promise<string> {
+  return readFile(join(DOCS_DIR, `${slug}.md`), 'utf8')
+}
+
+describe('parseDocsPage', () => {
+  it('reads the request line, description, scopes and rate-limit tier', async () => {
+    const facts = parseDocsPage(await page('conversations.list'), SERVER_URL)
+
+    expect(facts.method).toBe('conversations.list')
+    expect(facts.path).toBe('/conversations.list')
+    expect(facts.httpMethod).toBe('get')
+    expect(facts.description).toBe('Lists all channels in a Slack team.')
+    expect(facts.scopes.bot).toEqual(['channels:read', 'groups:read', 'im:read', 'mpim:read'])
+    expect(facts.rateLimitTier).toBe('Tier 2: 20+ per minute')
+  })
+
+  it('reads argument names, types, requiredness, defaults and examples', async () => {
+    const facts = parseDocsPage(await page('conversations.list'), SERVER_URL)
+    const byName = new Map(facts.parameters.map((parameter) => [parameter.name, parameter]))
+
+    expect(byName.get('cursor')).toMatchObject({
+      in: 'query',
+      required: false,
+      schema: { kind: 'scalar', type: 'string' },
+    })
+    expect(byName.get('limit')).toMatchObject({
+      required: false,
+      schema: { kind: 'scalar', type: 'number' },
+      default: 100,
+      example: 20,
+    })
+    expect(byName.get('exclude_archived')?.default).toBe(false)
+    expect(byName.get('types')?.default).toBe('public_channel')
+  })
+
+  it('marks required arguments', async () => {
+    const facts = parseDocsPage(await page('conversations.history'), SERVER_URL)
+    const channel = facts.parameters.find((parameter) => parameter.name === 'channel')
+
+    expect(channel?.required).toBe(true)
+    expect(channel?.description).toBe('Conversation ID to fetch history for.')
+  })
+
+  /**
+   * Coral sends credentials as a manifest header, so emitting `token` would put
+   * a required, unfillable argument on every generated relation.
+   */
+  it('omits the token argument', async () => {
+    for (const slug of ['conversations.list', 'users.info', 'auth.test']) {
+      const facts = parseDocsPage(await page(slug), SERVER_URL)
+
+      expect(facts.parameters.map((parameter) => parameter.name)).not.toContain('token')
+    }
+  })
+
+  /** Boolean arguments render a stray `0` between description and default. */
+  it('does not mistake rendering artefacts for a description', async () => {
+    const facts = parseDocsPage(await page('conversations.history'), SERVER_URL)
+    const inclusive = facts.parameters.find((parameter) => parameter.name === 'inclusive')
+
+    expect(inclusive?.description).toMatch(/^Include messages with/)
+    expect(inclusive?.description).not.toMatch(/^0/)
+  })
+
+  it('flattens documentation links to their label', async () => {
+    const facts = parseDocsPage(await page('conversations.history'), SERVER_URL)
+    const cursor = facts.parameters.find((parameter) => parameter.name === 'cursor')
+
+    expect(cursor?.description).toContain('See pagination for more detail.')
+    expect(cursor?.description).not.toContain('](')
+  })
+
+  it('reports a method Slack documents as POST rather than assuming GET', async () => {
+    const facts = parseDocsPage(await page('auth.test'), SERVER_URL)
+
+    expect(facts.httpMethod).toBe('post')
+  })
+
+  it('sorts parameters so the descriptor does not churn', async () => {
+    const facts = parseDocsPage(await page('conversations.list'), SERVER_URL)
+    const names = facts.parameters.map((parameter) => parameter.name)
+
+    expect(names).toEqual(names.toSorted((left, right) => left.localeCompare(right)))
+  })
+
+  it('parses every page in the snapshot without warnings', async () => {
+    const slugs = [
+      'auth.test',
+      'conversations.history',
+      'conversations.info',
+      'conversations.list',
+      'conversations.members',
+      'conversations.replies',
+      'search.messages',
+      'users.conversations',
+      'users.info',
+      'users.list',
+    ]
+
+    for (const slug of slugs) {
+      const facts = parseDocsPage(await page(slug), SERVER_URL)
+
+      expect(facts.warnings, `${slug} produced warnings`).toEqual([])
+      expect(facts.method.toLowerCase(), `${slug} method mismatch`).toBe(slug)
+      expect(facts.description, `${slug} has no description`).not.toBe('')
+    }
+  })
+
+  it('rejects a page whose request URL is not under the configured server', async () => {
+    const markdown = (await page('users.info')).replace(
+      'https://slack.com/api/users.info',
+      'https://example.com/users.info',
+    )
+
+    expect(() => parseDocsPage(markdown, SERVER_URL)).toThrow(DocsParseError)
+  })
+
+  it('rejects a page with no request line', () => {
+    expect(() => parseDocsPage('# nothing here\n', SERVER_URL)).toThrow(/no HTTP request line/)
+  })
+})
+
+describe('parseSourceUrl', () => {
+  it('reads the canonical page URL', async () => {
+    expect(parseSourceUrl(await page('users.list'))).toBe(
+      'https://docs.slack.dev/reference/methods/users.list',
+    )
+  })
+})

--- a/tools/openapi-forge/test/infer.test.ts
+++ b/tools/openapi-forge/test/infer.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+
+import { inferSchema, unify } from '../src/core/infer.ts'
+
+describe('inferSchema', () => {
+  it('types the properties of a wrapped-list envelope', () => {
+    const schema = inferSchema({
+      ok: true,
+      channels: [{ id: 'C1', num_members: 4, is_archived: false }],
+      response_metadata: { next_cursor: 'abc' },
+    })
+
+    expect(schema).toEqual({
+      kind: 'object',
+      properties: {
+        ok: { kind: 'scalar', type: 'boolean' },
+        channels: {
+          kind: 'array',
+          items: {
+            kind: 'object',
+            properties: {
+              id: { kind: 'scalar', type: 'string' },
+              num_members: { kind: 'scalar', type: 'integer' },
+              is_archived: { kind: 'scalar', type: 'boolean' },
+            },
+          },
+        },
+        response_metadata: {
+          kind: 'object',
+          properties: { next_cursor: { kind: 'scalar', type: 'string' } },
+        },
+      },
+    })
+  })
+
+  /**
+   * Coral turns a row's nested object into one JSON column however precisely
+   * it is described, so the default depth stops exactly where the detail stops
+   * being read.
+   */
+  it('describes a row property as a bare object or array', () => {
+    const schema = inferSchema({
+      channels: [{ id: 'C1', topic: { value: 'hi' }, previous_names: ['old'] }],
+    })
+
+    const items = schema.kind === 'object' ? schema.properties.channels : undefined
+    const row = items?.kind === 'array' ? items.items : undefined
+    const properties = row?.kind === 'object' ? row.properties : {}
+
+    expect(properties.topic).toEqual({ kind: 'object', properties: {} })
+    expect(properties.previous_names).toEqual({ kind: 'array', items: { kind: 'unknown' } })
+  })
+
+  it('unions across array elements rather than trusting the first', () => {
+    const schema = inferSchema({
+      messages: [
+        { ts: '1', text: 'a' },
+        { ts: '2', subtype: 'bot_message', bot_id: 'B1' },
+      ],
+    })
+
+    const messages = schema.kind === 'object' ? schema.properties.messages : undefined
+    const row = messages?.kind === 'array' ? messages.items : undefined
+
+    expect(row?.kind === 'object' ? Object.keys(row.properties).toSorted() : []).toEqual([
+      'bot_id',
+      'subtype',
+      'text',
+      'ts',
+    ])
+  })
+
+  it('distinguishes integers from other numbers', () => {
+    const schema = inferSchema({ count: 4, score: 0.5 })
+    const properties = schema.kind === 'object' ? schema.properties : {}
+
+    expect(properties.count).toEqual({ kind: 'scalar', type: 'integer' })
+    expect(properties.score).toEqual({ kind: 'scalar', type: 'number' })
+  })
+
+  /** A null says the field exists but not what it holds. */
+  it('treats null as unknown', () => {
+    const schema = inferSchema({ maybe: null })
+
+    expect(schema.kind === 'object' ? schema.properties.maybe : undefined).toEqual({
+      kind: 'unknown',
+    })
+  })
+
+  it('describes an empty array without inventing an item type', () => {
+    const schema = inferSchema({ items: [] })
+
+    expect(schema.kind === 'object' ? schema.properties.items : undefined).toEqual({
+      kind: 'array',
+      items: { kind: 'unknown' },
+    })
+  })
+})
+
+describe('unify', () => {
+  it('widens integer and number to number', () => {
+    expect(unify({ kind: 'scalar', type: 'integer' }, { kind: 'scalar', type: 'number' })).toEqual({
+      kind: 'scalar',
+      type: 'number',
+    })
+  })
+
+  /**
+   * Asserting a type here would produce a column that fails on real data, so
+   * disagreement collapses rather than picking a winner.
+   */
+  it('collapses genuinely conflicting scalar types to unknown', () => {
+    expect(unify({ kind: 'scalar', type: 'string' }, { kind: 'scalar', type: 'boolean' })).toEqual({
+      kind: 'unknown',
+    })
+  })
+
+  it('collapses a scalar merged with a container to unknown', () => {
+    expect(unify({ kind: 'scalar', type: 'string' }, { kind: 'object', properties: {} })).toEqual({
+      kind: 'unknown',
+    })
+  })
+
+  it('lets a known schema win over an unknown one', () => {
+    const known = { kind: 'scalar', type: 'string' } as const
+
+    expect(unify({ kind: 'unknown' }, known)).toEqual(known)
+    expect(unify(known, { kind: 'unknown' })).toEqual(known)
+  })
+
+  it('merges object properties from both sides', () => {
+    const merged = unify(
+      { kind: 'object', properties: { a: { kind: 'scalar', type: 'string' } } },
+      { kind: 'object', properties: { b: { kind: 'scalar', type: 'integer' } } },
+    )
+
+    expect(merged).toEqual({
+      kind: 'object',
+      properties: {
+        a: { kind: 'scalar', type: 'string' },
+        b: { kind: 'scalar', type: 'integer' },
+      },
+    })
+  })
+})


### PR DESCRIPTION
Implements the extract stage. The two halves of an operation's description come from two different upstream sources, because no single one has both.

## Requests come from the reference pages

Slack's reference pages, served as markdown, are the only statement of an operation's HTTP verb, its argument names, which are required, their defaults and their prose. The layout is regular across all 310 pages.

Three details are worth naming:

- **`token` is omitted.** It is documented on every method, but Coral sends credentials as a manifest header, so emitting it would put a required, unfillable argument on every relation.
- **Boolean arguments render a stray `0`** between description and default, so paragraphs are filtered rather than counted.
- **Documented literals are coerced to their argument's type.** Coral derives a page-size maximum from a numeric default and would ignore a string.

## Responses come from the recorded samples

The pages describe responses only by example, so the schema is read off the samples instead.

Inference is shallow on purpose: Coral types only a row object's direct properties, so three levels covers every column that can exist and more would add bytes nothing reads.

Where variants disagree the schema collapses to `unknown` rather than picking a winner. Asserting a type there would produce a column that fails on real data.

## A note on auth.test

It is documented as POST and is emitted as POST. Coral publishes an operation without a request body regardless of verb, and inventing a GET would be a claim Slack's own docs contradict. (The next PR removes it from scope for a different reason.)

---

https://claude.ai/code/session_01Tk8XhPE7SUfrEGKkasAbAG

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>