### PR TITLE
feat(reef): name what source discovery detected

### DIFF
--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -37,7 +37,7 @@ describe('source discovery', () => {
         }),
       ),
     ).toEqual({
-      auth: { kind: 'bearer', label: 'Bearer token' },
+      auth: { kind: 'bearer', label: 'a bearer token' },
       description: 'Weather observations and forecasts',
       format: 'openapi-json',
       probePath: '',
@@ -66,7 +66,11 @@ components:
       name: X-Api-Key
 `),
     ).toEqual({
-      auth: { headerName: 'X-Api-Key', kind: 'header', label: 'Header X-Api-Key' },
+      auth: {
+        headerName: 'X-Api-Key',
+        kind: 'header',
+        label: 'an API key in the X-Api-Key header',
+      },
       description: 'Weather observations and forecasts',
       format: 'openapi-yaml',
       probePath: '',
@@ -114,7 +118,7 @@ components:
           security: [{ oauth: [] }],
         }),
       ).auth,
-    ).toEqual({ kind: 'bearer', label: 'OAuth 2.0 bearer token' })
+    ).toEqual({ kind: 'bearer', label: 'an OAuth 2.0 bearer token' })
   })
 
   it('reports unsupported authentication without selecting an incompatible credential', () => {
@@ -129,7 +133,7 @@ components:
           security: [{ queryKey: [] }],
         }),
       ).auth,
-    ).toEqual({ kind: 'unsupported', label: 'query API key' })
+    ).toEqual({ kind: 'unsupported', label: 'a query API key' })
   })
 
   it('loads the URL and returns a query-safe source name', async () => {
@@ -152,12 +156,13 @@ components:
     )
 
     await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
-      auth: { kind: 'none', label: 'No authentication' },
+      auth: { kind: 'none', label: 'no authentication' },
       description: 'Status checks',
       format: 'openapi-json',
       name: 'source_123_status_api',
       serverUrl: 'https://status.example/api',
       status: 'success',
+      title: '123 Status API',
       url: 'https://status.example/openapi.json',
     })
   })
@@ -448,6 +453,7 @@ components:
       name: 'mcp',
       serverUrl: '',
       status: 'success',
+      title: '',
       url: 'https://tools.example/mcp',
     })
   })
@@ -468,6 +474,7 @@ components:
       name: 'sse',
       serverUrl: '',
       status: 'success',
+      title: '',
       url: 'https://tools.example/events/sse/?token=secret',
     })
   })

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -20,6 +20,7 @@ export type SourceDiscoveryData =
       name: string
       serverUrl: string
       status: 'success'
+      title: string
       url: string
     }
   | {
@@ -172,7 +173,7 @@ function inspectJsonAuth(document: Record<string, unknown>): SourceDetectedAuth 
     security?.length === 0 ||
     security?.some((requirement) => objectKeys(requirement).length === 0)
   ) {
-    return { kind: 'none', label: 'No authentication' }
+    return { kind: 'none', label: 'no authentication' }
   }
 
   const components = objectValue(document.components)
@@ -190,7 +191,7 @@ function inspectJsonAuth(document: Record<string, unknown>): SourceDetectedAuth 
 function inspectYamlAuth(lines: string[]): SourceDetectedAuth {
   const rootSecurity = lines.find((line) => indentation(line) === 0 && yamlKey(line) === 'security')
   if (rootSecurity && yamlScalar(rootSecurity) === '[]') {
-    return { kind: 'none', label: 'No authentication' }
+    return { kind: 'none', label: 'no authentication' }
   }
 
   const componentsIndex = findYamlKey(lines, 'components', 0)
@@ -214,21 +215,21 @@ function authFromScheme(scheme: Record<string, unknown> | undefined): SourceDete
   const name = stringValue(scheme.name)
 
   if (type === 'http' && httpScheme === 'bearer') {
-    return { kind: 'bearer', label: 'Bearer token' }
+    return { kind: 'bearer', label: 'a bearer token' }
   }
   if (type === 'oauth2') {
-    return { kind: 'bearer', label: 'OAuth 2.0 bearer token' }
+    return { kind: 'bearer', label: 'an OAuth 2.0 bearer token' }
   }
   if (type === 'openidconnect') {
-    return { kind: 'bearer', label: 'OpenID Connect bearer token' }
+    return { kind: 'bearer', label: 'an OpenID Connect bearer token' }
   }
   if (type === 'apikey' && location === 'header' && name) {
-    return { headerName: name, kind: 'header', label: `Header ${name}` }
+    return { headerName: name, kind: 'header', label: `an API key in the ${name} header` }
   }
   if (type === 'apikey') {
     return {
       kind: 'unsupported',
-      label: `${location || 'non-header'} API key`,
+      label: `a ${location || 'non-header'} API key`,
     }
   }
   if (type === 'http' && httpScheme) {
@@ -579,6 +580,7 @@ function discoveredSource(
     name: sourceName(metadata.title || fallbackTitle(sourceUrl)),
     serverUrl: metadata.serverUrl,
     status: 'success',
+    title: metadata.title,
     url,
     ...(metadata.inspectionError ? { inspectionError: metadata.inspectionError } : {}),
   }

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -12,12 +12,13 @@ type SuccessfulDiscovery = Extract<SourceDiscoveryData, { status: 'success' }>
 type DiscoveryLoader = (request: Request) => SourceDiscoveryData | Promise<SourceDiscoveryData>
 
 const DISCOVERY: SuccessfulDiscovery = {
-  auth: { kind: 'bearer', label: 'Bearer token' },
+  auth: { kind: 'bearer', label: 'a bearer token' },
   description: 'Weather observations and forecasts',
   format: 'openapi-yaml' as const,
   name: 'weather_api',
   serverUrl: 'https://weather.example/v1',
   status: 'success' as const,
+  title: 'Weather API',
   url: 'https://weather.example/openapi.yaml',
 }
 
@@ -135,7 +136,13 @@ describe('SourceCreateDialog', () => {
     await expect
       .element(screen.getByLabelText('Description (optional)'))
       .toHaveValue('Weather observations and forecasts')
-    await expect.element(screen.getByText('Detected an OpenAPI YAML document.')).toBeVisible()
+    await expect
+      .element(
+        screen.getByText(
+          'Detected the name, description, base URL, and type from the URL provided. Review the details below.',
+        ),
+      )
+      .toBeVisible()
 
     await screen.getByRole('button', { name: 'Next' }).click()
 
@@ -151,7 +158,11 @@ describe('SourceCreateDialog', () => {
   it('resets source-specific draft state when the URL changes', async () => {
     const discovery: SuccessfulDiscovery = {
       ...DISCOVERY,
-      auth: { headerName: 'X-Weather-Key', kind: 'header', label: 'Header X-Weather-Key' },
+      auth: {
+        headerName: 'X-Weather-Key',
+        kind: 'header',
+        label: 'an API key in the X-Weather-Key header',
+      },
     }
     const { screen } = await renderSourceCreate(discovery)
 
@@ -200,6 +211,7 @@ describe('SourceCreateDialog', () => {
       name: 'status_api',
       serverUrl: '',
       status: 'success',
+      title: '',
       url: 'https://status.example/openapi.yaml',
     }
     let resolveFirst: ((result: SourceDiscoveryData) => void) | undefined
@@ -293,13 +305,16 @@ describe('SourceCreateDialog', () => {
       name: 'tools',
       serverUrl: '',
       status: 'success',
+      title: '',
       url,
     })
 
     await screen.getByLabelText('Source URL').fill(url)
     await screen.getByRole('button', { name: 'Next' }).click()
 
-    await expect.element(screen.getByText('No OpenAPI document was detected.')).toBeVisible()
+    await expect
+      .element(screen.getByText('No OpenAPI document was detected. Fill in the details below.'))
+      .toBeVisible()
     await screen.getByRole('radio', { name: 'MCP server' }).click()
     await expect.element(screen.getByRole('radio', { name: 'MCP server' })).toBeChecked()
   })
@@ -313,20 +328,27 @@ describe('SourceCreateDialog', () => {
       name: 'mcp',
       serverUrl: '',
       status: 'success',
+      title: '',
       url,
     })
 
     await screen.getByLabelText('Source URL').fill(url)
     await screen.getByRole('button', { name: 'Next' }).click()
 
-    await expect.element(screen.getByText('Detected an MCP endpoint from its URL.')).toBeVisible()
+    await expect
+      .element(screen.getByText('Detected an MCP endpoint from its URL. Review the details below.'))
+      .toBeVisible()
     await expect.element(screen.getByRole('radio', { name: 'MCP server' })).toBeChecked()
   })
 
   it('prefills detected header authentication on the credentials step', async () => {
     const { screen } = await renderSourceCreate({
       ...DISCOVERY,
-      auth: { headerName: 'X-Api-Key', kind: 'header', label: 'Header X-Api-Key' },
+      auth: {
+        headerName: 'X-Api-Key',
+        kind: 'header',
+        label: 'an API key in the X-Api-Key header',
+      },
     })
 
     await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
@@ -335,7 +357,7 @@ describe('SourceCreateDialog', () => {
     await screen.getByRole('button', { name: 'Next' }).click()
 
     await expect
-      .element(screen.getByText('Detected authentication: Header X-Api-Key.'))
+      .element(screen.getByText('Detected an API key in the X-Api-Key header.'))
       .toBeVisible()
     await expect.element(screen.getByRole('radio', { name: 'Custom header' })).toBeChecked()
     await expect.element(screen.getByLabelText('Header name')).toHaveValue('X-Api-Key')

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -478,9 +478,7 @@ function DetailsStep({
   return (
     <div className={styles.fieldGroup}>
       {discovery ? (
-        <Typography.BodySmall variant="tertiary">
-          {discoverySummary(discovery)} Review the source details.
-        </Typography.BodySmall>
+        <Typography.BodySmall variant="primary">{discoverySummary(discovery)}</Typography.BodySmall>
       ) : null}
       <SourceField
         className={styles.fieldItem}
@@ -554,16 +552,33 @@ function DetailsStep({
 }
 
 function discoverySummary(discovery: {
+  description: string
   format: SourceDocumentFormat
   inspectionError?: string
+  serverUrl: string
+  title: string
 }): string {
-  if (discovery.format === 'mcp') return 'Detected an MCP endpoint from its URL.'
-  if (discovery.format === 'openapi-json') return 'Detected an OpenAPI JSON document.'
-  if (discovery.format === 'openapi-yaml') return 'Detected an OpenAPI YAML document.'
-  if (discovery.inspectionError) {
-    return `The source document could not be inspected. ${asSentence(discovery.inspectionError)}`
+  if (discovery.format === 'mcp') {
+    return 'Detected an MCP endpoint from its URL. Review the details below.'
   }
-  return 'No OpenAPI document was detected.'
+  if (discovery.format === 'unknown') {
+    const reason = discovery.inspectionError
+      ? `The source document could not be inspected. ${asSentence(discovery.inspectionError)}`
+      : 'No OpenAPI document was detected.'
+    return `${reason} Fill in the details below.`
+  }
+  const fields = [
+    ...(discovery.title ? ['name'] : []),
+    ...(discovery.description ? ['description'] : []),
+    ...(discovery.serverUrl ? ['base URL'] : []),
+    'type',
+  ]
+  return `Detected the ${sentenceList(fields)} from the URL provided. Review the details below.`
+}
+
+function sentenceList(items: string[]): string {
+  if (items.length < 3) return items.join(' and ')
+  return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`
 }
 
 function asSentence(value: string): string {
@@ -604,9 +619,7 @@ function CredentialsStep({
   return (
     <div className={styles.fieldGroup}>
       {discovery && discovery.auth.kind !== 'unknown' ? (
-        <Typography.BodySmall variant="tertiary">
-          Detected authentication: {discovery.auth.label}.
-        </Typography.BodySmall>
+        <Typography.BodySmall variant="primary">{authSummary(discovery.auth)}</Typography.BodySmall>
       ) : null}
       <SourceField className={styles.fieldItem} label="Authentication">
         <Radio.Group
@@ -739,6 +752,13 @@ function CredentialsStep({
       </div>
     </div>
   )
+}
+
+function authSummary(auth: SourceDetectedAuth): string {
+  if (auth.kind === 'unsupported') {
+    return `Detected ${auth.label}, which isn’t supported. Choose another method below.`
+  }
+  return `Detected ${auth.label}.`
 }
 
 function authChoiceFromDiscovery(auth: SourceDetectedAuth): AuthChoice | null {


### PR DESCRIPTION
## Summary

Says on the tin. Making the text less subtle, and telling users exactly what was detected. This will get more interesting with the next PR that will help with auth.

## Test plan

<img width="705" height="566" alt="image" src="https://github.com/user-attachments/assets/3a630d04-8237-45e5-94f3-da60ef144622" />
