### PR TITLE
feat(slack): describe auth with securitySchemes

### DIFF
--- a/sources/v4/slack/README.md
+++ b/sources/v4/slack/README.md
@@ -61,6 +61,25 @@ the query — see the first known limitation below.
 
 Verify with `coral source test slack_v4`.
 
+## Auth in the descriptor
+
+`openapi.yaml` declares `slackBotToken` and `slackUserToken` as OAuth2 schemes
+and gives every operation a `security` block naming the scopes it accepts, with
+the description Slack publishes for each.
+
+Coral ignores `securitySchemes` entirely — auth comes from `manifest.yaml` — so
+this is documentation rather than configuration, and `catalog-preview.md` is
+unchanged by it. It is *checked* documentation, though: the generator fails if
+an operation references a scope its scheme does not declare, which is what
+catches a method quietly gaining a scope upstream.
+
+Two details the block gets right that prose could not. An operation offers only
+the token classes Slack documents for it, so `search_messages` shows
+`slackUserToken` alone and `team_externalteams_list` shows `slackBotToken`
+alone. And scopes listed together are alternatives by default — any one of
+`channels:read`/`groups:read`/`im:read`/`mpim:read` is enough for
+`conversations_list` — except where the overlay says otherwise.
+
 ## What the catalog looks like
 
 `catalog-preview.md` in this directory is generated from the descriptor by

--- a/sources/v4/slack/openapi.yaml
+++ b/sources/v4/slack/openapi.yaml
@@ -6,7 +6,7 @@ openapi: 3.0.3
 info:
   title: Slack Web API
   description: "Read-only coverage of the Slack Web API, generated from Slack's published reference documentation and the response samples recorded in slackapi/java-slack-sdk. Slack publishes no OpenAPI 3.0 description of its own: the official slackapi/slack-api-specs is Swagger 2.0, was last updated in August 2020, and the repository was archived in March 2024."
-  version: 2026-07-30
+  version: 2026-07-31
 servers:
   - url: https://slack.com/api
 tags:
@@ -45,6 +45,11 @@ paths:
           schema:
             type: string
           description: encoded team id or enterprise id where the bot exists, required if org token is used
+      security:
+        - slackBotToken:
+            - users:read
+        - slackUserToken:
+            - users:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -143,6 +148,23 @@ paths:
             type: string
             default: "0"
           description: Only messages after this Unix timestamp will be included in results.
+      security:
+        - slackBotToken:
+            - channels:history
+        - slackBotToken:
+            - groups:history
+        - slackBotToken:
+            - im:history
+        - slackBotToken:
+            - mpim:history
+        - slackUserToken:
+            - channels:history
+        - slackUserToken:
+            - groups:history
+        - slackUserToken:
+            - im:history
+        - slackUserToken:
+            - mpim:history
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -208,6 +230,23 @@ paths:
             default: false
           description: Set to `true` to include the member count for the specified conversation. Defaults to `false`
           example: true
+      security:
+        - slackBotToken:
+            - channels:read
+        - slackBotToken:
+            - groups:read
+        - slackBotToken:
+            - im:read
+        - slackBotToken:
+            - mpim:read
+        - slackUserToken:
+            - channels:read
+        - slackUserToken:
+            - groups:read
+        - slackUserToken:
+            - im:read
+        - slackUserToken:
+            - mpim:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -395,6 +434,23 @@ paths:
             default: public_channel
           description: Mix and match channel types by providing a comma-separated list of any combination of `public_channel`, `private_channel`, `mpim`, `im`
           example: public_channel,private_channel
+      security:
+        - slackBotToken:
+            - channels:read
+        - slackBotToken:
+            - groups:read
+        - slackBotToken:
+            - im:read
+        - slackBotToken:
+            - mpim:read
+        - slackUserToken:
+            - channels:read
+        - slackUserToken:
+            - groups:read
+        - slackUserToken:
+            - im:read
+        - slackUserToken:
+            - mpim:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -455,6 +511,23 @@ paths:
             default: 100
           description: The maximum number of items to return. Fewer than the requested number of items may be returned, even if the end of the users list hasn't been reached.
           example: 20
+      security:
+        - slackBotToken:
+            - channels:read
+        - slackBotToken:
+            - groups:read
+        - slackBotToken:
+            - im:read
+        - slackBotToken:
+            - mpim:read
+        - slackUserToken:
+            - channels:read
+        - slackUserToken:
+            - groups:read
+        - slackUserToken:
+            - im:read
+        - slackUserToken:
+            - mpim:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -545,6 +618,23 @@ paths:
           schema:
             type: string
           description: Unique identifier of either a thread’s parent message or a message in the thread. `ts` must be the timestamp of an existing message with 0 or more replies. If there are no replies then just the single message referenced by `ts` will return - it is just an ordinary, unthreaded message.
+      security:
+        - slackBotToken:
+            - channels:history
+        - slackBotToken:
+            - groups:history
+        - slackBotToken:
+            - im:history
+        - slackBotToken:
+            - mpim:history
+        - slackUserToken:
+            - channels:history
+        - slackUserToken:
+            - groups:history
+        - slackUserToken:
+            - im:history
+        - slackUserToken:
+            - mpim:history
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -593,6 +683,11 @@ paths:
             type: string
           description: User to fetch status for (defaults to current user)
           example: U1234
+      security:
+        - slackBotToken:
+            - dnd:read
+        - slackUserToken:
+            - dnd:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -638,6 +733,11 @@ paths:
             type: string
           description: Comma-separated list of users to fetch Do Not Disturb status for
           example: U1234,W4567
+      security:
+        - slackBotToken:
+            - dnd:read
+        - slackUserToken:
+            - dnd:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -691,6 +791,11 @@ paths:
           schema:
             type: boolean
           description: Include a list of categories for Unicode emoji and the emoji in each category
+      security:
+        - slackBotToken:
+            - emoji:read
+        - slackUserToken:
+            - emoji:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -765,6 +870,11 @@ paths:
           schema:
             type: integer
             default: 1
+      security:
+        - slackBotToken:
+            - files:read
+        - slackUserToken:
+            - files:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -1302,6 +1412,11 @@ paths:
           schema:
             type: string
           description: Filter files created by a single user.
+      security:
+        - slackBotToken:
+            - files:read
+        - slackUserToken:
+            - files:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -1355,6 +1470,11 @@ paths:
             type: string
           description: Specify a file by providing its ID.
           example: F2147483862
+      security:
+        - slackBotToken:
+            - remote_files:read
+        - slackUserToken:
+            - remote_files:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -1859,6 +1979,11 @@ paths:
             default: now
           description: Filter files created before this timestamp (inclusive).
           example: "123456789"
+      security:
+        - slackBotToken:
+            - remote_files:read
+        - slackUserToken:
+            - remote_files:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -1898,6 +2023,11 @@ paths:
           schema:
             type: string
           description: Channel to get pinned items for.
+      security:
+        - slackBotToken:
+            - pins:read
+        - slackUserToken:
+            - pins:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -1959,6 +2089,11 @@ paths:
             type: string
           description: Timestamp of the message to get reactions for.
           example: "1524523204.000192"
+      security:
+        - slackBotToken:
+            - reactions:read
+        - slackUserToken:
+            - reactions:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2166,6 +2301,11 @@ paths:
           schema:
             type: string
           description: Show reactions made by this user. Defaults to the authed user.
+      security:
+        - slackBotToken:
+            - reactions:read
+        - slackUserToken:
+            - reactions:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2223,6 +2363,9 @@ paths:
           schema:
             type: string
           description: Encoded team id, required if org token is passed
+      security:
+        - slackUserToken:
+            - reminders:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2270,6 +2413,9 @@ paths:
           schema:
             type: string
           description: Encoded team id, required if org token is passed
+      security:
+        - slackUserToken:
+            - reminders:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2346,6 +2492,9 @@ paths:
           schema:
             type: string
           description: encoded team id to search in, required if org token is used
+      security:
+        - slackUserToken:
+            - search:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2499,6 +2648,9 @@ paths:
           schema:
             type: string
           description: encoded team id to search in, required if org token is used
+      security:
+        - slackUserToken:
+            - search:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2615,6 +2767,9 @@ paths:
           schema:
             type: string
           description: encoded team id to search in, required if org token is used
+      security:
+        - slackUserToken:
+            - search:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2708,6 +2863,9 @@ paths:
           schema:
             type: string
           description: encoded team id to list stars in, required if org token is used
+      security:
+        - slackUserToken:
+            - stars:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2781,6 +2939,9 @@ paths:
           schema:
             type: string
           description: encoded team id to get logs from, required if org token is used
+      security:
+        - slackUserToken:
+            - admin
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2857,6 +3018,9 @@ paths:
           schema:
             type: string
           description: A user to retrieve the billable information for. Defaults to all users.
+      security:
+        - slackUserToken:
+            - admin
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2935,6 +3099,10 @@ paths:
             type: string
             default: team_name
           description: Name of the parameter that we are sorting by
+      security:
+        - slackBotToken:
+            - conversations.connect:manage
+            - team:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -2988,6 +3156,11 @@ paths:
           schema:
             type: string
           description: Team to get info about; if omitted, will return information about the current team.
+      security:
+        - slackBotToken:
+            - team:read
+        - slackUserToken:
+            - team:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3120,6 +3293,9 @@ paths:
           schema:
             type: string
           description: Filter logs generated by this user’s actions. Defaults to all logs.
+      security:
+        - slackUserToken:
+            - admin
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3168,6 +3344,11 @@ paths:
             type: string
           description: Filter by visibility.
           example: all
+      security:
+        - slackBotToken:
+            - users.profile:read
+        - slackUserToken:
+            - users.profile:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3232,6 +3413,11 @@ paths:
           schema:
             type: string
           description: The user group's encoded team ID. Required if org token is used.
+      security:
+        - slackBotToken:
+            - usergroups:read
+        - slackUserToken:
+            - usergroups:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3282,6 +3468,11 @@ paths:
             type: string
           description: The encoded ID of the User Group.
           example: S0604QSJC
+      security:
+        - slackBotToken:
+            - usergroups:read
+        - slackUserToken:
+            - usergroups:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3356,6 +3547,23 @@ paths:
             type: string
           description: Browse conversations by a specific user ID's membership. Non-public channels are restricted to those where the calling user shares membership.
           example: W0B2345D
+      security:
+        - slackBotToken:
+            - channels:read
+        - slackBotToken:
+            - groups:read
+        - slackBotToken:
+            - im:read
+        - slackBotToken:
+            - mpim:read
+        - slackUserToken:
+            - channels:read
+        - slackUserToken:
+            - groups:read
+        - slackUserToken:
+            - im:read
+        - slackUserToken:
+            - mpim:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3399,6 +3607,11 @@ paths:
           schema:
             type: string
           description: User to get presence info on. Defaults to the authed user.
+      security:
+        - slackBotToken:
+            - users:read
+        - slackUserToken:
+            - users:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3436,6 +3649,9 @@ paths:
         - users
       summary: Get a user's identity.
       description: "Get a user's identity. Requires one of the scopes: identity:read. Rate limit: Tier 3: 50+ per minute. See https://docs.slack.dev/reference/methods/users.identity."
+      security:
+        - slackUserToken:
+            - identity:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3502,6 +3718,11 @@ paths:
           schema:
             type: string
           description: User to get info on
+      security:
+        - slackBotToken:
+            - users:read
+        - slackUserToken:
+            - users:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3707,6 +3928,11 @@ paths:
           schema:
             type: string
           description: encoded team id to list users in, required if org token is used
+      security:
+        - slackBotToken:
+            - users:read
+        - slackUserToken:
+            - users:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3755,6 +3981,11 @@ paths:
             type: string
           description: An email address belonging to a user in the workspace
           example: spengler@ghostbusters.example.com
+      security:
+        - slackBotToken:
+            - users:read.email
+        - slackUserToken:
+            - users:read.email
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -3913,6 +4144,11 @@ paths:
           schema:
             type: string
           description: User to retrieve profile info for
+      security:
+        - slackBotToken:
+            - users.profile:read
+        - slackUserToken:
+            - users.profile:read
       responses:
         "200":
           description: "Response envelope. Slack reports failures here with `ok: false`."
@@ -4008,6 +4244,67 @@ paths:
                   warning:
                     type: string
 components:
+  securitySchemes:
+    slackBotToken:
+      type: oauth2
+      description: A bot token (xoxb-), issued to the app itself. Reads what the bot user can see, which is the channels it has been added to.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://slack.com/oauth/v2/authorize
+          tokenUrl: https://slack.com/api/oauth.v2.access
+          scopes:
+            channels:history: View messages and other content in public channels that your Slack app has been added to
+            channels:read: View basic information about public channels in a workspace
+            conversations.connect:manage: Allows your Slack app to manage Slack Connect channels
+            dnd:read: View Do Not Disturb settings for people in a workspace
+            emoji:read: View custom emoji in a workspace
+            files:read: View files shared in channels and conversations that your Slack app has been added to
+            groups:history: View messages and other content in private channels that your Slack app has been added to
+            groups:read: View basic information about private channels that your Slack app has been added to
+            im:history: View messages and other content in direct messages that your Slack app has been added to
+            im:read: View basic information about direct messages that your Slack app has been added to
+            mpim:history: View messages and other content in group direct messages that your Slack app has been added to
+            mpim:read: View basic information about group direct messages that your Slack app has been added to
+            pins:read: View pinned content in channels and conversations that your Slack app has been added to
+            reactions:read: View emoji reactions and their associated content in channels and conversations that your Slack app has been added to
+            remote_files:read: View remote files added by the app in a workspace
+            team:read: View the name, email domain, and icon for workspaces your Slack app is connected to
+            usergroups:read: View user groups in a workspace
+            users:read: View people in a workspace
+            users:read.email: View email addresses of people in a workspace
+            users.profile:read: View profile details about people in a workspace
+    slackUserToken:
+      type: oauth2
+      description: A user token (xoxp-), issued on behalf of the authorizing user. Reads what that user can see, and is the only class Slack grants search:read.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://slack.com/oauth/v2_user/authorize
+          tokenUrl: https://slack.com/api/oauth.v2.user.access
+          scopes:
+            admin: Administer a workspace
+            channels:history: View messages and other content in public channels that your Slack app has been added to
+            channels:read: View basic information about public channels in a workspace
+            dnd:read: View Do Not Disturb settings for people in a workspace
+            emoji:read: View custom emoji in a workspace
+            files:read: View files shared in channels and conversations that your Slack app has been added to
+            groups:history: View messages and other content in private channels that your Slack app has been added to
+            groups:read: View basic information about private channels that your Slack app has been added to
+            identity:read: ""
+            im:history: View messages and other content in direct messages that your Slack app has been added to
+            im:read: View basic information about direct messages that your Slack app has been added to
+            mpim:history: View messages and other content in group direct messages that your Slack app has been added to
+            mpim:read: View basic information about group direct messages that your Slack app has been added to
+            pins:read: View pinned content in channels and conversations that your Slack app has been added to
+            reactions:read: View emoji reactions and their associated content in channels and conversations that your Slack app has been added to
+            reminders:read: View reminders created by your Slack app
+            remote_files:read: View remote files added by the app in a workspace
+            search:read: Search a workspace's content
+            stars:read: View a user's starred messages and files
+            team:read: View the name, email domain, and icon for workspaces your Slack app is connected to
+            usergroups:read: View user groups in a workspace
+            users:read: View people in a workspace
+            users:read.email: View email addresses of people in a workspace
+            users.profile:read: View profile details about people in a workspace
   schemas:
     Category:
       type: object

--- a/tools/openapi-forge/README.md
+++ b/tools/openapi-forge/README.md
@@ -31,6 +31,10 @@ discover → extract (per-API adapters) → ApiModel → emit OpenAPI 3.0.3 → 
   about the other.
 - **overlay** — hand-written corrections applied to the model before emission.
   The only file a human edits, so regenerating never discards their work.
+  It also carries judgements the source material cannot express: providers list
+  a method's scopes without saying whether they are alternatives or a required
+  set, and the answer differs per method, so `scopeRelation` declares the
+  exceptions to the `any` default.
 - **emit** — `ApiModel` to OpenAPI 3.0.3, with assertions for the constraints
   Coral's importer places on a descriptor.
 - **validate** — `cargo run -p xtask -- v4-preview <manifest>` renders the SQL

--- a/tools/openapi-forge/apis/slack/config.yaml
+++ b/tools/openapi-forge/apis/slack/config.yaml
@@ -10,6 +10,31 @@ serverUrl: https://slack.com/api
 # Written by `forge build`, relative to this file.
 output: ../../../../sources/v4/slack/openapi.yaml
 
+security:
+  # Slack issues two classes of token with different scope sets, and a method
+  # may accept only one of them — reminders.list is user-only, while
+  # team.externalTeams.list is bot-only. One scheme each is what lets an
+  # operation say which it takes.
+  #
+  # The endpoints are declared here rather than extracted: Slack documents them
+  # in prose at /authentication/installing-with-oauth, not in a form worth
+  # scraping. Both pairs are taken from that page.
+  schemes:
+    - name: slackBotToken
+      tokenClass: bot
+      description: >-
+        A bot token (xoxb-), issued to the app itself. Reads what the bot user
+        can see, which is the channels it has been added to.
+      authorizationUrl: https://slack.com/oauth/v2/authorize
+      tokenUrl: https://slack.com/api/oauth.v2.access
+    - name: slackUserToken
+      tokenClass: user
+      description: >-
+        A user token (xoxp-), issued on behalf of the authorizing user. Reads
+        what that user can see, and is the only class Slack grants search:read.
+      authorizationUrl: https://slack.com/oauth/v2_user/authorize
+      tokenUrl: https://slack.com/api/oauth.v2.user.access
+
 scope:
   # The read-only core of the Web API. Selected by two filters over the
   # thirteen non-admin families (bots, conversations, dnd, emoji, files, pins,

--- a/tools/openapi-forge/apis/slack/overlay.yaml
+++ b/tools/openapi-forge/apis/slack/overlay.yaml
@@ -21,6 +21,17 @@ parameters:
       as a float is wrong for every caller.
 
 operations:
+  team.externalTeams.list:
+    scopeRelation: all
+    reason: >-
+      Slack lists a method's scopes without saying how they relate, and the
+      relationship differs. The four `channels`/`groups`/`im`/`mpim` scopes on
+      the conversations methods are alternatives — one per conversation type,
+      any of which is sufficient — so `any` is the right default. This method is
+      the exception in scope: `team:read` and `conversations.connect:manage`
+      are unrelated scope families that a caller needs both of. Nothing in the
+      page distinguishes the two cases, so it is declared here.
+
   files.info:
     response:
       dropProperties:

--- a/tools/openapi-forge/apis/slack/snapshot/manifest.json
+++ b/tools/openapi-forge/apis/slack/snapshot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-07-30T10:51:36.382Z",
+  "fetchedAt": "2026-07-31T06:00:16.131Z",
   "inputs": [
     {
       "path": "docs/bots.info.md",
@@ -518,6 +518,174 @@
       "upstreamSha256": "cc4f49ee5d2861cfc5cb20e888454c75c5a018dba3422bbdcd2eff266995cf0f",
       "sha256": "7d7d3e7c898c429ccfa17fdea081066b3fea7152729ad8e82e5a996e4f092f75",
       "bytes": 1420
+    },
+    {
+      "path": "scopes/admin.md",
+      "url": "https://docs.slack.dev/reference/scopes/admin.md",
+      "upstreamSha256": "d322c6ab6952609879a0ddd2fed4a0fd22f39754947181751b33542b060c11f5",
+      "sha256": "d322c6ab6952609879a0ddd2fed4a0fd22f39754947181751b33542b060c11f5",
+      "bytes": 953
+    },
+    {
+      "path": "scopes/channels.history.md",
+      "url": "https://docs.slack.dev/reference/scopes/channels.history.md",
+      "upstreamSha256": "895b7d364df09660c2eadd7fbe0431538ec261d7775c6f01665a3f06ae021f2f",
+      "sha256": "895b7d364df09660c2eadd7fbe0431538ec261d7775c6f01665a3f06ae021f2f",
+      "bytes": 1424
+    },
+    {
+      "path": "scopes/channels.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/channels.read.md",
+      "upstreamSha256": "2cd2de7d9466ef7d46064ba4a3f1217811533dea9933fafe2498d5beb9c643d9",
+      "sha256": "2cd2de7d9466ef7d46064ba4a3f1217811533dea9933fafe2498d5beb9c643d9",
+      "bytes": 1260
+    },
+    {
+      "path": "scopes/conversations.connect.manage.md",
+      "url": "https://docs.slack.dev/reference/scopes/conversations.connect.manage.md",
+      "upstreamSha256": "057d361e7af0e6b23b8b0d2a45a5056033df44584c1277bf6f3bf2ca20a591fc",
+      "sha256": "057d361e7af0e6b23b8b0d2a45a5056033df44584c1277bf6f3bf2ca20a591fc",
+      "bytes": 1489
+    },
+    {
+      "path": "scopes/dnd.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/dnd.read.md",
+      "upstreamSha256": "1e42ec4b5209cdccbaba5be5577d8c5918acf2da7f712b2ca27ce134fb70dbd7",
+      "sha256": "1e42ec4b5209cdccbaba5be5577d8c5918acf2da7f712b2ca27ce134fb70dbd7",
+      "bytes": 495
+    },
+    {
+      "path": "scopes/emoji.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/emoji.read.md",
+      "upstreamSha256": "4610cc846552e7374db30a8f60049af59863f4e6df61ca89db817c7ca6aea547",
+      "sha256": "4610cc846552e7374db30a8f60049af59863f4e6df61ca89db817c7ca6aea547",
+      "bytes": 427
+    },
+    {
+      "path": "scopes/files.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/files.read.md",
+      "upstreamSha256": "c36944c0ce771440e9233835d723c5ad7c63cbaa24670a4af5f6d5694666f127",
+      "sha256": "c36944c0ce771440e9233835d723c5ad7c63cbaa24670a4af5f6d5694666f127",
+      "bytes": 1117
+    },
+    {
+      "path": "scopes/groups.history.md",
+      "url": "https://docs.slack.dev/reference/scopes/groups.history.md",
+      "upstreamSha256": "331c1864dd0abb0236882ef8ad25d21ff3e534711db890bdf9fe5dad31bb478c",
+      "sha256": "331c1864dd0abb0236882ef8ad25d21ff3e534711db890bdf9fe5dad31bb478c",
+      "bytes": 1485
+    },
+    {
+      "path": "scopes/groups.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/groups.read.md",
+      "upstreamSha256": "0deafa43d4a88b52158f4b0f3939d5dfe8bc3315677c3061f9c0c08da668d584",
+      "sha256": "0deafa43d4a88b52158f4b0f3939d5dfe8bc3315677c3061f9c0c08da668d584",
+      "bytes": 1298
+    },
+    {
+      "path": "scopes/im.history.md",
+      "url": "https://docs.slack.dev/reference/scopes/im.history.md",
+      "upstreamSha256": "301379d83fb555b9d53664bbeb64b85c38b181f9110837f5a72434c496b9073d",
+      "sha256": "301379d83fb555b9d53664bbeb64b85c38b181f9110837f5a72434c496b9073d",
+      "bytes": 1390
+    },
+    {
+      "path": "scopes/im.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/im.read.md",
+      "upstreamSha256": "5d97d1cd2bf74c3ee48703cdcce2ade81db64b19ef1bb08e2585486800cf32d5",
+      "sha256": "5d97d1cd2bf74c3ee48703cdcce2ade81db64b19ef1bb08e2585486800cf32d5",
+      "bytes": 760
+    },
+    {
+      "path": "scopes/mpim.history.md",
+      "url": "https://docs.slack.dev/reference/scopes/mpim.history.md",
+      "upstreamSha256": "95ee5cf3a63347ea85374e2fffc377afc43aefb56106f5b445f29c265538ccd8",
+      "sha256": "95ee5cf3a63347ea85374e2fffc377afc43aefb56106f5b445f29c265538ccd8",
+      "bytes": 1414
+    },
+    {
+      "path": "scopes/mpim.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/mpim.read.md",
+      "upstreamSha256": "75f9ea196677d3bced7f36f80c52a692597628d388cebaac6a3567c5ebe3697d",
+      "sha256": "75f9ea196677d3bced7f36f80c52a692597628d388cebaac6a3567c5ebe3697d",
+      "bytes": 773
+    },
+    {
+      "path": "scopes/pins.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/pins.read.md",
+      "upstreamSha256": "87be5ea5ea1cfa17419c66d0763da97bb47f850be7609aa22456dcf5cb6468d5",
+      "sha256": "87be5ea5ea1cfa17419c66d0763da97bb47f850be7609aa22456dcf5cb6468d5",
+      "bytes": 586
+    },
+    {
+      "path": "scopes/reactions.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/reactions.read.md",
+      "upstreamSha256": "160246361841ebf2dc682c1ce6ed1ae1872973d4cf26963eb150a0815d997409",
+      "sha256": "160246361841ebf2dc682c1ce6ed1ae1872973d4cf26963eb150a0815d997409",
+      "bytes": 641
+    },
+    {
+      "path": "scopes/reminders.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/reminders.read.md",
+      "upstreamSha256": "00b4fde17bed940ed4a8c7ec1f2ed6116b8ed3744fb9417e69ace6e639d18f86",
+      "sha256": "00b4fde17bed940ed4a8c7ec1f2ed6116b8ed3744fb9417e69ace6e639d18f86",
+      "bytes": 431
+    },
+    {
+      "path": "scopes/remote_files.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/remote_files.read.md",
+      "upstreamSha256": "e2289f47760359a1eb64bede431dc56ecca6dcdfd625c85caba305d93e6082d2",
+      "sha256": "e2289f47760359a1eb64bede431dc56ecca6dcdfd625c85caba305d93e6082d2",
+      "bytes": 458
+    },
+    {
+      "path": "scopes/search.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/search.read.md",
+      "upstreamSha256": "917a498afc66b798484b7d876cfbdc1a2374212f9bfa2206915b1825b2b79b56",
+      "sha256": "917a498afc66b798484b7d876cfbdc1a2374212f9bfa2206915b1825b2b79b56",
+      "bytes": 610
+    },
+    {
+      "path": "scopes/stars.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/stars.read.md",
+      "upstreamSha256": "2cf994b37f900dce83cb5793c6864d3fa5b25f75c7fcc6047fbf44c25c05eee2",
+      "sha256": "2cf994b37f900dce83cb5793c6864d3fa5b25f75c7fcc6047fbf44c25c05eee2",
+      "bytes": 391
+    },
+    {
+      "path": "scopes/team.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/team.read.md",
+      "upstreamSha256": "d46719a46ca2199849d30f8ef692b878b4f9fb11fb998af921f6477c73896722",
+      "sha256": "d46719a46ca2199849d30f8ef692b878b4f9fb11fb998af921f6477c73896722",
+      "bytes": 713
+    },
+    {
+      "path": "scopes/usergroups.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/usergroups.read.md",
+      "upstreamSha256": "8de4850a3d5130a68595793cba60515cfdfd5876f656a0af9b0561e2362e7cbd",
+      "sha256": "8de4850a3d5130a68595793cba60515cfdfd5876f656a0af9b0561e2362e7cbd",
+      "bytes": 775
+    },
+    {
+      "path": "scopes/users.profile.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/users.profile.read.md",
+      "upstreamSha256": "9edc5c02401ec64b6c115365fa5fb9edf3a9c299bfcb172b670b3e376425dc32",
+      "sha256": "9edc5c02401ec64b6c115365fa5fb9edf3a9c299bfcb172b670b3e376425dc32",
+      "bytes": 457
+    },
+    {
+      "path": "scopes/users.read.email.md",
+      "url": "https://docs.slack.dev/reference/scopes/users.read.email.md",
+      "upstreamSha256": "cef11c05a7cd4e64584b170f81c3a5e26972038baa20eb2bc6461edb61efc01a",
+      "sha256": "cef11c05a7cd4e64584b170f81c3a5e26972038baa20eb2bc6461edb61efc01a",
+      "bytes": 1346
+    },
+    {
+      "path": "scopes/users.read.md",
+      "url": "https://docs.slack.dev/reference/scopes/users.read.md",
+      "upstreamSha256": "f184c9ddb6344c1de7377698720a7afcd9599468ce7b2631ae2dae124b3b7635",
+      "sha256": "f184c9ddb6344c1de7377698720a7afcd9599468ce7b2631ae2dae124b3b7635",
+      "bytes": 744
     },
     {
       "path": "sdk/bots.ts",

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/admin.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/admin.md
@@ -1,0 +1,31 @@
+Source: https://docs.slack.dev/reference/scopes/admin
+
+# admin scope
+
+Administer a workspace
+
+## Facts
+
+**Supported token types**
+
+[`User`](/authentication/tokens#user)
+
+**Compatible API methods**
+
+[`admin.audit.anomaly.allow.getItem`](/reference/methods/admin.audit.anomaly.allow.getitem)
+
+[`admin.audit.anomaly.allow.updateItem`](/reference/methods/admin.audit.anomaly.allow.updateitem)
+
+[`team.accessLogs`](/reference/methods/team.accesslogs)
+
+[`team.billableInfo`](/reference/methods/team.billableinfo)
+
+[`team.integrationLogs`](/reference/methods/team.integrationlogs)
+
+## Usage info {#usage-info}
+
+This scope is quite special. It grants miscellaneous admin capabilities to the app that requests it, provided the installer is an admin allowed to grant those abilities.
+
+It allows access to [`team.accessLogs`](/reference/methods/team.accessLogs) and the [SCIM API](/admins/scim-api).
+
+This is not an all-inclusive list of admin token capabilities.

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/channels.history.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/channels.history.md
@@ -1,0 +1,53 @@
+Source: https://docs.slack.dev/reference/scopes/channels.history
+
+# channels:history scope
+
+View messages and other content in public channels that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.history`](/reference/methods/conversations.history)
+
+[`conversations.replies`](/reference/methods/conversations.replies)
+
+**Compatible events**
+
+[`assistant_app_thread`](/reference/events/assistant_app_thread)
+
+[`channel_convert_to_private`](/reference/events/channel_convert_to_private)
+
+[`channel_history_changed`](/reference/events/channel_history_changed)
+
+[`channel_posting_permissions`](/reference/events/channel_posting_permissions)
+
+[`document_mention`](/reference/events/document_mention)
+
+[`ekm_access_denied`](/reference/events/ekm_access_denied)
+
+[`me_message`](/reference/events/me_message)
+
+[`message`](/reference/events/message)
+
+[`message.channels`](/reference/events/message.channels)
+
+[`message_changed`](/reference/events/message_changed)
+
+[`message_deleted`](/reference/events/message_deleted)
+
+[`message_replied`](/reference/events/message_replied)
+
+[`reminder_add`](/reference/events/reminder_add)
+
+[`reply_broadcast`](/reference/events/reply_broadcast)
+
+[`thread_broadcast`](/reference/events/thread_broadcast)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/channels.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/channels.read.md
@@ -1,0 +1,49 @@
+Source: https://docs.slack.dev/reference/scopes/channels.read
+
+# channels:read scope
+
+View basic information about public channels in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.info`](/reference/methods/conversations.info)
+
+[`conversations.list`](/reference/methods/conversations.list)
+
+[`conversations.members`](/reference/methods/conversations.members)
+
+[`conversations.open`](/reference/methods/conversations.open)
+
+[`users.conversations`](/reference/methods/users.conversations)
+
+**Compatible events**
+
+[`channel_archive`](/reference/events/channel_archive)
+
+[`channel_created`](/reference/events/channel_created)
+
+[`channel_deleted`](/reference/events/channel_deleted)
+
+[`channel_left`](/reference/events/channel_left)
+
+[`channel_rename`](/reference/events/channel_rename)
+
+[`channel_shared`](/reference/events/channel_shared)
+
+[`channel_unarchive`](/reference/events/channel_unarchive)
+
+[`channel_unshared`](/reference/events/channel_unshared)
+
+[`member_joined_channel`](/reference/events/member_joined_channel)
+
+[`member_left_channel`](/reference/events/member_left_channel)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/conversations.connect.manage.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/conversations.connect.manage.md
@@ -1,0 +1,39 @@
+Source: https://docs.slack.dev/reference/scopes/conversations.connect.manage
+
+# conversations.connect:manage scope
+
+Allows your Slack app to manage Slack Connect channels
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.approveSharedInvite`](/reference/methods/conversations.approvesharedinvite)
+
+[`conversations.declineSharedInvite`](/reference/methods/conversations.declinesharedinvite)
+
+[`conversations.externalInvitePermissions.set`](/reference/methods/conversations.externalinvitepermissions.set)
+
+[`conversations.listConnectInvites`](/reference/methods/conversations.listconnectinvites)
+
+[`conversations.requestSharedInvite.approve`](/reference/methods/conversations.requestsharedinvite.approve)
+
+[`conversations.requestSharedInvite.deny`](/reference/methods/conversations.requestsharedinvite.deny)
+
+[`conversations.requestSharedInvite.list`](/reference/methods/conversations.requestsharedinvite.list)
+
+[`team.externalTeams.disconnect`](/reference/methods/team.externalteams.disconnect)
+
+[`team.externalTeams.list`](/reference/methods/team.externalteams.list)
+
+[`users.discoverableContacts.lookup`](/reference/methods/users.discoverablecontacts.lookup)
+
+## Usage info {#usage-info}
+
+This scope allows your app, when installed by an authorized user, to [manage (approve or decline) Slack Connect invitations](/apis/slack-connect/using-slack-connect-api-methods).

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/dnd.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/dnd.read.md
@@ -1,0 +1,25 @@
+Source: https://docs.slack.dev/reference/scopes/dnd.read
+
+# dnd:read scope
+
+View Do Not Disturb settings for people in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+**Compatible API methods**
+
+[`dnd.info`](/reference/methods/dnd.info)
+
+[`dnd.teamInfo`](/reference/methods/dnd.teaminfo)
+
+**Compatible events**
+
+[`dnd_updated`](/reference/events/dnd_updated)
+
+[`dnd_updated_user`](/reference/events/dnd_updated_user)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/emoji.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/emoji.read.md
@@ -1,0 +1,23 @@
+Source: https://docs.slack.dev/reference/scopes/emoji.read
+
+# emoji:read scope
+
+View custom emoji in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`emoji.list`](/reference/methods/emoji.list)
+
+**Compatible events**
+
+[`emoji_changed`](/reference/events/emoji_changed)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/files.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/files.read.md
@@ -1,0 +1,45 @@
+Source: https://docs.slack.dev/reference/scopes/files.read
+
+# files:read scope
+
+View files shared in channels and conversations that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`files.info`](/reference/methods/files.info)
+
+[`files.list`](/reference/methods/files.list)
+
+**Compatible events**
+
+[`file_change`](/reference/events/file_change)
+
+[`file_comment_added`](/reference/events/file_comment_added)
+
+[`file_comment_deleted`](/reference/events/file_comment_deleted)
+
+[`file_comment_edited`](/reference/events/file_comment_edited)
+
+[`file_created`](/reference/events/file_created)
+
+[`file_deleted`](/reference/events/file_deleted)
+
+[`file_public`](/reference/events/file_public)
+
+[`file_shared`](/reference/events/file_shared)
+
+[`file_unshared`](/reference/events/file_unshared)
+
+## Usage info {#usage-info}
+
+This scope allows an app to retrieve both information about files uploaded to workspaces as well as _download_ those files.

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/groups.history.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/groups.history.md
@@ -1,0 +1,55 @@
+Source: https://docs.slack.dev/reference/scopes/groups.history
+
+# groups:history scope
+
+View messages and other content in private channels that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.history`](/reference/methods/conversations.history)
+
+[`conversations.replies`](/reference/methods/conversations.replies)
+
+**Compatible events**
+
+[`assistant_app_thread`](/reference/events/assistant_app_thread)
+
+[`channel_convert_to_private`](/reference/events/channel_convert_to_private)
+
+[`channel_history_changed`](/reference/events/channel_history_changed)
+
+[`channel_posting_permissions`](/reference/events/channel_posting_permissions)
+
+[`document_mention`](/reference/events/document_mention)
+
+[`ekm_access_denied`](/reference/events/ekm_access_denied)
+
+[`group_history_changed`](/reference/events/group_history_changed)
+
+[`me_message`](/reference/events/me_message)
+
+[`message`](/reference/events/message)
+
+[`message.groups`](/reference/events/message.groups)
+
+[`message_changed`](/reference/events/message_changed)
+
+[`message_deleted`](/reference/events/message_deleted)
+
+[`message_replied`](/reference/events/message_replied)
+
+[`reminder_add`](/reference/events/reminder_add)
+
+[`reply_broadcast`](/reference/events/reply_broadcast)
+
+[`thread_broadcast`](/reference/events/thread_broadcast)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/groups.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/groups.read.md
@@ -1,0 +1,51 @@
+Source: https://docs.slack.dev/reference/scopes/groups.read
+
+# groups:read scope
+
+View basic information about private channels that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.info`](/reference/methods/conversations.info)
+
+[`conversations.list`](/reference/methods/conversations.list)
+
+[`conversations.members`](/reference/methods/conversations.members)
+
+[`conversations.open`](/reference/methods/conversations.open)
+
+[`users.conversations`](/reference/methods/users.conversations)
+
+**Compatible events**
+
+[`channel_shared`](/reference/events/channel_shared)
+
+[`channel_unshared`](/reference/events/channel_unshared)
+
+[`group_archive`](/reference/events/group_archive)
+
+[`group_close`](/reference/events/group_close)
+
+[`group_deleted`](/reference/events/group_deleted)
+
+[`group_left`](/reference/events/group_left)
+
+[`group_open`](/reference/events/group_open)
+
+[`group_rename`](/reference/events/group_rename)
+
+[`group_unarchive`](/reference/events/group_unarchive)
+
+[`member_joined_channel`](/reference/events/member_joined_channel)
+
+[`member_left_channel`](/reference/events/member_left_channel)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/im.history.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/im.history.md
@@ -1,0 +1,53 @@
+Source: https://docs.slack.dev/reference/scopes/im.history
+
+# im:history scope
+
+View messages and other content in direct messages that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.history`](/reference/methods/conversations.history)
+
+[`conversations.replies`](/reference/methods/conversations.replies)
+
+**Compatible events**
+
+[`assistant_app_thread`](/reference/events/assistant_app_thread)
+
+[`channel_convert_to_private`](/reference/events/channel_convert_to_private)
+
+[`channel_posting_permissions`](/reference/events/channel_posting_permissions)
+
+[`document_mention`](/reference/events/document_mention)
+
+[`ekm_access_denied`](/reference/events/ekm_access_denied)
+
+[`im_history_changed`](/reference/events/im_history_changed)
+
+[`me_message`](/reference/events/me_message)
+
+[`message`](/reference/events/message)
+
+[`message.im`](/reference/events/message.im)
+
+[`message_changed`](/reference/events/message_changed)
+
+[`message_deleted`](/reference/events/message_deleted)
+
+[`message_replied`](/reference/events/message_replied)
+
+[`reminder_add`](/reference/events/reminder_add)
+
+[`reply_broadcast`](/reference/events/reply_broadcast)
+
+[`thread_broadcast`](/reference/events/thread_broadcast)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/im.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/im.read.md
@@ -1,0 +1,33 @@
+Source: https://docs.slack.dev/reference/scopes/im.read
+
+# im:read scope
+
+View basic information about direct messages that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.info`](/reference/methods/conversations.info)
+
+[`conversations.list`](/reference/methods/conversations.list)
+
+[`conversations.members`](/reference/methods/conversations.members)
+
+[`users.conversations`](/reference/methods/users.conversations)
+
+**Compatible events**
+
+[`im_close`](/reference/events/im_close)
+
+[`im_created`](/reference/events/im_created)
+
+[`im_open`](/reference/events/im_open)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/mpim.history.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/mpim.history.md
@@ -1,0 +1,53 @@
+Source: https://docs.slack.dev/reference/scopes/mpim.history
+
+# mpim:history scope
+
+View messages and other content in group direct messages that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.history`](/reference/methods/conversations.history)
+
+[`conversations.replies`](/reference/methods/conversations.replies)
+
+**Compatible events**
+
+[`assistant_app_thread`](/reference/events/assistant_app_thread)
+
+[`channel_convert_to_private`](/reference/events/channel_convert_to_private)
+
+[`channel_history_changed`](/reference/events/channel_history_changed)
+
+[`channel_posting_permissions`](/reference/events/channel_posting_permissions)
+
+[`document_mention`](/reference/events/document_mention)
+
+[`ekm_access_denied`](/reference/events/ekm_access_denied)
+
+[`me_message`](/reference/events/me_message)
+
+[`message`](/reference/events/message)
+
+[`message.mpim`](/reference/events/message.mpim)
+
+[`message_changed`](/reference/events/message_changed)
+
+[`message_deleted`](/reference/events/message_deleted)
+
+[`message_replied`](/reference/events/message_replied)
+
+[`reminder_add`](/reference/events/reminder_add)
+
+[`reply_broadcast`](/reference/events/reply_broadcast)
+
+[`thread_broadcast`](/reference/events/thread_broadcast)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/mpim.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/mpim.read.md
@@ -1,0 +1,31 @@
+Source: https://docs.slack.dev/reference/scopes/mpim.read
+
+# mpim:read scope
+
+View basic information about group direct messages that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`conversations.info`](/reference/methods/conversations.info)
+
+[`conversations.list`](/reference/methods/conversations.list)
+
+[`conversations.members`](/reference/methods/conversations.members)
+
+[`conversations.open`](/reference/methods/conversations.open)
+
+[`users.conversations`](/reference/methods/users.conversations)
+
+**Compatible events**
+
+[`member_joined_channel`](/reference/events/member_joined_channel)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/pins.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/pins.read.md
@@ -1,0 +1,27 @@
+Source: https://docs.slack.dev/reference/scopes/pins.read
+
+# pins:read scope
+
+View pinned content in channels and conversations that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`pins.list`](/reference/methods/pins.list)
+
+**Compatible events**
+
+[`pin_added`](/reference/events/pin_added)
+
+[`pin_removed`](/reference/events/pin_removed)
+
+[`workflow_step_deleted`](/reference/events/workflow_step_deleted)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/reactions.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/reactions.read.md
@@ -1,0 +1,27 @@
+Source: https://docs.slack.dev/reference/scopes/reactions.read
+
+# reactions:read scope
+
+View emoji reactions and their associated content in channels and conversations that your Slack app has been added to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`reactions.get`](/reference/methods/reactions.get)
+
+[`reactions.list`](/reference/methods/reactions.list)
+
+**Compatible events**
+
+[`reaction_added`](/reference/events/reaction_added)
+
+[`reaction_removed`](/reference/events/reaction_removed)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/reminders.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/reminders.read.md
@@ -1,0 +1,21 @@
+Source: https://docs.slack.dev/reference/scopes/reminders.read
+
+# reminders:read scope
+
+View reminders created by your Slack app
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`reminders.info`](/reference/methods/reminders.info)
+
+[`reminders.list`](/reference/methods/reminders.list)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/remote_files.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/remote_files.read.md
@@ -1,0 +1,21 @@
+Source: https://docs.slack.dev/reference/scopes/remote_files.read
+
+# remote_files:read scope
+
+View remote files added by the app in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`files.remote.info`](/reference/methods/files.remote.info)
+
+[`files.remote.list`](/reference/methods/files.remote.list)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/search.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/search.read.md
@@ -1,0 +1,25 @@
+Source: https://docs.slack.dev/reference/scopes/search.read
+
+# search:read scope
+
+Search a workspace's content
+
+## Facts
+
+**Supported token types**
+
+[`User`](/authentication/tokens#user)
+
+**Compatible API methods**
+
+[`search.all`](/reference/methods/search.all)
+
+[`search.files`](/reference/methods/search.files)
+
+[`search.messages`](/reference/methods/search.messages)
+
+## Usage info {#usage-info}
+
+This is a legacy scope
+
+We recommend using the more granular [scopes](/apis/web-api/real-time-search-api#required-scopes) associated with the [Real-time Search API](/apis/web-api/real-time-search-api) instead.

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/stars.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/stars.read.md
@@ -1,0 +1,21 @@
+Source: https://docs.slack.dev/reference/scopes/stars.read
+
+# stars:read scope
+
+View a user's starred messages and files
+
+## Facts
+
+**Supported token types**
+
+[`User`](/authentication/tokens#user)
+
+**Compatible API methods**
+
+[`stars.list`](/reference/methods/stars.list)
+
+**Compatible events**
+
+[`star_added`](/reference/events/star_added)
+
+[`star_removed`](/reference/events/star_removed)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/team.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/team.read.md
@@ -1,0 +1,29 @@
+Source: https://docs.slack.dev/reference/scopes/team.read
+
+# team:read scope
+
+View the name, email domain, and icon for workspaces your Slack app is connected to
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+**Compatible API methods**
+
+[`team.externalTeams.list`](/reference/methods/team.externalteams.list)
+
+[`team.info`](/reference/methods/team.info)
+
+[`users.discoverableContacts.lookup`](/reference/methods/users.discoverablecontacts.lookup)
+
+**Compatible events**
+
+[`email_domain_changed`](/reference/events/email_domain_changed)
+
+[`team_domain_change`](/reference/events/team_domain_change)
+
+[`team_rename`](/reference/events/team_rename)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/usergroups.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/usergroups.read.md
@@ -1,0 +1,33 @@
+Source: https://docs.slack.dev/reference/scopes/usergroups.read
+
+# usergroups:read scope
+
+View user groups in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`usergroups.list`](/reference/methods/usergroups.list)
+
+[`usergroups.users.list`](/reference/methods/usergroups.users.list)
+
+**Compatible events**
+
+[`subteam_created`](/reference/events/subteam_created)
+
+[`subteam_members_changed`](/reference/events/subteam_members_changed)
+
+[`subteam_self_added`](/reference/events/subteam_self_added)
+
+[`subteam_self_removed`](/reference/events/subteam_self_removed)
+
+[`subteam_updated`](/reference/events/subteam_updated)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/users.profile.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/users.profile.read.md
@@ -1,0 +1,21 @@
+Source: https://docs.slack.dev/reference/scopes/users.profile.read
+
+# users.profile:read scope
+
+View profile details about people in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`team.profile.get`](/reference/methods/team.profile.get)
+
+[`users.profile.get`](/reference/methods/users.profile.get)

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/users.read.email.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/users.read.email.md
@@ -1,0 +1,29 @@
+Source: https://docs.slack.dev/reference/scopes/users.read.email
+
+# users:read.email scope
+
+View email addresses of people in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`users.lookupByEmail`](/reference/methods/users.lookupbyemail)
+
+## Usage info {#usage-info}
+
+Your Slack app may gain access to email addresses belonging to team members in a workspace by asking for `users:read.email`. This scope is now required to access the `email` field in user profiles retrieved with the Web API when using user or workspace tokens. Classic [`bot`](/authentication/tokens) tokens are granted access to the `email` field without needing further scopes.
+
+This scope must be requested at the same time as [`users:read`](/reference/scopes/users.read).
+
+Accessing Email Addresses
+
+The [`users:read.email`](/reference/scopes/users.read.email) OAuth scope is now required to access the `email` field in user objects returned by the [`users.list`](/reference/methods/users.list) and [`users.info`](/reference/methods/users.info) web API methods. [`users:read`](/reference/scopes/users.read) is no longer a sufficient scope for this data field. [Learn more](/changelog/2017-04-narrowing-email-access).

--- a/tools/openapi-forge/apis/slack/snapshot/scopes/users.read.md
+++ b/tools/openapi-forge/apis/slack/snapshot/scopes/users.read.md
@@ -1,0 +1,35 @@
+Source: https://docs.slack.dev/reference/scopes/users.read
+
+# users:read scope
+
+View people in a workspace
+
+## Facts
+
+**Supported token types**
+
+[`Bot`](/authentication/tokens#bot)
+
+[`User`](/authentication/tokens#user)
+
+[`Legacy Bot`](/authentication/tokens#legacy-bot)
+
+**Compatible API methods**
+
+[`bots.info`](/reference/methods/bots.info)
+
+[`users.getPresence`](/reference/methods/users.getpresence)
+
+[`users.info`](/reference/methods/users.info)
+
+[`users.list`](/reference/methods/users.list)
+
+**Compatible events**
+
+[`team_join`](/reference/events/team_join)
+
+[`user_change`](/reference/events/user_change)
+
+[`user_status_changed`](/reference/events/user_status_changed)
+
+[`user_profile_changed`](/reference/events/user_profile_changed)

--- a/tools/openapi-forge/src/adapters/slack/discover.ts
+++ b/tools/openapi-forge/src/adapters/slack/discover.ts
@@ -115,6 +115,11 @@ export function sampleUrlFor(method: string): string {
   return `${SAMPLE_RAW_BASE}/${method}.json`
 }
 
+/** The reference page for one scope, e.g. `channels.read`. */
+export function scopeUrlFor(slug: string): string {
+  return `${DOCS_ORIGIN}/reference/scopes/${slug}.md`
+}
+
 /**
  * Join the two indexes.
  *

--- a/tools/openapi-forge/src/adapters/slack/docs.ts
+++ b/tools/openapi-forge/src/adapters/slack/docs.ts
@@ -46,6 +46,12 @@ export interface DocsFacts {
    * omission from reading as a documentation gap.
    */
   documentedArguments: string[]
+  /**
+   * Scope name to the slug of its reference page. Taken from the link href
+   * rather than derived from the name, because the two differ:
+   * `conversations.connect:manage` lives at `conversations.connect.manage`.
+   */
+  scopeSlugs: Record<string, string>
   warnings: string[]
 }
 
@@ -60,7 +66,7 @@ const SOURCE_LINE = /^Source:\s*(\S+)/m
 const DESCRIPTION = /^\*\*Description\*\*(.*)$/m
 const REQUEST_LINE = /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(https?:\/\/\S+)$/m
 const RATE_LIMIT = /^\*\*Rate Limits\*\*\[([^\]]+)]/m
-const SCOPE_LINK = /\[`([^`]+)`]\(\/reference\/scopes\//g
+const SCOPE_LINK = /\[`([^`]+)`]\(\/reference\/scopes\/([^)]+)\)/g
 const ARGUMENT_HEADING = /^\*\*`([^`]+)`\*\*`([^`]+)`(Required|Optional)$/gm
 const DEFAULT_VALUE = /^_Default:_\s*`?([^`\n]*)`?$/m
 const EXAMPLE_VALUE = /^_Example:_\s*`?([^`\n]*)`?$/m
@@ -100,6 +106,7 @@ export function parseDocsPage(markdown: string, serverUrl: string): DocsFacts {
     httpMethod,
     description: cleanText(DESCRIPTION.exec(markdown)?.[1] ?? ''),
     scopes: parseScopes(markdown),
+    scopeSlugs: parseScopeSlugs(markdown),
     ...(rateLimitTier === undefined ? {} : { rateLimitTier }),
     parameters,
     documentedArguments,
@@ -128,6 +135,21 @@ function parseScopes(markdown: string): Scopes {
   const botPart = userIndex === -1 ? section : section.slice(0, userIndex)
   const userPart = userIndex === -1 ? '' : section.slice(userIndex)
   return { bot: scopeNames(botPart), user: scopeNames(userPart) }
+}
+
+/** Every scope the page links to, mapped to its reference-page slug. */
+function parseScopeSlugs(markdown: string): Record<string, string> {
+  const slugs: Record<string, string> = {}
+  const section = sliceBetween(markdown, '**Scopes**', '**Content types**')
+  for (const match of (section ?? '').matchAll(SCOPE_LINK)) {
+    const [, name, slug] = match
+    if (name !== undefined && slug !== undefined) {
+      slugs[name] = slug
+    }
+  }
+  return Object.fromEntries(
+    Object.entries(slugs).toSorted(([left], [right]) => left.localeCompare(right)),
+  )
 }
 
 function scopeNames(text: string): string[] {

--- a/tools/openapi-forge/src/adapters/slack/extract.ts
+++ b/tools/openapi-forge/src/adapters/slack/extract.ts
@@ -5,13 +5,23 @@
  * what is committed.
  */
 
-import type { ApiModel, ObjectNode, Operation, SchemaNode } from '../../core/model.ts'
+import type {
+  ApiModel,
+  ObjectNode,
+  Operation,
+  SchemaNode,
+  Scopes,
+  SecurityRequirement,
+  SecurityScheme,
+} from '../../core/model.ts'
 import type { ForgeConfig } from '../../core/config.ts'
 import type { Snapshot } from '../../core/snapshot.ts'
 import { inferSchema } from '../../core/infer.ts'
 import { pascalCase } from '../../core/emit.ts'
 import { parseDocsPage, parseSourceUrl } from './docs.ts'
 import { crossCheckArguments, parseSdkTypes } from './sdkTypes.ts'
+import type { ScopeFacts } from './scopes.ts'
+import { parseScopePage } from './scopes.ts'
 
 /** One method's inputs within the snapshot. */
 interface SnapshotEntry {
@@ -42,6 +52,8 @@ export async function extractApiModel(config: ForgeConfig, snapshot: Snapshot): 
   }
 
   const sdk = await readSdkTypes(snapshot)
+  const scopeFacts = await readScopeFacts(snapshot)
+  const undescribed = new Set<string>()
   const operations: Operation[] = []
   for (const entry of entries) {
     if (!configured.has(entry.method.toLowerCase())) {
@@ -50,14 +62,108 @@ export async function extractApiModel(config: ForgeConfig, snapshot: Snapshot): 
     operations.push(await buildOperation(entry, config, snapshot, sdk))
   }
 
+  const securitySchemes = buildSecuritySchemes(config, operations, scopeFacts, undescribed)
+  if (undescribed.size > 0) {
+    warnings.push(
+      `Slack publishes no reference page for these scopes, so they are emitted ` +
+        `without a description: ${[...undescribed].toSorted().join(', ')}`,
+    )
+  }
+
   return {
     api: config.api,
     title: config.title,
     description: config.description,
     serverUrl: config.serverUrl,
+    securitySchemes,
     operations: operations.toSorted((left, right) => left.id.localeCompare(right.id)),
     warnings,
   }
+}
+
+/** Scope reference pages, keyed by scope name. */
+async function readScopeFacts(snapshot: Snapshot): Promise<Map<string, ScopeFacts>> {
+  const facts = new Map<string, ScopeFacts>()
+  for (const input of snapshot.list('scopes/')) {
+    const parsed = parseScopePage(await snapshot.readText(input.path))
+    facts.set(parsed.name, parsed)
+  }
+  return facts
+}
+
+/**
+ * One scheme per configured token class, carrying the scopes in-scope
+ * operations actually use.
+ *
+ * OpenAPI requires every scope named in a `security` requirement to be
+ * declared by its scheme, so the scope map is built from the operations rather
+ * than from the full published list.
+ */
+function buildSecuritySchemes(
+  config: ForgeConfig,
+  operations: readonly Operation[],
+  scopeFacts: ReadonlyMap<string, ScopeFacts>,
+  undescribed: Set<string>,
+): SecurityScheme[] {
+  return config.securitySchemes.map((declared) => {
+    const scopes: Record<string, string> = {}
+    for (const operation of operations) {
+      for (const requirement of operation.security) {
+        if (requirement.scheme !== declared.name) {
+          continue
+        }
+        for (const scope of requirement.scopes) {
+          scopes[scope] = scopeFacts.get(scope)?.description ?? ''
+          if (!scopeFacts.has(scope)) {
+            undescribed.add(scope)
+          }
+        }
+      }
+    }
+    return {
+      name: declared.name,
+      description: declared.description,
+      authorizationUrl: declared.authorizationUrl,
+      tokenUrl: declared.tokenUrl,
+      scopes: Object.fromEntries(
+        Object.entries(scopes).toSorted(([left], [right]) => left.localeCompare(right)),
+      ),
+    }
+  })
+}
+
+/**
+ * Turn documented scopes into OpenAPI security requirements.
+ *
+ * Slack lists a method's scopes without saying how they relate, and the
+ * relationship differs: `conversations.list` accepts *any* of
+ * `channels:read`/`groups:read`/`im:read`/`mpim:read` — one per conversation
+ * type — while `team.externalTeams.list` needs *both* `team:read` and
+ * `conversations.connect:manage`. The two render identically, so the default is
+ * `any` and the overlay declares the exceptions.
+ */
+export function buildSecurity(
+  scopes: Scopes,
+  config: ForgeConfig,
+  relation: 'any' | 'all',
+): SecurityRequirement[] {
+  const requirements: SecurityRequirement[] = []
+  for (const scheme of config.securitySchemes) {
+    const granted = scheme.tokenClass === 'bot' ? scopes.bot : scopes.user
+    if (granted.length === 0) {
+      // A token class the operation does not accept at all — Slack omits the
+      // section entirely rather than listing an empty one.
+      continue
+    }
+    if (relation === 'all') {
+      requirements.push({ scheme: scheme.name, scopes: [...granted] })
+      continue
+    }
+    for (const scope of granted) {
+      requirements.push({ scheme: scheme.name, scopes: [scope] })
+    }
+  }
+  return requirements
 }
 
 /**
@@ -137,6 +243,7 @@ async function buildOperation(
     deprecated: false,
     ...(docsUrl === undefined ? {} : { docsUrl }),
     scopes: facts.scopes,
+    security: buildSecurity(facts.scopes, config, 'any'),
     ...(facts.rateLimitTier === undefined ? {} : { rateLimitTier: facts.rateLimitTier }),
     parameters: facts.parameters,
     response,

--- a/tools/openapi-forge/src/adapters/slack/index.ts
+++ b/tools/openapi-forge/src/adapters/slack/index.ts
@@ -21,12 +21,14 @@ import { applyOverlay, loadOverlay } from '../../core/overlay.ts'
 import { pruneSample } from '../../core/prune.ts'
 import { Snapshot, SnapshotWriter } from '../../core/snapshot.ts'
 import { extractApiModel } from './extract.ts'
+import { parseDocsPage } from './docs.ts'
 import {
   joinIndexes,
   parseMethodIndex,
   parseSampleIndex,
   parseSdkIndex,
   SAMPLE_INDEX_URL,
+  scopeUrlFor,
   SDK_INDEX_URL,
   sdkFilesFor,
   sdkUrlFor,
@@ -175,6 +177,33 @@ async function fetchSnapshot(): Promise<void> {
     sampleBytes += sample.length
     prunedBytes += pruned.length
     writer.add(samplePath(method), method.sampleUrl, sample, pruned)
+  }
+
+  // Which scope pages matter is only knowable from the method pages, so this
+  // round happens after they are in hand.
+  const scopeSlugs = new Set<string>()
+  for (const method of selected) {
+    const docs = bodies.get(method.docsUrl)
+    if (docs !== undefined) {
+      const facts = parseDocsPage(new TextDecoder().decode(docs), config.serverUrl)
+      for (const slug of Object.values(facts.scopeSlugs)) {
+        scopeSlugs.add(slug)
+      }
+    }
+  }
+  const scopeUrls = [...scopeSlugs].toSorted().map((slug) => scopeUrlFor(slug))
+  log(`downloading ${scopeUrls.length} scope reference pages`)
+  // Slack links to pages it does not always publish — `identity:read` 404s —
+  // so a missing one is recorded rather than fatal. The build then warns that
+  // the scope has no description.
+  const scopeBodies = await fetchAllBytes(scopeUrls, { optional: true })
+  for (const slug of [...scopeSlugs].toSorted()) {
+    const body = scopeBodies.get(scopeUrlFor(slug))
+    if (body === undefined) {
+      log(`  ${slug}: no scope reference page published`)
+      continue
+    }
+    writer.add(`scopes/${slug}.md`, scopeUrlFor(slug), body, new TextDecoder().decode(body))
   }
 
   const sdkFiles = sdkFilesFor(config.methods, parseSdkIndex(await fetchText(SDK_INDEX_URL)))

--- a/tools/openapi-forge/src/adapters/slack/scopes.ts
+++ b/tools/openapi-forge/src/adapters/slack/scopes.ts
@@ -1,0 +1,74 @@
+/**
+ * Parsing Slack's scope reference pages.
+ *
+ * Every scope has a page at `/reference/scopes/<slug>`, and the method pages
+ * link to it. The page opens with a one-line description — exactly what
+ * `securitySchemes.*.flows.*.scopes` wants — and states which token types can
+ * hold the scope, which independently confirms the bot/user split read off the
+ * method pages.
+ *
+ * ```
+ * # channels:read scope
+ * View basic information about public channels in a workspace
+ * ## Facts
+ * **Supported token types**
+ * [`Bot`](/authentication/tokens#bot)[`User`](/authentication/tokens#user)
+ * ```
+ */
+
+const HEADING = /^#\s+(\S+)\s+scope\s*$/m
+const TOKEN_TYPE = /\[`([^`]+)`]\(\/authentication\/tokens#/g
+
+/** One scope, as its reference page describes it. */
+export interface ScopeFacts {
+  /** The scope itself, e.g. `channels:read`. */
+  name: string
+  description: string
+  /** Token classes that may hold it, lowercased: `bot`, `user`, … */
+  tokenClasses: string[]
+}
+
+export class ScopeParseError extends Error {}
+
+export function parseScopePage(markdown: string): ScopeFacts {
+  const heading = HEADING.exec(markdown)
+  if (heading?.[1] === undefined) {
+    throw new ScopeParseError('no "# <scope> scope" heading found')
+  }
+
+  return {
+    name: heading[1],
+    description: descriptionAfter(markdown, heading.index + heading[0].length),
+    tokenClasses: tokenClasses(markdown),
+  }
+}
+
+/**
+ * The first prose line after the heading.
+ *
+ * Stops at the `## Facts` section, so a page with no description yields an
+ * empty string rather than swallowing the section that follows it.
+ */
+function descriptionAfter(markdown: string, from: number): string {
+  for (const line of markdown.slice(from).split('\n')) {
+    const text = line.trim()
+    if (text === '') {
+      continue
+    }
+    if (text.startsWith('#')) {
+      return ''
+    }
+    return text
+  }
+  return ''
+}
+
+function tokenClasses(markdown: string): string[] {
+  const classes = new Set<string>()
+  for (const match of markdown.matchAll(TOKEN_TYPE)) {
+    if (match[1] !== undefined) {
+      classes.add(match[1].toLowerCase())
+    }
+  }
+  return [...classes].toSorted((left, right) => left.localeCompare(right))
+}

--- a/tools/openapi-forge/src/core/config.ts
+++ b/tools/openapi-forge/src/core/config.ts
@@ -17,6 +17,22 @@ export const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..
 
 export class ConfigError extends Error {}
 
+/**
+ * One declared security scheme.
+ *
+ * The endpoints are here rather than extracted because providers document them
+ * in prose, not in a form worth scraping. `tokenClass` is what ties the scheme
+ * to the credential class an operation's documentation names.
+ */
+export interface SecuritySchemeConfig {
+  name: string
+  /** Credential class this scheme represents, e.g. `bot` or `user`. */
+  tokenClass: string
+  description: string
+  authorizationUrl: string
+  tokenUrl: string
+}
+
 export interface ForgeConfig {
   api: string
   title: string
@@ -25,6 +41,8 @@ export interface ForgeConfig {
   serverUrl: string
   /** Operation identifiers in scope, in the provider's own casing. */
   methods: string[]
+  /** Empty when the API's auth is not modelled in the descriptor. */
+  securitySchemes: SecuritySchemeConfig[]
   /** Directory holding config, overlay, and snapshot. */
   apiDir: string
   snapshotDir: string
@@ -40,6 +58,7 @@ interface RawConfig {
   serverUrl?: unknown
   output?: unknown
   scope?: { methods?: unknown }
+  security?: { schemes?: unknown }
 }
 
 export function apiDir(api: string): string {
@@ -88,11 +107,49 @@ export function parseConfig(raw: string, dir: string, path: string): ForgeConfig
     description: requireString(parsed.description, 'description', path),
     serverUrl: requireString(parsed.serverUrl, 'serverUrl', path),
     methods: (methods as string[]).toSorted((left, right) => left.localeCompare(right)),
+    securitySchemes: parseSecuritySchemes(parsed.security?.schemes, path),
     apiDir: dir,
     snapshotDir: join(dir, 'snapshot'),
     overlayPath: join(dir, 'overlay.yaml'),
     outputPath: isAbsolute(output) ? output : resolve(dir, output),
   }
+}
+
+function parseSecuritySchemes(value: unknown, path: string): SecuritySchemeConfig[] {
+  if (value === undefined) {
+    return []
+  }
+  if (!Array.isArray(value)) {
+    throw new ConfigError(`${path}: security.schemes must be a list`)
+  }
+  const schemes = value.map((entry, index) => {
+    const where = `${path}: security.schemes[${index}]`
+    if (typeof entry !== 'object' || entry === null) {
+      throw new ConfigError(`${where} must be a mapping`)
+    }
+    const scheme = entry as Record<string, unknown>
+    return {
+      name: requireString(scheme.name, 'name', where),
+      tokenClass: requireString(scheme.tokenClass, 'tokenClass', where),
+      description: requireString(scheme.description, 'description', where),
+      authorizationUrl: requireString(scheme.authorizationUrl, 'authorizationUrl', where),
+      tokenUrl: requireString(scheme.tokenUrl, 'tokenUrl', where),
+    }
+  })
+
+  // Both are keys elsewhere — scheme names in components, token classes when
+  // matching an operation's documented credentials — so duplicates would
+  // silently drop one.
+  for (const field of ['name', 'tokenClass'] as const) {
+    const seen = new Set<string>()
+    for (const scheme of schemes) {
+      if (seen.has(scheme[field])) {
+        throw new ConfigError(`${path}: two security schemes share the ${field} '${scheme[field]}'`)
+      }
+      seen.add(scheme[field])
+    }
+  }
+  return schemes
 }
 
 function requireString(value: unknown, field: string, path: string): string {

--- a/tools/openapi-forge/src/core/emit.ts
+++ b/tools/openapi-forge/src/core/emit.ts
@@ -17,7 +17,7 @@
 
 import { stringify } from 'yaml'
 
-import type { ApiModel, Operation, Parameter, SchemaNode } from './model.ts'
+import type { ApiModel, Operation, Parameter, SchemaNode, SecurityScheme } from './model.ts'
 
 export const OPENAPI_VERSION = '3.0.3'
 
@@ -74,10 +74,44 @@ function buildDocument(model: ApiModel, options: EmitOptions): JsonObject {
     paths,
   }
   const schemas = components.schemas()
-  if (Object.keys(schemas).length > 0) {
-    document.components = { schemas }
+  const securitySchemes = buildSecuritySchemes(model.securitySchemes)
+  if (Object.keys(schemas).length > 0 || Object.keys(securitySchemes).length > 0) {
+    document.components = {
+      ...(Object.keys(securitySchemes).length > 0 ? { securitySchemes } : {}),
+      ...(Object.keys(schemas).length > 0 ? { schemas } : {}),
+    }
   }
   return document
+}
+
+/**
+ * The declared authorization schemes.
+ *
+ * Every provider modelled here issues tokens through an authorization-code
+ * flow, which is the only flow OpenAPI can describe well enough to be worth
+ * emitting: it names the endpoints and enumerates the scopes.
+ */
+function buildSecuritySchemes(schemes: readonly SecurityScheme[]): JsonObject {
+  const emitted: JsonObject = {}
+  for (const scheme of schemes) {
+    if (Object.keys(scheme.scopes).length === 0) {
+      // A scheme no in-scope operation accepts would declare an empty scope
+      // map, which says nothing.
+      continue
+    }
+    emitted[scheme.name] = {
+      type: 'oauth2',
+      description: scheme.description,
+      flows: {
+        authorizationCode: {
+          authorizationUrl: scheme.authorizationUrl,
+          tokenUrl: scheme.tokenUrl,
+          scopes: scheme.scopes,
+        },
+      },
+    }
+  }
+  return emitted
 }
 
 function buildOperation(operation: Operation, components: ComponentRegistry): JsonObject {
@@ -92,6 +126,12 @@ function buildOperation(operation: Operation, components: ComponentRegistry): Js
   }
   if (operation.parameters.length > 0) {
     emitted.parameters = operation.parameters.map((parameter) => buildParameter(parameter))
+  }
+  if (operation.security.length > 0) {
+    // Each entry is an alternative; scopes within an entry are all required.
+    emitted.security = operation.security.map((requirement) => ({
+      [requirement.scheme]: requirement.scopes,
+    }))
   }
   emitted.responses = {
     '200': {
@@ -309,6 +349,64 @@ export function assertImportable(document: JsonObject): void {
   }
 
   assertUniqueOperationIds(document)
+  assertSecurityResolves(document)
+}
+
+/**
+ * Every scheme and scope named by an operation must be declared.
+ *
+ * OpenAPI requires it, and it is the check that catches drift: an operation
+ * that gains a scope upstream would otherwise reference one the scheme never
+ * declares, which most tooling silently ignores.
+ */
+function assertSecurityResolves(document: JsonObject): void {
+  const components = isJsonObject(document.components) ? document.components : {}
+  const schemes = isJsonObject(components.securitySchemes) ? components.securitySchemes : {}
+
+  const declared = new Map<string, Set<string>>()
+  for (const [name, scheme] of Object.entries(schemes)) {
+    const flows = isJsonObject(scheme) && isJsonObject(scheme.flows) ? scheme.flows : {}
+    const scopes = new Set<string>()
+    for (const flow of Object.values(flows)) {
+      if (isJsonObject(flow) && isJsonObject(flow.scopes)) {
+        for (const scope of Object.keys(flow.scopes)) {
+          scopes.add(scope)
+        }
+      }
+    }
+    declared.set(name, scopes)
+  }
+
+  for (const [path, item] of Object.entries(isJsonObject(document.paths) ? document.paths : {})) {
+    if (!isJsonObject(item)) {
+      continue
+    }
+    for (const [method, operation] of Object.entries(item)) {
+      if (!isJsonObject(operation) || !Array.isArray(operation.security)) {
+        continue
+      }
+      for (const requirement of operation.security) {
+        if (!isJsonObject(requirement)) {
+          continue
+        }
+        for (const [scheme, scopes] of Object.entries(requirement)) {
+          const known = declared.get(scheme)
+          if (known === undefined) {
+            throw new EmitError(
+              `${method.toUpperCase()} ${path} requires undeclared security scheme '${scheme}'`,
+            )
+          }
+          for (const scope of Array.isArray(scopes) ? scopes : []) {
+            if (typeof scope === 'string' && !known.has(scope)) {
+              throw new EmitError(
+                `${method.toUpperCase()} ${path} requires scope '${scope}', which '${scheme}' does not declare`,
+              )
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 function assertUniqueOperationIds(document: JsonObject): void {

--- a/tools/openapi-forge/src/core/http.ts
+++ b/tools/openapi-forge/src/core/http.ts
@@ -45,6 +45,18 @@ export async function fetchText(url: string): Promise<string> {
   return new TextDecoder().decode(await fetchBytes(url))
 }
 
+export interface FetchAllOptions {
+  concurrency?: number
+  /**
+   * Treat a "not found" as an absent result rather than a failure.
+   *
+   * For inputs a provider links to but does not always publish — Slack links
+   * to a reference page for `identity:read` that returns 404 — the alternative
+   * is failing the whole fetch over one missing page.
+   */
+  optional?: boolean
+}
+
 /**
  * Fetch many URLs with a bounded number in flight.
  *
@@ -53,24 +65,29 @@ export async function fetchText(url: string): Promise<string> {
  */
 export async function fetchAllBytes(
   urls: readonly string[],
-  concurrency: number = DEFAULT_CONCURRENCY,
-  onProgress?: (completed: number, total: number) => void,
+  options: FetchAllOptions = {},
 ): Promise<Map<string, Uint8Array>> {
   const results = new Map<string, Uint8Array>()
   const queue = [...new Set(urls)]
-  let completed = 0
 
-  const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
-    for (;;) {
-      const url = queue.shift()
-      if (url === undefined) {
-        return
+  const workers = Array.from(
+    { length: Math.min(options.concurrency ?? DEFAULT_CONCURRENCY, queue.length) },
+    async () => {
+      for (;;) {
+        const url = queue.shift()
+        if (url === undefined) {
+          return
+        }
+        try {
+          results.set(url, await fetchBytes(url))
+        } catch (error) {
+          if (!(options.optional === true && error instanceof FetchError)) {
+            throw error
+          }
+        }
       }
-      results.set(url, await fetchBytes(url))
-      completed += 1
-      onProgress?.(completed, results.size + queue.length)
-    }
-  })
+    },
+  )
 
   await Promise.all(workers)
   return results

--- a/tools/openapi-forge/src/core/model.ts
+++ b/tools/openapi-forge/src/core/model.ts
@@ -85,10 +85,39 @@ export interface Parameter {
   example?: string | number | boolean
 }
 
-/** Provider-documented auth scopes. Informational — Coral ignores them. */
+/** Provider-documented auth scopes, grouped by the token class that grants them. */
 export interface Scopes {
   bot: string[]
   user: string[]
+}
+
+/**
+ * One OAuth2 security scheme, emitted under `components.securitySchemes`.
+ *
+ * Providers that issue more than one class of token — an app/bot credential
+ * and a user credential, say — get one scheme each, because the scopes
+ * available to them differ and an operation may accept only one of the two.
+ */
+export interface SecurityScheme {
+  /** Key under `components.securitySchemes`, e.g. `slackBotToken`. */
+  name: string
+  description: string
+  authorizationUrl: string
+  tokenUrl: string
+  /** Scope name to its documented description. */
+  scopes: Record<string, string>
+}
+
+/**
+ * One way to authorize an operation.
+ *
+ * Scopes listed together are all required; alternatives are expressed by
+ * listing several requirements, matching OpenAPI's own semantics.
+ */
+export interface SecurityRequirement {
+  /** The {@link SecurityScheme} this satisfies. */
+  scheme: string
+  scopes: string[]
 }
 
 export interface Operation {
@@ -111,6 +140,11 @@ export interface Operation {
   /** Where this operation was extracted from, for provenance. */
   docsUrl?: string
   scopes?: Scopes
+  /**
+   * Accepted authorizations, as alternatives. Empty when the provider
+   * documents no scopes for the operation.
+   */
+  security: SecurityRequirement[]
   /** The provider's rate-limit tier label, if it publishes one. */
   rateLimitTier?: string
   parameters: Parameter[]
@@ -127,6 +161,8 @@ export interface ApiModel {
   description: string
   /** Absolute URL every operation path is relative to. */
   serverUrl: string
+  /** Schemes referenced by {@link Operation.security}. */
+  securitySchemes: SecurityScheme[]
   operations: Operation[]
   /** Problems that are not specific to one operation. */
   warnings: string[]

--- a/tools/openapi-forge/src/core/overlay.ts
+++ b/tools/openapi-forge/src/core/overlay.ts
@@ -15,7 +15,7 @@ import { readFile } from 'node:fs/promises'
 
 import { parse } from 'yaml'
 
-import type { ApiModel, Operation, Parameter, ScalarType } from './model.ts'
+import type { ApiModel, Operation, Parameter, ScalarType, SecurityRequirement } from './model.ts'
 
 export class OverlayError extends Error {}
 
@@ -46,6 +46,16 @@ export interface ResponseOverride {
   reason?: string
 }
 
+/**
+ * How an operation's documented scopes relate to one another.
+ *
+ * Providers routinely list several scopes without saying whether they are
+ * alternatives or a set that must all be held, and the answer differs per
+ * operation. `any` treats each scope as sufficient on its own; `all` requires
+ * the whole set.
+ */
+export type ScopeRelation = 'any' | 'all'
+
 export interface OperationOverride {
   summary?: string
   description?: string
@@ -54,6 +64,8 @@ export interface OperationOverride {
   drop?: boolean
   parameters?: Record<string, ParameterOverride>
   response?: ResponseOverride
+  /** Defaults to `any`; set `all` where the scopes are jointly required. */
+  scopeRelation?: ScopeRelation
   reason?: string
 }
 
@@ -181,7 +193,35 @@ function applyToOperation(
     ...(override?.deprecated === undefined ? {} : { deprecated: override.deprecated }),
     parameters,
     response: dropResponseProperties(operation, override?.response?.dropProperties, usage),
+    security: applyScopeRelation(operation.security, override?.scopeRelation),
   }
+}
+
+/**
+ * Regroup an operation's security requirements.
+ *
+ * Extraction emits one requirement per scope, which is what `any` means. `all`
+ * collapses every requirement for the same scheme into one, since scopes listed
+ * together inside a single requirement are jointly required.
+ */
+function applyScopeRelation(
+  security: SecurityRequirement[],
+  relation: ScopeRelation | undefined,
+): SecurityRequirement[] {
+  if (relation !== 'all' || security.length === 0) {
+    return security
+  }
+  const byScheme = new Map<string, string[]>()
+  for (const requirement of security) {
+    const scopes = byScheme.get(requirement.scheme) ?? []
+    for (const scope of requirement.scopes) {
+      if (!scopes.includes(scope)) {
+        scopes.push(scope)
+      }
+    }
+    byScheme.set(requirement.scheme, scopes)
+  }
+  return [...byScheme].map(([scheme, scopes]) => ({ scheme, scopes }))
 }
 
 function dropResponseProperties(

--- a/tools/openapi-forge/test/config.test.ts
+++ b/tools/openapi-forge/test/config.test.ts
@@ -51,6 +51,61 @@ describe('parseConfig', () => {
   })
 })
 
+function withSchemes(schemes: string): string {
+  return `${VALID}\nsecurity:\n  schemes:\n${schemes}`
+}
+
+function scheme(name: string, tokenClass: string): string {
+  return (
+    `    - name: ${name}\n      tokenClass: ${tokenClass}\n      description: A token.\n` +
+    `      authorizationUrl: https://example.com/auth\n      tokenUrl: https://example.com/token\n`
+  )
+}
+
+describe('parseConfig security', () => {
+  it('defaults to no schemes', () => {
+    expect(parseConfig(VALID, '/dir', 'config.yaml').securitySchemes).toEqual([])
+  })
+
+  it('parses declared schemes', () => {
+    const config = parseConfig(withSchemes(scheme('botToken', 'bot')), '/dir', 'config.yaml')
+
+    expect(config.securitySchemes).toEqual([
+      {
+        name: 'botToken',
+        tokenClass: 'bot',
+        description: 'A token.',
+        authorizationUrl: 'https://example.com/auth',
+        tokenUrl: 'https://example.com/token',
+      },
+    ])
+  })
+
+  /** Both are keys, so a duplicate would silently drop one. */
+  it('rejects two schemes sharing a name or a token class', () => {
+    expect(() =>
+      parseConfig(
+        withSchemes(scheme('botToken', 'bot') + scheme('botToken', 'user')),
+        '/dir',
+        'config.yaml',
+      ),
+    ).toThrow(/share the name/)
+    expect(() =>
+      parseConfig(
+        withSchemes(scheme('botToken', 'bot') + scheme('otherToken', 'bot')),
+        '/dir',
+        'config.yaml',
+      ),
+    ).toThrow(/share the tokenClass/)
+  })
+
+  it('names the missing field', () => {
+    const broken = scheme('botToken', 'bot').replace(/      tokenUrl: .*\n/, '')
+
+    expect(() => parseConfig(withSchemes(broken), '/dir', 'config.yaml')).toThrow(/'tokenUrl'/)
+  })
+})
+
 describe('loadConfig', () => {
   it('loads the committed Slack configuration', async () => {
     const config = await loadConfig('slack')
@@ -59,6 +114,10 @@ describe('loadConfig', () => {
     expect(config.serverUrl).toBe('https://slack.com/api')
     expect(config.outputPath).toMatch(/sources\/v4\/slack\/openapi\.yaml$/)
     expect(config.methods).toContain('conversations.history')
+    expect(config.securitySchemes.map((declared) => declared.name)).toEqual([
+      'slackBotToken',
+      'slackUserToken',
+    ])
   })
 
   it('reports an unknown API by path', async () => {

--- a/tools/openapi-forge/test/emit.test.ts
+++ b/tools/openapi-forge/test/emit.test.ts
@@ -15,6 +15,7 @@ function operation(overrides: Partial<Operation> = {}): Operation {
     description: 'Lists all channels.',
     deprecated: false,
     parameters: [],
+    security: [],
     response: { kind: 'object', properties: { ok: { kind: 'scalar', type: 'boolean' } } },
     warnings: [],
     ...overrides,
@@ -27,6 +28,7 @@ function model(operations: Operation[]): ApiModel {
     title: 'Demo',
     description: 'Demo API.',
     serverUrl: 'https://example.com/api',
+    securitySchemes: [],
     operations,
     warnings: [],
   }

--- a/tools/openapi-forge/test/extract.test.ts
+++ b/tools/openapi-forge/test/extract.test.ts
@@ -30,12 +30,14 @@ describe('extractApiModel', () => {
 
   /**
    * Listed rather than counted, so a new warning fails here rather than
-   * scrolling past in build output. Two are arguments Coral cannot represent;
-   * the other two are real gaps in Slack's own reference pages, found by
-   * cross-checking against the SDK's request types.
+   * scrolling past in build output. Two are arguments Coral cannot represent,
+   * two are real gaps in Slack's reference pages found by cross-checking
+   * against the SDK's request types, and one is a scope page Slack links to
+   * but does not publish.
    */
-  it('warns only about the four known discrepancies', () => {
+  it('warns only about the five known discrepancies', () => {
     expect(collectWarnings(model).toSorted()).toEqual([
+      'Slack publishes no reference page for these scopes, so they are emitted without a description: identity:read',
       'files.list: @slack/web-api accepts arguments the reference page does not document: count, page',
       'team.accessLogs: @slack/web-api accepts arguments the reference page does not document: before',
       "team.externalTeams.list: argument 'slack_connect_pref_filter' has unsupported type 'array'; omitted",

--- a/tools/openapi-forge/test/overlay.test.ts
+++ b/tools/openapi-forge/test/overlay.test.ts
@@ -30,6 +30,7 @@ function operation(overrides: Partial<Operation> = {}): Operation {
     description: 'Lists channels.',
     deprecated: false,
     parameters: [parameter()],
+    security: [],
     response: { kind: 'object', properties: {} },
     warnings: [],
     ...overrides,
@@ -42,6 +43,7 @@ function model(operations: Operation[]): ApiModel {
     title: 'Slack',
     description: 'Slack.',
     serverUrl: 'https://slack.com/api',
+    securitySchemes: [],
     operations,
     warnings: [],
   }
@@ -196,6 +198,58 @@ describe('applyOverlay', () => {
         operations: { 'conversations.list': { response: { dropProperties: ['nope'] } } },
       }),
     ).toThrow(/operations\.conversations\.list\.response\.dropProperties\.nope/)
+  })
+
+  /**
+   * Extraction emits one requirement per scope, which is what `any` means;
+   * `all` regroups them because scopes inside a single requirement are jointly
+   * required.
+   */
+  it('collapses security requirements when the scopes are jointly required', () => {
+    const source = model([
+      operation({
+        security: [
+          { scheme: 'botToken', scopes: ['team:read'] },
+          { scheme: 'botToken', scopes: ['connect:manage'] },
+        ],
+      }),
+    ])
+
+    const result = applyOverlay(source, {
+      operations: { 'conversations.list': { scopeRelation: 'all' } },
+    })
+
+    expect(result.operations[0]?.security).toEqual([
+      { scheme: 'botToken', scopes: ['team:read', 'connect:manage'] },
+    ])
+  })
+
+  it('keeps requirements separate per scheme when collapsing', () => {
+    const source = model([
+      operation({
+        security: [
+          { scheme: 'botToken', scopes: ['a'] },
+          { scheme: 'userToken', scopes: ['a'] },
+          { scheme: 'botToken', scopes: ['b'] },
+        ],
+      }),
+    ])
+
+    const result = applyOverlay(source, {
+      operations: { 'conversations.list': { scopeRelation: 'all' } },
+    })
+
+    expect(result.operations[0]?.security).toEqual([
+      { scheme: 'botToken', scopes: ['a', 'b'] },
+      { scheme: 'userToken', scopes: ['a'] },
+    ])
+  })
+
+  it('leaves security untouched under the default relation', () => {
+    const security = [{ scheme: 'botToken', scopes: ['a'] }]
+    const result = applyOverlay(model([operation({ security })]), {})
+
+    expect(result.operations[0]?.security).toEqual(security)
   })
 
   it('leaves a model with no overlay untouched', () => {

--- a/tools/openapi-forge/test/scopes.test.ts
+++ b/tools/openapi-forge/test/scopes.test.ts
@@ -1,0 +1,73 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { parseScopePage, ScopeParseError } from '../src/adapters/slack/scopes.ts'
+import { apiDir } from '../src/core/config.ts'
+
+const SCOPES_DIR = join(apiDir('slack'), 'snapshot', 'scopes')
+
+const PAGE = `Source: https://docs.slack.dev/reference/scopes/channels.read
+
+# channels:read scope
+
+View basic information about public channels in a workspace
+
+## Facts
+
+**Supported token types**
+
+[\`Bot\`](/authentication/tokens#bot)
+
+[\`User\`](/authentication/tokens#user)
+
+**Compatible API methods**
+
+[\`conversations.info\`](/reference/methods/conversations.info)
+`
+
+describe('parseScopePage', () => {
+  it('reads the scope, its description and its token classes', () => {
+    expect(parseScopePage(PAGE)).toEqual({
+      name: 'channels:read',
+      description: 'View basic information about public channels in a workspace',
+      tokenClasses: ['bot', 'user'],
+    })
+  })
+
+  /** A page with no prose must not swallow the section heading below it. */
+  it('yields an empty description rather than the next heading', () => {
+    const page = PAGE.replace('View basic information about public channels in a workspace\n', '')
+
+    expect(parseScopePage(page).description).toBe('')
+  })
+
+  it('rejects a page with no scope heading', () => {
+    expect(() => parseScopePage('# something else\n')).toThrow(ScopeParseError)
+  })
+
+  it('parses every scope page in the snapshot', async () => {
+    const files = await readdir(SCOPES_DIR)
+
+    expect(files.length).toBeGreaterThan(20)
+    for (const file of files) {
+      const facts = parseScopePage(await readFile(join(SCOPES_DIR, file), 'utf8'))
+
+      expect(facts.name, `${file} has no scope name`).not.toBe('')
+      expect(facts.description, `${file} has no description`).not.toBe('')
+      expect(facts.tokenClasses.length, `${file} lists no token types`).toBeGreaterThan(0)
+    }
+  })
+
+  /**
+   * The scope pages state token support independently of the method pages, so
+   * they confirm the bot/user split rather than restating it.
+   */
+  it('agrees with the method pages that search:read is user-only', async () => {
+    const facts = parseScopePage(await readFile(join(SCOPES_DIR, 'search.read.md'), 'utf8'))
+
+    expect(facts.tokenClasses).not.toContain('bot')
+    expect(facts.tokenClasses).toContain('user')
+  })
+})

--- a/tools/openapi-forge/test/security.test.ts
+++ b/tools/openapi-forge/test/security.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Coverage for the security stage, end to end over the committed snapshot.
+ *
+ * The interesting question is not whether the YAML is well-formed but whether
+ * it says the right thing: Slack lists a method's scopes without stating how
+ * they relate, and the relationship differs per method.
+ */
+
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+import { loadConfig } from '../src/core/config.ts'
+import { assertImportable, emitOpenApi, EmitError, OPENAPI_VERSION } from '../src/core/emit.ts'
+import { extractApiModel } from '../src/adapters/slack/extract.ts'
+import { applyOverlay, loadOverlay } from '../src/core/overlay.ts'
+import { Snapshot } from '../src/core/snapshot.ts'
+
+interface Document {
+  components: {
+    securitySchemes: Record<
+      string,
+      { type: string; flows: { authorizationCode: { scopes: Record<string, string> } } }
+    >
+  }
+  paths: Record<string, Record<string, { security?: Record<string, string[]>[] }>>
+}
+
+const spec = await (async () => {
+  const config = await loadConfig('slack')
+  const snapshot = await Snapshot.open(config.snapshotDir)
+  const model = applyOverlay(
+    await extractApiModel(config, snapshot),
+    await loadOverlay(config.overlayPath),
+  )
+  return parse(emitOpenApi(model, { version: '2026-07-30' })) as Document
+})()
+
+function securityOf(path: string): Record<string, string[]>[] {
+  return spec.paths[path]?.get?.security ?? []
+}
+
+describe('securitySchemes', () => {
+  it('declares one OAuth2 scheme per Slack token class', () => {
+    expect(Object.keys(spec.components.securitySchemes).toSorted()).toEqual([
+      'slackBotToken',
+      'slackUserToken',
+    ])
+    for (const scheme of Object.values(spec.components.securitySchemes)) {
+      expect(scheme.type).toBe('oauth2')
+    }
+  })
+
+  it('carries the description Slack publishes for each scope', () => {
+    const scopes = spec.components.securitySchemes.slackBotToken?.flows.authorizationCode.scopes
+
+    expect(scopes?.['channels:read']).toBe(
+      'View basic information about public channels in a workspace',
+    )
+  })
+
+  /** Slack links to a page for identity:read that returns 404. */
+  it('emits a scope with no published page rather than dropping it', () => {
+    const scopes = spec.components.securitySchemes.slackUserToken?.flows.authorizationCode.scopes
+
+    expect(scopes).toHaveProperty('identity:read')
+    expect(scopes?.['identity:read']).toBe('')
+  })
+})
+
+describe('operation security', () => {
+  /**
+   * conversations.list accepts any one of the four — each unlocks a
+   * conversation type — so they are alternatives, not a required set.
+   */
+  it('expresses alternative scopes as separate requirements', () => {
+    const security = securityOf('/conversations.list')
+
+    expect(security).toContainEqual({ slackBotToken: ['channels:read'] })
+    expect(security).toContainEqual({ slackBotToken: ['groups:read'] })
+    for (const requirement of security) {
+      expect(Object.values(requirement)[0]).toHaveLength(1)
+    }
+  })
+
+  /**
+   * team.externalTeams.list needs both, and nothing on the page says so — the
+   * overlay does.
+   */
+  it('expresses jointly required scopes as one requirement', () => {
+    expect(securityOf('/team.externalTeams.list')).toEqual([
+      { slackBotToken: ['conversations.connect:manage', 'team:read'] },
+    ])
+  })
+
+  it('offers both token classes where Slack documents both', () => {
+    const schemes = new Set(securityOf('/conversations.list').flatMap((r) => Object.keys(r)))
+
+    expect([...schemes].toSorted()).toEqual(['slackBotToken', 'slackUserToken'])
+  })
+
+  /** Slack omits the section entirely for a class a method does not accept. */
+  it('offers only the user token where the method is user-only', () => {
+    for (const path of ['/search.messages', '/reminders.list', '/team.accessLogs']) {
+      const schemes = new Set(securityOf(path).flatMap((r) => Object.keys(r)))
+
+      expect([...schemes], path).toEqual(['slackUserToken'])
+    }
+  })
+
+  it('offers only the bot token where the method is bot-only', () => {
+    const schemes = new Set(securityOf('/team.externalTeams.list').flatMap((r) => Object.keys(r)))
+
+    expect([...schemes]).toEqual(['slackBotToken'])
+  })
+
+  it('gives every operation at least one requirement', () => {
+    for (const [path, item] of Object.entries(spec.paths)) {
+      expect(item.get?.security?.length ?? 0, `${path} declares no security`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('assertImportable', () => {
+  const base = {
+    openapi: OPENAPI_VERSION,
+    paths: {
+      '/a': { get: { operationId: 'a/one', security: [{ scheme: ['read'] }] } },
+    },
+    components: {
+      securitySchemes: {
+        scheme: { type: 'oauth2', flows: { authorizationCode: { scopes: { read: 'Read.' } } } },
+      },
+    },
+  }
+
+  it('accepts security that resolves', () => {
+    expect(() => assertImportable({ ...base })).not.toThrow()
+  })
+
+  it('rejects a reference to an undeclared scheme', () => {
+    const document = {
+      ...base,
+      paths: { '/a': { get: { operationId: 'a/one', security: [{ other: ['read'] }] } } },
+    }
+
+    expect(() => assertImportable(document)).toThrow(/undeclared security scheme 'other'/)
+  })
+
+  /** The check that catches an operation gaining a scope upstream. */
+  it('rejects a reference to a scope the scheme does not declare', () => {
+    const document = {
+      ...base,
+      paths: { '/a': { get: { operationId: 'a/one', security: [{ scheme: ['write'] }] } } },
+    }
+
+    expect(() => assertImportable(document)).toThrow(
+      /requires scope 'write', which 'scheme' does not declare/,
+    )
+  })
+
+  it('reports the violation as an EmitError', () => {
+    const document = {
+      ...base,
+      paths: { '/a': { get: { operationId: 'a/one', security: [{ nope: [] }] } } },
+    }
+
+    expect(() => assertImportable(document)).toThrow(EmitError)
+  })
+})


### PR DESCRIPTION
A follow-up beyond the original plan. Describes Slack's auth in the descriptor itself.

## What it emits

Two OAuth2 schemes, `slackBotToken` and `slackUserToken`, and a `security` block on every operation naming the scopes it accepts:

```yaml
# conversations.list — any one of these is sufficient
security:
  - slackBotToken: [channels:read]
  - slackBotToken: [groups:read]
  ...
# team.externalTeams.list — both are required, and it is bot-only
security:
  - slackBotToken: [conversations.connect:manage, team:read]
```

## It is documentation, but checked documentation

Coral ignores `securitySchemes` entirely, so this changes nothing about the generated catalog — `catalog-preview.md` is byte-identical, which is the check that proves it inert.

What it buys is verifiability. The emitter fails if an operation references a scope its scheme does not declare, so a method quietly gaining a scope upstream becomes a build failure. The same facts folded into a description string, which is where they lived before, could never be checked that way.

## The one judgement the source material cannot supply

Slack lists a method's scopes without stating how they relate, and the relationship differs:

| Method | Scopes | Meaning |
| --- | --- | --- |
| `conversations.list` | `channels:read`, `groups:read`, `im:read`, `mpim:read` | **any** — one per conversation type |
| `team.externalTeams.list` | `team:read`, `conversations.connect:manage` | **all** — unrelated scope families |

The two render identically. So `any` is the default and the overlay's new `scopeRelation` declares the exception, with the reasoning recorded next to it. This affects 7 of the 37 methods; the other 30 list a single scope and are exact either way.

## What was already there

The scopes themselves were extracted from the start — only the emission is new. Scope *descriptions* are new, and come from Slack's own scope reference pages; 25 are now snapshotted.

Slack links to a page for `identity:read` that returns 404, so a missing scope page is recorded rather than fatal, and the build warns that the scope is emitted without a description.

## Also in this branch

A one-line fix at the bottom of the stack: `PaginationMode` gained a `NextUrlBody` variant on main (#1997), which made `v4-preview`'s exhaustive match non-exhaustive and stopped the crate compiling once the stack was rebased. That fix is on `sw/xtask-v4-preview` where it belongs, not here.

## What this unlocks

The manifest's OAuth scope list could now be generated from the descriptor rather than maintained by hand — which is exactly the drift that shipped in #2026 and had to be corrected after a live install. Not done here; it belongs in its own change.

## Verification

`catalog-preview.md` unchanged, `openapi-hydrate` resolves, `make slack-spec-check` clean, 157 forge tests pass, and a live `coral source add` against a real workspace still installs and returns 502 channels.

---

https://claude.ai/code/session_01Tk8XhPE7SUfrEGKkasAbAG

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
