### PR TITLE
feat(reef): honor OpenAPI authentication requirements

### DIFF
--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -11,7 +11,7 @@ type SourceCreateDialogProps = ComponentProps<typeof SourceCreateDialog>
 
 const DISCOVERY_PATH = '/workspaces/default/sources/discover'
 const DISCOVERY = {
-  auth: { kind: 'bearer' as const, label: 'Bearer token' },
+  auth: { headerNames: [], kind: 'bearer' as const, kinds: ['bearer' as const] },
   description: 'Weather observations and forecasts',
   format: 'openapi-yaml' as const,
   name: 'weather_api',

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -37,7 +37,7 @@ describe('source discovery', () => {
         }),
       ),
     ).toEqual({
-      auth: { kind: 'bearer', label: 'a bearer token' },
+      auth: { headerNames: [], kind: 'bearer', kinds: ['bearer'] },
       description: 'Weather observations and forecasts',
       format: 'openapi-json',
       probePath: '',
@@ -67,9 +67,9 @@ components:
 `),
     ).toEqual({
       auth: {
-        headerName: 'X-Api-Key',
+        headerNames: ['X-Api-Key'],
         kind: 'header',
-        label: 'an API key in the X-Api-Key header',
+        kinds: ['header'],
       },
       description: 'Weather observations and forecasts',
       format: 'openapi-yaml',
@@ -81,7 +81,7 @@ components:
 
   it('reports documents without an OpenAPI version as unknown', () => {
     expect(inspectSourceDocument('{"name":"not-openapi"}')).toEqual({
-      auth: { kind: 'unknown', label: '' },
+      auth: { kind: 'unknown' },
       description: '',
       format: 'unknown',
       probePath: '',
@@ -118,7 +118,11 @@ components:
           security: [{ oauth: [] }],
         }),
       ).auth,
-    ).toEqual({ kind: 'bearer', label: 'an OAuth 2.0 bearer token' })
+    ).toEqual({
+      headerNames: [],
+      kind: 'bearer',
+      kinds: ['bearer'],
+    })
   })
 
   it('reports unsupported authentication without selecting an incompatible credential', () => {
@@ -134,6 +138,315 @@ components:
         }),
       ).auth,
     ).toEqual({ kind: 'unsupported', label: 'a query API key' })
+  })
+
+  it('prefills names from only the chosen alternative', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              bearerAuth: { scheme: 'bearer', type: 'http' },
+              apiKey: { in: 'header', name: 'X-Api-Key', type: 'apiKey' },
+            },
+          },
+          info: { title: 'Weather API' },
+          openapi: '3.1.0',
+        }),
+      ).auth,
+    ).toEqual({
+      headerNames: [],
+      kind: 'bearer',
+      kinds: ['bearer', 'header'],
+    })
+  })
+
+  it('reports every header a requirement combines', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              apiKey: { in: 'header', name: 'DD-API-KEY', type: 'apiKey' },
+              appKey: { in: 'header', name: 'DD-APPLICATION-KEY', type: 'apiKey' },
+            },
+          },
+          info: { title: 'Metrics API' },
+          openapi: '3.1.0',
+          security: [{ apiKey: [], appKey: [] }],
+        }),
+      ).auth,
+    ).toEqual({
+      headerNames: ['DD-API-KEY', 'DD-APPLICATION-KEY'],
+      kind: 'header',
+      kinds: ['header'],
+    })
+  })
+
+  it('rejects a requirement that combines credential kinds the wizard cannot send together', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              bearerAuth: { scheme: 'bearer', type: 'http' },
+              clientId: { in: 'header', name: 'X-Client-Id', type: 'apiKey' },
+            },
+          },
+          info: { title: 'Mixed Auth API' },
+          openapi: '3.1.0',
+          security: [{ bearerAuth: [], clientId: [] }],
+        }),
+      ).auth,
+    ).toEqual({
+      kind: 'unsupported',
+      label: 'a bearer token and an API key in the X-Client-Id header',
+    })
+  })
+
+  // The three schemes X's own document declares, which between them cover both
+  // reasons an alternative is left out of the label.
+  it('names a credential once, and leaves out one it cannot send', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              BearerToken: { scheme: 'bearer', type: 'http' },
+              OAuth2UserToken: { flows: {}, type: 'oauth2' },
+              UserToken: { scheme: 'OAuth', type: 'http' },
+            },
+          },
+          info: { title: 'X API v2' },
+          openapi: '3.1.0',
+        }),
+      ).auth,
+    ).toEqual({ headerNames: [], kind: 'bearer', kinds: ['bearer'] })
+  })
+
+  it('reports every scheme a YAML document declares', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.1.0
+info:
+  title: Weather API
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+`).auth,
+    ).toEqual({
+      headerNames: [],
+      kind: 'bearer',
+      kinds: ['bearer', 'header'],
+    })
+  })
+
+  // Datadog's document is the case that motivated reading `security` from YAML: its
+  // one requirement needs both of its API keys, which a menu of schemes cannot say.
+  it('reads a YAML requirement that combines schemes', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.0.0
+info:
+  title: Datadog API
+security:
+  - apiKeyAuth: []
+    appKeyAuth: []
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: DD-API-KEY
+    appKeyAuth:
+      type: apiKey
+      in: header
+      name: DD-APPLICATION-KEY
+`).auth,
+    ).toEqual({
+      headerNames: ['DD-API-KEY', 'DD-APPLICATION-KEY'],
+      kind: 'header',
+      kinds: ['header'],
+    })
+  })
+
+  it('reads an unindented YAML security sequence', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.0.0
+info:
+  title: Datadog API
+security:
+- apiKeyAuth: []
+  appKeyAuth: []
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: DD-API-KEY
+    appKeyAuth:
+      type: apiKey
+      in: header
+      name: DD-APPLICATION-KEY
+`).auth,
+    ).toEqual({
+      headerNames: ['DD-API-KEY', 'DD-APPLICATION-KEY'],
+      kind: 'header',
+      kinds: ['header'],
+    })
+  })
+
+  it('reads separate YAML requirements as alternatives, and their scopes as neither', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.0.0
+info:
+  title: Scoped API
+security:
+  - oauth:
+      - read
+      - write
+  - apiKeyAuth: []
+components:
+  securitySchemes:
+    oauth:
+      type: oauth2
+      flows: {}
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+`).auth,
+    ).toEqual({
+      headerNames: [],
+      kind: 'bearer',
+      kinds: ['bearer', 'header'],
+    })
+  })
+
+  it('reads an empty YAML security block as no authentication', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.0.0
+info:
+  title: Open API
+security: []
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+`).auth,
+    ).toEqual({ headerNames: [], kind: 'none', kinds: ['none'] })
+  })
+
+  it('keeps optional authentication beside the scheme it is optional against', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: { securitySchemes: { bearerAuth: { scheme: 'bearer', type: 'http' } } },
+          info: { title: 'Optional API' },
+          openapi: '3.1.0',
+          security: [{ bearerAuth: [] }, {}],
+        }),
+      ).auth,
+    ).toEqual({
+      headerNames: [],
+      kind: 'bearer',
+      kinds: ['bearer', 'none'],
+    })
+  })
+
+  it('prefers a credential-bearing alternative over no authentication', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              apiKey: { in: 'header', name: 'X-Api-Key', type: 'apiKey' },
+            },
+          },
+          info: { title: 'Optional API' },
+          openapi: '3.1.0',
+          security: [{}, { apiKey: [] }],
+        }),
+      ).auth,
+    ).toEqual({
+      headerNames: ['X-Api-Key'],
+      kind: 'header',
+      kinds: ['none', 'header'],
+    })
+  })
+
+  it('reads what a requirement names and the document declares', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: { apiKey: { in: 'header', name: 'X-Api-Key', type: 'apiKey' } },
+          },
+          info: { title: 'Partial API' },
+          openapi: '3.1.0',
+          security: [{ apiKey: [], signature: [] }],
+        }),
+      ).auth,
+    ).toEqual({
+      headerNames: ['X-Api-Key'],
+      kind: 'header',
+      kinds: ['header'],
+    })
+  })
+
+  it('prefills only the chosen requirement when combined requirements are alternatives', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              apiKey: { in: 'header', name: 'X-Api-Key', type: 'apiKey' },
+              appKey: { in: 'header', name: 'X-App-Key', type: 'apiKey' },
+              legacyKey: { in: 'header', name: 'X-Legacy-Key', type: 'apiKey' },
+              legacySecret: { in: 'header', name: 'X-Legacy-Secret', type: 'apiKey' },
+            },
+          },
+          info: { title: 'Metrics API' },
+          openapi: '3.1.0',
+          security: [
+            { apiKey: [], appKey: [] },
+            { legacyKey: [], legacySecret: [] },
+          ],
+        }),
+      ).auth,
+    ).toEqual({
+      headerNames: ['X-Api-Key', 'X-App-Key'],
+      kind: 'header',
+      kinds: ['header'],
+    })
+  })
+
+  it('counts the unsupported schemes a label would run too long to name', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: Object.fromEntries(
+              ['a', 'b', 'c', 'd', 'e'].map((suffix) => [
+                `key${suffix}`,
+                { in: `cookie${suffix}`, name: `key_${suffix}`, type: 'apiKey' },
+              ]),
+            ),
+          },
+          info: { title: 'Crowded API' },
+          openapi: '3.1.0',
+        }),
+      ).auth,
+    ).toEqual({
+      kind: 'unsupported',
+      label: 'a cookiea API key or a cookieb API key or a cookiec API key, or 2 more',
+    })
   })
 
   it('loads the URL and returns a query-safe source name', async () => {
@@ -156,7 +469,7 @@ components:
     )
 
     await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
-      auth: { kind: 'none', label: 'no authentication' },
+      auth: { headerNames: [], kind: 'none', kinds: ['none'] },
       description: 'Status checks',
       format: 'openapi-json',
       name: 'source_123_status_api',
@@ -446,7 +759,7 @@ components:
     )
 
     await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
-      auth: { kind: 'unknown', label: '' },
+      auth: { kind: 'unknown' },
       description: '',
       format: 'mcp',
       inspectionError: 'The URL returned HTTP 405',
@@ -468,7 +781,7 @@ components:
     )
 
     await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
-      auth: { kind: 'unknown', label: '' },
+      auth: { kind: 'unknown' },
       description: '',
       format: 'mcp',
       name: 'sse',

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -204,6 +204,27 @@ components:
     })
   })
 
+  it('rejects a requirement that combines bearer schemes the wizard cannot send separately', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              userToken: { scheme: 'bearer', type: 'http' },
+              appToken: { flows: {}, type: 'oauth2' },
+            },
+          },
+          info: { title: 'Two Token API' },
+          openapi: '3.1.0',
+          security: [{ userToken: [], appToken: [] }],
+        }),
+      ).auth,
+    ).toEqual({
+      kind: 'unsupported',
+      label: 'a bearer token and an OAuth 2.0 bearer token',
+    })
+  })
+
   // The three schemes X's own document declares, which between them cover both
   // reasons an alternative is left out of the label.
   it('names a credential once, and leaves out one it cannot send', () => {
@@ -341,6 +362,22 @@ components:
       name: X-Api-Key
 `).auth,
     ).toEqual({ headerNames: [], kind: 'none', kinds: ['none'] })
+  })
+
+  it('does not guess when YAML security uses an unreadable flow sequence', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.0.0
+info:
+  title: Optional API
+security: [ {} ]
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+`).auth,
+    ).toEqual({ kind: 'unknown' })
   })
 
   it('keeps optional authentication beside the scheme it is optional against', () => {

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -225,6 +225,7 @@ function jsonAuthAlternatives(
 
 function inspectYamlAuth(lines: string[]): SourceDetectedAuth {
   const requirements = yamlSecurityRequirements(lines)
+  if (requirements === null) return unknownAuth()
   if (requirements?.length === 0) return detectedAuth([[NO_AUTH_SCHEME]])
 
   const componentsIndex = findYamlKey(lines, 'components', 0)
@@ -256,16 +257,17 @@ function inspectYamlAuth(lines: string[]): SourceDetectedAuth {
  * Scheme names under a root `security:` block, one entry per requirement. A `- name:`
  * line opens a requirement and every key indented within it joins the same one, which
  * is how a document spells "all of these at once" — Datadog's two API keys, for
- * instance. Returns nothing when there is no such block, or when it is written as a
- * flow sequence this line-based scanner cannot read. Sequence items may be indented
- * beneath `security:` or start at the same indentation, as YAML permits both.
+ * instance. Returns `undefined` when there is no such block and `null` when a present
+ * block uses syntax this line-based scanner cannot safely interpret. Sequence items
+ * may be indented beneath `security:` or start at the same indentation, as YAML
+ * permits both.
  */
-function yamlSecurityRequirements(lines: string[]): string[][] | undefined {
+function yamlSecurityRequirements(lines: string[]): string[][] | null | undefined {
   const index = findYamlKey(lines, 'security', 0)
   if (index < 0) return undefined
   const scalar = yamlScalar(lines[index])
   if (scalar === '[]') return []
-  if (scalar) return undefined
+  if (scalar) return null
 
   const requirements: string[][] = []
   let itemIndent = -1
@@ -287,7 +289,7 @@ function yamlSecurityRequirements(lines: string[]): string[][] | undefined {
     const key = indent > itemIndent ? yamlKey(trimmed) : null
     if (key) requirements[requirements.length - 1]?.push(key)
   }
-  return requirements.length > 0 ? requirements : undefined
+  return requirements.length > 0 ? requirements : null
 }
 
 function authFromScheme(scheme: Record<string, unknown> | undefined): AuthScheme {
@@ -387,12 +389,9 @@ function namedSchemes(alternative: AuthAlternative): AuthScheme[] {
 
 function isUsableAlternative(schemes: AuthAlternative): boolean {
   const kinds = new Set(schemes.map((scheme) => scheme.kind))
-  return (
-    kinds.size === 1 &&
-    schemes.every(
-      (scheme) => scheme.kind === 'bearer' || scheme.kind === 'header' || scheme.kind === 'none',
-    )
-  )
+  if (kinds.size !== 1) return false
+  const kind = schemes[0].kind
+  return kind === 'header' || (schemes.length === 1 && (kind === 'bearer' || kind === 'none'))
 }
 
 function headerNames(alternative: AuthAlternative): string[] {

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -5,11 +5,20 @@ const MAX_DESCRIPTOR_SIZE_MB = 64
 const MAX_DESCRIPTOR_BYTES = MAX_DESCRIPTOR_SIZE_MB * 1024 * 1024
 
 export type SourceDocumentFormat = 'mcp' | 'openapi-json' | 'openapi-yaml' | 'unknown'
-export type SourceDetectedAuth = {
-  headerName?: string
-  kind: 'bearer' | 'header' | 'none' | 'unknown' | 'unsupported'
-  label: string
-}
+
+/** A method the credentials step offers, so one a detected scheme can be answered with. */
+export type SourceAuthChoice = 'bearer' | 'header' | 'none'
+
+export type SourceDetectedAuth =
+  | { kind: 'unknown' }
+  | { kind: 'unsupported'; label: string }
+  | {
+      /** Header names needed together by the preselected alternative. */
+      headerNames: string[]
+      kind: SourceAuthChoice
+      /** Every usable method the document accepts, in declaration order. */
+      kinds: SourceAuthChoice[]
+    }
 
 export type SourceDiscoveryData =
   | {
@@ -167,32 +176,56 @@ function resolveServerUrl(url: string, variables: Record<string, unknown> | unde
   return resolved.includes('{') ? '' : resolved
 }
 
+/** One scheme as a document declares it. */
+type AuthScheme = {
+  headerName?: string
+  kind: SourceAuthChoice | 'unknown' | 'unsupported'
+  label: string
+}
+
+/**
+ * The ways a document says a request may be authenticated. Each entry is one
+ * requirement, and every scheme inside it is needed at once: OpenAPI reads several
+ * schemes in one requirement as AND and several requirements as OR, so
+ * "only one of the Security Requirement Objects needs to be satisfied".
+ */
+type AuthAlternative = AuthScheme[]
+
+const UNKNOWN_SCHEME: AuthScheme = { kind: 'unknown', label: '' }
+const NO_AUTH_SCHEME: AuthScheme = { kind: 'none', label: 'no authentication' }
+
 function inspectJsonAuth(document: Record<string, unknown>): SourceDetectedAuth {
-  const security = Array.isArray(document.security) ? document.security : undefined
-  if (
-    security?.length === 0 ||
-    security?.some((requirement) => objectKeys(requirement).length === 0)
-  ) {
-    return { kind: 'none', label: 'no authentication' }
-  }
+  const requirements = Array.isArray(document.security) ? document.security : undefined
+  return detectedAuth(jsonAuthAlternatives(document, requirements))
+}
+
+function jsonAuthAlternatives(
+  document: Record<string, unknown>,
+  requirements: unknown[] | undefined,
+): AuthAlternative[] {
+  if (requirements?.length === 0) return [[NO_AUTH_SCHEME]]
 
   const components = objectValue(document.components)
   const schemes =
     objectValue(components?.securitySchemes) ?? objectValue(document.securityDefinitions)
-  if (!schemes) return unknownAuth()
 
-  const requiredSchemeNames = security?.flatMap(objectKeys) ?? []
-  const candidates = requiredSchemeNames.length
-    ? requiredSchemeNames.map((name) => schemes[name])
-    : Object.values(schemes)
-  return bestDetectedAuth(candidates.map((scheme) => authFromScheme(objectValue(scheme))))
+  // Without a root `security` block the document does not say how its schemes
+  // combine, so each stands on its own.
+  if (!requirements) {
+    return Object.values(schemes ?? {}).map((scheme) => [authFromScheme(objectValue(scheme))])
+  }
+  return requirements.map((requirement) => {
+    const names = objectKeys(requirement)
+    // An empty requirement is how a document says a request may carry nothing, and
+    // it sits beside the others rather than replacing them.
+    if (names.length === 0) return [NO_AUTH_SCHEME]
+    return names.map((name) => authFromScheme(objectValue(schemes?.[name])))
+  })
 }
 
 function inspectYamlAuth(lines: string[]): SourceDetectedAuth {
-  const rootSecurity = lines.find((line) => indentation(line) === 0 && yamlKey(line) === 'security')
-  if (rootSecurity && yamlScalar(rootSecurity) === '[]') {
-    return { kind: 'none', label: 'no authentication' }
-  }
+  const requirements = yamlSecurityRequirements(lines)
+  if (requirements?.length === 0) return detectedAuth([[NO_AUTH_SCHEME]])
 
   const componentsIndex = findYamlKey(lines, 'components', 0)
   let schemesIndex =
@@ -200,15 +233,65 @@ function inspectYamlAuth(lines: string[]): SourceDetectedAuth {
   if (schemesIndex < 0) schemesIndex = findYamlKey(lines, 'securitydefinitions', 0)
   if (schemesIndex < 0) return unknownAuth()
 
-  return bestDetectedAuth(
-    yamlChildIndexes(lines, schemesIndex).map((index) =>
-      authFromScheme(yamlMappingFields(lines, index)),
+  // Scheme names arrive lowercased from the scanner on both sides of this lookup.
+  const schemes = new Map(
+    yamlChildIndexes(lines, schemesIndex).map((index) => [
+      yamlKey(lines[index]) ?? '',
+      yamlMappingFields(lines, index),
+    ]),
+  )
+  if (!requirements) {
+    return detectedAuth([...schemes.values()].map((fields) => [authFromScheme(fields)]))
+  }
+  return detectedAuth(
+    requirements.map((names) =>
+      names.length === 0
+        ? [NO_AUTH_SCHEME]
+        : names.map((name) => authFromScheme(schemes.get(name))),
     ),
   )
 }
 
-function authFromScheme(scheme: Record<string, unknown> | undefined): SourceDetectedAuth {
-  if (!scheme) return unknownAuth()
+/**
+ * Scheme names under a root `security:` block, one entry per requirement. A `- name:`
+ * line opens a requirement and every key indented within it joins the same one, which
+ * is how a document spells "all of these at once" — Datadog's two API keys, for
+ * instance. Returns nothing when there is no such block, or when it is written as a
+ * flow sequence this line-based scanner cannot read. Sequence items may be indented
+ * beneath `security:` or start at the same indentation, as YAML permits both.
+ */
+function yamlSecurityRequirements(lines: string[]): string[][] | undefined {
+  const index = findYamlKey(lines, 'security', 0)
+  if (index < 0) return undefined
+  const scalar = yamlScalar(lines[index])
+  if (scalar === '[]') return []
+  if (scalar) return undefined
+
+  const requirements: string[][] = []
+  let itemIndent = -1
+  const keyIndent = indentation(lines[index])
+  for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+    const line = lines[cursor]
+    if (!line.trim()) continue
+    const indent = indentation(line)
+    const trimmed = line.trim()
+    if (indent <= keyIndent && !trimmed.startsWith('-')) break
+    if (trimmed.startsWith('-')) {
+      if (itemIndent < 0) itemIndent = indent
+      // A deeper `-` is a scope under a scheme name, not another requirement.
+      if (indent !== itemIndent) continue
+      const key = yamlKey(trimmed.slice(1).trim())
+      requirements.push(key ? [key] : [])
+      continue
+    }
+    const key = indent > itemIndent ? yamlKey(trimmed) : null
+    if (key) requirements[requirements.length - 1]?.push(key)
+  }
+  return requirements.length > 0 ? requirements : undefined
+}
+
+function authFromScheme(scheme: Record<string, unknown> | undefined): AuthScheme {
+  if (!scheme) return UNKNOWN_SCHEME
   const type = stringValue(scheme.type).toLowerCase()
   const httpScheme = stringValue(scheme.scheme).toLowerCase()
   const location = stringValue(scheme.in).toLowerCase()
@@ -238,19 +321,99 @@ function authFromScheme(scheme: Record<string, unknown> | undefined): SourceDete
   if (type === 'basic') {
     return { kind: 'unsupported', label: 'HTTP basic authentication' }
   }
-  return unknownAuth()
+  return UNKNOWN_SCHEME
 }
 
-function bestDetectedAuth(candidates: SourceDetectedAuth[]): SourceDetectedAuth {
+/** The single answer the wizard needs: what to preselect, and what the document accepts. */
+function detectedAuth(declared: AuthAlternative[]): SourceDetectedAuth {
+  // A requirement may name a scheme the document never declares. What can be read
+  // stands, and an alternative left with nothing is dropped.
+  const named = declared.map(namedSchemes).filter((schemes) => schemes.length > 0)
+  // An alternative Coral cannot send is worth naming only when it is all the
+  // document offers. Beside a usable one it is noise: X's spec, for instance,
+  // declares OAuth 1.0a signing next to a plain bearer token.
+  const usable = named.filter(isUsableAlternative)
+  const alternatives = dedupeAlternatives(usable.length > 0 ? usable : named)
+  if (alternatives.length === 0) return unknownAuth()
+
+  // Only here is the document's own phrasing worth showing: there is no method to
+  // name instead, and which scheme it is says why.
+  if (usable.length === 0) {
+    return { kind: 'unsupported', label: authLabel(alternatives) }
+  }
+  const chosen = preferredAlternative(alternatives)
+  return {
+    headerNames: headerNames(chosen),
+    kind: choiceOf(chosen),
+    // Two alternatives answered by the same method read as one: a document offering a
+    // choice of API key headers still asks the user for a custom header.
+    kinds: [...new Set(alternatives.map(choiceOf))],
+  }
+}
+
+/** The method a usable alternative is answered with, whatever it combines. */
+function choiceOf(alternative: AuthAlternative): SourceAuthChoice {
+  return alternative[0].kind as SourceAuthChoice
+}
+
+/**
+ * The alternative the credentials step preselects. A bearer one goes first: it needs
+ * a token and nothing else, where a header alternative also needs its names right.
+ */
+function preferredAlternative(alternatives: AuthAlternative[]): AuthAlternative {
   return (
-    candidates.find((auth) => auth.kind === 'bearer' || auth.kind === 'header') ??
-    candidates.find((auth) => auth.kind !== 'unknown') ??
-    unknownAuth()
+    alternatives.find((schemes) => schemes.every((scheme) => scheme.kind === 'bearer')) ??
+    alternatives.find((schemes) => choiceOf(schemes) !== 'none') ??
+    alternatives[0]
   )
 }
 
+// A document is free to declare a dozen schemes, and a sentence naming all of them
+// stops being read.
+const MAX_LABELLED_ALTERNATIVES = 3
+
+function authLabel(alternatives: AuthAlternative[]): string {
+  const listed = alternatives
+    .slice(0, MAX_LABELLED_ALTERNATIVES)
+    .map((schemes) => schemes.map((scheme) => scheme.label).join(' and '))
+    .join(' or ')
+  const rest = alternatives.length - MAX_LABELLED_ALTERNATIVES
+  return rest > 0 ? `${listed}, or ${rest} more` : listed
+}
+
+function namedSchemes(alternative: AuthAlternative): AuthScheme[] {
+  return alternative.filter((scheme) => scheme.kind !== 'unknown')
+}
+
+function isUsableAlternative(schemes: AuthAlternative): boolean {
+  const kinds = new Set(schemes.map((scheme) => scheme.kind))
+  return (
+    kinds.size === 1 &&
+    schemes.every(
+      (scheme) => scheme.kind === 'bearer' || scheme.kind === 'header' || scheme.kind === 'none',
+    )
+  )
+}
+
+function headerNames(alternative: AuthAlternative): string[] {
+  return [
+    ...new Set(alternative.flatMap((scheme) => (scheme.headerName ? [scheme.headerName] : []))),
+  ]
+}
+
+/** Two alternatives are the same one when they would read the same. */
+function dedupeAlternatives(alternatives: AuthAlternative[]): AuthAlternative[] {
+  const seen = new Set<string>()
+  return alternatives.filter((schemes) => {
+    const key = schemes.map((scheme) => scheme.label).join(' and ')
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
 function unknownAuth(): SourceDetectedAuth {
-  return { kind: 'unknown', label: '' }
+  return { kind: 'unknown' }
 }
 
 function objectKeys(value: unknown): string[] {

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -119,9 +119,13 @@ export async function runSourcesAction(
       if (typeof manifestYaml !== 'string' || manifestYaml.trim().length === 0) {
         return actionError('import', name, 'Missing source manifest')
       }
-      const secretKey = formValue(formData, 'secret_key')
-      const secretValue = formValue(formData, 'secret_value')
-      const secrets = secretKey && secretValue ? [{ key: secretKey, value: secretValue }] : []
+      // One pair per credential, in field order: an API needing several headers at
+      // once sends a secret for each.
+      const secretValues = formData.getAll('secret_value')
+      const secrets = formData
+        .getAll('secret_key')
+        .map((key, index) => ({ key: String(key), value: String(secretValues[index] ?? '') }))
+        .filter((secret) => secret.key && secret.value)
       await importSourceManifest(sourceClient, workspace, manifestYaml, secrets)
       return actionSuccess('import', name)
     }

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -124,7 +124,10 @@ export async function runSourcesAction(
       const secretValues = formData.getAll('secret_value')
       const secrets = formData
         .getAll('secret_key')
-        .map((key, index) => ({ key: String(key), value: String(secretValues[index] ?? '') }))
+        .map((key, index) => ({
+          key: typeof key === 'string' ? key.trim() : '',
+          value: typeof secretValues[index] === 'string' ? secretValues[index].trim() : '',
+        }))
         .filter((secret) => secret.key && secret.value)
       await importSourceManifest(sourceClient, workspace, manifestYaml, secrets)
       return actionSuccess('import', name)

--- a/apps/reef/app/views/sources/source-create-headers.tsx
+++ b/apps/reef/app/views/sources/source-create-headers.tsx
@@ -1,0 +1,134 @@
+import { useId } from 'react'
+
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { Text as ButtonText } from '@/wax/components/button/text'
+import { TextInput } from '@/wax/components/inputs/text'
+
+import * as styles from './source-create.css'
+import { SourceField } from './source-presentation'
+
+/** One header a request carries. An API needing several gets a row for each. */
+export interface DraftHeader {
+  id: number
+  name: string
+  value: string
+}
+
+export function HeaderCredentialsEditor({
+  disabled,
+  headers,
+  onChange,
+}: {
+  disabled: boolean
+  headers: DraftHeader[]
+  onChange: (headers: DraftHeader[]) => void
+}) {
+  const idHeaderName = useId()
+  const idHeaderToken = useId()
+  const updateHeader = (index: number, patch: Partial<DraftHeader>) =>
+    onChange(headers.map((header, at) => (at === index ? { ...header, ...patch } : header)))
+
+  return (
+    <>
+      {headers.map((header, index) => (
+        <div className={styles.headerRow} key={header.id}>
+          <SourceField
+            className={styles.fieldItem}
+            htmlFor={`${idHeaderName}-${index}`}
+            label="Header name"
+          >
+            <TextInput
+              disabled={disabled}
+              id={`${idHeaderName}-${index}`}
+              onChange={(name) => updateHeader(index, { name })}
+              placeholder="X-Api-Key"
+              value={header.name}
+            />
+          </SourceField>
+          <SourceField
+            className={styles.fieldItem}
+            htmlFor={`${idHeaderToken}-${index}`}
+            label={`${header.name.trim() || 'Header'} value`}
+          >
+            <TextInput
+              disabled={disabled}
+              id={`${idHeaderToken}-${index}`}
+              onChange={(value) => updateHeader(index, { value })}
+              placeholder="Paste token"
+              type="password"
+              value={header.value}
+            />
+          </SourceField>
+          {headers.length > 1 ? (
+            <ButtonContainer
+              ariaLabel={`Remove ${header.name.trim() || `header ${index + 1}`}`}
+              className={styles.headerRemove}
+              disabled={disabled}
+              onClick={() => onChange(headers.filter(({ id }) => id !== header.id))}
+              size="32"
+              variant="bare"
+            >
+              <ButtonText>Remove header</ButtonText>
+            </ButtonContainer>
+          ) : null}
+        </div>
+      ))}
+      <div className={styles.headerActions}>
+        <ButtonContainer
+          disabled={disabled}
+          onClick={() =>
+            onChange([
+              ...headers,
+              {
+                id: Math.max(...headers.map(({ id }) => id)) + 1,
+                name: '',
+                value: '',
+              },
+            ])
+          }
+          size="32"
+          variant="secondary"
+        >
+          <ButtonText>Add header</ButtonText>
+        </ButtonContainer>
+      </div>
+    </>
+  )
+}
+
+export function detectedHeaders(names: string[], current: DraftHeader[]): DraftHeader[] {
+  return names.map((name, id) => ({
+    id,
+    name,
+    value:
+      current.find((header) => header.name.trim().toLowerCase() === name.trim().toLowerCase())
+        ?.value ?? '',
+  }))
+}
+
+/** Secret inputs backing custom headers, with collision-free normalized keys. */
+export function headerInputs(
+  headers: DraftHeader[],
+): { key: string; name: string; value: string }[] {
+  const taken = new Set<string>()
+  return headers.map((header) => {
+    const name = header.name.trim()
+    const base = headerInputKey(name)
+    let key = base
+    let suffix = 2
+    while (taken.has(key)) {
+      key = `${base}_${suffix}`
+      suffix += 1
+    }
+    taken.add(key)
+    return { key, name, value: header.value.trim() }
+  })
+}
+
+function headerInputKey(name: string): string {
+  const key = name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  return /^[A-Z]/.test(key) ? key : `HEADER_${key}`
+}

--- a/apps/reef/app/views/sources/source-create.css.ts
+++ b/apps/reef/app/views/sources/source-create.css.ts
@@ -47,6 +47,27 @@ export const oauthDevicePanel = style([
   },
 ])
 
+export const headerRow = style({
+  alignItems: 'end',
+  display: 'grid',
+  gap: 14,
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr)) auto',
+  '@media': {
+    'screen and (max-width: 600px)': {
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
+  },
+})
+
+export const headerRemove = style({
+  marginBlockEnd: 1,
+})
+
+export const headerActions = style({
+  display: 'flex',
+  gap: 6,
+})
+
 export const authPanelHidden = style({
   pointerEvents: 'none',
   visibility: 'hidden',

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { type FormEvent, type RefObject, useEffect, useId, useRef, useState } from 'react'
+import { Fragment, type FormEvent, type RefObject, useEffect, useId, useRef, useState } from 'react'
 import { Form, useFetcher, useNavigation } from 'react-router'
 
 import { Container as ButtonContainer } from '@/wax/components/button/container'
@@ -29,6 +29,21 @@ const RESERVED_SOURCE_NAMES = new Set(['coral', 'coral_admin', 'public'])
 type SurfaceType = 'openapi' | 'mcp'
 type AuthChoice = 'none' | 'bearer' | 'header' | 'oauthDevice'
 
+/** Named once, so the radio group and the detection summary say the same words. */
+const AUTH_CHOICE_LABELS: Record<AuthChoice, string> = {
+  bearer: 'Bearer token',
+  header: 'Custom header',
+  none: 'None',
+  oauthDevice: 'OAuth device flow',
+}
+
+/** One header a request carries. An API needing several gets a row for each. */
+interface DraftHeader {
+  id: number
+  name: string
+  value: string
+}
+
 interface Draft {
   name: string
   description: string
@@ -36,7 +51,7 @@ interface Draft {
   url: string
   baseUrl: string
   auth: AuthChoice
-  headerName: string
+  headers: DraftHeader[]
   oauthClientId: string
   oauthDeviceAuthorizationUrl: string
   oauthScopes: string
@@ -51,7 +66,7 @@ const EMPTY_DRAFT: Draft = {
   url: '',
   baseUrl: '',
   auth: 'bearer',
-  headerName: '',
+  headers: [{ id: 0, name: '', value: '' }],
   oauthClientId: '',
   oauthDeviceAuthorizationUrl: '',
   oauthScopes: '',
@@ -171,7 +186,12 @@ function SourceCreateDialogContent({
       ...(detectedAuth ? { auth: detectedAuth } : {}),
       baseUrl: result.serverUrl || current.baseUrl,
       description: result.description || current.description,
-      headerName: result.auth.headerName || current.headerName,
+      headers:
+        result.auth.kind !== 'unknown' &&
+        result.auth.kind !== 'unsupported' &&
+        result.auth.headerNames.length > 0
+          ? result.auth.headerNames.map((name, id) => ({ id, name, value: '' }))
+          : current.headers,
       name: result.name,
       surfaceType:
         result.format === 'mcp'
@@ -208,7 +228,9 @@ function SourceCreateDialogContent({
       if (draft.surfaceType === 'openapi' && baseUrlValidationError(draft.baseUrl)) return false
       return true
     }
-    if (draft.auth === 'header' && draft.headerName.trim().length === 0) return false
+    if (draft.auth === 'header') {
+      return draft.headers.every((header) => header.name.trim() && header.value.trim())
+    }
     if (draft.auth === 'oauthDevice') {
       return (
         isHttpsUrl(draft.oauthDeviceAuthorizationUrl) &&
@@ -242,12 +264,20 @@ function SourceCreateDialogContent({
       <input type="hidden" name="_intent" value="import" />
       <input type="hidden" name="name" value={draft.name.trim()} />
       <input type="hidden" name="manifest_yaml" value={buildManifestYaml(draft)} />
-      {draft.auth === 'bearer' || draft.auth === 'header' ? (
+      {draft.auth === 'bearer' ? (
         <>
           <input type="hidden" name="secret_key" value={SECRET_KEY} />
           <input type="hidden" name="secret_value" value={draft.token.trim()} />
         </>
       ) : null}
+      {draft.auth === 'header'
+        ? headerInputs(draft.headers).map((header) => (
+            <Fragment key={header.key}>
+              <input type="hidden" name="secret_key" value={header.key} />
+              <input type="hidden" name="secret_value" value={header.value} />
+            </Fragment>
+          ))
+        : null}
       {draft.auth === 'oauthDevice' ? (
         <>
           <input type="hidden" name="oauth_input_key" value={SECRET_KEY} />
@@ -603,19 +633,15 @@ function CredentialsStep({
   const idOAuthDeviceAuthorizationUrl = useId()
   const idOAuthScopes = useId()
   const idOAuthTokenUrl = useId()
-  const authChoices: { key: AuthChoice; label: string }[] =
+  const updateHeader = (index: number, patch: Partial<DraftHeader>) =>
+    update({
+      headers: draft.headers.map((header, at) => (at === index ? { ...header, ...patch } : header)),
+    })
+  // A custom header is an OpenAPI notion; an MCP server carries a bearer token.
+  const authChoices: AuthChoice[] =
     draft.surfaceType === 'openapi'
-      ? [
-          { key: 'none', label: 'None' },
-          { key: 'bearer', label: 'Bearer token' },
-          { key: 'oauthDevice', label: 'OAuth device flow' },
-          { key: 'header', label: 'Custom header' },
-        ]
-      : [
-          { key: 'none', label: 'None' },
-          { key: 'bearer', label: 'Bearer token' },
-          { key: 'oauthDevice', label: 'OAuth device flow' },
-        ]
+      ? ['none', 'bearer', 'oauthDevice', 'header']
+      : ['none', 'bearer', 'oauthDevice']
   return (
     <div className={styles.fieldGroup}>
       {discovery && discovery.auth.kind !== 'unknown' ? (
@@ -628,8 +654,8 @@ function CredentialsStep({
           onValueChange={(auth) => update({ auth })}
         >
           {authChoices.map((choice) => (
-            <Radio.Item key={choice.key} value={choice.key}>
-              {choice.label}
+            <Radio.Item key={choice} value={choice}>
+              {AUTH_CHOICE_LABELS[choice]}
             </Radio.Item>
           ))}
         </Radio.Group>
@@ -725,40 +751,98 @@ function CredentialsStep({
             draft.auth !== 'header' && styles.authPanelHidden,
           )}
         >
-          <SourceField className={styles.fieldItem} htmlFor={idHeaderName} label="Header name">
-            <TextInput
-              id={idHeaderName}
-              value={draft.headerName}
-              onChange={(value) => update({ headerName: value })}
-              placeholder="X-Api-Key"
+          {draft.headers.map((header, index) => (
+            <div className={styles.headerRow} key={header.id}>
+              <SourceField
+                className={styles.fieldItem}
+                htmlFor={`${idHeaderName}-${index}`}
+                label="Header name"
+              >
+                <TextInput
+                  id={`${idHeaderName}-${index}`}
+                  value={header.name}
+                  onChange={(name) => updateHeader(index, { name })}
+                  placeholder="X-Api-Key"
+                  disabled={disabled || draft.auth !== 'header'}
+                />
+              </SourceField>
+              <SourceField
+                className={styles.fieldItem}
+                htmlFor={`${idHeaderToken}-${index}`}
+                label={`${header.name.trim() || 'Header'} value`}
+              >
+                <TextInput
+                  id={`${idHeaderToken}-${index}`}
+                  type="password"
+                  value={header.value}
+                  onChange={(value) => updateHeader(index, { value })}
+                  placeholder="Paste token"
+                  disabled={disabled || draft.auth !== 'header'}
+                />
+              </SourceField>
+              {draft.headers.length > 1 ? (
+                <ButtonContainer
+                  ariaLabel={`Remove ${header.name.trim() || `header ${index + 1}`}`}
+                  className={styles.headerRemove}
+                  disabled={disabled || draft.auth !== 'header'}
+                  onClick={() =>
+                    update({ headers: draft.headers.filter(({ id }) => id !== header.id) })
+                  }
+                  size="32"
+                  variant="bare"
+                >
+                  <ButtonText>Remove header</ButtonText>
+                </ButtonContainer>
+              ) : null}
+            </div>
+          ))}
+          <div className={styles.headerActions}>
+            <ButtonContainer
               disabled={disabled || draft.auth !== 'header'}
-            />
-          </SourceField>
-          <SourceField
-            className={styles.fieldItem}
-            htmlFor={idHeaderToken}
-            label={`${draft.headerName.trim() || 'Header'} value`}
-          >
-            <TextInput
-              id={idHeaderToken}
-              type="password"
-              value={draft.token}
-              onChange={(value) => update({ token: value })}
-              placeholder="Paste token"
-              disabled={disabled || draft.auth !== 'header'}
-            />
-          </SourceField>
+              onClick={() =>
+                update({
+                  headers: [
+                    ...draft.headers,
+                    {
+                      id: Math.max(...draft.headers.map(({ id }) => id)) + 1,
+                      name: '',
+                      value: '',
+                    },
+                  ],
+                })
+              }
+              size="32"
+              variant="secondary"
+            >
+              <ButtonText>Add header</ButtonText>
+            </ButtonContainer>
+          </div>
         </div>
       </div>
     </div>
   )
 }
 
+/**
+ * What the document accepts, named as the methods below rather than as the schemes it
+ * declares: a reader who has to pick one of these radios is not helped by learning
+ * that the API calls its key `X-Figma-Token`, which the header field is prefilled with
+ * anyway.
+ */
 function authSummary(auth: SourceDetectedAuth): string {
   if (auth.kind === 'unsupported') {
     return `Detected ${auth.label}, which isn’t supported. Choose another method below.`
   }
-  return `Detected ${auth.label}.`
+  if (auth.kind === 'unknown') return ''
+  if (auth.kinds.length === 1) {
+    if (auth.kind === 'none') return 'Detected no authentication.'
+    return `Detected ${auth.kind === 'bearer' ? 'bearer token' : 'custom header'} authentication.`
+  }
+  const methods = auth.kinds.map((kind) => {
+    if (kind === 'none') return 'no authentication'
+    return kind === 'bearer' ? 'a bearer token' : 'a custom header'
+  })
+  return `This API accepts ${orList(methods)}.`
 }
 
 function authChoiceFromDiscovery(auth: SourceDetectedAuth): AuthChoice | null {
@@ -767,10 +851,7 @@ function authChoiceFromDiscovery(auth: SourceDetectedAuth): AuthChoice | null {
 }
 
 function draftIsDirty(draft: Draft): boolean {
-  return Object.keys(EMPTY_DRAFT).some((key) => {
-    const draftKey = key as keyof Draft
-    return draft[draftKey] !== EMPTY_DRAFT[draftKey]
-  })
+  return JSON.stringify(draft) !== JSON.stringify(EMPTY_DRAFT)
 }
 
 function sourceNameIsValid(name: string): boolean {
@@ -819,7 +900,16 @@ function buildManifestYaml(draft: Draft): string {
   const url = draft.url.trim()
   const lines: string[] = [`name: ${s(name)}`, 'dsl_version: 4']
   if (draft.description.trim()) lines.push(`description: ${s(draft.description.trim())}`)
-  if (draft.auth !== 'none') {
+  if (draft.auth === 'header') {
+    lines.push('inputs:')
+    for (const header of headerInputs(draft.headers)) {
+      lines.push(
+        `  ${header.key}:`,
+        '    kind: secret',
+        `    hint: ${s(`Value sent in the ${header.name} header`)}`,
+      )
+    }
+  } else if (draft.auth !== 'none') {
     lines.push(
       'inputs:',
       `  ${SECRET_KEY}:`,
@@ -867,17 +957,21 @@ function buildManifestYaml(draft: Draft): string {
     // Omitted base_url leaves coral-app to derive it from the document's servers block.
     if (draft.baseUrl.trim()) lines.push(`  base_url: ${s(draft.baseUrl.trim())}`)
     if (draft.auth !== 'none') {
-      const bearerAuth = draft.auth === 'bearer' || draft.auth === 'oauthDevice'
-      const headerName = bearerAuth ? 'Authorization' : draft.headerName.trim()
-      const template = bearerAuth ? `Bearer {{input.${SECRET_KEY}}}` : `{{input.${SECRET_KEY}}}`
-      lines.push(
-        '  auth:',
-        '    type: HeaderAuth',
-        '    headers:',
-        `      - name: ${s(headerName)}`,
-        '        from: template',
-        `        template: ${s(template)}`,
-      )
+      const headers =
+        draft.auth === 'header'
+          ? headerInputs(draft.headers).map((header) => ({
+              name: header.name,
+              template: `{{input.${header.key}}}`,
+            }))
+          : [{ name: 'Authorization', template: `Bearer {{input.${SECRET_KEY}}}` }]
+      lines.push('  auth:', '    type: HeaderAuth', '    headers:')
+      for (const header of headers) {
+        lines.push(
+          `      - name: ${s(header.name)}`,
+          '        from: template',
+          `        template: ${s(header.template)}`,
+        )
+      }
     }
   } else {
     lines.push('  type: mcp', '  server:', '    transport: streamable_http', `    url: ${s(url)}`)
@@ -886,6 +980,40 @@ function buildManifestYaml(draft: Draft): string {
     }
   }
   return lines.join('\n') + '\n'
+}
+
+/**
+ * The secret input backing each header. Keys are derived from the header name so a
+ * manifest with several of them reads, and a suffix breaks ties between names that
+ * normalize to the same key.
+ */
+function headerInputs(headers: DraftHeader[]): { key: string; name: string; value: string }[] {
+  const taken = new Set<string>()
+  return headers.map((header) => {
+    const name = header.name.trim()
+    const base = headerInputKey(name)
+    let key = base
+    let suffix = 2
+    while (taken.has(key)) {
+      key = `${base}_${suffix}`
+      suffix += 1
+    }
+    taken.add(key)
+    return { key, name, value: header.value.trim() }
+  })
+}
+
+function orList(items: string[]): string {
+  if (items.length < 3) return items.join(' or ')
+  return `${items.slice(0, -1).join(', ')}, or ${items.at(-1)}`
+}
+
+function headerInputKey(name: string): string {
+  const key = name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  return /^[A-Z]/.test(key) ? key : `HEADER_${key}`
 }
 
 function oauthScopes(value: string): string[] {

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -19,6 +19,12 @@ import type {
   SourceDocumentFormat,
 } from '@/routes/source-discovery'
 
+import {
+  detectedHeaders,
+  type DraftHeader,
+  HeaderCredentialsEditor,
+  headerInputs,
+} from './source-create-headers'
 import * as styles from './source-create.css'
 import { formatFieldName, SourceError, SourceField, SourceHeader } from './source-presentation'
 
@@ -35,13 +41,6 @@ const AUTH_CHOICE_LABELS: Record<AuthChoice, string> = {
   header: 'Custom header',
   none: 'None',
   oauthDevice: 'OAuth device flow',
-}
-
-/** One header a request carries. An API needing several gets a row for each. */
-interface DraftHeader {
-  id: number
-  name: string
-  value: string
 }
 
 interface Draft {
@@ -190,7 +189,7 @@ function SourceCreateDialogContent({
         result.auth.kind !== 'unknown' &&
         result.auth.kind !== 'unsupported' &&
         result.auth.headerNames.length > 0
-          ? result.auth.headerNames.map((name, id) => ({ id, name, value: '' }))
+          ? detectedHeaders(result.auth.headerNames, current.headers)
           : current.headers,
       name: result.name,
       surfaceType:
@@ -627,16 +626,10 @@ function CredentialsStep({
   disabled: boolean
 }) {
   const idBearerToken = useId()
-  const idHeaderName = useId()
-  const idHeaderToken = useId()
   const idOAuthClientId = useId()
   const idOAuthDeviceAuthorizationUrl = useId()
   const idOAuthScopes = useId()
   const idOAuthTokenUrl = useId()
-  const updateHeader = (index: number, patch: Partial<DraftHeader>) =>
-    update({
-      headers: draft.headers.map((header, at) => (at === index ? { ...header, ...patch } : header)),
-    })
   // A custom header is an OpenAPI notion; an MCP server carries a bearer token.
   const authChoices: AuthChoice[] =
     draft.surfaceType === 'openapi'
@@ -751,72 +744,11 @@ function CredentialsStep({
             draft.auth !== 'header' && styles.authPanelHidden,
           )}
         >
-          {draft.headers.map((header, index) => (
-            <div className={styles.headerRow} key={header.id}>
-              <SourceField
-                className={styles.fieldItem}
-                htmlFor={`${idHeaderName}-${index}`}
-                label="Header name"
-              >
-                <TextInput
-                  id={`${idHeaderName}-${index}`}
-                  value={header.name}
-                  onChange={(name) => updateHeader(index, { name })}
-                  placeholder="X-Api-Key"
-                  disabled={disabled || draft.auth !== 'header'}
-                />
-              </SourceField>
-              <SourceField
-                className={styles.fieldItem}
-                htmlFor={`${idHeaderToken}-${index}`}
-                label={`${header.name.trim() || 'Header'} value`}
-              >
-                <TextInput
-                  id={`${idHeaderToken}-${index}`}
-                  type="password"
-                  value={header.value}
-                  onChange={(value) => updateHeader(index, { value })}
-                  placeholder="Paste token"
-                  disabled={disabled || draft.auth !== 'header'}
-                />
-              </SourceField>
-              {draft.headers.length > 1 ? (
-                <ButtonContainer
-                  ariaLabel={`Remove ${header.name.trim() || `header ${index + 1}`}`}
-                  className={styles.headerRemove}
-                  disabled={disabled || draft.auth !== 'header'}
-                  onClick={() =>
-                    update({ headers: draft.headers.filter(({ id }) => id !== header.id) })
-                  }
-                  size="32"
-                  variant="bare"
-                >
-                  <ButtonText>Remove header</ButtonText>
-                </ButtonContainer>
-              ) : null}
-            </div>
-          ))}
-          <div className={styles.headerActions}>
-            <ButtonContainer
-              disabled={disabled || draft.auth !== 'header'}
-              onClick={() =>
-                update({
-                  headers: [
-                    ...draft.headers,
-                    {
-                      id: Math.max(...draft.headers.map(({ id }) => id)) + 1,
-                      name: '',
-                      value: '',
-                    },
-                  ],
-                })
-              }
-              size="32"
-              variant="secondary"
-            >
-              <ButtonText>Add header</ButtonText>
-            </ButtonContainer>
-          </div>
+          <HeaderCredentialsEditor
+            disabled={disabled || draft.auth !== 'header'}
+            headers={draft.headers}
+            onChange={(headers) => update({ headers })}
+          />
         </div>
       </div>
     </div>
@@ -982,38 +914,9 @@ function buildManifestYaml(draft: Draft): string {
   return lines.join('\n') + '\n'
 }
 
-/**
- * The secret input backing each header. Keys are derived from the header name so a
- * manifest with several of them reads, and a suffix breaks ties between names that
- * normalize to the same key.
- */
-function headerInputs(headers: DraftHeader[]): { key: string; name: string; value: string }[] {
-  const taken = new Set<string>()
-  return headers.map((header) => {
-    const name = header.name.trim()
-    const base = headerInputKey(name)
-    let key = base
-    let suffix = 2
-    while (taken.has(key)) {
-      key = `${base}_${suffix}`
-      suffix += 1
-    }
-    taken.add(key)
-    return { key, name, value: header.value.trim() }
-  })
-}
-
 function orList(items: string[]): string {
   if (items.length < 3) return items.join(' or ')
   return `${items.slice(0, -1).join(', ')}, or ${items.at(-1)}`
-}
-
-function headerInputKey(name: string): string {
-  const key = name
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-  return /^[A-Z]/.test(key) ? key : `HEADER_${key}`
 }
 
 function oauthScopes(value: string): string[] {


### PR DESCRIPTION
## Summary

OpenAPI spec has a field that describes the auth method for the API; let's make use of that to e.g. pre-populate inputs if needed, select the correct auth method. Ie use that info (when available) to make life easier for users

## Test plan

For [Lord's votes](https://lordsvotes-api.parliament.uk/swagger/v1/swagger.json)
<img width="689" height="403" alt="image" src="https://github.com/user-attachments/assets/ed4b0a3e-aa31-46a9-b45e-776aacdc6817" />


For [Figma](https://raw.githubusercontent.com/figma/rest-api-spec/refs/heads/main/openapi/openapi.yaml)
<img width="691" height="327" alt="image" src="https://github.com/user-attachments/assets/4c64a82e-bd35-420d-97cc-81b3aa0bb3b8" />

For [Cloudflare](https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json)
<img width="670" height="265" alt="image" src="https://github.com/user-attachments/assets/96630779-e9cf-4166-8ccc-b2fbce5ea7cf" />
