### PR TITLE
feat(sources/atlascloud): add Atlas Cloud source

### DIFF
--- a/sources/community/atlascloud/manifest.yaml
+++ b/sources/community/atlascloud/manifest.yaml
@@ -1,0 +1,231 @@
+name: atlascloud
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query Atlas Cloud language models and run bounded chat completions through SQL.
+base_url: https://api.atlascloud.ai/v1
+inputs:
+  ATLASCLOUD_API_KEY:
+    kind: secret
+    hint: |
+      Atlas Cloud API key.
+
+      Create or copy an API key from:
+      https://www.atlascloud.ai/console/api-keys
+
+      The key is sent as a Bearer token to the Atlas Cloud API.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.ATLASCLOUD_API_KEY}}"
+test_queries:
+  - SELECT id, object, owned_by FROM atlascloud.models LIMIT 5
+tables:
+  - name: models
+    description: Atlas Cloud language models available from GET /models.
+    request:
+      method: GET
+      path: /models
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Model identifier used in Atlas Cloud chat requests.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: created
+        type: Int64
+        nullable: true
+        description: Model creation timestamp when returned by the API.
+      - name: owned_by
+        type: Utf8
+        nullable: true
+        description: Model owner metadata when returned by the API.
+
+  - name: chat_completions
+    description: Run one non-streaming Atlas Cloud chat completion using required bounded SQL filters.
+    filters:
+      - name: model
+        required: true
+      - name: prompt
+        required: true
+      - name: max_tokens
+        required: true
+    request:
+      method: POST
+      path: /chat/completions
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - messages
+            - "0"
+            - role
+          from: literal
+          value: user
+        - path:
+            - messages
+            - "0"
+            - content
+          from: filter
+          key: prompt
+        - path:
+            - max_tokens
+          from: filter_int
+          key: max_tokens
+        - path:
+            - stream
+          from: literal
+          value: false
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model supplied in the SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: prompt
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Prompt supplied in the SQL filter.
+        expr:
+          kind: from_filter
+          key: prompt
+      - name: max_tokens
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Positive max_tokens value supplied in the SQL filter.
+        expr:
+          kind: from_filter
+          key: max_tokens
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Chat completion response ID.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: created
+        type: Int64
+        nullable: true
+        description: Response creation timestamp.
+      - name: returned_model
+        type: Utf8
+        nullable: true
+        description: Actual model returned by Atlas Cloud.
+        expr:
+          kind: path
+          path:
+            - model
+      - name: usage
+        type: Json
+        nullable: true
+        description: Token usage metadata returned by Atlas Cloud.
+      - name: prompt_tokens
+        type: Int64
+        nullable: true
+        description: Prompt token count when returned by Atlas Cloud.
+        expr:
+          kind: path
+          path:
+            - usage
+            - prompt_tokens
+      - name: completion_tokens
+        type: Int64
+        nullable: true
+        description: Completion token count when returned by Atlas Cloud.
+        expr:
+          kind: path
+          path:
+            - usage
+            - completion_tokens
+      - name: total_tokens
+        type: Int64
+        nullable: true
+        description: Total token count when returned by Atlas Cloud.
+        expr:
+          kind: path
+          path:
+            - usage
+            - total_tokens
+      - name: choices
+        type: Json
+        nullable: true
+        description: Raw choices array returned by Atlas Cloud.
+      - name: index
+        type: Int64
+        nullable: true
+        description: First choice index.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - index
+      - name: finish_reason
+        type: Utf8
+        nullable: true
+        description: Why the model stopped.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - finish_reason
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Assistant response text.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - message
+            - content
+      - name: reasoning_content
+        type: Utf8
+        nullable: true
+        description: Reasoning text when returned by the model.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - message
+            - reasoning_content
+      - name: message_role
+        type: Utf8
+        nullable: true
+        description: Assistant message role.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - message
+            - role


### PR DESCRIPTION
## Summary

- add an Atlas Cloud community source backed by the OpenAI-compatible API
- expose the available language-model catalog through `atlascloud.models`
- expose bounded, non-streaming chat completions through `atlascloud.chat_completions`
- keep credentials in the required `ATLASCLOUD_API_KEY` secret input

## Validation

- `make lint-sources`
- `cargo test --locked -p coral-spec --lib` (444 passed)
- direct `coral-spec` parse of the new manifest
- live Atlas Cloud `/v1/models` check (123 models; default model present)
- live non-streaming `/v1/chat/completions` check
- `git diff --check` and credential scan

## Notes

A full `coral source lint` CLI build reached the final linker step but could not complete because the local volume ran out of space. The manifest was validated directly with `parse_source_manifest_yaml`, and the complete `coral-spec` library suite passed.