### PR TITLE
feat(desktop): add About Coral to the app menu

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,4 +1,17 @@
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
+import { execFileSync } from 'node:child_process'
+
+// Fills the About panel's build-number slot; empty outside a git checkout.
+function buildCommit(): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return ''
+  }
+}
 
 export function createConfig(env: NodeJS.ProcessEnv = process.env) {
   return defineConfig({
@@ -9,6 +22,7 @@ export function createConfig(env: NodeJS.ProcessEnv = process.env) {
       // the auto-updater stays inert (it cannot install updates into an
       // unsigned app, and only release builds publish an update feed).
       define: {
+        __CORAL_DESKTOP_COMMIT__: JSON.stringify(buildCommit()),
         __CORAL_DESKTOP_RELEASE__: JSON.stringify(env.CORAL_DESKTOP_RELEASE === '1'),
       },
       build: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,10 @@ import { createShutdownCoordinator } from './shutdown'
 
 const SHUTDOWN_TIMEOUT_MS = 6000
 
+// Baked in by electron.vite.config.ts; the guard covers other build paths.
+declare const __CORAL_DESKTOP_COMMIT__: string
+const buildCommit = typeof __CORAL_DESKTOP_COMMIT__ === 'undefined' ? '' : __CORAL_DESKTOP_COMMIT__
+
 let mainWindow: BrowserWindow | null = null
 let sidecar: CoralSidecar | null = null
 let sidecarPromise: Promise<CoralSidecar> | null = null
@@ -279,11 +283,26 @@ function publishDesktopUpdateState(state: DesktopUpdateState): void {
   }
 }
 
+function installAboutPanel() {
+  app.setAboutPanelOptions({
+    applicationName: 'Coral',
+    applicationVersion: app.getVersion(),
+    // The panel always parenthesizes a build number, falling back to
+    // CFBundleVersion — which release-please keeps equal to the app version.
+    version: buildCommit,
+    // macOS draws the bundle icon and ignores iconPath.
+    ...(process.platform === 'darwin' ? {} : { iconPath: currentWindowIconPath() }),
+  })
+}
+
 function installMenu() {
   const template: Electron.MenuItemConstructorOptions[] = [
     {
       label: 'Coral',
       submenu: [
+        // `role: 'about'` would label itself from app.name, the package name in dev.
+        { label: 'About Coral', click: () => app.showAboutPanel() },
+        { type: 'separator' },
         ...(desktopUpdatesSupported()
           ? ([
               {
@@ -292,9 +311,9 @@ function installMenu() {
                   void checkForDesktopUpdates({ interactive: true })
                 },
               },
+              { type: 'separator' },
             ] satisfies Electron.MenuItemConstructorOptions[])
           : []),
-        { type: 'separator' },
         { role: 'quit' },
       ],
     },
@@ -368,6 +387,7 @@ function startApplication(): void {
     updatePlatformIcon()
     nativeTheme.on('updated', updatePlatformIcon)
     registerIpcHandlers()
+    installAboutPanel()
     installMenu()
     installAutoUpdater({
       allowUpdateQuit: shutdownCoordinator.allowQuit,


### PR DESCRIPTION
## Summary

Currently there's no way of knowing which version of Coral Desktop you have installed. Adding an "About" menu that opens a native dialog that tells you version + commit sha

## Test plan

<img width="286" height="194" alt="image" src="https://github.com/user-attachments/assets/13f7a80a-02e7-4cf3-9b62-bc831b31be33" />