### PR TITLE
chore(spec): add missing auth block to v4 Gitlab source

### DIFF
--- a/sources/v4/gitlab/manifest.yaml
+++ b/sources/v4/gitlab/manifest.yaml
@@ -50,4 +50,10 @@ surface:
   type: openapi
   url: https://gitlab.com/gitlab-org/gitlab/-/raw/master/doc/api/openapi/openapi_v3.yaml
   base_url: '{{input.GITLAB_API_BASE}}'
+  auth:
+    type: HeaderAuth
+    headers:
+      - name: Authorization
+        from: template
+        template: Bearer {{input.GITLAB_TOKEN}}
 test_queries: []


### PR DESCRIPTION
Copied from the v3 source. This should have been added in the initial commit of the spec but I missed it.