### PR TITLE
fix(search): use singular observed source identity

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1178,7 +1178,6 @@ enabled = false
             .enqueue_if_current(
                 &workspace,
                 &ObservedValuesQueueJob {
-                    owner_source_name: "github".to_string(),
                     source_name: "github".to_string(),
                     source_scope_id: "scope".to_string(),
                     surface_kind: ObservedValuesSurfaceKind::Table,
@@ -1638,7 +1637,6 @@ backend = "unsupported"
             .enqueue_if_current(
                 &workspace,
                 &ObservedValuesQueueJob {
-                    owner_source_name: "github".to_string(),
                     source_name: "github".to_string(),
                     source_scope_id: "scope".to_string(),
                     surface_kind: ObservedValuesSurfaceKind::Table,
@@ -1687,7 +1685,6 @@ backend = "unsupported"
             .enqueue_if_current(
                 &workspace,
                 &ObservedValuesQueueJob {
-                    owner_source_name: "github".to_string(),
                     source_name: "github".to_string(),
                     source_scope_id: "scope".to_string(),
                     surface_kind: ObservedValuesSurfaceKind::Table,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -356,8 +356,8 @@ impl SearchManager {
         if request.scope == SearchDataScope::All {
             return match &request.target {
                 SearchClearTarget::Workspace => self.clear_workspace_all(&request.workspace_name),
-                SearchClearTarget::Source(owner_source_name) => {
-                    self.clear_source_all(&request.workspace_name, owner_source_name)
+                SearchClearTarget::Source(source_name) => {
+                    self.clear_source_all(&request.workspace_name, source_name)
                 }
             };
         }
@@ -412,12 +412,12 @@ impl SearchManager {
     fn clear_source_all(
         &self,
         workspace_name: &WorkspaceName,
-        owner_source_name: &crate::sources::SourceName,
+        source_name: &crate::sources::SourceName,
     ) -> Result<ClearSearchDataResponse, SearchManagerError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)
             .map_err(|error| search_clear_sqlite_app_error(&error))?;
         let (catalog, observed) = store
-            .clear_source_all(owner_source_name.as_str())
+            .clear_source_all(source_name.as_str())
             .map_err(|error| search_clear_sqlite_app_error(&error))?;
         let compaction = store.compact_after_clear();
         Ok(ClearSearchDataResponse {

--- a/crates/coral-app/src/search/migrations/0005_observed_source_identity.sql
+++ b/crates/coral-app/src/search/migrations/0005_observed_source_identity.sql
@@ -1,0 +1,104 @@
+-- One installed source publishes exactly one SQL namespace, so observed values
+-- carry a single canonical `source_name` instead of the historical
+-- owner/component pair. This file restates the complete observed schema so a
+-- full replay converges here; the version-5 hook in `apply_migration` renames
+-- the legacy tables out of the way first and copies their rows back afterwards.
+
+CREATE TABLE IF NOT EXISTS observed_workspace_generations (
+    workspace TEXT PRIMARY KEY,
+    generation INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS observed_source_generations (
+    workspace TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    generation INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (workspace, source_name)
+);
+
+CREATE TABLE IF NOT EXISTS observed_values (
+    workspace TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    surface_kind TEXT NOT NULL,
+    surface_name TEXT NOT NULL,
+    column_name TEXT NOT NULL,
+    value_key TEXT NOT NULL,
+    display_value TEXT NOT NULL,
+    search_text TEXT NOT NULL,
+    first_observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_observed_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    observation_count INTEGER NOT NULL DEFAULT 1,
+    source_generation INTEGER NOT NULL,
+    workspace_generation INTEGER NOT NULL,
+    PRIMARY KEY (
+        workspace,
+        source_name,
+        source_scope_id,
+        surface_kind,
+        surface_name,
+        column_name,
+        value_key
+    )
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS observed_values_fts USING fts5(
+    workspace UNINDEXED,
+    source_name UNINDEXED,
+    source_scope_id UNINDEXED,
+    surface_kind UNINDEXED,
+    surface_name UNINDEXED,
+    column_name UNINDEXED,
+    value_key UNINDEXED,
+    display_value,
+    search_text,
+    tokenize = 'trigram'
+);
+
+INSERT INTO observed_values_fts(observed_values_fts, rank)
+VALUES ('secure-delete', 1);
+
+CREATE TABLE IF NOT EXISTS observed_queue_jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    source_scope_id TEXT NOT NULL,
+    surface_kind TEXT NOT NULL,
+    surface_name TEXT NOT NULL,
+    workspace_generation INTEGER NOT NULL,
+    source_generation INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_observed_queue_jobs_workspace_id
+    ON observed_queue_jobs (workspace, id);
+CREATE INDEX IF NOT EXISTS idx_observed_queue_jobs_source
+    ON observed_queue_jobs (
+        workspace,
+        source_name,
+        source_scope_id
+    );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_observed_queue_jobs_pending_scope
+    ON observed_queue_jobs (
+        workspace,
+        source_name,
+        source_scope_id,
+        surface_kind,
+        surface_name,
+        workspace_generation,
+        source_generation
+    );
+CREATE INDEX IF NOT EXISTS idx_observed_values_source
+    ON observed_values (
+        workspace,
+        source_name,
+        source_scope_id
+    );
+CREATE INDEX IF NOT EXISTS idx_observed_values_workspace_last_observed
+    ON observed_values (workspace, last_observed_at);

--- a/crates/coral-app/src/search/observed/governance.rs
+++ b/crates/coral-app/src/search/observed/governance.rs
@@ -19,7 +19,6 @@ const SELECT_STALE_OBSERVED_VALUE_KEYS_SQL: &str = "
         rowid,
         last_observed_at,
         observation_count,
-        owner_source_name,
         source_name,
         source_scope_id,
         surface_kind,
@@ -38,7 +37,6 @@ const SELECT_OLDEST_OBSERVED_VALUE_KEYS_SQL: &str = "
         rowid,
         last_observed_at,
         observation_count,
-        owner_source_name,
         source_name,
         source_scope_id,
         surface_kind,
@@ -97,7 +95,6 @@ struct ObservedValueKey {
     canonical_rowid: i64,
     last_observed_at: String,
     observation_count: i64,
-    owner_source_name: String,
     source_name: String,
     source_scope_id: String,
     surface_kind: String,
@@ -300,13 +297,12 @@ fn observed_value_key_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Obse
         canonical_rowid: row.get(0)?,
         last_observed_at: row.get(1)?,
         observation_count: row.get(2)?,
-        owner_source_name: row.get(3)?,
-        source_name: row.get(4)?,
-        source_scope_id: row.get(5)?,
-        surface_kind: row.get(6)?,
-        surface_name: row.get(7)?,
-        column_name: row.get(8)?,
-        value_key: row.get(9)?,
+        source_name: row.get(3)?,
+        source_scope_id: row.get(4)?,
+        surface_kind: row.get(5)?,
+        surface_name: row.get(6)?,
+        column_name: row.get(7)?,
+        value_key: row.get(8)?,
     })
 }
 
@@ -408,20 +404,18 @@ fn delete_canonical_observed_value_key(
             DELETE FROM observed_values
             WHERE rowid = ?1
               AND workspace = ?2
-              AND owner_source_name = ?3
-              AND source_name = ?4
-              AND source_scope_id = ?5
-              AND surface_kind = ?6
-              AND surface_name = ?7
-              AND column_name = ?8
-              AND value_key = ?9
-              AND last_observed_at = ?10
-              AND observation_count = ?11
+              AND source_name = ?3
+              AND source_scope_id = ?4
+              AND surface_kind = ?5
+              AND surface_name = ?6
+              AND column_name = ?7
+              AND value_key = ?8
+              AND last_observed_at = ?9
+              AND observation_count = ?10
             ",
             params![
                 key.canonical_rowid,
                 workspace_name.as_str(),
-                &key.owner_source_name,
                 &key.source_name,
                 &key.source_scope_id,
                 &key.surface_kind,
@@ -445,19 +439,17 @@ fn stage_governance_delete_key(
             "
             INSERT INTO temp.{GOVERNANCE_DELETE_KEYS_TABLE} (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
                 surface_name,
                 column_name,
                 value_key
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             "
         ),
         params![
             workspace_name.as_str(),
-            &key.owner_source_name,
             &key.source_name,
             &key.source_scope_id,
             &key.surface_kind,
@@ -478,7 +470,6 @@ fn delete_staged_fts_rows(transaction: &Transaction<'_>) -> Result<(), SqliteSea
                 SELECT 1
                 FROM temp.{GOVERNANCE_DELETE_KEYS_TABLE} AS deletion
                 WHERE deletion.workspace = observed_values_fts.workspace
-                  AND deletion.owner_source_name = observed_values_fts.owner_source_name
                   AND deletion.source_name = observed_values_fts.source_name
                   AND deletion.source_scope_id = observed_values_fts.source_scope_id
                   AND deletion.surface_kind = observed_values_fts.surface_kind
@@ -498,7 +489,6 @@ fn ensure_governance_delete_keys_table(connection: &Connection) -> Result<(), Sq
         "
         CREATE TEMP TABLE IF NOT EXISTS {GOVERNANCE_DELETE_KEYS_TABLE} (
             workspace TEXT NOT NULL,
-            owner_source_name TEXT NOT NULL,
             source_name TEXT NOT NULL,
             source_scope_id TEXT NOT NULL,
             surface_kind TEXT NOT NULL,
@@ -507,7 +497,6 @@ fn ensure_governance_delete_keys_table(connection: &Connection) -> Result<(), Sq
             value_key TEXT NOT NULL,
             PRIMARY KEY (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -629,15 +618,15 @@ mod tests {
     fn stale_row_cap_reports_budget_exhaustion_with_time_remaining() {
         let mut connection = observed_values_connection();
         let workspace = WorkspaceName::default();
-        for (owner, value_key, last_observed_at) in [
-            ("owner-a", "first", "2000-01-01T00:00:00.000Z"),
-            ("owner-b", "second", "2001-01-01T00:00:00.000Z"),
-            ("owner-c", "third", "2002-01-01T00:00:00.000Z"),
+        for (source_name, value_key, last_observed_at) in [
+            ("source-a", "first", "2000-01-01T00:00:00.000Z"),
+            ("source-b", "second", "2001-01-01T00:00:00.000Z"),
+            ("source-c", "third", "2002-01-01T00:00:00.000Z"),
         ] {
             insert_observed_value(
                 &connection,
                 &workspace,
-                owner,
+                source_name,
                 value_key,
                 last_observed_at,
                 1,
@@ -664,15 +653,15 @@ mod tests {
     fn eviction_row_cap_reports_budget_exhaustion_while_observed_work_remains() {
         let mut connection = observed_values_connection();
         let workspace = WorkspaceName::default();
-        for (owner, value_key) in [
-            ("owner-a", "first"),
-            ("owner-b", "second"),
-            ("owner-c", "third"),
+        for (source_name, value_key) in [
+            ("source-a", "first"),
+            ("source-b", "second"),
+            ("source-c", "third"),
         ] {
             insert_observed_value(
                 &connection,
                 &workspace,
-                owner,
+                source_name,
                 value_key,
                 "9999-01-01T00:00:00.000Z",
                 1,
@@ -737,7 +726,7 @@ mod tests {
                 SET display_value = 'fresh',
                     search_text = 'fresh',
                     observation_count = observation_count + 1
-                WHERE workspace = ?1 AND owner_source_name = 'github'
+                WHERE workspace = ?1 AND source_name = 'github'
                 ",
                 params![workspace.as_str()],
             )
@@ -747,7 +736,7 @@ mod tests {
                 "
                 UPDATE observed_values_fts
                 SET display_value = 'fresh', search_text = 'fresh'
-                WHERE workspace = ?1 AND owner_source_name = 'github'
+                WHERE workspace = ?1 AND source_name = 'github'
                 ",
                 params![workspace.as_str()],
             )
@@ -776,15 +765,15 @@ mod tests {
     fn governance_deletes_a_batch_from_canonical_and_fts_once() {
         let mut connection = observed_values_connection();
         let workspace = WorkspaceName::default();
-        for (owner, value_key, last_observed_at) in [
-            ("owner-a", "first", "2020-01-01T00:00:00.000Z"),
-            ("owner-b", "second", "2021-01-01T00:00:00.000Z"),
-            ("owner-c", "third", "2022-01-01T00:00:00.000Z"),
+        for (source_name, value_key, last_observed_at) in [
+            ("source-a", "first", "2020-01-01T00:00:00.000Z"),
+            ("source-b", "second", "2021-01-01T00:00:00.000Z"),
+            ("source-c", "third", "2022-01-01T00:00:00.000Z"),
         ] {
             insert_observed_value(
                 &connection,
                 &workspace,
-                owner,
+                source_name,
                 value_key,
                 last_observed_at,
                 1,
@@ -814,7 +803,7 @@ mod tests {
             .execute_batch(include_str!("../migrations/0002_observed_values.sql"))
             .expect("v2 observed-values schema");
         let workspace = WorkspaceName::default();
-        seed_legacy_fts_tombstones(&connection);
+        seed_legacy_v2_fts_tombstones(&connection);
         connection
             .execute_batch(include_str!(
                 "../migrations/0003_observed_values_governance.sql"
@@ -908,17 +897,17 @@ mod tests {
     fn observed_values_connection() -> Connection {
         let connection = Connection::open_in_memory().expect("connection");
         connection
-            .execute_batch(include_str!("../migrations/0002_observed_values.sql"))
-            .expect("observed-values schema");
-        connection
             .execute_batch(include_str!(
-                "../migrations/0003_observed_values_governance.sql"
+                "../migrations/0005_observed_source_identity.sql"
             ))
-            .expect("observed-values governance schema");
+            .expect("observed-values schema");
         connection
     }
 
-    fn seed_legacy_fts_tombstones(connection: &Connection) {
+    /// Historical fixture: writes rows in the pre-#1791 owner/component shape
+    /// against the v2 schema, which is the point of the test that uses it --
+    /// FTS pages written before `secure-delete` was enabled in v3.
+    fn seed_legacy_v2_fts_tombstones(connection: &Connection) {
         connection
             .execute_batch(
                 "
@@ -985,7 +974,7 @@ mod tests {
     fn insert_observed_value(
         connection: &Connection,
         workspace: &WorkspaceName,
-        owner_source_name: &str,
+        source_name: &str,
         value_key: &str,
         last_observed_at: &str,
         observation_count: i64,
@@ -995,7 +984,6 @@ mod tests {
                 "
                 INSERT INTO observed_values (
                     workspace,
-                    owner_source_name,
                     source_name,
                     source_scope_id,
                     surface_kind,
@@ -1010,13 +998,13 @@ mod tests {
                     source_generation,
                     workspace_generation
                 ) VALUES (
-                    ?1, ?2, 'shared-schema', 'scope', 'table', 'issues', 'title',
+                    ?1, ?2, 'scope', 'table', 'issues', 'title',
                     ?3, ?3, ?3, ?4, ?4, ?5, 0, 0
                 )
                 ",
                 params![
                     workspace.as_str(),
-                    owner_source_name,
+                    source_name,
                     value_key,
                     last_observed_at,
                     observation_count,
@@ -1028,7 +1016,6 @@ mod tests {
                 "
                 INSERT INTO observed_values_fts (
                     workspace,
-                    owner_source_name,
                     source_name,
                     source_scope_id,
                     surface_kind,
@@ -1037,9 +1024,9 @@ mod tests {
                     value_key,
                     display_value,
                     search_text
-                ) VALUES (?1, ?2, 'shared-schema', 'scope', 'table', 'issues', 'title', ?3, ?3, ?3)
+                ) VALUES (?1, ?2, 'scope', 'table', 'issues', 'title', ?3, ?3, ?3)
                 ",
-                params![workspace.as_str(), owner_source_name, value_key],
+                params![workspace.as_str(), source_name, value_key],
             )
             .expect("insert FTS observed value");
     }

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -60,18 +60,18 @@ impl ObservedValuesLiveScopeLoader {
         let mut live_scopes = Vec::new();
         let mut failed_sources = Vec::new();
         for source in sources {
-            let owner_source_name = source.name.as_str().to_string();
+            let source_name = source.name.as_str().to_string();
             match self.load_source_scopes(workspace_name, &source) {
                 Ok(source_scopes) => live_scopes.extend(source_scopes),
                 Err(error) => {
                     tracing::debug!(
                         workspace = %workspace_name,
-                        source = %owner_source_name,
+                        source = %source_name,
                         error = %error,
                         "skipping observed-value live scope for source"
                     );
                     failed_sources.push(ObservedValuesLiveScopeLoadFailure {
-                        owner_source_name,
+                        source_name,
                         message: error.to_string(),
                     });
                 }
@@ -177,8 +177,8 @@ mod tests {
         assert_eq!(second.live_scopes.len(), 1);
         let first_scope = first.live_scopes.first().expect("first live scope");
         let second_scope = second.live_scopes.first().expect("second live scope");
-        assert_eq!(first_scope.owner_source_name, "github");
         assert_eq!(first_scope.source_name, "github");
+        assert_eq!(second_scope.source_name, "github");
         assert_eq!(first_scope.surface_kind, ObservedValuesSurfaceKind::Table);
         assert_eq!(first_scope.surface_name, "issues");
         assert_ne!(first_scope.source_scope_id, second_scope.source_scope_id);
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(live_scope.source_name, "github");
         assert_eq!(load.failed_sources.len(), 1);
         let failed_source = load.failed_sources.first().expect("failed source");
-        assert_eq!(failed_source.owner_source_name, "broken");
+        assert_eq!(failed_source.source_name, "broken");
     }
 
     fn install_source(

--- a/crates/coral-app/src/search/observed/policy.rs
+++ b/crates/coral-app/src/search/observed/policy.rs
@@ -4,7 +4,6 @@ use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ObservedValuesLiveScope {
-    pub(crate) owner_source_name: String,
     pub(crate) source_name: String,
     pub(crate) source_scope_id: String,
     pub(crate) surface_kind: ObservedValuesSurfaceKind,
@@ -13,7 +12,7 @@ pub(crate) struct ObservedValuesLiveScope {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ObservedValuesLiveScopeLoadFailure {
-    pub(crate) owner_source_name: String,
+    pub(crate) source_name: String,
     pub(crate) message: String,
 }
 
@@ -53,10 +52,10 @@ impl ObservedValuesRetrievalPolicy {
         !self.failed_sources.is_empty()
     }
 
-    pub(crate) fn failed_owner_source_names(&self) -> Vec<&str> {
+    pub(crate) fn failed_source_names(&self) -> Vec<&str> {
         self.failed_sources
             .iter()
-            .map(|failure| failure.owner_source_name.as_str())
+            .map(|failure| failure.source_name.as_str())
             .collect()
     }
 
@@ -93,7 +92,7 @@ mod tests {
 
         assert!(policy.has_load_failures());
         assert_eq!(policy.failed_source_count(), 2);
-        assert_eq!(policy.failed_owner_source_names(), vec!["jira", "slack"]);
+        assert_eq!(policy.failed_source_names(), vec!["jira", "slack"]);
         assert_eq!(policy.failed_sources().len(), 2);
     }
 
@@ -116,7 +115,6 @@ mod tests {
 
     fn live_scope(source_name: &str, source_scope_id: &str) -> ObservedValuesLiveScope {
         ObservedValuesLiveScope {
-            owner_source_name: source_name.to_string(),
             source_name: source_name.to_string(),
             source_scope_id: source_scope_id.to_string(),
             surface_kind: ObservedValuesSurfaceKind::Table,
@@ -126,7 +124,7 @@ mod tests {
 
     fn load_failure(source_name: &str, message: &str) -> ObservedValuesLiveScopeLoadFailure {
         ObservedValuesLiveScopeLoadFailure {
-            owner_source_name: source_name.to_string(),
+            source_name: source_name.to_string(),
             message: message.to_string(),
         }
     }

--- a/crates/coral-app/src/search/observed/provider.rs
+++ b/crates/coral-app/src/search/observed/provider.rs
@@ -210,9 +210,9 @@ impl ObservedValuesProvider {
                 .store
                 .clear_workspace_and_advance_epoch(request.workspace_name)
                 .map_err(|error| observed_sqlite_app_error(&error))?,
-            SearchClearTarget::Source(owner_source_name) => self
+            SearchClearTarget::Source(source_name) => self
                 .store
-                .clear_source_and_advance_epoch(request.workspace_name, owner_source_name.as_str())
+                .clear_source_and_advance_epoch(request.workspace_name, source_name.as_str())
                 .map_err(|error| observed_sqlite_app_error(&error))?,
         };
         Ok(SearchProviderClearOutcome {
@@ -507,9 +507,9 @@ fn observed_policy_load_failure_note(policy: &ObservedValuesRetrievalPolicy) -> 
     if !policy.has_load_failures() {
         return None;
     }
-    let owner_source_names = policy.failed_owner_source_names().join(", ");
+    let source_names = policy.failed_source_names().join(", ");
     Some(format!(
-        "observed value search skipped {} source(s) whose live scopes could not be loaded: {owner_source_names}",
+        "observed value search skipped {} source(s) whose live scopes could not be loaded: {source_names}",
         policy.failed_source_count()
     ))
 }
@@ -740,8 +740,8 @@ fn observed_rebuild_note(
     if policy.has_load_failures() {
         note.push_str("; skipped ");
         note.push_str(&policy.failed_source_count().to_string());
-        note.push_str(" owner source(s) whose live scopes could not be loaded: ");
-        note.push_str(&policy.failed_owner_source_names().join(", "));
+        note.push_str(" source(s) whose live scopes could not be loaded: ");
+        note.push_str(&policy.failed_source_names().join(", "));
     }
     note
 }

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -147,10 +147,10 @@ impl SearchObservationHandle {
     pub(crate) fn clear_source(
         &self,
         workspace_name: &WorkspaceName,
-        owner_source_name: &str,
+        source_name: &str,
     ) -> Result<(), AppError> {
         self.store
-            .clear_source_and_advance_epoch(workspace_name, owner_source_name)
+            .clear_source_and_advance_epoch(workspace_name, source_name)
             .map(|_result| ())
             .map_err(|error| observed_values_store_error(&error))
     }
@@ -216,7 +216,6 @@ impl SourceScanObservedValuesPublisher {
                 tracing::debug!(
                     workspace = %self.workspace_name.as_str(),
                     source = %scope.source_name,
-                    source_owner = %scope.owner_source_name,
                     surface = %observation.surface_name,
                     "dropping observed-values source-scan observation because writer queue is full"
                 );
@@ -226,7 +225,6 @@ impl SourceScanObservedValuesPublisher {
                 tracing::debug!(
                     workspace = %self.workspace_name.as_str(),
                     source = %scope.source_name,
-                    source_owner = %scope.owner_source_name,
                     surface = %observation.surface_name,
                     "dropping observed-values source-scan observation because writer is stopped"
                 );
@@ -265,7 +263,6 @@ impl SourceScanObservedValuesPublisher {
         };
         permit.send(ObservedValuesWrite {
             workspace_name: self.workspace_name.clone(),
-            owner_source_name: scope.owner_source_name.clone(),
             source_name: scope.source_name.clone(),
             source_scope_id: scope.source_scope_id.clone(),
             surface_kind,
@@ -486,16 +483,11 @@ mod tests {
         }
 
         // Only the coherent source registered a surface, so only its
-        // observation is captured; the divergent package writes nothing, and
-        // failing it does not abort capture for its neighbour.
+        // observation is captured; the divergent package writes nothing.
         let identities = wait_for_source_identities(&layout, &workspace, 1);
         assert_eq!(
             identities,
-            [(
-                "github_mcp_v4".to_string(),
-                "github_mcp_v4".to_string(),
-                "list_issues".to_string(),
-            )]
+            [("github_mcp_v4".to_string(), "list_issues".to_string())]
         );
     }
 
@@ -510,6 +502,60 @@ mod tests {
         // this error into a per-source load failure.
         assert!(error.to_string().contains("github_v4"));
         assert!(error.to_string().contains("github_v4_rest"));
+    }
+
+    #[test]
+    fn independent_sources_are_captured_and_cleared_in_isolation() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let handle = SearchObservationHandle::new(layout.clone());
+        let rest = single_component_query_source("github_v4");
+        let mcp = single_component_query_source("github_mcp_v4");
+        let extensions = handle.extensions_for(
+            &workspace,
+            &[
+                SearchObservationSource::for_test(&rest),
+                SearchObservationSource::for_test(&mcp),
+            ],
+        );
+        let publisher = extensions
+            .source_observation_publishers
+            .first()
+            .expect("publisher");
+        let batch = title_batch();
+
+        for source_name in ["github_v4", "github_mcp_v4"] {
+            publisher.publish_source_scan(SourceScanObservation {
+                source_name,
+                surface_kind: SourceObservationSurfaceKind::Table,
+                surface_name: "list_issues",
+                batch: &batch,
+            });
+        }
+
+        let identities = wait_for_source_identities(&layout, &workspace, 2);
+        assert_eq!(
+            identities,
+            [
+                ("github_v4".to_string(), "list_issues".to_string()),
+                ("github_mcp_v4".to_string(), "list_issues".to_string()),
+            ]
+        );
+
+        // The REST and MCP interfaces are separate installed sources: clearing
+        // one leaves the other's queued observation untouched.
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        store
+            .clear_source_and_advance_epoch(&workspace, "github_v4")
+            .expect("clear one installed source");
+        assert_eq!(
+            store
+                .queue_source_identities(&workspace)
+                .expect("queue identities"),
+            [("github_mcp_v4".to_string(), "list_issues".to_string())]
+        );
     }
 
     #[test]
@@ -644,9 +690,9 @@ tables:
         )
     }
 
-    /// Package in the pre-#1791 shape: components named differently from the
-    /// package that carries them. Unreachable through the sources domain, which
-    /// is exactly what the tripwire defends against.
+    /// Synthetic package in the pre-#1791 shape: components named differently
+    /// from the package that carries them. Unreachable through the sources
+    /// domain, which is exactly what the tripwire defends against.
     fn divergent_component_query_source() -> QuerySource {
         QuerySource::from_runtime_components(
             RuntimeSourcePackage {
@@ -734,7 +780,7 @@ tables:
         layout: &AppStateLayout,
         workspace: &WorkspaceName,
         expected_count: usize,
-    ) -> Vec<(String, String, String)> {
+    ) -> Vec<(String, String)> {
         let store = SqliteObservedValuesStore::new(layout.clone());
         for _ in 0..100 {
             let identities = store

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -19,6 +19,23 @@ pub(super) struct SurfaceKey {
     pub(super) surface_name: String,
 }
 
+/// A runtime component whose name diverges from its package's source name.
+///
+/// Since #1791 one source publishes exactly one surface and one SQL namespace,
+/// and the sources domain copies both names from the same `manifest.common.name`
+/// field, so this is unreachable on every production path. Search still refuses
+/// the source here rather than writing rows under an identity that would select
+/// nothing back — a tripwire at the single seam that derives identity from a
+/// runtime package, not an enforcement boundary.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "source '{source_name}' exposes runtime component '{component_source_name}'; one installed source must publish exactly one runtime schema"
+)]
+pub(crate) struct ObservedSourceIdentityMismatch {
+    source_name: String,
+    component_source_name: String,
+}
+
 /// Opaque identity supplied by the app-owned runtime-package boundary.
 ///
 /// The queue substrate does not interpret either value. The app-wiring PR
@@ -48,28 +65,10 @@ impl<'a> SourceScopeSeed<'a> {
     }
 }
 
-/// A runtime component whose name diverges from its package's source name.
-///
-/// Since #1791 one source publishes exactly one surface and one SQL namespace,
-/// and the sources domain copies both names from the same `manifest.common.name`
-/// field, so this is unreachable on every production path. Search still refuses
-/// the source rather than writing rows under an identity that would select
-/// nothing back -- a tripwire at the single seam that derives identity from a
-/// runtime package, not an enforcement boundary.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error(
-    "source '{source_name}' exposes runtime component '{component_source_name}'; one installed source must publish exactly one runtime schema"
-)]
-pub(crate) struct ObservedSourceIdentityMismatch {
-    source_name: String,
-    component_source_name: String,
-}
-
 #[derive(Debug, Clone)]
 pub(super) struct ObservedSourceSurfaceScope {
-    /// Canonical installed source that owns lifecycle clears and invalidation epochs.
-    pub(super) owner_source_name: String,
-    /// Runtime component schema used in SQL and search results.
+    /// Installed source: lifecycle clears, invalidation epochs, and the SQL
+    /// namespace used in search results — one name, because they are one thing.
     pub(super) source_name: String,
     surface_key: SurfaceKey,
     pub(super) source_scope_id: String,
@@ -82,7 +81,6 @@ impl ObservedSourceSurfaceScope {
 
     pub(super) fn live_scope(&self) -> ObservedValuesLiveScope {
         ObservedValuesLiveScope {
-            owner_source_name: self.owner_source_name.clone(),
             source_name: self.source_name.clone(),
             source_scope_id: self.source_scope_id.clone(),
             surface_kind: self.surface_key.surface_kind,
@@ -121,8 +119,7 @@ pub(super) fn source_surface_scopes(
             RuntimeSourceComponent::Http(manifest) => {
                 scopes.extend(manifest.tables.iter().map(|table| {
                     surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
+                        source_name,
                         ObservedValuesSurfaceKind::Table,
                         table.name(),
                         seed,
@@ -130,8 +127,7 @@ pub(super) fn source_surface_scopes(
                 }));
                 scopes.extend(manifest.functions.iter().map(|function| {
                     surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
+                        source_name,
                         ObservedValuesSurfaceKind::Function,
                         function.name.as_str(),
                         seed,
@@ -141,8 +137,7 @@ pub(super) fn source_surface_scopes(
             RuntimeSourceComponent::File(manifest) => {
                 scopes.extend(manifest.tables.iter().map(|table| {
                     surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
+                        source_name,
                         ObservedValuesSurfaceKind::Table,
                         table.name(),
                         seed,
@@ -152,8 +147,7 @@ pub(super) fn source_surface_scopes(
             RuntimeSourceComponent::Mcp(manifest) => {
                 scopes.extend(manifest.tables.iter().map(|table| {
                     surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
+                        source_name,
                         ObservedValuesSurfaceKind::Table,
                         table.name(),
                         seed,
@@ -161,8 +155,7 @@ pub(super) fn source_surface_scopes(
                 }));
                 scopes.extend(manifest.functions.iter().map(|function| {
                     surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
+                        source_name,
                         ObservedValuesSurfaceKind::Function,
                         function.name(),
                         seed,
@@ -175,8 +168,7 @@ pub(super) fn source_surface_scopes(
 }
 
 fn surface_scope(
-    source: &QuerySource,
-    component_source_name: &str,
+    source_name: &str,
     surface_kind: ObservedValuesSurfaceKind,
     surface_name: &str,
     seed: SourceScopeSeed<'_>,
@@ -185,16 +177,15 @@ fn surface_scope(
         format_version: SOURCE_SCOPE_FORMAT_VERSION,
         runtime_contract_fingerprint: seed.runtime_contract_fingerprint,
         credential_revision: seed.credential_revision,
-        component_source_name,
+        source_name,
         surface_kind: surface_kind.as_str(),
         surface_name,
     })
     .expect("observed-values source scope must serialize");
     ObservedSourceSurfaceScope {
-        owner_source_name: source.source_name().to_string(),
-        source_name: component_source_name.to_string(),
+        source_name: source_name.to_string(),
         surface_key: SurfaceKey {
-            source_name: component_source_name.to_string(),
+            source_name: source_name.to_string(),
             surface_kind,
             surface_name: surface_name.to_string(),
         },
@@ -207,33 +198,31 @@ struct ScopeFingerprint<'a> {
     format_version: u8,
     runtime_contract_fingerprint: &'a str,
     credential_revision: Uuid,
-    component_source_name: &'a str,
+    // The serialized key is a stable on-disk format: these bytes are hashed
+    // into `source_scope_id`, which every stored observed row is keyed by.
+    // Renaming the Rust field to match the singular identity model must not
+    // rotate scope ids, or migrated rows would be fail-closed invisible.
+    #[serde(rename = "component_source_name")]
+    source_name: &'a str,
     surface_kind: &'static str,
     surface_name: &'a str,
 }
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
-
     use super::{SOURCE_SCOPE_FORMAT_VERSION, ScopeFingerprint};
     use crate::hash::sha256_hex;
+    use uuid::Uuid;
 
-    /// Pins the exact bytes hashed into `source_scope_id`.
-    ///
-    /// Every stored observed row is keyed by that id and retrieval is
-    /// fail-closed, so a change to this serialization silently hides the entire
-    /// observed corpus rather than failing anything. The struct is private and
-    /// its field names are part of the on-disk format, not an implementation
-    /// detail -- if a refactor needs to rename one, it owes a `#[serde(rename)]`
-    /// and this test must keep passing untouched.
+    /// Pins the hashed bytes across the `component_source_name` -> `source_name`
+    /// Rust rename. A change here invalidates every stored observed row.
     #[test]
-    fn scope_fingerprint_hash_is_stable() {
+    fn scope_fingerprint_hash_is_stable_across_the_field_rename() {
         let scope_bytes = serde_json::to_vec(&ScopeFingerprint {
             format_version: SOURCE_SCOPE_FORMAT_VERSION,
             runtime_contract_fingerprint: "v1:test-runtime-contract",
             credential_revision: Uuid::nil(),
-            component_source_name: "github_v4",
+            source_name: "github_v4",
             surface_kind: "table",
             surface_name: "issues",
         })

--- a/crates/coral-app/src/search/observed/sqlite_projection.rs
+++ b/crates/coral-app/src/search/observed/sqlite_projection.rs
@@ -94,7 +94,6 @@ pub(crate) struct ObservedValuesSearchHits {
 #[derive(Debug)]
 struct ObservedQueueJobRow {
     id: i64,
-    owner_source_name: String,
     source_name: String,
     source_scope_id: String,
     surface_kind: ObservedValuesSurfaceKind,
@@ -107,7 +106,6 @@ struct ObservedQueueJobRow {
 #[derive(Debug)]
 struct RawObservedQueueJobRow {
     id: i64,
-    owner_source_name: String,
     source_name: String,
     source_scope_id: String,
     surface_kind: String,
@@ -143,7 +141,6 @@ pub(crate) enum ObservedFtsRebuildPhase {
 struct CanonicalObservedFtsRow {
     rowid: i64,
     workspace: String,
-    owner_source_name: String,
     source_name: String,
     source_scope_id: String,
     surface_kind: String,
@@ -159,7 +156,6 @@ impl CanonicalObservedFtsRow {
     fn payload_bytes(&self) -> usize {
         self.workspace
             .len()
-            .saturating_add(self.owner_source_name.len())
             .saturating_add(self.source_name.len())
             .saturating_add(self.source_scope_id.len())
             .saturating_add(self.surface_kind.len())
@@ -176,7 +172,6 @@ impl CanonicalObservedFtsRow {
 struct RawObservedFtsRow {
     rowid: i64,
     workspace: Value,
-    owner_source_name: Value,
     source_name: Value,
     source_scope_id: Value,
     surface_kind: Value,
@@ -190,7 +185,6 @@ struct RawObservedFtsRow {
 impl RawObservedFtsRow {
     fn payload_bytes(&self) -> usize {
         observed_fts_value_payload_bytes(&self.workspace)
-            .saturating_add(observed_fts_value_payload_bytes(&self.owner_source_name))
             .saturating_add(observed_fts_value_payload_bytes(&self.source_name))
             .saturating_add(observed_fts_value_payload_bytes(&self.source_scope_id))
             .saturating_add(observed_fts_value_payload_bytes(&self.surface_kind))
@@ -221,7 +215,6 @@ impl RawObservedQueueJobRow {
     fn decode(self) -> Result<ObservedQueueJobRow, (i64, String)> {
         let Self {
             id,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind: surface_kind_raw,
@@ -238,7 +231,6 @@ impl RawObservedQueueJobRow {
         };
         Ok(ObservedQueueJobRow {
             id,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -578,7 +570,7 @@ fn next_raw_observed_fts_rows(
     max_batch_payload_bytes: usize,
 ) -> Result<Vec<RawObservedFtsRow>, SqliteSearchError> {
     let first_sql = "
-        SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+        SELECT rowid, workspace, source_name, source_scope_id,
                surface_kind, surface_name, column_name, value_key, display_value, search_text
         FROM observed_values_fts
         WHERE rowid >= ?1 AND rowid <= ?2
@@ -586,7 +578,7 @@ fn next_raw_observed_fts_rows(
         LIMIT ?3
         ";
     let next_sql = "
-        SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+        SELECT rowid, workspace, source_name, source_scope_id,
                surface_kind, surface_name, column_name, value_key, display_value, search_text
         FROM observed_values_fts
         WHERE rowid > ?1 AND rowid <= ?2
@@ -631,15 +623,14 @@ fn raw_observed_fts_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawObserved
     Ok(RawObservedFtsRow {
         rowid: row.get(0)?,
         workspace: row.get(1)?,
-        owner_source_name: row.get(2)?,
-        source_name: row.get(3)?,
-        source_scope_id: row.get(4)?,
-        surface_kind: row.get(5)?,
-        surface_name: row.get(6)?,
-        column_name: row.get(7)?,
-        value_key: row.get(8)?,
-        display_value: row.get(9)?,
-        search_text: row.get(10)?,
+        source_name: row.get(2)?,
+        source_scope_id: row.get(3)?,
+        surface_kind: row.get(4)?,
+        surface_name: row.get(5)?,
+        column_name: row.get(6)?,
+        value_key: row.get(7)?,
+        display_value: row.get(8)?,
+        search_text: row.get(9)?,
     })
 }
 
@@ -650,7 +641,7 @@ fn raw_observed_fts_row_by_rowid(
     connection
         .query_row(
             "
-            SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+            SELECT rowid, workspace, source_name, source_scope_id,
                    surface_kind, surface_name, column_name, value_key, display_value, search_text
             FROM observed_values_fts
             WHERE rowid = ?1
@@ -670,7 +661,7 @@ fn next_canonical_observed_rows(
     max_batch_payload_bytes: usize,
 ) -> Result<Vec<CanonicalObservedFtsRow>, SqliteSearchError> {
     let first_sql = "
-        SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+        SELECT rowid, workspace, source_name, source_scope_id,
                surface_kind, surface_name, column_name, value_key, display_value,
                search_text, last_observed_at
         FROM observed_values
@@ -679,7 +670,7 @@ fn next_canonical_observed_rows(
         LIMIT ?3
         ";
     let next_sql = "
-        SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+        SELECT rowid, workspace, source_name, source_scope_id,
                surface_kind, surface_name, column_name, value_key, display_value,
                search_text, last_observed_at
         FROM observed_values
@@ -727,16 +718,15 @@ fn canonical_observed_fts_row(
     Ok(CanonicalObservedFtsRow {
         rowid: row.get(0)?,
         workspace: row.get(1)?,
-        owner_source_name: row.get(2)?,
-        source_name: row.get(3)?,
-        source_scope_id: row.get(4)?,
-        surface_kind: row.get(5)?,
-        surface_name: row.get(6)?,
-        column_name: row.get(7)?,
-        value_key: row.get(8)?,
-        display_value: row.get(9)?,
-        search_text: row.get(10)?,
-        last_observed_at: row.get(11)?,
+        source_name: row.get(2)?,
+        source_scope_id: row.get(3)?,
+        surface_kind: row.get(4)?,
+        surface_name: row.get(5)?,
+        column_name: row.get(6)?,
+        value_key: row.get(7)?,
+        display_value: row.get(8)?,
+        search_text: row.get(9)?,
+        last_observed_at: row.get(10)?,
     })
 }
 
@@ -747,7 +737,7 @@ fn canonical_observed_row_by_rowid(
     connection
         .query_row(
             "
-            SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+            SELECT rowid, workspace, source_name, source_scope_id,
                    surface_kind, surface_name, column_name, value_key, display_value,
                    search_text, last_observed_at
             FROM observed_values
@@ -766,7 +756,6 @@ fn canonical_observed_row_for_fts_key(
 ) -> Result<Option<CanonicalObservedFtsRow>, SqliteSearchError> {
     let (
         Some(workspace),
-        Some(owner_source_name),
         Some(source_name),
         Some(source_scope_id),
         Some(surface_kind),
@@ -775,7 +764,6 @@ fn canonical_observed_row_for_fts_key(
         Some(value_key),
     ) = (
         observed_fts_text(&fts.workspace),
-        observed_fts_text(&fts.owner_source_name),
         observed_fts_text(&fts.source_name),
         observed_fts_text(&fts.source_scope_id),
         observed_fts_text(&fts.surface_kind),
@@ -789,22 +777,20 @@ fn canonical_observed_row_for_fts_key(
     connection
         .query_row(
             "
-            SELECT rowid, workspace, owner_source_name, source_name, source_scope_id,
+            SELECT rowid, workspace, source_name, source_scope_id,
                    surface_kind, surface_name, column_name, value_key, display_value,
                    search_text, last_observed_at
             FROM observed_values
             WHERE workspace = ?1
-              AND owner_source_name = ?2
-              AND source_name = ?3
-              AND source_scope_id = ?4
-              AND surface_kind = ?5
-              AND surface_name = ?6
-              AND column_name = ?7
-              AND value_key = ?8
+              AND source_name = ?2
+              AND source_scope_id = ?3
+              AND surface_kind = ?4
+              AND surface_name = ?5
+              AND column_name = ?6
+              AND value_key = ?7
             ",
             params![
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -830,7 +816,6 @@ fn observed_fts_content_matches_canonical(
     canonical: &CanonicalObservedFtsRow,
 ) -> bool {
     observed_fts_text(&fts.workspace) == Some(canonical.workspace.as_str())
-        && observed_fts_text(&fts.owner_source_name) == Some(canonical.owner_source_name.as_str())
         && observed_fts_text(&fts.source_name) == Some(canonical.source_name.as_str())
         && observed_fts_text(&fts.source_scope_id) == Some(canonical.source_scope_id.as_str())
         && observed_fts_text(&fts.surface_kind) == Some(canonical.surface_kind.as_str())
@@ -857,14 +842,14 @@ fn observed_fts_value_payload_bytes(value: &Value) -> usize {
     }
 }
 
-fn observed_owner_failed(
+fn observed_source_failed(
     connection: &Connection,
-    owner_source_name: &str,
+    source_name: &str,
 ) -> Result<bool, SqliteSearchError> {
     connection
         .query_row(
-            "SELECT EXISTS(SELECT 1 FROM observed_policy_failed_sources WHERE owner_source_name = ?1)",
-            params![owner_source_name],
+            "SELECT EXISTS(SELECT 1 FROM observed_policy_failed_sources WHERE source_name = ?1)",
+            params![source_name],
             |row| row.get(0),
         )
         .map_err(SqliteSearchError::from)
@@ -880,15 +865,13 @@ fn canonical_observed_scope_is_live(
             SELECT EXISTS(
                 SELECT 1
                 FROM observed_live_source_scopes
-                WHERE owner_source_name = ?1
-                  AND source_name = ?2
-                  AND source_scope_id = ?3
-                  AND surface_kind = ?4
-                  AND surface_name = ?5
+                WHERE source_name = ?1
+                  AND source_scope_id = ?2
+                  AND surface_kind = ?3
+                  AND surface_name = ?4
             )
             ",
             params![
-                &canonical.owner_source_name,
                 &canonical.source_name,
                 &canonical.source_scope_id,
                 &canonical.surface_kind,
@@ -899,14 +882,14 @@ fn canonical_observed_scope_is_live(
         .map_err(SqliteSearchError::from)
 }
 
-fn raw_observed_fts_owner_failed(
+fn raw_observed_fts_source_failed(
     connection: &Connection,
     fts: &RawObservedFtsRow,
 ) -> Result<bool, SqliteSearchError> {
-    let Some(owner_source_name) = observed_fts_text(&fts.owner_source_name) else {
+    let Some(source_name) = observed_fts_text(&fts.source_name) else {
         return Ok(false);
     };
-    observed_owner_failed(connection, owner_source_name)
+    observed_source_failed(connection, source_name)
 }
 
 fn canonical_observed_row_is_retrievable_at_cutoff(
@@ -916,7 +899,7 @@ fn canonical_observed_row_is_retrievable_at_cutoff(
     canonical: &CanonicalObservedFtsRow,
 ) -> Result<bool, SqliteSearchError> {
     Ok(canonical.workspace == workspace_name.as_str()
-        && !observed_owner_failed(connection, &canonical.owner_source_name)?
+        && !observed_source_failed(connection, &canonical.source_name)?
         && canonical_observed_scope_is_live(connection, canonical)?
         && canonical.last_observed_at.as_str() >= retention_cutoff)
 }
@@ -1084,7 +1067,7 @@ fn observed_fts_cleanup_decision(
     retention_cutoff: &str,
     fts: &RawObservedFtsRow,
 ) -> Result<ObservedFtsCleanupDecision, SqliteSearchError> {
-    if raw_observed_fts_owner_failed(connection, fts)? {
+    if raw_observed_fts_source_failed(connection, fts)? {
         return Ok(ObservedFtsCleanupDecision::PRESERVE);
     }
     match observed_fts_text(&fts.workspace) {
@@ -1096,7 +1079,7 @@ fn observed_fts_cleanup_decision(
     let target_canonical = canonical_observed_row_by_rowid(connection, fts.rowid)?;
     if let Some(target_canonical) = target_canonical.as_ref()
         && (target_canonical.workspace != workspace_name.as_str()
-            || observed_owner_failed(connection, &target_canonical.owner_source_name)?)
+            || observed_source_failed(connection, &target_canonical.source_name)?)
     {
         return Ok(ObservedFtsCleanupDecision::PRESERVE);
     }
@@ -1107,7 +1090,7 @@ fn observed_fts_cleanup_decision(
         });
     };
     if canonical.workspace != workspace_name.as_str()
-        || observed_owner_failed(connection, &canonical.owner_source_name)?
+        || observed_source_failed(connection, &canonical.source_name)?
     {
         return Ok(ObservedFtsCleanupDecision::PRESERVE);
     }
@@ -1280,7 +1263,7 @@ fn canonical_observed_mutation(
     fts: Option<&RawObservedFtsRow>,
 ) -> Result<CanonicalObservedMutation, SqliteSearchError> {
     if canonical.workspace != workspace_name.as_str()
-        || observed_owner_failed(connection, &canonical.owner_source_name)?
+        || observed_source_failed(connection, &canonical.source_name)?
     {
         return Ok(CanonicalObservedMutation {
             delete_fts: false,
@@ -1290,7 +1273,7 @@ fn canonical_observed_mutation(
     }
     let protected_fts = match fts {
         Some(fts) => {
-            raw_observed_fts_owner_failed(connection, fts)?
+            raw_observed_fts_source_failed(connection, fts)?
                 || observed_fts_text(&fts.workspace)
                     .is_some_and(|workspace| workspace != workspace_name.as_str())
                 || raw_observed_fts_is_valid_unrelated_occupant(
@@ -1370,7 +1353,6 @@ fn insert_aligned_observed_fts_row(
         INSERT INTO observed_values_fts (
             rowid,
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -1379,12 +1361,11 @@ fn insert_aligned_observed_fts_row(
             value_key,
             display_value,
             search_text
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
         ",
         params![
             canonical.rowid,
             &canonical.workspace,
-            &canonical.owner_source_name,
             &canonical.source_name,
             &canonical.source_scope_id,
             &canonical.surface_kind,
@@ -1564,7 +1545,6 @@ fn search_observed_values_fts(
         FROM observed_values_fts f
         JOIN observed_values v
             ON v.workspace = f.workspace
-            AND v.owner_source_name = f.owner_source_name
             AND v.source_name = f.source_name
             AND v.source_scope_id = f.source_scope_id
             AND v.surface_kind = f.surface_kind
@@ -1572,8 +1552,7 @@ fn search_observed_values_fts(
             AND v.column_name = f.column_name
             AND v.value_key = f.value_key
         JOIN observed_live_source_scopes s
-            ON s.owner_source_name = v.owner_source_name
-            AND s.source_name = v.source_name
+            ON s.source_name = v.source_name
             AND s.source_scope_id = v.source_scope_id
             AND s.surface_kind = v.surface_kind
             AND s.surface_name = v.surface_name
@@ -1626,8 +1605,7 @@ fn search_observed_values_short_terms(
             v.observation_count
         FROM observed_values v
         JOIN observed_live_source_scopes s
-            ON s.owner_source_name = v.owner_source_name
-            AND s.source_name = v.source_name
+            ON s.source_name = v.source_name
             AND s.source_scope_id = v.source_scope_id
             AND s.surface_kind = v.surface_kind
             AND s.surface_name = v.surface_name
@@ -1697,8 +1675,7 @@ where
         }
     };
 
-    let current_generation =
-        observed_generations(&transaction, workspace_name, &job.owner_source_name)?;
+    let current_generation = observed_generations(&transaction, workspace_name, &job.source_name)?;
     let job_generation = ObservedValuesEpoch {
         workspace_generation: job.workspace_generation,
         source_generation: job.source_generation,
@@ -1798,7 +1775,6 @@ fn upsert_observed_value(
             "
         INSERT INTO observed_values (
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -1823,16 +1799,14 @@ fn upsert_observed_value(
             ?7,
             ?8,
             ?9,
-            ?10,
             strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
             strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
             1,
-            ?11,
-            ?12
+            ?10,
+            ?11
         )
         ON CONFLICT(
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -1850,7 +1824,6 @@ fn upsert_observed_value(
         ",
             params![
                 workspace_name.as_str(),
-                &job.owner_source_name,
                 &job.source_name,
                 &job.source_scope_id,
                 job.surface_kind.as_str(),
@@ -1880,7 +1853,6 @@ fn refresh_observed_fts_row(
         INSERT INTO observed_values_fts (
             rowid,
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -1890,12 +1862,11 @@ fn refresh_observed_fts_row(
             display_value,
             search_text
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
         ",
         params![
             canonical_rowid,
             workspace_name.as_str(),
-            &job.owner_source_name,
             &job.source_name,
             &job.source_scope_id,
             job.surface_kind.as_str(),
@@ -1919,17 +1890,15 @@ fn delete_observed_fts_rows_for_projection_key(
         "
         DELETE FROM observed_values_fts
         WHERE workspace = ?1
-          AND owner_source_name = ?2
-          AND source_name = ?3
-          AND source_scope_id = ?4
-          AND surface_kind = ?5
-          AND surface_name = ?6
-          AND column_name = ?7
-          AND value_key = ?8
+          AND source_name = ?2
+          AND source_scope_id = ?3
+          AND surface_kind = ?4
+          AND surface_name = ?5
+          AND column_name = ?6
+          AND value_key = ?7
         ",
         params![
             workspace_name.as_str(),
-            &job.owner_source_name,
             &job.source_name,
             &job.source_scope_id,
             job.surface_kind.as_str(),
@@ -1951,7 +1920,6 @@ fn next_queue_job(
             "
             SELECT
                 id,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -1982,14 +1950,13 @@ fn observed_queue_job_from_row(
 ) -> rusqlite::Result<RawObservedQueueJobRow> {
     Ok(RawObservedQueueJobRow {
         id: row.get(0)?,
-        owner_source_name: row.get(1)?,
-        source_name: row.get(2)?,
-        source_scope_id: row.get(3)?,
-        surface_kind: row.get(4)?,
-        surface_name: row.get(5)?,
-        workspace_generation: row.get(6)?,
-        source_generation: row.get(7)?,
-        payload_json: row.get(8)?,
+        source_name: row.get(1)?,
+        source_scope_id: row.get(2)?,
+        surface_kind: row.get(3)?,
+        surface_name: row.get(4)?,
+        workspace_generation: row.get(5)?,
+        source_generation: row.get(6)?,
+        payload_json: row.get(7)?,
     })
 }
 
@@ -2017,7 +1984,7 @@ fn observed_search_hit_from_row(
 fn observed_generations(
     connection: &Connection,
     workspace_name: &WorkspaceName,
-    owner_source_name: &str,
+    source_name: &str,
 ) -> Result<ObservedValuesEpoch, SqliteSearchError> {
     let workspace_generation = connection
         .query_row(
@@ -2038,7 +2005,7 @@ fn observed_generations(
             FROM observed_source_generations
             WHERE workspace = ?1 AND source_name = ?2
             ",
-            params![workspace_name.as_str(), owner_source_name],
+            params![workspace_name.as_str(), source_name],
             |row| row.get(0),
         )
         .optional()?
@@ -2185,13 +2152,11 @@ fn prepare_live_scope_table(
     connection.execute_batch(
         "
         CREATE TEMP TABLE IF NOT EXISTS observed_live_source_scopes (
-            owner_source_name TEXT NOT NULL,
             source_name TEXT NOT NULL,
             source_scope_id TEXT NOT NULL,
             surface_kind TEXT NOT NULL,
             surface_name TEXT NOT NULL,
             PRIMARY KEY (
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -2204,18 +2169,16 @@ fn prepare_live_scope_table(
     let mut statement = connection.prepare(
         "
         INSERT OR IGNORE INTO observed_live_source_scopes (
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
             surface_name
         )
-        VALUES (?1, ?2, ?3, ?4, ?5)
+        VALUES (?1, ?2, ?3, ?4)
         ",
     )?;
     for scope in policy.live_scopes() {
         statement.execute(params![
-            &scope.owner_source_name,
             &scope.source_name,
             &scope.source_scope_id,
             scope.surface_kind.as_str(),
@@ -2232,19 +2195,19 @@ fn prepare_failed_source_table(
     connection.execute_batch(
         "
         CREATE TEMP TABLE IF NOT EXISTS observed_policy_failed_sources (
-            owner_source_name TEXT NOT NULL PRIMARY KEY
+            source_name TEXT NOT NULL PRIMARY KEY
         ) WITHOUT ROWID;
         DELETE FROM observed_policy_failed_sources;
         ",
     )?;
     let mut statement = connection.prepare(
         "
-        INSERT OR IGNORE INTO observed_policy_failed_sources (owner_source_name)
+        INSERT OR IGNORE INTO observed_policy_failed_sources (source_name)
         VALUES (?1)
         ",
     )?;
     for failure in policy.failed_sources() {
-        statement.execute(params![&failure.owner_source_name])?;
+        statement.execute(params![&failure.source_name])?;
     }
     Ok(())
 }
@@ -2287,7 +2250,7 @@ fn purgeable_observed_value_count(
             AND NOT EXISTS (
                 SELECT 1
                 FROM observed_policy_failed_sources failed
-                WHERE failed.owner_source_name = v.owner_source_name
+                WHERE failed.source_name = v.source_name
             )
         ",
         params![workspace_name.as_str()],
@@ -2310,7 +2273,7 @@ fn stale_observed_value_count_at_cutoff(
             AND NOT EXISTS (
                 SELECT 1
                 FROM observed_policy_failed_sources failed
-                WHERE failed.owner_source_name = v.owner_source_name
+                WHERE failed.source_name = v.source_name
             )
         ",
         params![workspace_name.as_str(), retention_cutoff],
@@ -2329,8 +2292,7 @@ fn eligible_observed_value_count(
         SELECT COUNT(*)
         FROM observed_values v
         JOIN observed_live_source_scopes s
-            ON s.owner_source_name = v.owner_source_name
-            AND s.source_name = v.source_name
+            ON s.source_name = v.source_name
             AND s.source_scope_id = v.source_scope_id
             AND s.surface_kind = v.surface_kind
             AND s.surface_name = v.surface_name
@@ -2353,8 +2315,7 @@ fn eligible_observed_value_count_at_cutoff(
         SELECT COUNT(*)
         FROM observed_values v
         JOIN observed_live_source_scopes s
-            ON s.owner_source_name = v.owner_source_name
-            AND s.source_name = v.source_name
+            ON s.source_name = v.source_name
             AND s.source_scope_id = v.source_scope_id
             AND s.surface_kind = v.surface_kind
             AND s.surface_name = v.surface_name
@@ -2571,7 +2532,7 @@ mod tests {
         store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_identity("github", "github", "old-scope", "old value"),
+                &test_job_with_identity("github", "old-scope", "old value"),
                 epoch,
             )
             .expect("enqueue old observation");
@@ -2590,7 +2551,7 @@ mod tests {
         store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_identity("github", "github", "fresh-scope", "fresh value"),
+                &test_job_with_identity("github", "fresh-scope", "fresh value"),
                 epoch,
             )
             .expect("enqueue fresh observation");
@@ -2639,7 +2600,7 @@ mod tests {
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout.clone());
         let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
-        let mut poison = test_job_with_identity("github", "github", "bad-scope", "Bad value");
+        let mut poison = test_job_with_identity("github", "bad-scope", "Bad value");
         poison.payload_json = "{not-json".to_string();
         store
             .enqueue_if_current(&workspace, &poison, epoch)
@@ -2647,7 +2608,7 @@ mod tests {
         store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_identity("github", "github", "good-scope", "Good value"),
+                &test_job_with_identity("github", "good-scope", "Good value"),
                 epoch,
             )
             .expect("enqueue valid job");
@@ -2686,7 +2647,7 @@ mod tests {
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout.clone());
         let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
-        let mut poison = test_job_with_identity("github", "github", "bad-scope", "Bad value");
+        let mut poison = test_job_with_identity("github", "bad-scope", "Bad value");
         poison.payload_json = "{not-json".to_string();
         store
             .enqueue_if_current(&workspace, &poison, epoch)
@@ -2706,7 +2667,7 @@ mod tests {
         store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_identity("github", "github", "good-scope", "Good value"),
+                &test_job_with_identity("github", "good-scope", "Good value"),
                 epoch,
             )
             .expect("enqueue active job");
@@ -2741,14 +2702,14 @@ mod tests {
         store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_identity("github", "github", "bad-scope", "Bad value"),
+                &test_job_with_identity("github", "bad-scope", "Bad value"),
                 epoch,
             )
             .expect("enqueue malformed job");
         store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_identity("github", "github", "good-scope", "Good value"),
+                &test_job_with_identity("github", "good-scope", "Good value"),
                 epoch,
             )
             .expect("enqueue valid job");
@@ -2793,63 +2754,44 @@ mod tests {
     }
 
     #[test]
-    fn multi_surface_retrieval_preserves_owner_and_query_schemas() {
+    fn independent_sources_are_retrieved_and_cleared_in_isolation() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout.clone());
-        enqueue_multi_surface_identity_fixture(&store, &workspace);
+        enqueue_independent_source_fixture(&store, &workspace);
 
         let backing = SqliteSearchStore::open_workspace(&layout, &workspace).expect("store");
-        let mut connection = backing.connect_for_test().expect("connection");
-        let result = drain_observed_queue(
-            &mut connection,
-            &workspace,
-            ObservedValuesDrainBudget::new(10, Duration::from_secs(1)),
-            |_| Ok(false),
-            |_, _| Ok(ObservedValuesProjectionReclamation::default()),
-        )
-        .expect("drain");
-        assert_eq!(result.queue_jobs_processed, 1);
-        assert_eq!(result.canonical_rows_upserted, 1);
-        assert_eq!(result.fts_rows_written, 1);
+        let connection = backing.connect_for_test().expect("connection");
 
-        let canonical_identities = identity_rows(
+        let canonical_sources = source_rows(
             &connection,
-            "SELECT owner_source_name, source_name FROM observed_values \
+            "SELECT source_name FROM observed_values \
              WHERE workspace = ?1 ORDER BY source_name",
             &workspace,
         );
-        let searched_identities = identity_rows(
+        let searched_sources = source_rows(
             &connection,
-            "SELECT owner_source_name, source_name FROM observed_values_fts \
+            "SELECT source_name FROM observed_values_fts \
              WHERE workspace = ?1 AND observed_values_fts MATCH 'payment' \
              ORDER BY source_name",
             &workspace,
         );
-        let expected = vec![
-            ("github_v4".to_string(), "github_v4_mcp".to_string()),
-            ("github_v4".to_string(), "github_v4_rest".to_string()),
-            ("other_owner".to_string(), "github_v4_rest".to_string()),
-        ];
-        assert_eq!(canonical_identities, expected);
-        assert_eq!(searched_identities, expected);
+        let expected = vec!["github_mcp_v4".to_string(), "github_v4".to_string()];
+        assert_eq!(canonical_sources, expected);
+        assert_eq!(searched_sources, expected);
 
         let policy = ObservedValuesRetrievalPolicy::new(
-            [
-                ("github_v4_rest", "rest-scope"),
-                ("github_v4_mcp", "mcp-scope"),
-            ]
-            .into_iter()
-            .map(|(source_name, source_scope_id)| ObservedValuesLiveScope {
-                owner_source_name: "github_v4".to_string(),
-                source_name: source_name.to_string(),
-                source_scope_id: source_scope_id.to_string(),
-                surface_kind: ObservedValuesSurfaceKind::Table,
-                surface_name: "issues".to_string(),
-            })
-            .collect(),
+            [("github_v4", "rest-scope"), ("github_mcp_v4", "mcp-scope")]
+                .into_iter()
+                .map(|(source_name, source_scope_id)| ObservedValuesLiveScope {
+                    source_name: source_name.to_string(),
+                    source_scope_id: source_scope_id.to_string(),
+                    surface_kind: ObservedValuesSurfaceKind::Table,
+                    surface_name: "issues".to_string(),
+                })
+                .collect(),
             30,
         );
         let hits = search_observed_values(
@@ -2859,25 +2801,31 @@ mod tests {
             10,
             &policy,
         )
-        .expect("search both runtime schemas");
+        .expect("search both installed sources");
         let mut result_schemas = hits
             .hits
             .iter()
             .map(|hit| hit.source_name.as_str())
             .collect::<Vec<_>>();
         result_schemas.sort_unstable();
-        assert_eq!(result_schemas, ["github_v4_mcp", "github_v4_rest"]);
-        assert!(
-            hits.hits
-                .iter()
-                .all(|hit| hit.display_value != "Other payment outage")
-        );
+        assert_eq!(result_schemas, ["github_mcp_v4", "github_v4"]);
 
+        // The REST and MCP interfaces of one provider are independent sources:
+        // clearing one must leave the other completely intact.
         let cleared = store
             .clear_source_and_advance_epoch(&workspace, "github_v4")
-            .expect("clear logical source owner");
-        assert_eq!(cleared.values, 2);
-        assert_eq!(cleared.fts_rows, 2);
+            .expect("clear one installed source");
+        assert_eq!(cleared.values, 1);
+        assert_eq!(cleared.fts_rows, 1);
+        assert_eq!(
+            source_rows(
+                &connection,
+                "SELECT source_name FROM observed_values \
+                 WHERE workspace = ?1 ORDER BY source_name",
+                &workspace,
+            ),
+            ["github_mcp_v4".to_string()]
+        );
     }
 
     #[test]
@@ -2909,7 +2857,6 @@ mod tests {
 
         let policy = ObservedValuesRetrievalPolicy::new(
             vec![ObservedValuesLiveScope {
-                owner_source_name: "github".to_string(),
                 source_name: "github".to_string(),
                 source_scope_id: "eu".to_string(),
                 surface_kind: ObservedValuesSurfaceKind::Table,
@@ -2930,7 +2877,6 @@ mod tests {
     fn retention_modifier_formats_sqlite_datetime_modifier() {
         let policy = ObservedValuesRetrievalPolicy::new(
             vec![ObservedValuesLiveScope {
-                owner_source_name: "github".to_string(),
                 source_name: "github".to_string(),
                 source_scope_id: "scope".to_string(),
                 surface_kind: ObservedValuesSurfaceKind::Table,
@@ -2943,18 +2889,16 @@ mod tests {
     }
 
     fn test_job() -> ObservedValuesQueueJob {
-        test_job_with_identity("github", "github", "scope", "Payment outage")
+        test_job_with_identity("github", "scope", "Payment outage")
     }
 
     fn test_job_with_identity(
-        owner_source_name: &str,
         source_name: &str,
         source_scope_id: &str,
         display_value: &str,
     ) -> ObservedValuesQueueJob {
         let value_key = display_value.to_ascii_lowercase().replace(' ', "-");
         ObservedValuesQueueJob {
-            owner_source_name: owner_source_name.to_string(),
             source_name: source_name.to_string(),
             source_scope_id: source_scope_id.to_string(),
             surface_kind: ObservedValuesSurfaceKind::Table,
@@ -2965,67 +2909,44 @@ mod tests {
         }
     }
 
-    fn enqueue_multi_surface_identity_fixture(
+    fn enqueue_independent_source_fixture(
         store: &SqliteObservedValuesStore,
         workspace: &WorkspaceName,
     ) {
-        let generation = store
-            .capture_epoch(workspace, "github_v4")
-            .expect("owner generation");
         for (source_name, source_scope_id, display_value) in [
-            ("github_v4_rest", "rest-scope", "REST payment outage"),
-            ("github_v4_mcp", "mcp-scope", "MCP payment outage"),
+            ("github_v4", "rest-scope", "REST payment outage"),
+            ("github_mcp_v4", "mcp-scope", "MCP payment outage"),
         ] {
+            let generation = store
+                .capture_epoch(workspace, source_name)
+                .expect("source generation");
             store
                 .enqueue_if_current(
                     workspace,
-                    &test_job_with_identity(
-                        "github_v4",
-                        source_name,
-                        source_scope_id,
-                        display_value,
-                    ),
+                    &test_job_with_identity(source_name, source_scope_id, display_value),
                     generation,
                 )
-                .expect("enqueue component observation");
+                .expect("enqueue source observation");
         }
-        let first_drain = store
+        let drained = store
             .drain_queue(
                 workspace,
                 ObservedValuesDrainBudget::new(10, Duration::from_secs(1)),
             )
-            .expect("drain component observations");
-        assert_eq!(first_drain.queue_jobs_processed, 2);
-
-        let other_owner_generation = store
-            .capture_epoch(workspace, "other_owner")
-            .expect("other owner generation");
-        store
-            .enqueue_if_current(
-                workspace,
-                &test_job_with_identity(
-                    "other_owner",
-                    "github_v4_rest",
-                    "rest-scope",
-                    "Other payment outage",
-                ),
-                other_owner_generation,
-            )
-            .expect("enqueue same runtime scope for another owner");
+            .expect("drain source observations");
+        assert_eq!(drained.queue_jobs_processed, 2);
     }
 
-    fn identity_rows(
+    fn source_rows(
         connection: &rusqlite::Connection,
         sql: &str,
         workspace: &WorkspaceName,
-    ) -> Vec<(String, String)> {
-        let mut statement = connection.prepare(sql).expect("identity query");
+    ) -> Vec<String> {
+        let mut statement = connection.prepare(sql).expect("source query");
         let rows = statement
-            .query_map(params![workspace.as_str()], |row| {
-                Ok((row.get(0)?, row.get(1)?))
-            })
-            .expect("query identity rows");
+            .query_map(params![workspace.as_str()], |row| row.get(0))
+            .expect("query source rows");
         rows.collect::<Result<Vec<_>, _>>()
-            .expect("collect identity rows")
+            .expect("collect source rows")
     }
 }

--- a/crates/coral-app/src/search/observed/sqlite_queue.rs
+++ b/crates/coral-app/src/search/observed/sqlite_queue.rs
@@ -62,9 +62,7 @@ pub(crate) struct ObservedValueCandidate {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValuesQueueJob {
-    /// Canonical installed source that owns lifecycle clears and generations.
-    pub(crate) owner_source_name: String,
-    /// Runtime component schema used in SQL and search results.
+    /// Installed source: lifecycle clears, generations, and the SQL namespace.
     pub(crate) source_name: String,
     pub(crate) source_scope_id: String,
     pub(crate) surface_kind: ObservedValuesSurfaceKind,

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -60,10 +60,10 @@ impl SqliteObservedValuesStore {
     pub(crate) fn capture_epoch(
         &self,
         workspace_name: &WorkspaceName,
-        owner_source_name: &str,
+        source_name: &str,
     ) -> Result<ObservedValuesEpoch, SqliteSearchError> {
-        let mut epochs = self.capture_epochs_for_sources(workspace_name, [owner_source_name])?;
-        let Some(epoch) = epochs.remove(owner_source_name) else {
+        let mut epochs = self.capture_epochs_for_sources(workspace_name, [source_name])?;
+        let Some(epoch) = epochs.remove(source_name) else {
             return Ok(ObservedValuesEpoch::ZERO);
         };
         Ok(epoch)
@@ -72,15 +72,15 @@ impl SqliteObservedValuesStore {
     pub(crate) fn capture_epochs_for_sources<'a>(
         &self,
         workspace_name: &WorkspaceName,
-        owner_source_names: impl IntoIterator<Item = &'a str>,
+        source_names: impl IntoIterator<Item = &'a str>,
     ) -> Result<BTreeMap<String, ObservedValuesEpoch>, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
         let mut epochs = BTreeMap::new();
-        for owner_source_name in owner_source_names {
+        for source_name in source_names {
             epochs.insert(
-                owner_source_name.to_string(),
-                read_epoch(&connection, workspace_name, owner_source_name)?,
+                source_name.to_string(),
+                read_epoch(&connection, workspace_name, source_name)?,
             );
         }
         Ok(epochs)
@@ -121,13 +121,13 @@ impl SqliteObservedValuesStore {
     pub(crate) fn clear_source_and_advance_epoch(
         &self,
         workspace_name: &WorkspaceName,
-        owner_source_name: &str,
+        source_name: &str,
     ) -> Result<ObservedValuesClearResult, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let mut connection = store.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let result =
-            clear_observed_source_in_transaction(&transaction, workspace_name, owner_source_name)?;
+            clear_observed_source_in_transaction(&transaction, workspace_name, source_name)?;
         transaction.commit()?;
         Ok(result)
     }
@@ -336,19 +336,19 @@ impl SqliteObservedValuesStore {
     pub(crate) fn queue_source_identities(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Vec<(String, String, String)>, SqliteSearchError> {
+    ) -> Result<Vec<(String, String)>, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
         let mut statement = connection.prepare(
             "
-            SELECT owner_source_name, source_name, surface_name
+            SELECT source_name, surface_name
             FROM observed_queue_jobs
             WHERE workspace = ?1
             ORDER BY id
             ",
         )?;
         let rows = statement.query_map(params![workspace_name.as_str()], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            Ok((row.get(0)?, row.get(1)?))
         })?;
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(SqliteSearchError::from)
@@ -384,7 +384,7 @@ fn enqueue_if_current_in_transaction(
     captured_epoch: ObservedValuesEpoch,
     policy: ObservedValuesStoragePolicy,
 ) -> Result<ObservedValuesEnqueueResult, SqliteSearchError> {
-    let current_epoch = read_epoch(transaction, workspace_name, &job.owner_source_name)?;
+    let current_epoch = read_epoch(transaction, workspace_name, &job.source_name)?;
     if current_epoch != captured_epoch {
         return Ok(ObservedValuesEnqueueResult::StaleEpoch);
     }
@@ -405,7 +405,6 @@ fn enqueue_if_current_in_transaction(
         "
             INSERT INTO observed_queue_jobs (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -425,13 +424,11 @@ fn enqueue_if_current_in_transaction(
                 ?6,
                 ?7,
                 ?8,
-                ?9,
                 strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
                 strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
             )
             ON CONFLICT(
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -446,7 +443,6 @@ fn enqueue_if_current_in_transaction(
             ",
         params![
             workspace_name.as_str(),
-            &job.owner_source_name,
             &job.source_name,
             &job.source_scope_id,
             job.surface_kind.as_str(),
@@ -488,21 +484,21 @@ pub(crate) fn clear_observed_workspace_in_transaction(
 pub(crate) fn clear_observed_source_in_transaction(
     transaction: &Transaction<'_>,
     workspace_name: &WorkspaceName,
-    owner_source_name: &str,
+    source_name: &str,
 ) -> Result<ObservedValuesClearResult, SqliteSearchError> {
     let deleted_fts_count = transaction.execute(
-        "DELETE FROM observed_values_fts WHERE workspace = ?1 AND owner_source_name = ?2",
-        params![workspace_name.as_str(), owner_source_name],
+        "DELETE FROM observed_values_fts WHERE workspace = ?1 AND source_name = ?2",
+        params![workspace_name.as_str(), source_name],
     )?;
     let deleted_value_count = transaction.execute(
-        "DELETE FROM observed_values WHERE workspace = ?1 AND owner_source_name = ?2",
-        params![workspace_name.as_str(), owner_source_name],
+        "DELETE FROM observed_values WHERE workspace = ?1 AND source_name = ?2",
+        params![workspace_name.as_str(), source_name],
     )?;
     let deleted_queue_job_count = transaction.execute(
-        "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND owner_source_name = ?2",
-        params![workspace_name.as_str(), owner_source_name],
+        "DELETE FROM observed_queue_jobs WHERE workspace = ?1 AND source_name = ?2",
+        params![workspace_name.as_str(), source_name],
     )?;
-    advance_source_epoch(transaction, workspace_name, owner_source_name)?;
+    advance_source_epoch(transaction, workspace_name, source_name)?;
     Ok(ObservedValuesClearResult {
         values: u32::try_from(deleted_value_count).unwrap_or(u32::MAX),
         fts_rows: u32::try_from(deleted_fts_count).unwrap_or(u32::MAX),
@@ -546,18 +542,16 @@ fn pending_queue_job_id(
             SELECT id
             FROM observed_queue_jobs
             WHERE workspace = ?1
-              AND owner_source_name = ?2
-              AND source_name = ?3
-              AND source_scope_id = ?4
-              AND surface_kind = ?5
-              AND surface_name = ?6
-              AND workspace_generation = ?7
-              AND source_generation = ?8
-              AND attempts < ?9
+              AND source_name = ?2
+              AND source_scope_id = ?3
+              AND surface_kind = ?4
+              AND surface_name = ?5
+              AND workspace_generation = ?6
+              AND source_generation = ?7
+              AND attempts < ?8
             ",
             params![
                 workspace_name.as_str(),
-                &job.owner_source_name,
                 &job.source_name,
                 &job.source_scope_id,
                 job.surface_kind.as_str(),
@@ -575,7 +569,7 @@ fn pending_queue_job_id(
 fn read_epoch(
     connection: &Connection,
     workspace_name: &WorkspaceName,
-    owner_source_name: &str,
+    source_name: &str,
 ) -> Result<ObservedValuesEpoch, SqliteSearchError> {
     let workspace_generation = connection
         .query_row(
@@ -596,7 +590,7 @@ fn read_epoch(
             FROM observed_source_generations
             WHERE workspace = ?1 AND source_name = ?2
             ",
-            params![workspace_name.as_str(), owner_source_name],
+            params![workspace_name.as_str(), source_name],
             |row| row.get(0),
         )
         .optional()?
@@ -627,7 +621,7 @@ fn advance_workspace_epoch(
 fn advance_source_epoch(
     connection: &Connection,
     workspace_name: &WorkspaceName,
-    owner_source_name: &str,
+    source_name: &str,
 ) -> Result<(), SqliteSearchError> {
     connection.execute(
         "
@@ -642,7 +636,7 @@ fn advance_source_epoch(
             generation = generation + 1,
             updated_at = excluded.updated_at
         ",
-        params![workspace_name.as_str(), owner_source_name],
+        params![workspace_name.as_str(), source_name],
     )?;
     Ok(())
 }

--- a/crates/coral-app/src/search/observed/sqlite_store/tests.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store/tests.rs
@@ -1,5 +1,4 @@
 use std::cell::Cell;
-use std::fs;
 use std::path::Path;
 use std::sync::mpsc::sync_channel;
 use std::thread;
@@ -253,53 +252,51 @@ fn immediate_transaction_is_locked(connection: &mut rusqlite::Connection) -> boo
 }
 
 #[test]
-fn clear_source_removes_every_component_schema_owned_by_that_source() {
+fn clear_source_removes_only_that_installed_source() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let workspace = WorkspaceName::default();
     let store = SqliteObservedValuesStore::new(layout.clone());
-    let jobs = multi_schema_clear_jobs();
+    let jobs = independent_source_clear_jobs();
     seed_projected_and_pending_jobs(&layout, &workspace, &store, &jobs);
 
     let backing = SqliteSearchStore::open_workspace(&layout, &workspace).expect("store");
     let connection = backing.connect_for_test().expect("connection");
-    for table_name in [
-        "observed_values",
-        "observed_values_fts",
-        "observed_queue_jobs",
-    ] {
-        assert_owner_component_schema_count(&connection, table_name, &workspace, "github_v4", 2);
-    }
-    assert_projected_owner_names(
+    assert_projected_source_names(
         &connection,
         &workspace,
-        &["github_v4", "github_v4", "jira_v4"],
+        &["github_mcp_v4", "github_v4", "jira_v4"],
     );
     drop(connection);
 
     let result = store
         .clear_source_and_advance_epoch(&workspace, "github_v4")
-        .expect("clear github owner");
+        .expect("clear github_v4");
 
-    assert_eq!(result.values, 2);
-    assert_eq!(result.fts_rows, 2);
-    assert_eq!(result.queue_jobs, 2);
+    // `github_v4` and `github_mcp_v4` are two independent sources, not two
+    // components of one: clearing the REST source must not touch the MCP one.
+    assert_eq!(result.values, 1);
+    assert_eq!(result.fts_rows, 1);
+    assert_eq!(result.queue_jobs, 1);
     let connection = backing.connect_for_test().expect("reconnect");
-    assert_projected_owner_names(&connection, &workspace, &["jira_v4"]);
+    assert_projected_source_names(&connection, &workspace, &["github_mcp_v4", "jira_v4"]);
     assert_eq!(
         store
             .capture_epoch(&workspace, "github_v4")
-            .expect("github epoch after clear")
+            .expect("github_v4 epoch after clear")
             .source_generation,
         1
     );
-    assert_eq!(
-        store
-            .capture_epoch(&workspace, "jira_v4")
-            .expect("jira epoch after clear")
-            .source_generation,
-        0
-    );
+    for untouched in ["github_mcp_v4", "jira_v4"] {
+        assert_eq!(
+            store
+                .capture_epoch(&workspace, untouched)
+                .expect("untouched epoch after clear")
+                .source_generation,
+            0,
+            "clearing github_v4 must not advance the {untouched} epoch"
+        );
+    }
 }
 
 #[test]
@@ -724,17 +721,17 @@ fn boundary_crossing_projection_respects_eviction_cap_and_keeps_job_queued() {
 }
 
 #[test]
-fn upgraded_v2_fts_tombstones_are_compacted_without_a_queued_job() {
+fn fts_tombstones_are_compacted_without_a_queued_job() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let workspace = WorkspaceName::default();
     let database_path = layout.search_sqlite_file(&workspace);
-    seed_v2_fts_tombstones(&database_path);
+    seed_fts_tombstones(&database_path);
 
     let ordinary_store = SqliteObservedValuesStore::new(layout.clone());
     let generation = ordinary_store
         .capture_epoch(&workspace, "github")
-        .expect("upgrade v2 database and capture generation");
+        .expect("capture generation");
     let backing = SqliteSearchStore::open_workspace(&layout, &workspace).expect("store");
     let connection = backing.connect_for_test().expect("connection");
     let secure_delete: i64 = connection
@@ -745,9 +742,7 @@ fn upgraded_v2_fts_tombstones_are_compacted_without_a_queued_job() {
         )
         .expect("secure-delete setting");
     assert_eq!(secure_delete, 1);
-    assert!(
-        observed_fts_mergeable_segments_exist(&connection).expect("mergeable legacy FTS segments")
-    );
+    assert!(observed_fts_mergeable_segments_exist(&connection).expect("mergeable FTS segments"));
     let live_bytes_before = live_database_bytes_for_test(&connection);
     let page_size: i64 = connection
         .query_row("PRAGMA page_size", [], |row| row.get(0))
@@ -816,15 +811,15 @@ fn upgraded_v2_fts_tombstones_are_compacted_without_a_queued_job() {
 }
 
 #[test]
-fn upgraded_v2_fts_tombstones_are_compacted_during_enqueue() {
+fn fts_tombstones_are_compacted_during_enqueue() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let workspace = WorkspaceName::default();
-    seed_v2_fts_tombstones(&layout.search_sqlite_file(&workspace));
+    seed_fts_tombstones(&layout.search_sqlite_file(&workspace));
     let ordinary_store = SqliteObservedValuesStore::new(layout.clone());
     let generation = ordinary_store
         .capture_epoch(&workspace, "github")
-        .expect("upgrade v2 database and capture generation");
+        .expect("capture generation");
     let backing = SqliteSearchStore::open_workspace(&layout, &workspace).expect("store");
     let connection = backing.connect_for_test().expect("connection");
     let live_bytes = live_database_bytes_for_test(&connection);
@@ -1096,17 +1091,17 @@ fn eviction_preserves_same_value_key_owned_by_another_source() {
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let workspace = WorkspaceName::default();
     let initial_store = SqliteObservedValuesStore::new(layout.clone());
-    for owner_source_name in ["owner-a", "owner-b"] {
+    for source_name in ["source-a", "source-b"] {
         let generation = initial_store
-            .capture_epoch(&workspace, owner_source_name)
+            .capture_epoch(&workspace, source_name)
             .expect("generation");
         initial_store
             .enqueue_if_current(
                 &workspace,
-                &test_job_with_owner(owner_source_name),
+                &test_job_for_shared_value(source_name),
                 generation,
             )
-            .expect("enqueue owner observation");
+            .expect("enqueue source observation");
     }
     initial_store
         .drain_queue(&workspace, drain_budget())
@@ -1117,8 +1112,8 @@ fn eviction_preserves_same_value_key_owned_by_another_source() {
         .execute(
             "
             UPDATE observed_values
-            SET last_observed_at = CASE owner_source_name
-                WHEN 'owner-a' THEN '2020-01-01T00:00:00.000Z'
+            SET last_observed_at = CASE source_name
+                WHEN 'source-a' THEN '2020-01-01T00:00:00.000Z'
                 ELSE '2021-01-01T00:00:00.000Z'
             END
             WHERE workspace = ?1
@@ -1147,8 +1142,8 @@ fn eviction_preserves_same_value_key_owned_by_another_source() {
     let connection = backing.connect_for_test().expect("connection");
     for table_name in ["observed_values", "observed_values_fts"] {
         assert_eq!(
-            projected_owner_names(&connection, table_name, &workspace),
-            ["owner-b"],
+            projected_source_names(&connection, table_name, &workspace),
+            ["source-b"],
             "eviction should remove one exact {table_name} identity"
         );
     }
@@ -1454,10 +1449,10 @@ fn projection_realigns_a_legacy_same_key_fts_row_without_leaving_a_duplicate() {
         .execute(
             "
             INSERT INTO observed_values_fts (
-                rowid, workspace, owner_source_name, source_name, source_scope_id,
+                rowid, workspace, source_name, source_scope_id,
                 surface_kind, surface_name, column_name, value_key, display_value, search_text
             )
-            SELECT ?2, workspace, owner_source_name, source_name, source_scope_id,
+            SELECT ?2, workspace, source_name, source_scope_id,
                    surface_kind, surface_name, column_name, value_key, display_value, search_text
             FROM observed_values
             WHERE rowid = ?1
@@ -1497,9 +1492,9 @@ fn projection_realigns_a_legacy_same_key_fts_row_without_leaving_a_duplicate() {
 #[test]
 #[expect(
     clippy::too_many_lines,
-    reason = "the collision test verifies projection rollback, failed-owner preservation, recovery, and retry as one state transition"
+    reason = "the collision test verifies projection rollback, failed-source preservation, recovery, and retry as one state transition"
 )]
-fn projection_and_rebuild_preserve_an_unrelated_failed_owner_rowid_collision() {
+fn projection_and_rebuild_preserve_an_unrelated_failed_source_rowid_collision() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let workspace = WorkspaceName::default();
@@ -1537,16 +1532,16 @@ fn projection_and_rebuild_preserve_an_unrelated_failed_owner_rowid_collision() {
         .execute(
             "
             INSERT INTO observed_values_fts (
-                rowid, workspace, owner_source_name, source_name, source_scope_id,
+                rowid, workspace, source_name, source_scope_id,
                 surface_kind, surface_name, column_name, value_key, display_value, search_text
             ) VALUES (
-                ?1, ?2, 'jira', 'jira', 'failed-scope', 'table', 'issues', 'title',
-                'failed-key', 'Failed owner value', 'failed owner value'
+                ?1, ?2, 'jira', 'failed-scope', 'table', 'issues', 'title',
+                'failed-key', 'Failed source value', 'failed source value'
             )
             ",
             params![canonical_rowid, workspace.as_str()],
         )
-        .expect("occupy the canonical rowid with a failed-owner row");
+        .expect("occupy the canonical rowid with a failed-source row");
     drop(connection);
 
     store
@@ -1565,7 +1560,7 @@ fn projection_and_rebuild_preserve_an_unrelated_failed_owner_rowid_collision() {
     let state: (String, String, String) = connection
         .query_row(
             "
-            SELECT v.display_value, f.owner_source_name, f.display_value
+            SELECT v.display_value, f.source_name, f.display_value
             FROM observed_values v
             JOIN observed_values_fts f ON f.rowid = v.rowid
             WHERE v.rowid = ?1
@@ -1579,7 +1574,7 @@ fn projection_and_rebuild_preserve_an_unrelated_failed_owner_rowid_collision() {
         (
             "Original value".to_string(),
             "jira".to_string(),
-            "Failed owner value".to_string(),
+            "Failed source value".to_string(),
         ),
         "the failed projection transaction must preserve both canonical and unrelated FTS content"
     );
@@ -1591,14 +1586,14 @@ fn projection_and_rebuild_preserve_an_unrelated_failed_owner_rowid_collision() {
         .expect("rebuild while Jira is failed");
     assert_eq!(blocked.fts_rows_rebuilt, 0);
     let connection = backing.connect_for_test().expect("connection");
-    let owner_while_failed: String = connection
+    let source_while_failed: String = connection
         .query_row(
-            "SELECT owner_source_name FROM observed_values_fts WHERE rowid = ?1",
+            "SELECT source_name FROM observed_values_fts WHERE rowid = ?1",
             params![canonical_rowid],
             |row| row.get(0),
         )
-        .expect("failed-owner occupant");
-    assert_eq!(owner_while_failed, "jira");
+        .expect("failed-source occupant");
+    assert_eq!(source_while_failed, "jira");
     drop(connection);
 
     let recovered = store
@@ -1615,7 +1610,7 @@ fn projection_and_rebuild_preserve_an_unrelated_failed_owner_rowid_collision() {
     let recovered_state: (i64, String, String) = connection
         .query_row(
             "
-            SELECT COUNT(*), MIN(owner_source_name), MIN(display_value)
+            SELECT COUNT(*), MIN(source_name), MIN(display_value)
             FROM observed_values_fts
             WHERE rowid = ?1
             ",
@@ -1812,10 +1807,10 @@ fn rebuild_converges_a_healthy_legacy_rowid_collision_without_duplicates_or_loss
         .execute(
             "
             INSERT INTO observed_values_fts (
-                rowid, workspace, owner_source_name, source_name, source_scope_id,
+                rowid, workspace, source_name, source_scope_id,
                 surface_kind, surface_name, column_name, value_key, display_value, search_text
             )
-            SELECT ?2, workspace, owner_source_name, source_name, source_scope_id,
+            SELECT ?2, workspace, source_name, source_scope_id,
                    surface_kind, surface_name, column_name, value_key, display_value, search_text
             FROM observed_values
             WHERE rowid = ?1
@@ -1914,12 +1909,12 @@ fn rebuild_breaks_a_healthy_two_row_legacy_collision_cycle() {
         .execute(
             "
             INSERT INTO observed_values_fts (
-                rowid, workspace, owner_source_name, source_name, source_scope_id,
+                rowid, workspace, source_name, source_scope_id,
                 surface_kind, surface_name, column_name, value_key, display_value, search_text
             )
             SELECT
                 CASE value_key WHEN 'key-a' THEN ?2 ELSE ?1 END,
-                workspace, owner_source_name, source_name, source_scope_id,
+                workspace, source_name, source_scope_id,
                 surface_kind, surface_name, column_name, value_key, display_value, search_text
             FROM observed_values
             WHERE rowid IN (?1, ?2)
@@ -1932,10 +1927,10 @@ fn rebuild_breaks_a_healthy_two_row_legacy_collision_cycle() {
         .execute(
             "
             INSERT INTO observed_values_fts (
-                rowid, workspace, owner_source_name, source_name, source_scope_id,
+                rowid, workspace, source_name, source_scope_id,
                 surface_kind, surface_name, column_name, value_key, display_value, search_text
             )
-            SELECT ?2, workspace, owner_source_name, source_name, source_scope_id,
+            SELECT ?2, workspace, source_name, source_scope_id,
                    surface_kind, surface_name, column_name, value_key, display_value, search_text
             FROM observed_values
             WHERE rowid = ?1
@@ -2067,7 +2062,6 @@ fn rebuild_fts_reconciles_corrupt_rows_in_bounded_commits() {
             "
             INSERT INTO observed_values_fts (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -2079,7 +2073,6 @@ fn rebuild_fts_reconciles_corrupt_rows_in_bounded_commits() {
             )
             SELECT
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -2110,7 +2103,6 @@ fn rebuild_fts_reconciles_corrupt_rows_in_bounded_commits() {
             "
             INSERT INTO observed_values_fts (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -2119,7 +2111,7 @@ fn rebuild_fts_reconciles_corrupt_rows_in_bounded_commits() {
                 value_key,
                 display_value,
                 search_text
-            ) VALUES (?1, 'github', 'github', 'scope-orphan', 'table', 'issues', 'title',
+            ) VALUES (?1, 'github', 'scope-orphan', 'table', 'issues', 'title',
                 'invoice-orphan', 'Invoice orphan', 'invoice orphan')
             ",
             params![workspace.as_str()],
@@ -2391,15 +2383,15 @@ fn rebuild_fts_repairs_non_text_derived_keys_by_rowid() {
         .execute_batch(&format!(
             "
             INSERT INTO observed_values_fts VALUES (
-                '{}', 'github', NULL, 'scope-null', 'table', 'issues', 'title',
+                '{}', NULL, 'scope-null', 'table', 'issues', 'title',
                 'null-key', 'Null key', 'null key'
             );
             INSERT INTO observed_values_fts VALUES (
-                '{}', 'github', X'676974687562', 'scope-blob', 'table', 'issues', 'title',
+                '{}', X'676974687562', 'scope-blob', 'table', 'issues', 'title',
                 'blob-key', 'Blob key', 'blob key'
             );
             INSERT INTO observed_values_fts VALUES (
-                '{}', 'github', 7, 'scope-integer', 'table', 'issues', 'title',
+                '{}', 7, 'scope-integer', 'table', 'issues', 'title',
                 'integer-key', 'Integer key', 'integer key'
             );
             ",
@@ -2454,12 +2446,12 @@ fn rebuild_fts_keyset_covers_the_entire_sqlite_rowid_domain() {
             .execute(
                 "
                 INSERT INTO observed_values (
-                    rowid, workspace, owner_source_name, source_name, source_scope_id,
+                    rowid, workspace, source_name, source_scope_id,
                     surface_kind, surface_name, column_name, value_key, display_value,
                     search_text, first_observed_at, last_observed_at, observation_count,
                     source_generation, workspace_generation
                 ) VALUES (
-                    ?1, ?2, 'github', 'github', ?3, 'table', 'issues', 'title', ?4, ?5,
+                    ?1, ?2, 'github', ?3, 'table', 'issues', 'title', ?4, ?5,
                     ?6, '2020-01-01T00:00:00.000Z', '9999-01-01T00:00:00.000Z', 1, 0, 0
                 )
                 ",
@@ -2477,10 +2469,10 @@ fn rebuild_fts_keyset_covers_the_entire_sqlite_rowid_domain() {
             .execute(
                 "
                 INSERT INTO observed_values_fts (
-                    rowid, workspace, owner_source_name, source_name, source_scope_id,
+                    rowid, workspace, source_name, source_scope_id,
                     surface_kind, surface_name, column_name, value_key, display_value, search_text
                 ) VALUES (
-                    ?1, ?2, 'github', ?3, ?4, 'table', 'issues', 'title', ?5, ?6, ?7
+                    ?1, ?2, ?3, ?4, 'table', 'issues', 'title', ?5, ?6, ?7
                 )
                 ",
                 params![
@@ -2499,7 +2491,7 @@ fn rebuild_fts_keyset_covers_the_entire_sqlite_rowid_domain() {
 
     let policy = ObservedValuesRetrievalPolicy::new(
         rows.iter()
-            .map(|(_, scope, _, _)| test_live_scope_for_owner("github", scope, "issues"))
+            .map(|(_, scope, _, _)| test_live_scope_for_source("github", scope, "issues"))
             .collect(),
         365,
     );
@@ -2605,7 +2597,7 @@ fn rebuild_fts_reuses_one_retention_cutoff_across_batches() {
     let policy = ObservedValuesRetrievalPolicy::new(
         scopes
             .iter()
-            .map(|scope| test_live_scope_for_owner("github", scope, "issues"))
+            .map(|scope| test_live_scope_for_source("github", scope, "issues"))
             .collect(),
         1,
     );
@@ -2684,7 +2676,7 @@ fn rebuild_fts_preserves_rows_for_sources_with_live_scope_load_failures() {
     store
         .enqueue_if_current(
             &workspace,
-            &test_job_for_owner("github", "live-scope", "issues", "Payment current"),
+            &test_job_for_source("github", "live-scope", "issues", "Payment current"),
             github_generation,
         )
         .expect("enqueue github");
@@ -2694,7 +2686,7 @@ fn rebuild_fts_preserves_rows_for_sources_with_live_scope_load_failures() {
     store
         .enqueue_if_current(
             &workspace,
-            &test_job_for_owner("github", "removed-scope", "issues", "Payment removed"),
+            &test_job_for_source("github", "removed-scope", "issues", "Payment removed"),
             github_generation,
         )
         .expect("enqueue removed github scope");
@@ -2704,7 +2696,7 @@ fn rebuild_fts_preserves_rows_for_sources_with_live_scope_load_failures() {
     store
         .enqueue_if_current(
             &workspace,
-            &test_job_for_owner("jira", "unknown-scope", "issues", "Payment blocked"),
+            &test_job_for_source("jira", "unknown-scope", "issues", "Payment blocked"),
             jira_generation,
         )
         .expect("enqueue jira");
@@ -2732,8 +2724,8 @@ fn rebuild_fts_preserves_rows_for_sources_with_live_scope_load_failures() {
 
     let recovered_policy = ObservedValuesRetrievalPolicy::new(
         vec![
-            test_live_scope_for_owner("github", "live-scope", "issues"),
-            test_live_scope_for_owner("jira", "unknown-scope", "issues"),
+            test_live_scope_for_source("github", "live-scope", "issues"),
+            test_live_scope_for_source("jira", "unknown-scope", "issues"),
         ],
         365,
     );
@@ -2847,7 +2839,7 @@ fn test_job_with(
     surface_name: &str,
     display_value: &str,
 ) -> ObservedValuesQueueJob {
-    test_job_for_owner("github", source_scope_id, surface_name, display_value)
+    test_job_for_source("github", source_scope_id, surface_name, display_value)
 }
 
 fn test_job_with_stable_key(
@@ -2864,30 +2856,13 @@ fn test_job_with_stable_key(
     job
 }
 
-fn test_job_for_owner(
-    owner_source_name: &str,
-    source_scope_id: &str,
-    surface_name: &str,
-    display_value: &str,
-) -> ObservedValuesQueueJob {
-    test_job_with_identity(
-        owner_source_name,
-        owner_source_name,
-        source_scope_id,
-        surface_name,
-        display_value,
-    )
-}
-
-fn test_job_with_identity(
-    owner_source_name: &str,
+fn test_job_for_source(
     source_name: &str,
     source_scope_id: &str,
     surface_name: &str,
     display_value: &str,
 ) -> ObservedValuesQueueJob {
     ObservedValuesQueueJob {
-        owner_source_name: owner_source_name.to_string(),
         source_name: source_name.to_string(),
         source_scope_id: source_scope_id.to_string(),
         surface_kind: ObservedValuesSurfaceKind::Table,
@@ -2896,10 +2871,10 @@ fn test_job_with_identity(
     }
 }
 
-fn test_job_with_owner(owner_source_name: &str) -> ObservedValuesQueueJob {
+/// Two independent sources observing the same value on the same surface name.
+fn test_job_for_shared_value(source_name: &str) -> ObservedValuesQueueJob {
     ObservedValuesQueueJob {
-        owner_source_name: owner_source_name.to_string(),
-        source_name: "shared_query_schema".to_string(),
+        source_name: source_name.to_string(),
         source_scope_id: "shared-scope".to_string(),
         surface_kind: ObservedValuesSurfaceKind::Table,
         surface_name: "issues".to_string(),
@@ -2914,7 +2889,7 @@ fn enqueue_test_jobs(
 ) {
     for job in jobs {
         let generation = store
-            .capture_epoch(workspace, &job.owner_source_name)
+            .capture_epoch(workspace, &job.source_name)
             .expect("generation");
         assert!(matches!(
             store
@@ -2925,29 +2900,11 @@ fn enqueue_test_jobs(
     }
 }
 
-fn multi_schema_clear_jobs() -> [ObservedValuesQueueJob; 3] {
+fn independent_source_clear_jobs() -> [ObservedValuesQueueJob; 3] {
     [
-        test_job_with_identity(
-            "github_v4",
-            "github_v4_rest",
-            "rest-scope",
-            "issues",
-            "REST payment issue",
-        ),
-        test_job_with_identity(
-            "github_v4",
-            "github_v4_mcp",
-            "mcp-scope",
-            "pulls",
-            "MCP payment issue",
-        ),
-        test_job_with_identity(
-            "jira_v4",
-            "jira_v4_mcp",
-            "jira-scope",
-            "issues",
-            "Jira payment issue",
-        ),
+        test_job_for_source("github_v4", "rest-scope", "issues", "REST payment issue"),
+        test_job_for_source("github_mcp_v4", "mcp-scope", "pulls", "MCP payment issue"),
+        test_job_for_source("jira_v4", "jira-scope", "issues", "Jira payment issue"),
     ]
 }
 
@@ -2978,7 +2935,7 @@ fn insert_queue_job_for_test(
     job: &ObservedValuesQueueJob,
 ) {
     let generation = store
-        .capture_epoch(workspace, &job.owner_source_name)
+        .capture_epoch(workspace, &job.source_name)
         .expect("generation");
     let backing = SqliteSearchStore::open_workspace(layout, workspace).expect("store");
     let connection = backing.connect_for_test().expect("connection");
@@ -2987,7 +2944,6 @@ fn insert_queue_job_for_test(
             "
             INSERT INTO observed_queue_jobs (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -2995,11 +2951,10 @@ fn insert_queue_job_for_test(
                 workspace_generation,
                 source_generation,
                 payload_json
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
             ",
             params![
                 workspace.as_str(),
-                &job.owner_source_name,
                 &job.source_name,
                 &job.source_scope_id,
                 job.surface_kind.as_str(),
@@ -3031,29 +2986,14 @@ fn bulk_test_job(
     job
 }
 
-fn seed_v2_fts_tombstones(database_path: &Path) {
-    fs::create_dir_all(database_path.parent().expect("search database parent"))
-        .expect("create search database parent");
-    let connection = Connection::open(database_path).expect("raw v2 connection");
-    connection
-        .execute_batch(include_str!("../../migrations/0001_catalog_search.sql"))
-        .expect("v1 search schema");
-    connection
-        .execute_batch(include_str!("../../migrations/0002_observed_values.sql"))
-        .expect("v2 observed-values schema");
-    connection
-        .execute(
-            "
-            INSERT INTO search_meta (key, value)
-            VALUES ('schema_version', '2')
-            ON CONFLICT(key) DO UPDATE SET value = excluded.value
-            ",
-            [],
-        )
-        .expect("record v2 schema version");
-    connection
-        .pragma_update(None, "user_version", 2)
-        .expect("record v2 user version");
+/// Leaves the FTS index full of deleted-but-unmerged rows on the current
+/// schema. The version-5 migration rebuilds FTS from the canonical table, so
+/// tombstones that matter now are the ones ordinary deletes and evictions
+/// produce after the upgrade -- which is what these tests exercise.
+fn seed_fts_tombstones(database_path: &Path) {
+    SqliteSearchStore::open(database_path, WorkspaceName::default())
+        .expect("create current-schema database");
+    let connection = Connection::open(database_path).expect("raw connection");
     connection
         .execute_batch(
             "
@@ -3064,7 +3004,6 @@ fn seed_v2_fts_tombstones(database_path: &Path) {
             )
             INSERT INTO observed_values (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -3080,14 +3019,13 @@ fn seed_v2_fts_tombstones(database_path: &Path) {
                 workspace_generation
             )
             SELECT
-                'default', 'github', 'github', 'legacy', 'table', 'issues', 'title',
+                'default', 'github', 'legacy', 'table', 'issues', 'title',
                 printf('legacy-%d', id), hex(randomblob(256)), hex(randomblob(256)),
                 '2020-01-01T00:00:00.000Z', '2020-01-01T00:00:00.000Z', 1, 0, 0
             FROM rows;
 
             INSERT INTO observed_values_fts (
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -3099,7 +3037,6 @@ fn seed_v2_fts_tombstones(database_path: &Path) {
             )
             SELECT
                 workspace,
-                owner_source_name,
                 source_name,
                 source_scope_id,
                 surface_kind,
@@ -3114,8 +3051,7 @@ fn seed_v2_fts_tombstones(database_path: &Path) {
             DELETE FROM observed_values_fts;
             ",
         )
-        .expect("create v2 FTS tombstones");
-    assert!(observed_fts_mergeable_segments_exist(&connection).expect("mergeable v2 FTS segments"));
+        .expect("create FTS tombstones");
 }
 
 fn live_database_bytes_for_test(connection: &rusqlite::Connection) -> u64 {
@@ -3153,8 +3089,8 @@ fn test_policy_with_failed_sources(
         test_live_scopes(scopes),
         failed_sources
             .iter()
-            .map(|owner_source_name| ObservedValuesLiveScopeLoadFailure {
-                owner_source_name: (*owner_source_name).to_string(),
+            .map(|source_name| ObservedValuesLiveScopeLoadFailure {
+                source_name: (*source_name).to_string(),
                 message: "failed to load".to_string(),
             })
             .collect(),
@@ -3165,18 +3101,17 @@ fn test_policy_with_failed_sources(
 fn test_live_scopes(scopes: &[(&str, &str)]) -> Vec<ObservedValuesLiveScope> {
     scopes
         .iter()
-        .map(|(scope, surface)| test_live_scope_for_owner("github", scope, surface))
+        .map(|(scope, surface)| test_live_scope_for_source("github", scope, surface))
         .collect()
 }
 
-fn test_live_scope_for_owner(
-    owner_source_name: &str,
+fn test_live_scope_for_source(
+    source_name: &str,
     source_scope_id: &str,
     surface_name: &str,
 ) -> ObservedValuesLiveScope {
     ObservedValuesLiveScope {
-        owner_source_name: owner_source_name.to_string(),
-        source_name: owner_source_name.to_string(),
+        source_name: source_name.to_string(),
         source_scope_id: source_scope_id.to_string(),
         surface_kind: ObservedValuesSurfaceKind::Table,
         surface_name: surface_name.to_string(),
@@ -3187,23 +3122,22 @@ fn drain_budget() -> ObservedValuesDrainBudget {
     ObservedValuesDrainBudget::new(10, Duration::from_secs(1))
 }
 
-fn projected_owner_names(
+fn projected_source_names(
     connection: &rusqlite::Connection,
     table_name: &str,
     workspace: &WorkspaceName,
 ) -> Vec<String> {
-    let sql = format!(
-        "SELECT owner_source_name FROM {table_name} WHERE workspace = ?1 ORDER BY owner_source_name"
-    );
-    let mut statement = connection.prepare(&sql).expect("owner query");
+    let sql =
+        format!("SELECT source_name FROM {table_name} WHERE workspace = ?1 ORDER BY source_name");
+    let mut statement = connection.prepare(&sql).expect("source query");
     let rows = statement
         .query_map(params![workspace.as_str()], |row| row.get(0))
-        .expect("query owner rows");
+        .expect("query source rows");
     rows.collect::<Result<Vec<_>, _>>()
-        .expect("collect owner rows")
+        .expect("collect source rows")
 }
 
-fn assert_projected_owner_names(
+fn assert_projected_source_names(
     connection: &rusqlite::Connection,
     workspace: &WorkspaceName,
     expected: &[&str],
@@ -3214,34 +3148,11 @@ fn assert_projected_owner_names(
         "observed_queue_jobs",
     ] {
         assert_eq!(
-            projected_owner_names(connection, table_name, workspace),
+            projected_source_names(connection, table_name, workspace),
             expected,
-            "unexpected owners in {table_name}"
+            "unexpected sources in {table_name}"
         );
     }
-}
-
-fn assert_owner_component_schema_count(
-    connection: &rusqlite::Connection,
-    table_name: &str,
-    workspace: &WorkspaceName,
-    owner_source_name: &str,
-    expected: i64,
-) {
-    let sql = format!(
-        "SELECT COUNT(DISTINCT source_name) FROM {table_name} WHERE workspace = ?1 AND owner_source_name = ?2"
-    );
-    let component_schema_count: i64 = connection
-        .query_row(
-            &sql,
-            params![workspace.as_str(), owner_source_name],
-            |row| row.get(0),
-        )
-        .expect("component schema count");
-    assert_eq!(
-        component_schema_count, expected,
-        "unexpected component schema count in {table_name}"
-    );
 }
 
 fn advance_source_epoch_for_test(

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -29,7 +29,6 @@ struct ObservedValuesWriterShared {
 #[derive(Debug)]
 pub(super) struct ObservedValuesWrite {
     pub(super) workspace_name: WorkspaceName,
-    pub(super) owner_source_name: String,
     pub(super) source_name: String,
     pub(super) source_scope_id: String,
     pub(super) surface_kind: ObservedValuesSurfaceKind,
@@ -134,7 +133,6 @@ fn run_observed_values_writer(
 ) {
     while let Some(write) = receiver.blocking_recv() {
         let job = ObservedValuesQueueJob {
-            owner_source_name: write.owner_source_name,
             source_name: write.source_name,
             source_scope_id: write.source_scope_id,
             surface_kind: write.surface_kind,
@@ -263,7 +261,6 @@ mod tests {
     fn test_write() -> ObservedValuesWrite {
         ObservedValuesWrite {
             workspace_name: WorkspaceName::default(),
-            owner_source_name: "github".to_string(),
             source_name: "github".to_string(),
             source_scope_id: "scope".to_string(),
             surface_kind: ObservedValuesSurfaceKind::Table,

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -2,9 +2,9 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use rusqlite::{Connection, ErrorCode, TransactionBehavior};
+use rusqlite::{Connection, ErrorCode, Transaction, TransactionBehavior};
 
 use crate::search::catalog::sqlite_index::{
     CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
@@ -20,7 +20,7 @@ use crate::state::AppStateLayout;
 use crate::storage::fs::create_new_file_private;
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 4;
+pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 5;
 
 struct SearchSqliteMigration {
     version: u32,
@@ -46,6 +46,10 @@ const SEARCH_SQLITE_MIGRATIONS: &[SearchSqliteMigration] = &[
     SearchSqliteMigration {
         version: 4,
         sql: include_str!("migrations/0004_catalog_source_ownership.sql"),
+    },
+    SearchSqliteMigration {
+        version: 5,
+        sql: include_str!("migrations/0005_observed_source_identity.sql"),
     },
 ];
 
@@ -86,7 +90,7 @@ impl SqliteSearchStore {
         configure_connection(&connection)?;
         let capabilities = detect_capabilities(&connection)?;
         ensure_supported(&capabilities)?;
-        migrate_if_needed(&mut connection)?;
+        migrate_if_needed(&mut connection, &workspace_name)?;
 
         Ok(Self {
             path,
@@ -164,20 +168,17 @@ impl SqliteSearchStore {
 
     pub(crate) fn clear_source_all(
         &self,
-        owner_source_name: &str,
+        source_name: &str,
     ) -> Result<(CatalogClearResult, ObservedValuesClearResult), SqliteSearchError> {
         let mut connection = self.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let catalog = clear_catalog_source_documents_in_transaction(
             &transaction,
             &self.workspace_name,
-            owner_source_name,
+            source_name,
         )?;
-        let observed = clear_observed_source_in_transaction(
-            &transaction,
-            &self.workspace_name,
-            owner_source_name,
-        )?;
+        let observed =
+            clear_observed_source_in_transaction(&transaction, &self.workspace_name, source_name)?;
         transaction.commit()?;
         Ok((catalog, observed))
     }
@@ -447,7 +448,10 @@ fn ensure_supported(capabilities: &SqliteSearchCapabilities) -> Result<(), Sqlit
     Ok(())
 }
 
-fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchError> {
+fn migrate_if_needed(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+) -> Result<(), SqliteSearchError> {
     if schema_is_current(connection)? {
         return Ok(());
     }
@@ -460,9 +464,31 @@ fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchErro
         });
     }
 
+    // A singular observed schema must never reach the owner-era replay below.
+    // Migration 0002 names `owner_source_name` in three index statements, and
+    // creating one of those indexes when it is *missing* fails against singular
+    // tables -- which would route intact observed values and queue jobs into the
+    // discarding reset further down. Restating the current-era objects first
+    // repairs the gap and also makes the later replay inert, because
+    // `CREATE INDEX IF NOT EXISTS` short-circuits on the index name before it
+    // resolves the column list.
+    if observed_schema_has_singular_tables(connection)? {
+        match apply_singular_observed_migrations(connection, workspace_name) {
+            Ok(()) if schema_is_current(connection)? => return Ok(()),
+            Ok(()) => {}
+            Err(error) if schema_rebuild_can_recover(&error) => {
+                tracing::warn!(
+                    error = %error,
+                    "singular observed-values schema repair failed before replaying migrations"
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
     // Replay the full idempotent history before upgrading so a damaged older
     // schema cannot carry missing objects into the current version.
-    match apply_all_migrations(connection) {
+    match apply_all_migrations(connection, workspace_name) {
         Ok(()) if schema_is_current(connection)? => return Ok(()),
         Ok(()) => {
             tracing::warn!("SQLite search schema remained incomplete after replaying migrations");
@@ -481,7 +507,7 @@ fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchErro
             "resetting incompatible observed-values schema while preserving the catalog index"
         );
         discard_observed_values_schema(connection)?;
-        apply_all_migrations(connection)?;
+        apply_all_migrations(connection, workspace_name)?;
         if schema_is_current(connection)? {
             return Ok(());
         }
@@ -492,7 +518,7 @@ fn migrate_if_needed(connection: &mut Connection) -> Result<(), SqliteSearchErro
 
     tracing::warn!("rebuilding the disposable search index after catalog schema repair failed");
     discard_search_index_schema(connection)?;
-    apply_all_migrations(connection)?;
+    apply_all_migrations(connection, workspace_name)?;
     if !schema_is_current(connection)? {
         return Err(SqliteSearchError::IncompleteSchemaAfterRebuild {
             schema_version: SEARCH_SQLITE_SCHEMA_VERSION,
@@ -525,9 +551,12 @@ fn sqlite_error_code(error: &rusqlite::Error) -> Option<ErrorCode> {
     }
 }
 
-fn apply_all_migrations(connection: &mut Connection) -> Result<(), SqliteSearchError> {
+fn apply_all_migrations(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+) -> Result<(), SqliteSearchError> {
     for migration in SEARCH_SQLITE_MIGRATIONS {
-        apply_migration(connection, migration)?;
+        apply_migration(connection, migration, workspace_name)?;
     }
     Ok(())
 }
@@ -618,14 +647,329 @@ fn discard_search_index_schema(connection: &mut Connection) -> Result<(), Sqlite
     Ok(())
 }
 
+/// Legacy observed tables renamed aside by the version-5 hook before the
+/// singular schema is created, then copied from and dropped in the same
+/// transaction.
+const LEGACY_OBSERVED_VALUES_TABLE: &str = "observed_values_legacy_v4";
+const LEGACY_OBSERVED_QUEUE_JOBS_TABLE: &str = "observed_queue_jobs_legacy_v4";
+
+/// Columns carried across the version-5 copy, one constant per table.
+///
+/// Each is interpolated into both halves of an `INSERT ... SELECT`, so the two
+/// lists cannot drift. Written out twice they could, and a mismatch would not
+/// fail -- it would shuffle values between columns as the migration copied them.
+const OBSERVED_VALUES_COPY_COLUMNS: &str = "
+    workspace,
+    source_name,
+    source_scope_id,
+    surface_kind,
+    surface_name,
+    column_name,
+    value_key,
+    display_value,
+    search_text,
+    first_observed_at,
+    last_observed_at,
+    observation_count,
+    source_generation,
+    workspace_generation
+";
+
+/// `id` is carried explicitly so queue ordering survives; `SQLite` advances the
+/// `AUTOINCREMENT` sequence to match the highest inserted id.
+const OBSERVED_QUEUE_JOBS_COPY_COLUMNS: &str = "
+    id,
+    workspace,
+    source_name,
+    source_scope_id,
+    surface_kind,
+    surface_name,
+    workspace_generation,
+    source_generation,
+    payload_json,
+    attempts,
+    last_error,
+    created_at,
+    updated_at
+";
+
+/// `rowid` is carried explicitly: the projection keys every FTS row to its
+/// canonical rowid and refreshes by inserting at that exact rowid. Letting fts5
+/// assign fresh sequential rowids would silently misalign the two whenever
+/// canonical rowids are gapped -- as they are after eviction or a stale purge --
+/// and the next refresh of a gapped row would collide with whichever value now
+/// occupies its rowid, failing the queue job until it dead-letters.
+const OBSERVED_VALUES_FTS_COPY_COLUMNS: &str = "
+    rowid,
+    workspace,
+    source_name,
+    source_scope_id,
+    surface_kind,
+    surface_name,
+    column_name,
+    value_key,
+    display_value,
+    search_text
+";
+
+/// First migration whose observed schema is singular. A database that already
+/// reached it must be repaired from here, never by replaying the owner-era DDL
+/// below it.
+const SINGULAR_OBSERVED_SCHEMA_VERSION: u32 = 5;
+
+/// Observed tables that carried the pre-#1791 owner/component identity pair.
+const OWNER_ERA_OBSERVED_TABLES: &[&str] = &[
+    "observed_values",
+    "observed_values_fts",
+    "observed_queue_jobs",
+];
+
+/// Restates the current-era observed schema without replaying owner-era DDL.
+///
+/// Every statement is `IF NOT EXISTS`, so this fills in missing objects and
+/// leaves existing rows alone.
+fn apply_singular_observed_migrations(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+) -> Result<(), SqliteSearchError> {
+    for migration in SEARCH_SQLITE_MIGRATIONS
+        .iter()
+        .filter(|migration| migration.version >= SINGULAR_OBSERVED_SCHEMA_VERSION)
+    {
+        apply_migration(connection, migration, workspace_name)?;
+    }
+    Ok(())
+}
+
+/// Whether any observed table has already dropped the owner column.
+///
+/// Probed per table because a partially repaired sidecar can be singular in one
+/// table while another still carries the pair; the owner-era DDL is unsafe as
+/// soon as *one* table has moved on.
+fn observed_schema_has_singular_tables(connection: &Connection) -> Result<bool, SqliteSearchError> {
+    for table_name in OWNER_ERA_OBSERVED_TABLES {
+        if tables_exist(connection, &[table_name])?
+            && !schema_query_is_valid(
+                connection,
+                &format!("SELECT owner_source_name FROM {table_name} LIMIT 0"),
+            )?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Which observed tables still carry the pre-#1791 owner/component identity
+/// pair, decided per table so a partially repaired sidecar is healed by the
+/// same preserving path rather than falling through to the discarding reset.
+#[derive(Debug, Clone, Copy)]
+struct LegacyObservedIdentity {
+    values: bool,
+    queue_jobs: bool,
+    fts: bool,
+}
+
+/// Row counts carried across the version-5 transform, for the migration log.
+#[derive(Debug, Clone, Copy, Default)]
+struct PreservedObservedRows {
+    values: usize,
+    discarded_values: i64,
+    queue_jobs: usize,
+    discarded_queue_jobs: i64,
+}
+
+impl LegacyObservedIdentity {
+    const NONE: Self = Self {
+        values: false,
+        queue_jobs: false,
+        fts: false,
+    };
+
+    /// A missing table reads as not-legacy, which is what fresh and
+    /// already-singular databases need.
+    fn detect(transaction: &Transaction<'_>) -> Result<Self, SqliteSearchError> {
+        Ok(Self {
+            values: schema_query_is_valid(
+                transaction,
+                "SELECT owner_source_name FROM observed_values LIMIT 0",
+            )?,
+            queue_jobs: schema_query_is_valid(
+                transaction,
+                "SELECT owner_source_name FROM observed_queue_jobs LIMIT 0",
+            )?,
+            fts: schema_query_is_valid(
+                transaction,
+                "SELECT owner_source_name FROM observed_values_fts LIMIT 0",
+            )?,
+        })
+    }
+
+    const fn is_legacy(self) -> bool {
+        self.values || self.queue_jobs || self.fts
+    }
+
+    /// The FTS index is a projection of `observed_values`, so it is rebuilt
+    /// whenever either side is legacy.
+    const fn rebuilds_fts(self) -> bool {
+        self.values || self.fts
+    }
+
+    fn move_legacy_objects_aside(
+        self,
+        transaction: &Transaction<'_>,
+    ) -> Result<(), SqliteSearchError> {
+        if self.values {
+            // SQLite keeps index *names* attached to a renamed table, so 0005's
+            // `CREATE INDEX` statements would silently no-op and leave the new
+            // table unindexed. Drop them by name before the rename lands.
+            transaction.execute_batch(&format!(
+                "
+                DROP TABLE IF EXISTS {LEGACY_OBSERVED_VALUES_TABLE};
+                DROP INDEX IF EXISTS idx_observed_values_source;
+                DROP INDEX IF EXISTS idx_observed_values_workspace_last_observed;
+                ALTER TABLE observed_values RENAME TO {LEGACY_OBSERVED_VALUES_TABLE};
+                "
+            ))?;
+        }
+        if self.queue_jobs {
+            transaction.execute_batch(&format!(
+                "
+                DROP TABLE IF EXISTS {LEGACY_OBSERVED_QUEUE_JOBS_TABLE};
+                DROP INDEX IF EXISTS idx_observed_queue_jobs_workspace_id;
+                DROP INDEX IF EXISTS idx_observed_queue_jobs_source;
+                DROP INDEX IF EXISTS idx_observed_queue_jobs_pending_scope;
+                ALTER TABLE observed_queue_jobs RENAME TO {LEGACY_OBSERVED_QUEUE_JOBS_TABLE};
+                "
+            ))?;
+        }
+        if self.rebuilds_fts() {
+            // Dropping the fts5 table takes its shadow tables with it.
+            transaction.execute_batch("DROP TABLE IF EXISTS observed_values_fts")?;
+        }
+        Ok(())
+    }
+
+    fn copy_preserved_rows(
+        self,
+        transaction: &Transaction<'_>,
+    ) -> Result<PreservedObservedRows, SqliteSearchError> {
+        let mut preserved = PreservedObservedRows::default();
+        if self.values {
+            (preserved.values, preserved.discarded_values) = copy_preserved_rows(
+                transaction,
+                LEGACY_OBSERVED_VALUES_TABLE,
+                "observed_values",
+                OBSERVED_VALUES_COPY_COLUMNS,
+            )?;
+        }
+        if self.queue_jobs {
+            (preserved.queue_jobs, preserved.discarded_queue_jobs) = copy_preserved_rows(
+                transaction,
+                LEGACY_OBSERVED_QUEUE_JOBS_TABLE,
+                "observed_queue_jobs",
+                OBSERVED_QUEUE_JOBS_COPY_COLUMNS,
+            )?;
+        }
+        if self.rebuilds_fts() {
+            repopulate_observed_fts_from_canonical(transaction)?;
+        }
+        Ok(preserved)
+    }
+}
+
+/// Copies rows whose two identities agreed from a renamed legacy table into its
+/// singular replacement, drops the legacy table, and reports
+/// `(preserved, discarded)`.
+///
+/// Divergence is unreachable on production paths, so a nonzero discard count in
+/// the wild would falsify that premise -- which is why it is logged.
+///
+/// `legacy_table`, `target_table`, and `columns` are interpolated into SQL, so
+/// every caller passes a constant defined in this file. None of them is reachable
+/// from a request, a manifest, or a stored row.
+fn copy_preserved_rows(
+    transaction: &Transaction<'_>,
+    legacy_table: &str,
+    target_table: &str,
+    columns: &str,
+) -> Result<(usize, i64), SqliteSearchError> {
+    let discarded = transaction.query_row(
+        &format!(
+            "
+            SELECT COUNT(*)
+            FROM {legacy_table}
+            WHERE owner_source_name <> source_name
+            "
+        ),
+        [],
+        |row| row.get(0),
+    )?;
+    let preserved = transaction.execute(
+        &format!(
+            "
+            INSERT INTO {target_table} ({columns})
+            SELECT {columns}
+            FROM {legacy_table}
+            WHERE owner_source_name = source_name
+            "
+        ),
+        [],
+    )?;
+    transaction.execute_batch(&format!("DROP TABLE {legacy_table}"))?;
+    Ok((preserved, discarded))
+}
+
+/// `observed_values` already holds exactly the preserved rows and carries both
+/// indexed columns, so the values are searchable the moment this transaction
+/// commits -- no reconcile gap.
+fn repopulate_observed_fts_from_canonical(
+    transaction: &Transaction<'_>,
+) -> Result<(), SqliteSearchError> {
+    transaction.execute(
+        &format!(
+            "
+            INSERT INTO observed_values_fts ({OBSERVED_VALUES_FTS_COPY_COLUMNS})
+            SELECT {OBSERVED_VALUES_FTS_COPY_COLUMNS}
+            FROM observed_values
+            "
+        ),
+        [],
+    )?;
+    Ok(())
+}
+
 fn apply_migration(
     connection: &mut Connection,
     migration: &SearchSqliteMigration,
+    workspace_name: &WorkspaceName,
 ) -> Result<(), SqliteSearchError> {
+    let started_at = Instant::now();
     let transaction = connection.transaction()?;
     let initializes_catalog_source_ownership =
         migration.version == 4 && !tables_exist(&transaction, &["catalog_source_owners"])?;
+    let legacy_observed = if migration.version == 5 {
+        LegacyObservedIdentity::detect(&transaction)?
+    } else {
+        LegacyObservedIdentity::NONE
+    };
+    // The renames must precede `execute_batch`: 0005 creates its tables with
+    // `IF NOT EXISTS`, so it would no-op against legacy tables still occupying
+    // the canonical names.
+    legacy_observed.move_legacy_objects_aside(&transaction)?;
     transaction.execute_batch(migration.sql)?;
+    let preserved = legacy_observed.copy_preserved_rows(&transaction)?;
+    if legacy_observed.is_legacy() {
+        tracing::info!(
+            workspace = %workspace_name.as_str(),
+            preserved_values = preserved.values,
+            discarded_divergent_values = preserved.discarded_values,
+            preserved_queue_jobs = preserved.queue_jobs,
+            discarded_divergent_queue_jobs = preserved.discarded_queue_jobs,
+            duration_ms = started_at.elapsed().as_millis(),
+            "migrated observed-values storage to singular source identity"
+        );
+    }
     if initializes_catalog_source_ownership {
         // Existing catalog rows predate durable installed-owner identity. They
         // are disposable and cannot be safely backfilled for multi-component
@@ -764,7 +1108,6 @@ fn observed_values_schema_is_current(connection: &Connection) -> Result<bool, Sq
         "
         SELECT
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -784,7 +1127,6 @@ fn observed_values_schema_is_current(connection: &Connection) -> Result<bool, Sq
         "
         SELECT
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -800,7 +1142,6 @@ fn observed_values_schema_is_current(connection: &Connection) -> Result<bool, Sq
         SELECT
             id,
             workspace,
-            owner_source_name,
             source_name,
             source_scope_id,
             surface_kind,
@@ -817,6 +1158,19 @@ fn observed_values_schema_is_current(connection: &Connection) -> Result<bool, Sq
         ",
     ] {
         if !schema_query_is_valid(connection, query)? {
+            return Ok(false);
+        }
+    }
+
+    // Presence probes cannot see a *surplus* column, and a surviving legacy
+    // queue table (`owner_source_name NOT NULL`, no default) would pass the
+    // probes above and then reject every rewritten enqueue with no self-heal.
+    for query in [
+        "SELECT owner_source_name FROM observed_values LIMIT 0",
+        "SELECT owner_source_name FROM observed_values_fts LIMIT 0",
+        "SELECT owner_source_name FROM observed_queue_jobs LIMIT 0",
+    ] {
+        if schema_query_is_valid(connection, query)? {
             return Ok(false);
         }
     }
@@ -926,8 +1280,10 @@ mod tests {
         let mut connection = rusqlite::Connection::open(&path).expect("raw connection");
 
         for migration in SEARCH_SQLITE_MIGRATIONS {
-            super::apply_migration(&mut connection, migration).expect("first apply");
-            super::apply_migration(&mut connection, migration).expect("second apply");
+            super::apply_migration(&mut connection, migration, &WorkspaceName::default())
+                .expect("first apply");
+            super::apply_migration(&mut connection, migration, &WorkspaceName::default())
+                .expect("second apply");
         }
 
         let user_version: u32 = connection
@@ -942,9 +1298,10 @@ mod tests {
         let path = temp.path().join("search.sqlite3");
         let mut connection = Connection::open(&path).expect("raw v2 connection");
         for migration in SEARCH_SQLITE_MIGRATIONS.iter().take(2) {
-            super::apply_migration(&mut connection, migration).expect("apply v2 history");
+            super::apply_migration(&mut connection, migration, &WorkspaceName::default())
+                .expect("apply v2 history");
         }
-        seed_observed_queue_job(&connection);
+        seed_legacy_v4_observed_queue_job(&connection);
         assert!(!index_exists(
             &connection,
             "idx_observed_values_workspace_last_observed"
@@ -966,10 +1323,11 @@ mod tests {
         let path = temp.path().join("search.sqlite3");
         let mut connection = Connection::open(&path).expect("raw v3 connection");
         for migration in SEARCH_SQLITE_MIGRATIONS.iter().take(3) {
-            super::apply_migration(&mut connection, migration).expect("apply v3 history");
+            super::apply_migration(&mut connection, migration, &WorkspaceName::default())
+                .expect("apply v3 history");
         }
         seed_catalog_document(&connection);
-        seed_observed_queue_job(&connection);
+        seed_legacy_v4_observed_queue_job(&connection);
         connection
             .execute(
                 "INSERT INTO search_meta (key, value) VALUES ('catalog_snapshot_fingerprint:default', 'legacy')",
@@ -1294,7 +1652,7 @@ mod tests {
             .expect("seed catalog source owner");
         connection
             .execute(
-                "INSERT INTO observed_values (workspace, owner_source_name, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation) VALUES ('default', 'github', 'github_v4_mcp', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue', 0, 0)",
+                "INSERT INTO observed_values (workspace, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation) VALUES ('default', 'github', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue', 0, 0)",
                 [],
             )
             .expect("seed observed value");
@@ -1319,7 +1677,7 @@ mod tests {
             .expect("catalog count");
         let observed_count: i64 = connection
             .query_row(
-                "SELECT COUNT(*) FROM observed_values WHERE workspace = 'default' AND owner_source_name = 'github' AND source_name = 'github_v4_mcp'",
+                "SELECT COUNT(*) FROM observed_values WHERE workspace = 'default' AND source_name = 'github'",
                 [],
                 |row| row.get(0),
             )
@@ -1386,14 +1744,14 @@ mod tests {
             })
             .expect("refresh catalog projection");
         let connection = store.connect_for_test().expect("connect");
-        for (owner_source_name, source_name, display_value) in [
-            ("github_v4", "github_v4_rest", "Payment issue"),
-            ("slack_v4", "slack_v4_rest", "Payment message"),
+        for (source_name, display_value) in [
+            ("github_v4", "Payment issue"),
+            ("slack_v4", "Payment message"),
         ] {
             connection
                 .execute(
-                    "INSERT INTO observed_values (workspace, owner_source_name, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation) VALUES ('default', ?1, ?2, 'scope', 'table', 'items', 'title', ?3, ?3, ?3, 0, 0)",
-                    (owner_source_name, source_name, display_value),
+                    "INSERT INTO observed_values (workspace, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation) VALUES ('default', ?1, 'scope', 'table', 'items', 'title', ?2, ?2, ?2, 0, 0)",
+                    (source_name, display_value),
                 )
                 .expect("seed observed value");
         }
@@ -1417,17 +1775,17 @@ mod tests {
             .expect("query catalog sources")
             .collect::<Result<Vec<_>, _>>()
             .expect("catalog sources");
-        let remaining_observed_owners = connection
+        let remaining_observed_sources = connection
             .prepare(
-                "SELECT owner_source_name FROM observed_values WHERE workspace = 'default' ORDER BY owner_source_name",
+                "SELECT source_name FROM observed_values WHERE workspace = 'default' ORDER BY source_name",
             )
-            .expect("prepare observed owners")
+            .expect("prepare observed sources")
             .query_map([], |row| row.get::<_, String>(0))
-            .expect("query observed owners")
+            .expect("query observed sources")
             .collect::<Result<Vec<_>, _>>()
-            .expect("observed owners");
+            .expect("observed sources");
         assert_eq!(remaining_catalog_sources, ["slack_v4_rest"]);
-        assert_eq!(remaining_observed_owners, ["slack_v4"]);
+        assert_eq!(remaining_observed_sources, ["slack_v4"]);
     }
 
     #[test]
@@ -1632,6 +1990,7 @@ mod tests {
         super::apply_migration(
             &mut connection,
             SEARCH_SQLITE_MIGRATIONS.first().expect("v1 migration"),
+            &WorkspaceName::default(),
         )
         .expect("apply v1 migration");
         connection
@@ -1708,10 +2067,10 @@ mod tests {
                 VALUES ('default', 'github', 'github', 'fingerprint');
                 INSERT INTO search_meta (key, value)
                 VALUES ('catalog_snapshot_fingerprint:default', 'fingerprint');
-                INSERT INTO observed_values (workspace, owner_source_name, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation)
-                VALUES ('default', 'github', 'github', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue', 0, 0);
-                INSERT INTO observed_values_fts (workspace, owner_source_name, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text)
-                VALUES ('default', 'github', 'github', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue');
+                INSERT INTO observed_values (workspace, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation)
+                VALUES ('default', 'github', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue', 0, 0);
+                INSERT INTO observed_values_fts (workspace, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text)
+                VALUES ('default', 'github', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue');
                 CREATE TRIGGER fail_workspace_epoch_insert
                 BEFORE INSERT ON observed_workspace_generations
                 BEGIN
@@ -1754,12 +2113,12 @@ mod tests {
             ),
             observed_fts_values: matching_row_count(
                 connection,
-                "SELECT COUNT(*) FROM observed_values_fts WHERE workspace = 'default' AND owner_source_name = 'github' AND source_name = 'github' AND source_scope_id = 'scope' AND surface_kind = 'table' AND surface_name = 'issues' AND column_name = 'title' AND value_key = 'value' AND display_value = 'Payment issue' AND search_text = 'payment issue'",
+                "SELECT COUNT(*) FROM observed_values_fts WHERE workspace = 'default' AND source_name = 'github' AND source_scope_id = 'scope' AND surface_kind = 'table' AND surface_name = 'issues' AND column_name = 'title' AND value_key = 'value' AND display_value = 'Payment issue' AND search_text = 'payment issue'",
                 "observed FTS value count",
             ),
             observed_queue_jobs: matching_row_count(
                 connection,
-                "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = 'default' AND owner_source_name = 'github' AND source_name = 'github' AND source_scope_id = 'fixture-scope' AND surface_kind = 'table' AND surface_name = 'issues' AND workspace_generation = 0 AND source_generation = 0 AND payload_json = '{}'",
+                "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = 'default' AND source_name = 'github' AND source_scope_id = 'fixture-scope' AND surface_kind = 'table' AND surface_name = 'issues' AND workspace_generation = 0 AND source_generation = 0 AND payload_json = '{}'",
                 "observed queue job count",
             ),
             observed_workspace_generations: matching_row_count(
@@ -1783,13 +2142,396 @@ mod tests {
         }
     }
 
+    // ---- version-5 observed-identity migration -------------------------------
+
+    #[test]
+    fn seeded_v4_upgrade_preserves_equal_identity_observed_rows() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = seed_v4_observed_fixture(&path);
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+
+        assert_eq!(
+            observed_source_names(&connection, "observed_values"),
+            ["github_mcp_v4", "github_v4"],
+            "rows whose two identities were equal must survive"
+        );
+        // Preserved values are searchable the moment the migration commits --
+        // the FTS index is rebuilt from the canonical table in the same
+        // transaction, so there is no reconcile gap.
+        assert_eq!(
+            matching_row_count(
+                &connection,
+                "SELECT COUNT(*) FROM observed_values_fts WHERE observed_values_fts MATCH 'payment'",
+                "searchable preserved values",
+            ),
+            2
+        );
+        assert_eq!(
+            observed_source_names(&connection, "observed_values_fts"),
+            ["github_mcp_v4", "github_v4"]
+        );
+        assert_eq!(
+            observed_source_names(&connection, "observed_queue_jobs"),
+            ["github_v4"],
+            "queue jobs follow the same preserve-equal-rows rule"
+        );
+        assert_eq!(
+            matching_row_count(
+                &connection,
+                "SELECT id FROM observed_queue_jobs",
+                "preserved queue job id",
+            ),
+            7,
+            "explicit ids are carried across so queue ordering is stable"
+        );
+        assert_eq!(
+            matching_row_count(
+                &connection,
+                "SELECT generation FROM observed_workspace_generations WHERE workspace = 'default'",
+                "workspace generation",
+            ),
+            3
+        );
+        assert_eq!(
+            matching_row_count(
+                &connection,
+                "SELECT generation FROM observed_source_generations WHERE source_name = 'github_v4'",
+                "source generation",
+            ),
+            5
+        );
+        assert!(
+            !observed_tables_carry_owner_column(&connection),
+            "no observed table may keep the legacy owner column"
+        );
+    }
+
+    #[test]
+    fn already_singular_schema_replay_preserves_observed_rows() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = open_current_search_connection(&path);
+        seed_singular_observed_value(&connection, "github_v4", "payment outage");
+        seed_observed_queue_job(&connection);
+        drop(connection);
+
+        // Reopening replays the whole idempotent history; the version-5 hook
+        // must be a complete no-op against a schema that is already singular.
+        let connection = open_current_search_connection(&path);
+
+        assert_eq!(observed_value_count(&connection), 1);
+        assert_eq!(observed_queue_job_count(&connection), 1);
+    }
+
+    #[test]
+    fn mis_stamped_v5_is_repaired_with_data_preserved() {
+        for legacy_table in [
+            "observed_values",
+            "observed_values_fts",
+            "observed_queue_jobs",
+        ] {
+            let temp = tempdir().expect("tempdir");
+            let path = temp.path().join("search.sqlite3");
+            let connection = seed_v4_observed_fixture(&path);
+            if legacy_table != "observed_values" {
+                // Leave the owner column on only one table, so the repair path
+                // cannot lean on detecting it everywhere.
+                make_observed_values_singular(&connection);
+            }
+            if legacy_table != "observed_queue_jobs" {
+                make_observed_queue_jobs_singular(&connection);
+            }
+            if legacy_table == "observed_queue_jobs" {
+                rebuild_observed_fts_as_singular(&connection);
+            }
+            connection
+                .pragma_update(None, "user_version", SEARCH_SQLITE_SCHEMA_VERSION)
+                .expect("mis-stamp the schema version");
+            assert!(
+                !super::schema_is_current(&connection).expect("validate mis-stamped schema"),
+                "a surplus owner column on {legacy_table} must fail validation"
+            );
+            drop(connection);
+
+            let connection = open_current_search_connection(&path);
+
+            assert!(
+                observed_value_count(&connection) > 0,
+                "repairing a mis-stamped {legacy_table} must preserve observed data"
+            );
+            assert!(!observed_tables_carry_owner_column(&connection));
+        }
+    }
+
+    #[test]
+    fn missing_singular_index_is_repaired_without_discarding_observed_data() {
+        // Migration 0002 builds three of the five observed indexes over
+        // `owner_source_name`. On a singular database a *missing* one of those
+        // cannot be replayed, and before the singular-era repair that failure
+        // routed intact data into the discarding reset.
+        for index_name in [
+            "idx_observed_values_source",
+            "idx_observed_queue_jobs_source",
+            "idx_observed_queue_jobs_pending_scope",
+        ] {
+            let temp = tempdir().expect("tempdir");
+            let path = temp.path().join("search.sqlite3");
+            let connection = open_current_search_connection(&path);
+            seed_singular_observed_value(&connection, "github_v4", "payment outage");
+            seed_observed_queue_job(&connection);
+            connection
+                .execute_batch(&format!("DROP INDEX {index_name}"))
+                .expect("drop a singular index");
+            assert!(
+                !super::schema_is_current(&connection).expect("validate damaged schema"),
+                "a missing {index_name} must fail validation"
+            );
+            drop(connection);
+
+            let connection = open_current_search_connection(&path);
+
+            assert_eq!(
+                observed_value_count(&connection),
+                1,
+                "repairing a missing {index_name} must preserve observed values"
+            );
+            assert_eq!(
+                observed_queue_job_count(&connection),
+                1,
+                "repairing a missing {index_name} must preserve queued jobs"
+            );
+            assert!(index_exists(&connection, index_name));
+        }
+    }
+
+    #[test]
+    fn fts_repair_keeps_fts_rowids_aligned_with_gapped_canonical_rowids() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let connection = open_current_search_connection(&path);
+        for source_name in ["source_a", "source_b", "source_c"] {
+            seed_singular_observed_value(&connection, source_name, "payment outage");
+        }
+        // Eviction and stale purges leave gaps, so canonical rowids are not a
+        // dense 1..N sequence the FTS index can reproduce by counting.
+        connection
+            .execute("DELETE FROM observed_values WHERE rowid = 1", [])
+            .expect("evict the first canonical row");
+        rebuild_observed_fts_as_owner_era(&connection);
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+
+        let misaligned: i64 = connection
+            .query_row(
+                "
+                SELECT COUNT(*)
+                FROM observed_values v
+                LEFT JOIN observed_values_fts f
+                    ON f.rowid = v.rowid
+                   AND f.value_key = v.value_key
+                WHERE f.rowid IS NULL
+                ",
+                [],
+                |row| row.get(0),
+            )
+            .expect("rowid alignment query");
+        assert_eq!(
+            misaligned, 0,
+            "every preserved row must keep its canonical rowid in the FTS index"
+        );
+        assert_eq!(observed_value_count(&connection), 2);
+    }
+
+    /// Replaces the FTS index with the pre-#1791 shape, leaving the canonical
+    /// table singular -- the partial-repair state the version-5 hook heals.
+    fn rebuild_observed_fts_as_owner_era(connection: &Connection) {
+        connection
+            .execute_batch(
+                "
+                DROP TABLE observed_values_fts;
+                CREATE VIRTUAL TABLE observed_values_fts USING fts5(
+                    workspace UNINDEXED,
+                    owner_source_name UNINDEXED,
+                    source_name UNINDEXED,
+                    source_scope_id UNINDEXED,
+                    surface_kind UNINDEXED,
+                    surface_name UNINDEXED,
+                    column_name UNINDEXED,
+                    value_key UNINDEXED,
+                    display_value,
+                    search_text,
+                    tokenize = 'trigram'
+                );
+                ",
+            )
+            .expect("install an owner-era FTS index");
+    }
+
+    fn seed_v4_observed_fixture(path: &std::path::Path) -> Connection {
+        let mut connection = Connection::open(path).expect("raw v4 connection");
+        for migration in SEARCH_SQLITE_MIGRATIONS.iter().take(4) {
+            super::apply_migration(&mut connection, migration, &WorkspaceName::default())
+                .expect("apply v4 history");
+        }
+        connection
+            .execute_batch(
+                "
+                INSERT INTO observed_values (
+                    workspace, owner_source_name, source_name, source_scope_id, surface_kind,
+                    surface_name, column_name, value_key, display_value, search_text,
+                    source_generation, workspace_generation
+                ) VALUES
+                    ('default', 'github_v4', 'github_v4', 'rest-scope', 'table', 'issues',
+                     'title', 'rest', 'REST payment outage', 'rest payment outage', 0, 0),
+                    ('default', 'github_mcp_v4', 'github_mcp_v4', 'mcp-scope', 'table', 'issues',
+                     'title', 'mcp', 'MCP payment outage', 'mcp payment outage', 0, 0),
+                    ('default', 'github_v4', 'github_v4_rest', 'rest-scope', 'table', 'issues',
+                     'title', 'divergent', 'Divergent value', 'divergent value', 0, 0);
+
+                INSERT INTO observed_values_fts (
+                    workspace, owner_source_name, source_name, source_scope_id, surface_kind,
+                    surface_name, column_name, value_key, display_value, search_text
+                )
+                SELECT workspace, owner_source_name, source_name, source_scope_id, surface_kind,
+                       surface_name, column_name, value_key, display_value, search_text
+                FROM observed_values;
+
+                INSERT INTO observed_queue_jobs (
+                    id, workspace, owner_source_name, source_name, source_scope_id, surface_kind,
+                    surface_name, workspace_generation, source_generation, payload_json
+                ) VALUES
+                    (7, 'default', 'github_v4', 'github_v4', 'rest-scope', 'table', 'issues',
+                     0, 0, '{}'),
+                    (8, 'default', 'github_v4', 'github_v4_rest', 'rest-scope', 'table', 'pulls',
+                     0, 0, '{}');
+
+                INSERT INTO observed_workspace_generations (workspace, generation)
+                VALUES ('default', 3);
+                INSERT INTO observed_source_generations (workspace, source_name, generation)
+                VALUES ('default', 'github_v4', 5);
+                ",
+            )
+            .expect("seed v4 observed fixture");
+        connection
+    }
+
+    fn seed_singular_observed_value(connection: &Connection, source_name: &str, search_text: &str) {
+        connection
+            .execute(
+                "
+                INSERT INTO observed_values (
+                    workspace, source_name, source_scope_id, surface_kind, surface_name,
+                    column_name, value_key, display_value, search_text,
+                    source_generation, workspace_generation
+                ) VALUES ('default', ?1, 'scope', 'table', 'issues', 'title', 'key', ?2, ?2, 0, 0)
+                ",
+                (source_name, search_text),
+            )
+            .expect("seed singular observed value");
+    }
+
+    fn make_observed_values_singular(connection: &Connection) {
+        connection
+            .execute_batch(
+                "
+                DROP INDEX IF EXISTS idx_observed_values_source;
+                DROP INDEX IF EXISTS idx_observed_values_workspace_last_observed;
+                ALTER TABLE observed_values RENAME TO observed_values_owner_era;
+                ",
+            )
+            .expect("move the owner-era canonical table aside");
+        connection
+            .execute_batch(include_str!("migrations/0005_observed_source_identity.sql"))
+            .expect("create the singular canonical table");
+        connection
+            .execute_batch(
+                "
+                INSERT INTO observed_values (
+                    workspace, source_name, source_scope_id, surface_kind, surface_name,
+                    column_name, value_key, display_value, search_text, first_observed_at,
+                    last_observed_at, observation_count, source_generation, workspace_generation
+                )
+                SELECT workspace, source_name, source_scope_id, surface_kind, surface_name,
+                       column_name, value_key, display_value, search_text, first_observed_at,
+                       last_observed_at, observation_count, source_generation, workspace_generation
+                FROM observed_values_owner_era
+                WHERE owner_source_name = source_name;
+                DROP TABLE observed_values_owner_era;
+                ",
+            )
+            .expect("copy rows into the singular canonical table");
+    }
+
+    fn make_observed_queue_jobs_singular(connection: &Connection) {
+        connection
+            .execute_batch(
+                "
+                DROP INDEX IF EXISTS idx_observed_queue_jobs_workspace_id;
+                DROP INDEX IF EXISTS idx_observed_queue_jobs_source;
+                DROP INDEX IF EXISTS idx_observed_queue_jobs_pending_scope;
+                DROP TABLE observed_queue_jobs;
+                ",
+            )
+            .expect("drop the owner-era queue table");
+        connection
+            .execute_batch(include_str!("migrations/0005_observed_source_identity.sql"))
+            .expect("create the singular queue table");
+    }
+
+    fn rebuild_observed_fts_as_singular(connection: &Connection) {
+        connection
+            .execute_batch("DROP TABLE observed_values_fts")
+            .expect("drop the owner-era FTS table");
+        connection
+            .execute_batch(include_str!("migrations/0005_observed_source_identity.sql"))
+            .expect("create the singular FTS table");
+    }
+
+    fn observed_source_names(connection: &Connection, table_name: &str) -> Vec<String> {
+        let sql = format!("SELECT source_name FROM {table_name} ORDER BY source_name");
+        let mut statement = connection.prepare(&sql).expect("source-name query");
+        statement
+            .query_map([], |row| row.get(0))
+            .expect("query source names")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect source names")
+    }
+
+    fn observed_tables_carry_owner_column(connection: &Connection) -> bool {
+        [
+            "observed_values",
+            "observed_values_fts",
+            "observed_queue_jobs",
+        ]
+        .into_iter()
+        .any(|table_name| {
+            super::schema_query_is_valid(
+                connection,
+                &format!("SELECT owner_source_name FROM {table_name} LIMIT 0"),
+            )
+            .expect("owner-column probe")
+        })
+    }
+
+    fn observed_value_count(connection: &Connection) -> i64 {
+        connection
+            .query_row("SELECT COUNT(*) FROM observed_values", [], |row| row.get(0))
+            .expect("observed value count")
+    }
+
     fn matching_row_count(connection: &Connection, query: &str, context: &str) -> i64 {
         connection
             .query_row(query, [], |row| row.get(0))
             .expect(context)
     }
 
-    fn seed_observed_queue_job(connection: &Connection) {
+    /// Seeds the pre-#1791 owner/component shape, for tests that build a v2/v3
+    /// era database and then upgrade through the version-5 copy path.
+    fn seed_legacy_v4_observed_queue_job(connection: &Connection) {
         connection
             .execute(
                 "
@@ -1806,6 +2548,35 @@ mod tests {
                 ) VALUES (
                     'default',
                     'github',
+                    'github',
+                    'fixture-scope',
+                    'table',
+                    'issues',
+                    0,
+                    0,
+                    '{}'
+                )
+                ",
+                [],
+            )
+            .expect("seed legacy observed queue job");
+    }
+
+    fn seed_observed_queue_job(connection: &Connection) {
+        connection
+            .execute(
+                "
+                INSERT INTO observed_queue_jobs (
+                    workspace,
+                    source_name,
+                    source_scope_id,
+                    surface_kind,
+                    surface_name,
+                    workspace_generation,
+                    source_generation,
+                    payload_json
+                ) VALUES (
+                    'default',
                     'github',
                     'fixture-scope',
                     'table',

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -21,6 +21,7 @@ use coral_client::default_workspace;
 use coral_engine::{
     EngineExtensions, QuerySource, SourceDecorator, SourceDecoratorError, SourceTables,
 };
+use rusqlite::OptionalExtension as _;
 use serde_json::json;
 use tonic::{Code, Request};
 use wiremock::matchers::{method, path};
@@ -1372,6 +1373,76 @@ async fn source_scoped_all_clear_does_not_load_manifest_and_bumps_generation() {
 }
 
 #[tokio::test]
+async fn source_scoped_clear_leaves_the_other_installed_source_intact() {
+    // `github_v4` and `github_mcp_v4` are the two-interfaces-one-provider shape
+    // that #1791 made two independent sources. Clearing one must not disturb
+    // the other, all the way out through the public RPC.
+    let harness = GrpcHarness::new_with_observed_values_search().await;
+    for source_name in ["github_v4", "github_mcp_v4"] {
+        harness
+            .import_source(
+                named_searchable_manifest_yaml(source_name),
+                Vec::new(),
+                Vec::new(),
+            )
+            .await;
+    }
+    harness
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: SearchIndexProvider::Catalog as i32,
+            force: false,
+        }))
+        .await
+        .expect("seed catalog projection");
+    let sqlite_path = harness
+        .config_dir()
+        .join("workspaces/default/search/search.sqlite3");
+    let initial_cleared = source_generation(&sqlite_path, "github_v4");
+    let initial_untouched = source_generation(&sqlite_path, "github_mcp_v4");
+
+    let clear = harness
+        .search_client()
+        .clear_search_data(Request::new(ClearSearchDataRequest {
+            workspace: Some(default_workspace()),
+            scope: SearchDataScope::All as i32,
+            target: Some(SearchClearTarget {
+                target: Some(search_clear_target::Target::SourceName(
+                    "github_v4".to_string(),
+                )),
+            }),
+        }))
+        .await
+        .expect("source-scoped clear")
+        .into_inner();
+
+    assert_eq!(clear.results.len(), 2);
+    assert_eq!(
+        source_generation(&sqlite_path, "github_v4"),
+        initial_cleared + 1
+    );
+    assert_eq!(
+        source_generation(&sqlite_path, "github_mcp_v4"),
+        initial_untouched,
+        "clearing github_v4 must not advance the github_mcp_v4 epoch"
+    );
+    let connection = rusqlite::Connection::open(&sqlite_path).expect("open search sqlite");
+    let surviving_catalog_sources: Vec<String> = connection
+        .prepare(
+            "SELECT DISTINCT source_name FROM catalog_documents \
+             WHERE workspace = 'default' AND source_name IN ('github_v4', 'github_mcp_v4') \
+             ORDER BY source_name",
+        )
+        .expect("prepare catalog sources")
+        .query_map([], |row| row.get(0))
+        .expect("query catalog sources")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect catalog sources");
+    assert_eq!(surviving_catalog_sources, ["github_mcp_v4"]);
+}
+
+#[tokio::test]
 async fn search_table_preview_columns_do_not_inherit_table_matched_fields() {
     let harness = GrpcHarness::new().await;
     harness
@@ -1725,9 +1796,26 @@ fn catalog_clear_detail(
         .expect("catalog clear detail")
 }
 
+fn source_generation(sqlite_path: &std::path::Path, source_name: &str) -> i64 {
+    rusqlite::Connection::open(sqlite_path)
+        .expect("open search sqlite")
+        .query_row(
+            "SELECT generation FROM observed_source_generations WHERE workspace = 'default' AND source_name = ?1",
+            [source_name],
+            |row| row.get(0),
+        )
+        .optional()
+        .expect("source generation query")
+        .unwrap_or(0)
+}
+
 fn searchable_manifest_yaml() -> String {
+    named_searchable_manifest_yaml("searchable")
+}
+
+fn named_searchable_manifest_yaml(source_name: &str) -> String {
     manifest_yaml(&json!({
-        "name": "searchable",
+        "name": source_name,
         "version": "0.1.0",
         "dsl_version": 3,
         "backend": "http",


### PR DESCRIPTION
## What

Collapses the observed-values pipeline onto one canonical `source_name` and
migrates the sidecar to schema **v5**, preserving observed data.

Since #1791 one DSL v4 source publishes exactly one surface and one SQL
namespace, so `owner_source_name` (lifecycle owner) and `source_name`
(query-visible schema) are the same thing. The equality this rests on is
checked at the capture seam by #2078, downstack.

## Reviewing this

~55% of the diff is tests, and most of the rest is mechanical. Suggested order:

| Where the thinking is | |
|---|---|
| `migrations/0005_observed_source_identity.sql` | the target schema (104 lines) |
| `search/sqlite_store.rs` **above `mod tests`** | migration hook, validation probes, singular-era repair (~430 lines) |

| Mechanical — forced renames, safe to skim | |
|---|---|
| `sqlite_projection.rs`, `governance.rs`, `observed/sqlite_store.rs` | drop the owner column from structs and SQL |
| `sqlite_store/tests.rs`, inline test modules | fixtures follow the struct change |

## Migration design (v4 → v5, preserve equal rows)

All inside `apply_migration`'s single transaction, so an interrupted upgrade
rolls back to intact v4:

1. Detect the legacy shape, **per table** — `observed_values`,
   `observed_queue_jobs`, `observed_values_fts` independently. A sidecar that is
   singular in one and legacy in another then heals through the *preserving*
   path instead of falling through to the discarding reset.
2. Rename legacy tables aside and drop the five legacy indexes **by name** —
   SQLite keeps index names attached to renamed tables, so 0005's
   `CREATE INDEX` would otherwise silently no-op and leave the new table
   unindexed. This ordering is load-bearing: 0005 uses `IF NOT EXISTS`, so it
   would no-op against legacy tables still holding the canonical names.
3. `execute_batch(0005)` — the complete singular schema.
4. Copy back every row whose two identities agreed, then repopulate FTS from the
   canonical table. Preserved values are searchable the moment the transaction
   commits — no reconcile gap.

Rows with divergent identities are discarded. Unreachable on production paths,
so this only affects synthetic state; preserved and discarded counts are logged
so a nonzero discard in the wild is visible and falsifiable.

## Two failure modes worth your attention

**Repairing a singular schema must not replay owner-era DDL.** Migration 0002
names `owner_source_name` in three of the five index statements. If one of those
indexes goes missing on a v5 database, the full-history replay cannot recreate
it, and the resulting "recoverable" error routed **all observed values and queue
jobs** into `discard_observed_values_schema`. So a singular schema is now
repaired from version 5 onward first. That also makes the later replay inert,
because `CREATE INDEX IF NOT EXISTS` short-circuits on the index name before it
resolves the column list.

**FTS rows carry their canonical `rowid` explicitly.** The projection keys every
FTS row to its canonical rowid and refreshes by inserting at that exact rowid.
Letting fts5 assign fresh sequential rowids misaligns the two whenever canonical
rowids are gapped (after eviction), and the next refresh of a gapped row
collides with whatever now occupies its rowid, failing that queue job until it
dead-letters.

Both are covered by tests verified to fail without their fix.

## Validation gains absence probes

On all three owner-bearing tables. Presence probes cannot see a *surplus*
column, so a surviving legacy queue table (`owner_source_name NOT NULL`, no
default) would pass validation and then reject every rewritten enqueue with no
self-heal.

## Scope ids are byte-stable

The Rust field is renamed with `#[serde(rename = "component_source_name")]` and
`SOURCE_SCOPE_FORMAT_VERSION` stays 1. The hash pinned in #2077 still passes
untouched — that is what proves no bytes moved. Rotating scope ids here would
make every preserved row fail-closed invisible.

## Compatibility

The sidecar becomes **forward-only** at v5: older binaries refuse a newer
`user_version`. Do not run old and new binaries against the same config
directory.

No wire, CLI-flag, or JSON changes: hit `schema_name` was always populated from
`source_name`, and hits never read the owner column. No `github_v4_mcp` alias.
No change to `sources/manager.rs`.
