### PR TITLE
feat(reef): add a base URL field to source creation

### DIFF
--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -15,6 +15,7 @@ const DISCOVERY = {
   description: 'Weather observations and forecasts',
   format: 'openapi-yaml' as const,
   name: 'weather_api',
+  serverUrl: 'https://weather.example/v1',
   status: 'success' as const,
   url: 'https://weather.example/openapi.yaml',
 }

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -8,6 +8,10 @@ const serverlessSpec = JSON.stringify({
   paths: { '/data/Divisions/groupedbyparty': {}, '/data/Divisions/{divisionId}': {} },
 })
 
+/** A response as `fetch` returns it after following a redirect: `url` is the final one. */
+const servedFrom = (response: Response, url: string) =>
+  Object.defineProperty(response, 'url', { value: url })
+
 const discoverRequest = (url: string) =>
   new Request(`http://reef.test/workspaces/default/sources/discover?url=${encodeURIComponent(url)}`)
 
@@ -176,6 +180,54 @@ components:
     await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toMatchObject({
       serverUrl: 'https://status.example/v1',
     })
+  })
+
+  it('resolves a relative server URL against a redirected document location', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        servedFrom(
+          new Response(
+            JSON.stringify({
+              info: { title: 'Status API' },
+              openapi: '3.0.3',
+              servers: [{ url: '/v1' }],
+            }),
+            { status: 200 },
+          ),
+          'https://api.status.example/openapi.json',
+        ),
+      ),
+    )
+
+    await expect(
+      loader({
+        request: discoverRequest('https://docs.status.example/openapi.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: 'https://api.status.example/v1' })
+  })
+
+  it('probes the redirected document location rather than the requested host', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        servedFrom(
+          new Response(serverlessSpec, { status: 200 }),
+          'https://api.status.example/openapi.json',
+        ),
+      )
+      .mockResolvedValueOnce(new Response('[]', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://docs.status.example/openapi.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: 'https://api.status.example' })
+
+    expect(fetchMock.mock.calls[1][0].toString()).toBe(
+      'https://api.status.example/data/Divisions/groupedbyparty',
+    )
   })
 
   it('derives the server URL from the fetch origin when a probed path is served', async () => {

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -283,6 +283,31 @@ components:
     ).resolves.toMatchObject({ serverUrl: '' })
   })
 
+  it('does not probe a Swagger 2 document, whose base URL is not in `servers`', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          basePath: '/v1',
+          host: 'api.status.example',
+          info: { title: 'Status API' },
+          paths: { '/data/divisions': {} },
+          schemes: ['https'],
+          swagger: '2.0',
+        }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://api.status.example/swagger/v1/swagger.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: '' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('cancels the probe when the discovery request is aborted', async () => {
     const controller = new AbortController()
     const probeSignals: (AbortSignal | undefined)[] = []

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -228,6 +228,28 @@ components:
     ).resolves.toMatchObject({ serverUrl: '' })
   })
 
+  it('does not probe a path key that resolves to another host', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          info: { title: 'Lords Votes API' },
+          openapi: '3.0.1',
+          paths: { '//attacker.example/data': {} },
+        }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://raw.githubusercontent.com/org/repo/openapi.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: '' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('does not probe when a declared server URL cannot be resolved', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -308,13 +308,13 @@ components:
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the document metadata when the probe times out', async () => {
+  it('keeps the document metadata when the probe request fails', async () => {
     vi.stubGlobal(
       'fetch',
       vi
         .fn()
         .mockResolvedValueOnce(new Response(serverlessSpec, { status: 200 }))
-        .mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError')),
+        .mockRejectedValueOnce(new TypeError('fetch failed')),
     )
 
     const discovered = await loader({

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -308,6 +308,27 @@ components:
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the document metadata when the probe times out', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response(serverlessSpec, { status: 200 }))
+        .mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError')),
+    )
+
+    const discovered = await loader({
+      request: discoverRequest('https://api.status.example/openapi.json'),
+    } as Parameters<typeof loader>[0])
+
+    expect(discovered).toMatchObject({
+      name: 'lords_votes_api',
+      serverUrl: '',
+      status: 'success',
+    })
+    expect(discovered).not.toHaveProperty('inspectionError')
+  })
+
   it('cancels the probe when the discovery request is aborted', async () => {
     const controller = new AbortController()
     const probeSignals: (AbortSignal | undefined)[] = []

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -2,6 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { inspectSourceDocument, loader } from './source-discovery'
 
+const serverlessSpec = JSON.stringify({
+  info: { title: 'Lords Votes API' },
+  openapi: '3.0.1',
+  paths: { '/data/Divisions/groupedbyparty': {}, '/data/Divisions/{divisionId}': {} },
+})
+
+const discoverRequest = (url: string) =>
+  new Request(`http://reef.test/workspaces/default/sources/discover?url=${encodeURIComponent(url)}`)
+
 describe('source discovery', () => {
   afterEach(() => vi.unstubAllGlobals())
 
@@ -17,12 +26,15 @@ describe('source discovery', () => {
           info: { description: 'Weather observations and forecasts', title: 'Weather API' },
           openapi: '3.1.0',
           security: [{ bearerAuth: [] }],
+          servers: [{ url: 'https://weather.example/v1' }],
         }),
       ),
     ).toEqual({
       auth: { kind: 'bearer', label: 'Bearer token' },
       description: 'Weather observations and forecasts',
       format: 'openapi-json',
+      probePath: '',
+      serverUrl: 'https://weather.example/v1',
       title: 'Weather API',
     })
   })
@@ -35,6 +47,9 @@ info:
   description: >
     Weather observations
     and forecasts
+servers:
+  - url: https://weather.example/v1
+    description: Production
 paths: {}
 components:
   securitySchemes:
@@ -47,6 +62,8 @@ components:
       auth: { headerName: 'X-Api-Key', kind: 'header', label: 'Header X-Api-Key' },
       description: 'Weather observations and forecasts',
       format: 'openapi-yaml',
+      probePath: '',
+      serverUrl: 'https://weather.example/v1',
       title: 'Weather API',
     })
   })
@@ -56,8 +73,28 @@ components:
       auth: { kind: 'unknown', label: '' },
       description: '',
       format: 'unknown',
+      probePath: '',
+      serverUrl: '',
       title: '',
     })
+  })
+
+  it('resolves server URL variables from their declared defaults', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          info: { title: 'Region API' },
+          openapi: '3.1.0',
+          servers: [
+            { url: 'https://{region}.example.com/{version}', variables: { region: {} } },
+            {
+              url: 'https://{region}.example.com/{version}',
+              variables: { region: { default: 'eu' }, version: { default: 'v2' } },
+            },
+          ],
+        }),
+      ).serverUrl,
+    ).toBe('https://eu.example.com/v2')
   })
 
   it('maps OAuth security schemes to a bearer credential', () => {
@@ -97,6 +134,7 @@ components:
             info: { description: 'Status checks', title: '123 Status API' },
             openapi: '3.0.3',
             security: [],
+            servers: [{ url: 'https://status.example/api' }],
           }),
           { status: 200 },
         ),
@@ -111,9 +149,129 @@ components:
       description: 'Status checks',
       format: 'openapi-json',
       name: 'source_123_status_api',
+      serverUrl: 'https://status.example/api',
       status: 'success',
       url: 'https://status.example/openapi.json',
     })
+  })
+
+  it('resolves a relative server URL against the document location', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            info: { title: 'Status API' },
+            openapi: '3.0.3',
+            servers: [{ url: '/v1' }],
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const request = new Request(
+      'http://reef.test/workspaces/default/sources/discover?url=https%3A%2F%2Fstatus.example%2Fdocs%2Fopenapi.json',
+    )
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toMatchObject({
+      serverUrl: 'https://status.example/v1',
+    })
+  })
+
+  it('derives the server URL from the fetch origin when a probed path is served', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(serverlessSpec, { status: 200 }))
+      .mockResolvedValueOnce(new Response('[]', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://lordsvotes-api.parliament.uk/swagger/v1/swagger.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: 'https://lordsvotes-api.parliament.uk' })
+
+    expect(fetchMock.mock.calls[1][0].toString()).toBe(
+      'https://lordsvotes-api.parliament.uk/data/Divisions/groupedbyparty',
+    )
+  })
+
+  it('keeps a credentialed API when the probe asks for authentication', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response(serverlessSpec, { status: 200 }))
+        .mockResolvedValueOnce(new Response('', { status: 401 })),
+    )
+
+    await expect(
+      loader({
+        request: discoverRequest('https://lordsvotes-api.parliament.uk/swagger/v1/swagger.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: 'https://lordsvotes-api.parliament.uk' })
+  })
+
+  it('leaves the server URL empty when the probed path is not served', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response(serverlessSpec, { status: 200 }))
+        .mockResolvedValueOnce(new Response('', { status: 404 })),
+    )
+
+    await expect(
+      loader({
+        request: discoverRequest('https://raw.githubusercontent.com/org/repo/openapi.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: '' })
+  })
+
+  it('does not probe when a declared server URL cannot be resolved', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          info: { title: 'Region API' },
+          openapi: '3.0.3',
+          paths: { '/status': {} },
+          servers: [{ url: 'https://{region}.example.com' }],
+        }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://docs.example.com/openapi.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: '' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not probe when the document declares its own servers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          info: { title: 'Status API' },
+          openapi: '3.0.3',
+          paths: { '/status': {} },
+          servers: [{ url: 'https://status.example/api' }],
+        }),
+        { status: 200 },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://mirror.example/specs/status.json'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toMatchObject({ serverUrl: 'https://status.example/api' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('rejects non-HTTPS discovery URLs without fetching them', async () => {
@@ -143,6 +301,7 @@ components:
       format: 'mcp',
       inspectionError: 'The URL returned HTTP 405',
       name: 'mcp',
+      serverUrl: '',
       status: 'success',
       url: 'https://tools.example/mcp',
     })
@@ -162,6 +321,7 @@ components:
       description: '',
       format: 'mcp',
       name: 'sse',
+      serverUrl: '',
       status: 'success',
       url: 'https://tools.example/events/sse/?token=secret',
     })

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -12,8 +12,11 @@ const serverlessSpec = JSON.stringify({
 const servedFrom = (response: Response, url: string) =>
   Object.defineProperty(response, 'url', { value: url })
 
-const discoverRequest = (url: string) =>
-  new Request(`http://reef.test/workspaces/default/sources/discover?url=${encodeURIComponent(url)}`)
+const discoverRequest = (url: string, signal?: AbortSignal) =>
+  new Request(
+    `http://reef.test/workspaces/default/sources/discover?url=${encodeURIComponent(url)}`,
+    signal ? { signal } : undefined,
+  )
 
 describe('source discovery', () => {
   afterEach(() => vi.unstubAllGlobals())
@@ -278,6 +281,28 @@ components:
         request: discoverRequest('https://raw.githubusercontent.com/org/repo/openapi.json'),
       } as Parameters<typeof loader>[0]),
     ).resolves.toMatchObject({ serverUrl: '' })
+  })
+
+  it('cancels the probe when the discovery request is aborted', async () => {
+    const controller = new AbortController()
+    const probeSignals: (AbortSignal | undefined)[] = []
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(serverlessSpec, { status: 200 }))
+      .mockImplementationOnce((_url: URL, init: RequestInit) => {
+        probeSignals.push(init.signal ?? undefined)
+        controller.abort()
+        return Promise.reject(new DOMException('The operation was aborted', 'AbortError'))
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      loader({
+        request: discoverRequest('https://api.status.example/openapi.json', controller.signal),
+      } as Parameters<typeof loader>[0]),
+    ).rejects.toThrow()
+
+    expect(probeSignals[0]?.aborted).toBe(true)
   })
 
   it('does not probe a path key that resolves to another host', async () => {

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -64,12 +64,13 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
     const document = await responseTextWithinLimit(response)
     const metadata = inspectSourceDocument(document)
     const documentUrl = documentLocation(response, sourceUrl)
-    return discoveredSource(rawUrl, sourceUrl, {
-      ...metadata,
-      serverUrl:
-        absoluteServerUrl(metadata.serverUrl, documentUrl) ||
-        (await derivedServerUrl(documentUrl, metadata.probePath, request.signal)),
-    })
+    const serverUrl =
+      absoluteServerUrl(metadata.serverUrl, documentUrl) ||
+      (await derivedServerUrl(documentUrl, metadata.probePath, signal))
+    // A probe that times out costs only the base URL, but a caller who navigated
+    // away gets no answer at all.
+    request.signal.throwIfAborted()
+    return discoveredSource(rawUrl, sourceUrl, { ...metadata, serverUrl })
   } catch (error) {
     if (request.signal.aborted) throw error
     let inspectionError = 'The source URL could not be loaded'
@@ -498,25 +499,24 @@ function sourceName(title: string): string {
  * 403 included, means the host routes the path, which is what is being checked.
  * The probe reaches only the origin the caller already had us fetch: a path key
  * is document-controlled, and a network-path one such as `//host/data` would
- * otherwise resolve to a host of the document's choosing.
+ * otherwise resolve to a host of the document's choosing. It runs inside
+ * discovery's own deadline, and every way it can fail leaves the base URL to the
+ * user rather than costing the metadata already read from the document.
  */
 async function derivedServerUrl(
   documentUrl: URL,
   probePath: string,
-  requestSignal: AbortSignal,
+  discoverySignal: AbortSignal,
 ): Promise<string> {
   if (!probePath) return ''
   try {
     const probeUrl = new URL(probePath, documentUrl.origin)
     if (probeUrl.origin !== documentUrl.origin) return ''
     const response = await fetch(probeUrl, {
-      signal: AbortSignal.any([requestSignal, AbortSignal.timeout(5_000)]),
+      signal: AbortSignal.any([discoverySignal, AbortSignal.timeout(5_000)]),
     })
     return response.status === 404 || response.status === 410 ? '' : documentUrl.origin
-  } catch (error) {
-    // A caller who navigated away gets the loader's abort handling; every other
-    // failure means the origin does not serve the path.
-    if (requestSignal.aborted) throw error
+  } catch {
     return ''
   }
 }

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -483,12 +483,16 @@ function sourceName(title: string): string {
  *
  * Only 404/410 and a failed request rule the origin out. Anything else, 401 and
  * 403 included, means the host routes the path, which is what is being checked.
- * The probe reaches only the origin the caller already had us fetch.
+ * The probe reaches only the origin the caller already had us fetch: a path key
+ * is document-controlled, and a network-path one such as `//host/data` would
+ * otherwise resolve to a host of the document's choosing.
  */
 async function derivedServerUrl(sourceUrl: URL, probePath: string): Promise<string> {
   if (!probePath) return ''
   try {
-    const response = await fetch(new URL(probePath, sourceUrl.origin), {
+    const probeUrl = new URL(probePath, sourceUrl.origin)
+    if (probeUrl.origin !== sourceUrl.origin) return ''
+    const response = await fetch(probeUrl, {
       signal: AbortSignal.timeout(5_000),
     })
     return response.status === 404 || response.status === 410 ? '' : sourceUrl.origin

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -102,12 +102,17 @@ export function inspectSourceDocument(document: string): {
       auth: inspectJsonAuth(json),
       description: stringValue(info?.description),
       format: 'openapi-json',
-      // OpenAPI defines an absent or empty `servers` block as one entry with a url
-      // of `/`, and a relative server url as relative to where the document is
-      // served. So that case, and only that case, gets a base URL derived from the
-      // document's own location. A declared entry that will not resolve points
+      // OpenAPI 3 defines an absent or empty `servers` block as one entry with a
+      // url of `/`, and a relative server url as relative to where the document
+      // is served. So that case, and only that case, gets a base URL derived from
+      // the document's own location. A declared entry that will not resolve points
       // somewhere we cannot infer, and is left for the user to fill in.
-      probePath: servers.length === 0 ? firstConcretePath(json) : '',
+      //
+      // Swagger 2 has no `servers` at all — it spells the base URL out in `host`,
+      // `basePath` and `schemes` — so an empty block there says nothing about
+      // where the API lives, and a derived origin would drop whatever `basePath`
+      // declared. Those documents are left for the user to fill in.
+      probePath: isOpenApi3(json) && servers.length === 0 ? firstConcretePath(json) : '',
       serverUrl: resolvedServerUrl(servers),
       title: stringValue(info?.title),
     }
@@ -441,6 +446,11 @@ function parseJsonObject(document: string): Record<string, unknown> | null {
 
 function hasOpenApiVersion(document: Record<string, unknown>): boolean {
   return typeof document.openapi === 'string' || typeof document.swagger === 'string'
+}
+
+/** `openapi` is OpenAPI 3's version key; a Swagger 2 document carries `swagger`. */
+function isOpenApi3(document: Record<string, unknown>): boolean {
+  return typeof document.openapi === 'string'
 }
 
 function objectValue(value: unknown): Record<string, unknown> | undefined {

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -18,6 +18,7 @@ export type SourceDiscoveryData =
       format: SourceDocumentFormat
       inspectionError?: string
       name: string
+      serverUrl: string
       status: 'success'
       url: string
     }
@@ -55,13 +56,17 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
         description: '',
         format: 'unknown',
         inspectionError: `The URL returned HTTP ${response.status}`,
+        serverUrl: '',
         title: '',
       })
     }
 
     const document = await responseTextWithinLimit(response)
     const metadata = inspectSourceDocument(document)
-    return discoveredSource(rawUrl, sourceUrl, metadata)
+    return discoveredSource(rawUrl, sourceUrl, {
+      ...metadata,
+      serverUrl: metadata.serverUrl || (await derivedServerUrl(sourceUrl, metadata.probePath)),
+    })
   } catch (error) {
     if (request.signal.aborted) throw error
     let inspectionError = 'The source URL could not be loaded'
@@ -72,6 +77,7 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
       description: '',
       format: 'unknown',
       inspectionError,
+      serverUrl: '',
       title: '',
     })
   }
@@ -81,23 +87,74 @@ export function inspectSourceDocument(document: string): {
   auth: SourceDetectedAuth
   description: string
   format: SourceDocumentFormat
+  probePath: string
+  serverUrl: string
   title: string
 } {
   const json = parseJsonObject(document)
   if (json && hasOpenApiVersion(json)) {
     const info = objectValue(json.info)
+    const servers = Array.isArray(json.servers) ? json.servers : []
     return {
       auth: inspectJsonAuth(json),
       description: stringValue(info?.description),
       format: 'openapi-json',
+      // OpenAPI defines an absent or empty `servers` block as one entry with a url
+      // of `/`, and a relative server url as relative to where the document is
+      // served. So that case, and only that case, gets a base URL derived from the
+      // document's own location. A declared entry that will not resolve points
+      // somewhere we cannot infer, and is left for the user to fill in.
+      probePath: servers.length === 0 ? firstConcretePath(json) : '',
+      serverUrl: resolvedServerUrl(servers),
       title: stringValue(info?.title),
     }
   }
 
+  // The YAML scanner is line-based, so a YAML document declaring no servers
+  // leaves the field empty for the user to fill rather than being probed.
   const yaml = inspectOpenApiYaml(document)
-  if (yaml) return { ...yaml, format: 'openapi-yaml' }
+  if (yaml) return { ...yaml, format: 'openapi-yaml', probePath: '' }
 
-  return { auth: unknownAuth(), description: '', format: 'unknown', title: '' }
+  return {
+    auth: unknownAuth(),
+    description: '',
+    format: 'unknown',
+    probePath: '',
+    serverUrl: '',
+    title: '',
+  }
+}
+
+/**
+ * An operation path that can be requested as written, for checking whether a host
+ * serves this API. A `{placeholder}` left in the URL would 404 on its own merits.
+ */
+function firstConcretePath(document: Record<string, unknown>): string {
+  const paths = objectValue(document.paths)
+  return Object.keys(paths ?? {}).find((path) => path.startsWith('/') && !path.includes('{')) ?? ''
+}
+
+/**
+ * First `servers[]` entry whose URL resolves, mirroring coral-spec's
+ * `openapi_server_url`: `{name}` placeholders come from `variables.<name>.default`,
+ * and an entry with an unresolvable placeholder is skipped rather than used raw.
+ */
+function resolvedServerUrl(servers: unknown[]): string {
+  for (const entry of servers) {
+    const server = objectValue(entry)
+    const url = stringValue(server?.url)
+    if (!url) continue
+    const resolved = resolveServerUrl(url, objectValue(server?.variables))
+    if (resolved) return resolved
+  }
+  return ''
+}
+
+function resolveServerUrl(url: string, variables: Record<string, unknown> | undefined): string {
+  const resolved = url.replace(/\{([^{}]*)\}/g, (placeholder, name: string) => {
+    return stringValue(objectValue(variables?.[name])?.default) || placeholder
+  })
+  return resolved.includes('{') ? '' : resolved
 }
 
 function inspectJsonAuth(document: Record<string, unknown>): SourceDetectedAuth {
@@ -217,6 +274,7 @@ async function responseTextWithinLimit(response: Response): Promise<string> {
 function inspectOpenApiYaml(document: string): {
   auth: SourceDetectedAuth
   description: string
+  serverUrl: string
   title: string
 } | null {
   const lines = document.replace(/^\uFEFF/, '').split(/\r?\n/)
@@ -228,9 +286,10 @@ function inspectOpenApiYaml(document: string): {
   if (!hasVersion) return null
 
   const infoIndex = lines.findIndex((line) => indentation(line) === 0 && yamlKey(line) === 'info')
-  if (infoIndex < 0) return { auth: inspectYamlAuth(lines), description: '', title: '' }
+  const serverUrl = inspectYamlServerUrl(lines)
+  if (infoIndex < 0) return { auth: inspectYamlAuth(lines), description: '', serverUrl, title: '' }
   const infoIndent = lines.slice(infoIndex + 1).find((line) => line.trim() && indentation(line) > 0)
-  if (!infoIndent) return { auth: inspectYamlAuth(lines), description: '', title: '' }
+  if (!infoIndent) return { auth: inspectYamlAuth(lines), description: '', serverUrl, title: '' }
   const fieldIndent = indentation(infoIndent)
 
   let title = ''
@@ -250,7 +309,26 @@ function inspectOpenApiYaml(document: string): {
       }
     }
   }
-  return { auth: inspectYamlAuth(lines), description, title }
+  return { auth: inspectYamlAuth(lines), description, serverUrl, title }
+}
+
+/**
+ * First plain `- url:` entry under a top-level `servers:` block. Unlike the JSON
+ * path this does not resolve `{name}` placeholders — the scanner cannot read the
+ * nested `variables` mapping of a sequence item — so a templated entry is skipped
+ * and the wizard falls back to asking for the base URL.
+ */
+function inspectYamlServerUrl(lines: string[]): string {
+  const serversIndex = findYamlKey(lines, 'servers', 0)
+  if (serversIndex < 0) return ''
+  for (let index = serversIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() && indentation(line) === 0) break
+    if (!/^-?\s*url\s*:/.test(line.trim())) continue
+    const url = yamlScalar(line)
+    if (url && !url.includes('{')) return url
+  }
+  return ''
 }
 
 function yamlBlock(lines: string[], start: number, parentIndent: number, folded: boolean): string {
@@ -396,6 +474,48 @@ function sourceName(title: string): string {
   return name
 }
 
+/**
+ * OpenAPI treats an absent or empty `servers` block as a single `/` entry, so the
+ * origin of the URL we fetched is the document's own answer for where the API
+ * lives — right when the spec is served by the API, wrong when it is served by a
+ * file host such as `raw.githubusercontent.com`. One request tells the two apart:
+ * a file host has no such route, while an API answers or asks for credentials.
+ *
+ * Only 404/410 and a failed request rule the origin out. Anything else, 401 and
+ * 403 included, means the host routes the path, which is what is being checked.
+ * The probe reaches only the origin the caller already had us fetch.
+ */
+async function derivedServerUrl(sourceUrl: URL, probePath: string): Promise<string> {
+  if (!probePath) return ''
+  try {
+    const response = await fetch(new URL(probePath, sourceUrl.origin), {
+      signal: AbortSignal.timeout(5_000),
+    })
+    return response.status === 404 || response.status === 410 ? '' : sourceUrl.origin
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * A base URL is joined with operation paths that already lead with `/`, so a
+ * trailing slash would produce `https://host//data`. `new URL().toString()` adds
+ * one to every bare origin, which is what a derived server URL always is.
+ */
+function trimTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
+/** Resolve a relative `servers[].url` such as `/v1` against the document location. */
+function absoluteServerUrl(serverUrl: string, fetchUrl: URL): string {
+  if (!serverUrl) return ''
+  try {
+    return trimTrailingSlash(new URL(serverUrl, fetchUrl).toString())
+  } catch {
+    return ''
+  }
+}
+
 function discoveryError(url: string, message: string): SourceDiscoveryData {
   return { message, status: 'error', url }
 }
@@ -408,6 +528,7 @@ function discoveredSource(
     description: string
     format: SourceDocumentFormat
     inspectionError?: string
+    serverUrl: string
     title: string
   },
 ): SourceDiscoveryData {
@@ -419,6 +540,7 @@ function discoveredSource(
         ? 'mcp'
         : metadata.format,
     name: sourceName(metadata.title || fallbackTitle(sourceUrl)),
+    serverUrl: absoluteServerUrl(metadata.serverUrl, sourceUrl),
     status: 'success',
     url,
     ...(metadata.inspectionError ? { inspectionError: metadata.inspectionError } : {}),

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -63,9 +63,12 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
 
     const document = await responseTextWithinLimit(response)
     const metadata = inspectSourceDocument(document)
+    const documentUrl = documentLocation(response, sourceUrl)
     return discoveredSource(rawUrl, sourceUrl, {
       ...metadata,
-      serverUrl: metadata.serverUrl || (await derivedServerUrl(sourceUrl, metadata.probePath)),
+      serverUrl:
+        absoluteServerUrl(metadata.serverUrl, documentUrl) ||
+        (await derivedServerUrl(documentUrl, metadata.probePath)),
     })
   } catch (error) {
     if (request.signal.aborted) throw error
@@ -520,6 +523,19 @@ function absoluteServerUrl(serverUrl: string, fetchUrl: URL): string {
   }
 }
 
+/**
+ * Where the document was actually served from, which a redirect can move to
+ * another host entirely. Both a relative `servers[].url` and an origin probe
+ * describe the API relative to the document, not to the URL that was typed.
+ */
+function documentLocation(response: Response, sourceUrl: URL): URL {
+  try {
+    return new URL(response.url)
+  } catch {
+    return sourceUrl
+  }
+}
+
 function discoveryError(url: string, message: string): SourceDiscoveryData {
   return { message, status: 'error', url }
 }
@@ -544,7 +560,7 @@ function discoveredSource(
         ? 'mcp'
         : metadata.format,
     name: sourceName(metadata.title || fallbackTitle(sourceUrl)),
-    serverUrl: absoluteServerUrl(metadata.serverUrl, sourceUrl),
+    serverUrl: metadata.serverUrl,
     status: 'success',
     url,
     ...(metadata.inspectionError ? { inspectionError: metadata.inspectionError } : {}),

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -68,7 +68,7 @@ export async function loader({ request }: Route.LoaderArgs): Promise<SourceDisco
       ...metadata,
       serverUrl:
         absoluteServerUrl(metadata.serverUrl, documentUrl) ||
-        (await derivedServerUrl(documentUrl, metadata.probePath)),
+        (await derivedServerUrl(documentUrl, metadata.probePath, request.signal)),
     })
   } catch (error) {
     if (request.signal.aborted) throw error
@@ -490,16 +490,23 @@ function sourceName(title: string): string {
  * is document-controlled, and a network-path one such as `//host/data` would
  * otherwise resolve to a host of the document's choosing.
  */
-async function derivedServerUrl(sourceUrl: URL, probePath: string): Promise<string> {
+async function derivedServerUrl(
+  documentUrl: URL,
+  probePath: string,
+  requestSignal: AbortSignal,
+): Promise<string> {
   if (!probePath) return ''
   try {
-    const probeUrl = new URL(probePath, sourceUrl.origin)
-    if (probeUrl.origin !== sourceUrl.origin) return ''
+    const probeUrl = new URL(probePath, documentUrl.origin)
+    if (probeUrl.origin !== documentUrl.origin) return ''
     const response = await fetch(probeUrl, {
-      signal: AbortSignal.timeout(5_000),
+      signal: AbortSignal.any([requestSignal, AbortSignal.timeout(5_000)]),
     })
-    return response.status === 404 || response.status === 410 ? '' : sourceUrl.origin
-  } catch {
+    return response.status === 404 || response.status === 410 ? '' : documentUrl.origin
+  } catch (error) {
+    // A caller who navigated away gets the loader's abort handling; every other
+    // failure means the origin does not serve the path.
+    if (requestSignal.aborted) throw error
     return ''
   }
 }

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -16,6 +16,7 @@ const DISCOVERY: SuccessfulDiscovery = {
   description: 'Weather observations and forecasts',
   format: 'openapi-yaml' as const,
   name: 'weather_api',
+  serverUrl: 'https://weather.example/v1',
   status: 'success' as const,
   url: 'https://weather.example/openapi.yaml',
 }
@@ -174,6 +175,7 @@ describe('SourceCreateDialog', () => {
       auth: { kind: 'unknown', label: '' },
       description: '',
       name: 'status_api',
+      serverUrl: 'https://status.example/v2',
       url: replacementUrl,
     })
     await screen.getByLabelText('Source URL').fill(replacementUrl)
@@ -181,6 +183,7 @@ describe('SourceCreateDialog', () => {
 
     await expect.element(screen.getByLabelText('Name')).toHaveValue('status_api')
     await expect.element(screen.getByLabelText('Description (optional)')).toHaveValue('')
+    await expect.element(screen.getByLabelText('Base URL')).toHaveValue('https://status.example/v2')
 
     await screen.getByRole('button', { name: 'Next' }).click()
     await expect.element(screen.getByRole('radio', { name: 'Bearer token' })).toBeChecked()
@@ -195,6 +198,7 @@ describe('SourceCreateDialog', () => {
       description: '',
       format: 'unknown',
       name: 'status_api',
+      serverUrl: '',
       status: 'success',
       url: 'https://status.example/openapi.yaml',
     }
@@ -287,6 +291,7 @@ describe('SourceCreateDialog', () => {
       description: '',
       format: 'unknown',
       name: 'tools',
+      serverUrl: '',
       status: 'success',
       url,
     })
@@ -306,6 +311,7 @@ describe('SourceCreateDialog', () => {
       description: '',
       format: 'mcp',
       name: 'mcp',
+      serverUrl: '',
       status: 'success',
       url,
     })
@@ -345,7 +351,48 @@ describe('SourceCreateDialog', () => {
     const manifest = submittedManifest()
     expect(manifest).toContain('\ninputs:\n  API_TOKEN:\n    kind: secret\n')
     expect(manifest).toContain('\nsurface:\n  type: openapi\n')
+    expect(manifest).toContain('\n  base_url: "https://weather.example/v1"\n')
     expect(manifest).not.toContain('\nsurfaces:\n')
+  })
+
+  it('blocks an OpenAPI source until the base URL is a valid URL', async () => {
+    const { screen } = await renderSourceCreate({ ...DISCOVERY, serverUrl: '' })
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Base URL')).toHaveValue('')
+    await expect.element(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+
+    const baseUrlInput = screen.getByLabelText('Base URL')
+    await baseUrlInput.fill('weather.example')
+    await userEvent.tab()
+    await expect.element(screen.getByText('Enter a valid URL, including the scheme.')).toBeVisible()
+    await expect.element(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+
+    await baseUrlInput.fill('https://weather.example/v1')
+    await expect.element(screen.getByRole('button', { name: 'Next' })).toBeEnabled()
+  })
+
+  it('disables the base URL for MCP sources and omits it from the manifest', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Base URL')).toBeEnabled()
+
+    await screen.getByRole('radio', { name: 'MCP server' }).click()
+    await expect.element(screen.getByLabelText('Base URL')).toBeDisabled()
+    await expect
+      .element(
+        screen.getByText(
+          'MCP servers are reached at the source URL, so they have no separate base URL.',
+        ),
+      )
+      .toBeVisible()
+    expect(submittedManifest()).not.toContain('base_url')
+
+    await screen.getByRole('radio', { name: 'REST API (OpenAPI)' }).click()
+    await expect.element(screen.getByLabelText('Base URL')).toBeEnabled()
   })
 
   it('keeps the credentials dialog height stable across authentication choices', async () => {

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -34,6 +34,7 @@ interface Draft {
   description: string
   surfaceType: SurfaceType
   url: string
+  baseUrl: string
   auth: AuthChoice
   headerName: string
   oauthClientId: string
@@ -48,6 +49,7 @@ const EMPTY_DRAFT: Draft = {
   description: '',
   surfaceType: 'openapi',
   url: '',
+  baseUrl: '',
   auth: 'bearer',
   headerName: '',
   oauthClientId: '',
@@ -167,6 +169,7 @@ function SourceCreateDialogContent({
     setDraft((current) => ({
       ...current,
       ...(detectedAuth ? { auth: detectedAuth } : {}),
+      baseUrl: result.serverUrl || current.baseUrl,
       description: result.description || current.description,
       headerName: result.auth.headerName || current.headerName,
       name: result.name,
@@ -202,6 +205,7 @@ function SourceCreateDialogContent({
     if (step === 0) return draft.url.trim().startsWith('https://')
     if (step === 1) {
       if (!sourceNameIsValid(draft.name.trim())) return false
+      if (draft.surfaceType === 'openapi' && baseUrlValidationError(draft.baseUrl)) return false
       return true
     }
     if (draft.auth === 'header' && draft.headerName.trim().length === 0) return false
@@ -463,9 +467,13 @@ function DetailsStep({
 }) {
   const idName = useId()
   const idDescription = useId()
+  const idBaseUrl = useId()
   const [nameTouched, setNameTouched] = useState(false)
+  const [baseUrlTouched, setBaseUrlTouched] = useState(false)
   const name = draft.name.trim()
   const nameError = nameTouched ? sourceNameValidationError(name) : null
+  const mcp = draft.surfaceType === 'mcp'
+  const baseUrlError = !mcp && baseUrlTouched ? baseUrlValidationError(draft.baseUrl) : null
 
   return (
     <div className={styles.fieldGroup}>
@@ -502,6 +510,27 @@ function DetailsStep({
           value={draft.description}
           onChange={(value) => update({ description: value })}
           placeholder="What this source connects to"
+        />
+      </SourceField>
+      <SourceField
+        className={styles.fieldItem}
+        hint={
+          <Typography.BodySmall variant={baseUrlError ? 'error' : 'tertiary'}>
+            {mcp
+              ? 'MCP servers are reached at the source URL, so they have no separate base URL.'
+              : (baseUrlError ?? 'Requests are sent to this URL.')}
+          </Typography.BodySmall>
+        }
+        htmlFor={idBaseUrl}
+        label="Base URL"
+      >
+        <TextInput
+          disabled={mcp}
+          id={idBaseUrl}
+          value={draft.baseUrl}
+          onBlur={() => setBaseUrlTouched(true)}
+          onChange={(value) => update({ baseUrl: value })}
+          placeholder="https://api.example.com/v1"
         />
       </SourceField>
       <SourceField className={styles.fieldItem} label="Type">
@@ -736,6 +765,20 @@ function isHttpsUrl(value: string): boolean {
   }
 }
 
+/** Base URLs also allow http:// so sources can point at a local API. */
+function baseUrlValidationError(value: string): string | null {
+  const baseUrl = value.trim()
+  if (!baseUrl) return 'Enter the base URL requests are sent to.'
+  let protocol: string
+  try {
+    protocol = new URL(baseUrl).protocol
+  } catch {
+    return 'Enter a valid URL, including the scheme.'
+  }
+  if (protocol !== 'https:' && protocol !== 'http:') return 'Use an http:// or https:// URL.'
+  return null
+}
+
 function sourceNameValidationError(name: string): string | null {
   if (!name) return 'Enter a source name.'
   if (RESERVED_SOURCE_NAMES.has(name)) {
@@ -801,6 +844,8 @@ function buildManifestYaml(draft: Draft): string {
 
   if (draft.surfaceType === 'openapi') {
     lines.push('  type: openapi', `  url: ${s(url)}`)
+    // Omitted base_url leaves coral-app to derive it from the document's servers block.
+    if (draft.baseUrl.trim()) lines.push(`  base_url: ${s(draft.baseUrl.trim())}`)
     if (draft.auth !== 'none') {
       const bearerAuth = draft.auth === 'bearer' || draft.auth === 'oauthDevice'
       const headerName = bearerAuth ? 'Authorization' : draft.headerName.trim()


### PR DESCRIPTION
## Summary

For OpenAPI spec sources, we need a separate base URL, to tell Coral _which endpoint_ to hit when fetching the data; the first URL points to the OpenAPI spec, which is _not_ what we need.


## Test plan

Paste https://lordsvotes-api.parliament.uk/swagger/v1/swagger.json, check base URL is inferred correctly.


https://github.com/user-attachments/assets/ef4b1361-6890-43a1-9e25-a6bcff642207

