### PR TITLE
refactor(search): remove catalog source ownership projection

### DIFF
--- a/apps/docs/guides/search-with-coral.mdx
+++ b/apps/docs/guides/search-with-coral.mdx
@@ -45,9 +45,8 @@ example.
 
 Here, `github` is the query-visible SQL schema. JSON and MCP results include it
 in `sql_reference`. A catalog-backed table uses a three-part
-`catalog.schema.table` reference. For a source with multiple runtime components,
-the query-visible schema can differ from the installed source name because each
-component can publish its own SQL schema.
+`catalog.schema.table` reference. The schema is also the installed source name:
+one source publishes one SQL namespace.
 
 When more fields matched than were shown, the result reports how many were left
 out so you can widen the query rather than assume the column does not exist.
@@ -102,7 +101,7 @@ To remove observed values for a workspace:
 coral search-index clear --scope observed-values --workspace default --yes
 ```
 
-To remove them for one installed source and every runtime schema and surface it owns, pass the canonical installed source name:
+To remove them for one installed source, pass its name:
 
 ```shellscript
 coral search-index clear --scope observed-values --source github --workspace default --yes

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -165,9 +165,8 @@ Clear Coral's local search data for one workspace.
 Clear deletes local search data, so Coral requires both `--yes` and an explicit
 `--workspace NAME`.
 
-`--source` accepts the canonical installed source name, not a runtime SQL
-schema. It clears the selected scope for every runtime schema and surface owned
-by that source.
+`--source` accepts the installed source name, which is also its SQL schema
+name. It clears the selected scope for that source.
 
 ```shellscript
 coral search-index clear --scope all --workspace work --yes
@@ -181,7 +180,7 @@ coral search-index clear --scope all --source github --workspace work --yes
 | Option                    | Type   | Default  | Description                                               |
 | ------------------------- | ------ | -------- | --------------------------------------------------------- |
 | `--scope`                 | enum   | required | Search data scope to clear: `all` or `observed-values`    |
-| `--source`                | string | unset    | Installed source owner whose runtime schemas and surfaces are cleared |
+| `--source`                | string | unset    | Installed source whose local search state is cleared      |
 | global `--workspace NAME` | string | required | Workspace whose search data will be cleared               |
 | `--yes`                   | flag   | required | Confirm destructive search-data deletion                  |
 

--- a/crates/coral-app/src/catalog/model.rs
+++ b/crates/coral-app/src/catalog/model.rs
@@ -1,6 +1,6 @@
 //! App-private catalog resolution models.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use coral_engine::CatalogInfo;
 
@@ -9,6 +9,4 @@ use coral_engine::CatalogInfo;
 pub(crate) struct CatalogResolution {
     pub(crate) catalog: CatalogInfo,
     pub(crate) failed_source_names: BTreeSet<String>,
-    /// Runtime schema name to canonical installed source owner.
-    pub(crate) runtime_schema_owners: BTreeMap<String, String>,
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -94,7 +94,6 @@ enum CatalogColumnLoading {
 struct LoadedQuerySource {
     source: InstalledSource,
     query_source: QuerySource,
-    runtime_schema_name: String,
     runtime_contract_fingerprint: RuntimeContractFingerprint,
     credential_material: BTreeMap<String, String>,
 }
@@ -102,32 +101,6 @@ struct LoadedQuerySource {
 struct QuerySourceLoad {
     loaded: Vec<LoadedQuerySource>,
     failed_source_names: BTreeSet<String>,
-}
-
-/// Maps each loaded runtime schema to its canonical installed source owner.
-fn runtime_schema_owners(
-    loaded_sources: &[LoadedQuerySource],
-) -> Result<BTreeMap<String, String>, AppError> {
-    let mut owners = BTreeMap::new();
-    for loaded in loaded_sources {
-        match owners.entry(loaded.runtime_schema_name.clone()) {
-            std::collections::btree_map::Entry::Vacant(entry) => {
-                entry.insert(loaded.source.name.as_str().to_string());
-            }
-            std::collections::btree_map::Entry::Occupied(entry)
-                if entry.get().as_str() != loaded.source.name.as_str() =>
-            {
-                return Err(AppError::InvalidInput(format!(
-                    "catalog runtime schema '{}' is owned by both '{}' and '{}'",
-                    entry.key(),
-                    entry.get(),
-                    loaded.source.name
-                )));
-            }
-            std::collections::btree_map::Entry::Occupied(_) => {}
-        }
-    }
-    Ok(owners)
 }
 
 #[derive(Clone, Default)]
@@ -386,8 +359,6 @@ impl QueryManager {
                     .await?;
                 let mut failed_source_names = source_load.failed_source_names;
                 failed_source_names.extend(failure_recorder.failed_source_names());
-                let runtime_schema_owners =
-                    runtime_schema_owners(&source_load.loaded).map_err(QueryManagerError::App)?;
                 let mut catalog = runtime
                     .list_catalog(catalog_filter, schema_filter)
                     .await
@@ -401,7 +372,6 @@ impl QueryManager {
                 Ok(CatalogResolution {
                     catalog,
                     failed_source_names,
-                    runtime_schema_owners,
                 })
             },
             |resolution| {
@@ -728,7 +698,6 @@ impl QueryManager {
             LoadedQuerySource {
                 source: source.clone(),
                 query_source: loaded_runtime.query_source,
-                runtime_schema_name: installed.source_spec.schema_name().to_string(),
                 runtime_contract_fingerprint: loaded_runtime.runtime_contract_fingerprint,
                 credential_material: stored_secrets,
             },
@@ -3389,11 +3358,9 @@ tables:
 ",
         )
         .expect("parse source manifest");
-        let runtime_schema_name = source_spec.schema_name().to_string();
         let loaded_source = LoadedQuerySource {
             source: installed_source,
             query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
-            runtime_schema_name,
             runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("contract"),
             credential_material: BTreeMap::from([(
                 "API_TOKEN".to_string(),
@@ -3570,7 +3537,6 @@ tables:
                 credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Bundled,
             },
-            runtime_schema_name: source_spec.schema_name().to_string(),
             query_source: QuerySource::new(source_spec.clone(), BTreeMap::new(), BTreeMap::new()),
             runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("contract"),
             credential_material: BTreeMap::from([(
@@ -3649,7 +3615,6 @@ tables:
                 credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Bundled,
             },
-            runtime_schema_name: source_spec.schema_name().to_string(),
             query_source: QuerySource::new(source_spec.clone(), BTreeMap::new(), BTreeMap::new()),
             runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("contract"),
             credential_material: BTreeMap::new(),

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -142,11 +142,7 @@ impl CatalogMetadataProvider {
         request: &SearchRequest,
         resolution: &CatalogResolution,
     ) -> Result<CatalogProjection, SqliteSearchError> {
-        let catalog_fingerprint =
-            CatalogSearchSnapshot::fingerprint_catalog_with_runtime_schema_owners(
-                &resolution.catalog,
-                &resolution.runtime_schema_owners,
-            );
+        let catalog_fingerprint = CatalogSearchSnapshot::fingerprint_catalog(&resolution.catalog);
         let store = SqliteSearchStore::open_workspace(&self.layout, &request.workspace_name)?;
         let capabilities = store.capabilities();
         tracing::debug!(
@@ -193,10 +189,7 @@ impl CatalogMetadataProvider {
             });
         }
 
-        let snapshot = CatalogSearchSnapshot::from_catalog_with_runtime_schema_owners(
-            &resolution.catalog,
-            &resolution.runtime_schema_owners,
-        );
+        let snapshot = CatalogSearchSnapshot::from_catalog(&resolution.catalog);
         let expected_document_count = u32::try_from(snapshot.documents.len()).unwrap_or(u32::MAX);
         let index_snapshot = snapshot.index_snapshot();
         match store.refresh_catalog_projection(&index_snapshot) {
@@ -235,11 +228,7 @@ impl CatalogMetadataProvider {
         resolution: &CatalogResolution,
         force: bool,
     ) -> Result<SearchMaintenanceResult, SearchManagerError> {
-        let snapshot = CatalogSearchSnapshot::from_catalog_with_runtime_schema_owners(
-            &resolution.catalog,
-            &resolution.runtime_schema_owners,
-        )
-        .index_snapshot();
+        let snapshot = CatalogSearchSnapshot::from_catalog(&resolution.catalog).index_snapshot();
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)
             .map_err(|error| search_sqlite_app_error(&error))?;
         let result = store

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -1,7 +1,5 @@
 //! Catalog search snapshot built from app-owned engine catalog views.
 
-use std::collections::BTreeMap;
-
 use coral_engine::{
     CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
     TableFunctionResultColumnInfo, TableInfo,
@@ -14,7 +12,13 @@ use crate::search::catalog::sqlite_index::{
 };
 use crate::search::result::{FieldRole, SearchSurfaceKind};
 
-const CATALOG_SEARCH_SNAPSHOT_VERSION: &str = "catalog-search-snapshot-v4";
+// Bumped when the ownership projection was removed: every stored fingerprint
+// must mismatch the recomputed one, so each workspace refreshes exactly once
+// before its catalog documents are trusted again. `-v4` already shipped on main
+// for grouped catalog surfaces (#2041), so this removal needs its own value --
+// reusing `-v4` would leave already-refreshed workspaces matching, and the
+// refresh this migration depends on would silently never run.
+const CATALOG_SEARCH_SNAPSHOT_VERSION: &str = "catalog-search-snapshot-v5";
 
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogSearchSnapshot {
@@ -23,40 +27,18 @@ pub(crate) struct CatalogSearchSnapshot {
 }
 
 impl CatalogSearchSnapshot {
-    #[cfg(test)]
     pub(crate) fn from_catalog(catalog: &CatalogInfo) -> Self {
-        Self::from_catalog_with_runtime_schema_owners(catalog, &BTreeMap::new())
-    }
-
-    pub(crate) fn from_catalog_with_runtime_schema_owners(
-        catalog: &CatalogInfo,
-        runtime_schema_owners: &BTreeMap<String, String>,
-    ) -> Self {
-        let runtime_schema_owners =
-            normalized_runtime_schema_owners(catalog, runtime_schema_owners);
         let mut documents = catalog_documents(catalog);
-        for document in &mut documents {
-            document.owner_source_name = runtime_schema_owners
-                .get(&document.source_name)
-                .cloned()
-                .unwrap_or_else(|| document.source_name.clone());
-        }
         documents.sort_by(|left, right| left.doc_id.cmp(&right.doc_id));
-        let fingerprint = catalog_snapshot_fingerprint(catalog, &runtime_schema_owners);
+        let fingerprint = catalog_snapshot_fingerprint(catalog);
         Self {
             documents,
             fingerprint,
         }
     }
 
-    pub(crate) fn fingerprint_catalog_with_runtime_schema_owners(
-        catalog: &CatalogInfo,
-        runtime_schema_owners: &BTreeMap<String, String>,
-    ) -> String {
-        catalog_snapshot_fingerprint(
-            catalog,
-            &normalized_runtime_schema_owners(catalog, runtime_schema_owners),
-        )
+    pub(crate) fn fingerprint_catalog(catalog: &CatalogInfo) -> String {
+        catalog_snapshot_fingerprint(catalog)
     }
 
     pub(crate) fn index_snapshot(&self) -> CatalogIndexSnapshot {
@@ -75,7 +57,6 @@ impl CatalogSearchSnapshot {
 pub(crate) struct CatalogDocument {
     pub(crate) doc_id: String,
     pub(crate) doc_kind: CatalogDocumentKind,
-    pub(crate) owner_source_name: String,
     pub(crate) source_name: String,
     pub(crate) catalog_name: Option<String>,
     pub(crate) surface_kind: Option<SearchSurfaceKind>,
@@ -100,7 +81,6 @@ impl CatalogDocument {
         CatalogIndexDocument {
             doc_id: self.doc_id.clone(),
             doc_kind: catalog_document_kind_to_index(self.doc_kind),
-            owner_source_name: self.owner_source_name.clone(),
             source_name: self.source_name.clone(),
             catalog_name: self.catalog_name.clone(),
             surface_kind: surface_kind_as_str(self.surface_kind).to_string(),
@@ -170,29 +150,6 @@ fn catalog_documents(catalog: &CatalogInfo) -> Vec<CatalogDocument> {
     documents
 }
 
-fn normalized_runtime_schema_owners(
-    catalog: &CatalogInfo,
-    runtime_schema_owners: &BTreeMap<String, String>,
-) -> BTreeMap<String, String> {
-    let mut normalized = runtime_schema_owners.clone();
-    for source_name in catalog
-        .tables
-        .iter()
-        .map(|table| table.schema_name.as_str())
-        .chain(
-            catalog
-                .table_functions
-                .iter()
-                .map(|function| function.schema_name.as_str()),
-        )
-    {
-        normalized
-            .entry(source_name.to_string())
-            .or_insert_with(|| source_name.to_string());
-    }
-    normalized
-}
-
 fn table_documents(table: &TableInfo, documents: &mut Vec<CatalogDocument>) {
     let qualified_name = qualified_name(
         table.catalog_name.as_deref(),
@@ -202,7 +159,6 @@ fn table_documents(table: &TableInfo, documents: &mut Vec<CatalogDocument>) {
     documents.push(CatalogDocument {
         doc_id: format!("catalog:table:{qualified_name}"),
         doc_kind: CatalogDocumentKind::CatalogTable,
-        owner_source_name: table.schema_name.clone(),
         source_name: table.schema_name.clone(),
         catalog_name: table.catalog_name.clone(),
         surface_kind: Some(SearchSurfaceKind::Table),
@@ -243,7 +199,6 @@ fn table_column_document(
     documents.push(CatalogDocument {
         doc_id: format!("column:table:{surface_qualified_name}:{}", column.name),
         doc_kind: CatalogDocumentKind::ColumnHint,
-        owner_source_name: table.schema_name.clone(),
         source_name: table.schema_name.clone(),
         catalog_name: table.catalog_name.clone(),
         surface_kind: Some(SearchSurfaceKind::Table),
@@ -276,7 +231,6 @@ fn table_required_filter_document(
     documents.push(CatalogDocument {
         doc_id: format!("filter:table:{surface_qualified_name}:{filter}"),
         doc_kind: CatalogDocumentKind::ColumnHint,
-        owner_source_name: table.schema_name.clone(),
         source_name: table.schema_name.clone(),
         catalog_name: table.catalog_name.clone(),
         surface_kind: Some(SearchSurfaceKind::Table),
@@ -317,7 +271,6 @@ fn table_function_documents(function: &TableFunctionInfo, documents: &mut Vec<Ca
     documents.push(CatalogDocument {
         doc_id: format!("catalog:function:{qualified_name}"),
         doc_kind: CatalogDocumentKind::CatalogTableFunction,
-        owner_source_name: function.schema_name.clone(),
         source_name: function.schema_name.clone(),
         catalog_name: None,
         surface_kind: Some(SearchSurfaceKind::TableFunction),
@@ -362,7 +315,6 @@ fn table_function_argument_document(
             argument.name
         ),
         doc_kind: CatalogDocumentKind::ColumnHint,
-        owner_source_name: function.schema_name.clone(),
         source_name: function.schema_name.clone(),
         catalog_name: None,
         surface_kind: Some(SearchSurfaceKind::TableFunction),
@@ -395,7 +347,6 @@ fn table_function_result_column_document(
             column.name
         ),
         doc_kind: CatalogDocumentKind::ColumnHint,
-        owner_source_name: function.schema_name.clone(),
         source_name: function.schema_name.clone(),
         catalog_name: None,
         surface_kind: Some(SearchSurfaceKind::TableFunction),
@@ -434,18 +385,9 @@ fn join_search_text<const N: usize>(parts: [&str; N]) -> String {
         .join(" ")
 }
 
-fn catalog_snapshot_fingerprint(
-    catalog: &CatalogInfo,
-    runtime_schema_owners: &BTreeMap<String, String>,
-) -> String {
+fn catalog_snapshot_fingerprint(catalog: &CatalogInfo) -> String {
     let mut hasher = Sha256::new();
     update_hash(&mut hasher, CATALOG_SEARCH_SNAPSHOT_VERSION);
-
-    for (runtime_schema_name, owner_source_name) in runtime_schema_owners {
-        update_hash(&mut hasher, "runtime_schema_owner");
-        update_hash(&mut hasher, runtime_schema_name);
-        update_hash(&mut hasher, owner_source_name);
-    }
 
     let mut tables = catalog.tables.iter().collect::<Vec<_>>();
     tables.sort_by(|left, right| {
@@ -552,7 +494,6 @@ fn update_hash(hasher: &mut Sha256, value: &str) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
 
     use coral_engine::{CatalogInfo, TableInfo};
 
@@ -590,34 +531,6 @@ mod tests {
                 .documents
                 .iter()
                 .all(|document| document.catalog_name.as_deref() == Some("primary"))
-        );
-    }
-
-    #[test]
-    fn snapshot_fingerprint_and_documents_include_installed_source_ownership() {
-        let catalog = catalog_with_table("messages");
-        let first = CatalogSearchSnapshot::from_catalog_with_runtime_schema_owners(
-            &catalog,
-            &BTreeMap::from([("fixture".to_string(), "owner_a".to_string())]),
-        );
-        let second = CatalogSearchSnapshot::from_catalog_with_runtime_schema_owners(
-            &catalog,
-            &BTreeMap::from([("fixture".to_string(), "owner_b".to_string())]),
-        );
-
-        assert_ne!(first.fingerprint, second.fingerprint);
-        assert!(
-            first
-                .documents
-                .iter()
-                .all(|document| document.owner_source_name == "owner_a")
-        );
-        assert!(
-            first
-                .index_snapshot()
-                .documents
-                .iter()
-                .all(|document| document.owner_source_name == "owner_a")
         );
     }
 

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -1,7 +1,5 @@
 //! `SQLite` catalog metadata projection and retrieval primitives.
 
-use std::collections::BTreeMap;
-
 use rusqlite::{
     Connection, OptionalExtension as _, Transaction, TransactionBehavior, params, types::Type,
 };
@@ -206,7 +204,6 @@ pub(crate) struct CatalogIndexSnapshot {
 pub(crate) struct CatalogIndexDocument {
     pub(crate) doc_id: String,
     pub(crate) doc_kind: CatalogIndexDocumentKind,
-    pub(crate) owner_source_name: String,
     pub(crate) source_name: String,
     pub(crate) catalog_name: Option<String>,
     pub(crate) surface_kind: String,
@@ -283,7 +280,6 @@ fn replace_catalog_documents(
     snapshot: &CatalogIndexSnapshot,
 ) -> Result<(), SqliteSearchError> {
     delete_catalog_projection_rows(transaction, workspace_name)?;
-    insert_catalog_source_owners(transaction, workspace_name, snapshot)?;
     insert_catalog_snapshot_documents(transaction, workspace_name, snapshot)?;
     set_catalog_fingerprint(transaction, workspace_name, &snapshot.fingerprint)?;
     Ok(())
@@ -301,49 +297,6 @@ fn delete_catalog_projection_rows(
         "DELETE FROM catalog_documents WHERE workspace = ?1",
         params![workspace_name.as_str()],
     )?;
-    transaction.execute(
-        "DELETE FROM catalog_source_owners WHERE workspace = ?1",
-        params![workspace_name.as_str()],
-    )?;
-    Ok(())
-}
-
-fn insert_catalog_source_owners(
-    transaction: &Transaction<'_>,
-    workspace_name: &WorkspaceName,
-    snapshot: &CatalogIndexSnapshot,
-) -> Result<(), SqliteSearchError> {
-    let mut insert = transaction.prepare(
-        "
-        INSERT INTO catalog_source_owners (
-            workspace,
-            source_name,
-            owner_source_name,
-            snapshot_fingerprint,
-            updated_at
-        )
-        VALUES (?1, ?2, ?3, ?4, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-        ON CONFLICT(workspace, source_name) DO UPDATE SET
-            owner_source_name = excluded.owner_source_name,
-            snapshot_fingerprint = excluded.snapshot_fingerprint,
-            updated_at = excluded.updated_at
-        ",
-    )?;
-    let mut source_owners = BTreeMap::new();
-    for document in &snapshot.documents {
-        source_owners.insert(
-            document.source_name.as_str(),
-            document.owner_source_name.as_str(),
-        );
-    }
-    for (source_name, owner_source_name) in source_owners {
-        insert.execute(params![
-            workspace_name.as_str(),
-            source_name,
-            owner_source_name,
-            &snapshot.fingerprint,
-        ])?;
-    }
     Ok(())
 }
 
@@ -441,10 +394,6 @@ pub(crate) fn clear_catalog_workspace_documents_in_transaction(
         "DELETE FROM catalog_documents WHERE workspace = ?1",
         params![workspace_name.as_str()],
     )?;
-    transaction.execute(
-        "DELETE FROM catalog_source_owners WHERE workspace = ?1",
-        params![workspace_name.as_str()],
-    )?;
     clear_catalog_fingerprint(transaction, workspace_name)?;
     Ok(CatalogClearResult {
         deleted_document_count: u32::try_from(deleted_document_count).unwrap_or(u32::MAX),
@@ -466,42 +415,28 @@ fn clear_catalog_source_documents(
 pub(crate) fn clear_catalog_source_documents_in_transaction(
     transaction: &Transaction<'_>,
     workspace_name: &WorkspaceName,
-    owner_source_name: &str,
+    source_name: &str,
 ) -> Result<CatalogClearResult, SqliteSearchError> {
+    // `doc_id` is not workspace-qualified, so the FTS delete keeps its own
+    // workspace guard even though the subquery already carries one.
     transaction.execute(
         "
         DELETE FROM catalog_documents_fts
         WHERE workspace = ?1
           AND doc_id IN (
-              SELECT documents.doc_id
-              FROM catalog_documents AS documents
-              INNER JOIN catalog_source_owners AS owners
-                  ON owners.workspace = documents.workspace
-                 AND owners.source_name = documents.source_name
-              WHERE documents.workspace = ?1
-                AND owners.owner_source_name = ?2
+              SELECT doc_id
+              FROM catalog_documents
+              WHERE workspace = ?1 AND source_name = ?2
           )
         ",
-        params![workspace_name.as_str(), owner_source_name],
+        params![workspace_name.as_str(), source_name],
     )?;
     let deleted_document_count = transaction.execute(
         "
         DELETE FROM catalog_documents
-        WHERE workspace = ?1
-          AND source_name IN (
-              SELECT source_name
-              FROM catalog_source_owners
-              WHERE workspace = ?1 AND owner_source_name = ?2
-          )
+        WHERE workspace = ?1 AND source_name = ?2
         ",
-        params![workspace_name.as_str(), owner_source_name],
-    )?;
-    transaction.execute(
-        "
-        DELETE FROM catalog_source_owners
-        WHERE workspace = ?1 AND owner_source_name = ?2
-        ",
-        params![workspace_name.as_str(), owner_source_name],
+        params![workspace_name.as_str(), source_name],
     )?;
     clear_catalog_fingerprint(transaction, workspace_name)?;
     Ok(CatalogClearResult {
@@ -534,32 +469,18 @@ fn catalog_fingerprint(
     let Some(fingerprint) = fingerprint else {
         return Ok(None);
     };
-    let ownership_is_incomplete: bool = connection.query_row(
+    let projection_is_stale: bool = connection.query_row(
         "
-        SELECT
-            EXISTS (
-                SELECT 1
-                FROM catalog_documents AS documents
-                LEFT JOIN catalog_source_owners AS owners
-                    ON owners.workspace = documents.workspace
-                   AND owners.source_name = documents.source_name
-                WHERE documents.workspace = ?1
-                  AND (
-                      owners.source_name IS NULL
-                      OR documents.snapshot_fingerprint <> ?2
-                      OR owners.snapshot_fingerprint <> ?2
-                  )
-            )
-            OR EXISTS (
-                SELECT 1
-                FROM catalog_source_owners
-                WHERE workspace = ?1 AND snapshot_fingerprint <> ?2
-            )
+        SELECT EXISTS (
+            SELECT 1
+            FROM catalog_documents
+            WHERE workspace = ?1 AND snapshot_fingerprint <> ?2
+        )
         ",
         params![workspace_name.as_str(), &fingerprint],
         |row| row.get(0),
     )?;
-    if ownership_is_incomplete {
+    if projection_is_stale {
         Ok(None)
     } else {
         Ok(Some(fingerprint))

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -133,7 +133,6 @@ fn refresh_to_empty_snapshot_clears_projection_and_persists_fingerprint() {
     assert_eq!(refresh.document_count, 0);
     assert_eq!(store.catalog_document_count().expect("document count"), 0);
     assert_eq!(catalog_fts_document_count(&store), 0);
-    assert_eq!(catalog_source_owner_count(&store), 0);
     assert_eq!(
         persisted_catalog_fingerprint(&store),
         empty_snapshot.fingerprint
@@ -151,7 +150,7 @@ fn refresh_to_empty_snapshot_clears_projection_and_persists_fingerprint() {
 }
 
 #[test]
-fn duplicate_document_refresh_rolls_back_documents_fts_owners_and_fingerprint() {
+fn duplicate_document_refresh_rolls_back_documents_fts_and_fingerprint() {
     let temp = tempdir().expect("tempdir");
     let store = catalog_store(&temp);
     let original_snapshot = catalog_index_snapshot();
@@ -229,11 +228,6 @@ fn clear_workspace_removes_workspace_documents_and_invalidates_fingerprint() {
         "clear should remove workspace FTS rows"
     );
     assert_eq!(
-        catalog_source_owner_count(&store),
-        0,
-        "clear should remove persisted source ownership"
-    );
-    assert_eq!(
         schema_version(&store),
         crate::search::sqlite_store::SEARCH_SQLITE_SCHEMA_VERSION.to_string(),
         "clear should leave schema metadata intact"
@@ -290,95 +284,119 @@ fn clear_source_removes_only_source_documents_and_invalidates_fingerprint() {
 }
 
 #[test]
-fn clear_installed_source_uses_persisted_component_ownership_after_restart() {
+fn clear_source_leaves_the_other_provider_interface_stranded_nowhere() {
     let temp = tempdir().expect("tempdir");
     let store = catalog_store(&temp);
     let snapshot = CatalogIndexSnapshot {
-        fingerprint: "multi-component-catalog-v1".to_string(),
+        fingerprint: "independent-sources-v1".to_string(),
         documents: vec![
-            owned_document(
-                "github_v4",
-                DocumentInput {
-                    doc_id: "catalog:table:github_v4_rest.issues",
-                    doc_kind: CatalogIndexDocumentKind::CatalogTable,
-                    source_name: "github_v4_rest",
-                    surface_kind: "table",
-                    surface_name: "issues",
-                    field_name: "",
-                    field_role: "",
-                    qualified_name: "github_v4_rest.issues",
-                    title: "issues",
-                    description: "GitHub issues",
-                    searchable_text: "github rest issues",
-                },
-            ),
-            owned_document(
-                "github_v4",
-                DocumentInput {
-                    doc_id: "catalog:function:github_v4_mcp.search_issues",
-                    doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
-                    source_name: "github_v4_mcp",
-                    surface_kind: "table_function",
-                    surface_name: "search_issues",
-                    field_name: "",
-                    field_role: "",
-                    qualified_name: "github_v4_mcp.search_issues",
-                    title: "search_issues",
-                    description: "Search GitHub issues",
-                    searchable_text: "github mcp search issues",
-                },
-            ),
-            owned_document(
-                "slack_v4",
-                DocumentInput {
-                    doc_id: "catalog:table:slack_v4_rest.messages",
-                    doc_kind: CatalogIndexDocumentKind::CatalogTable,
-                    source_name: "slack_v4_rest",
-                    surface_kind: "table",
-                    surface_name: "messages",
-                    field_name: "",
-                    field_role: "",
-                    qualified_name: "slack_v4_rest.messages",
-                    title: "messages",
-                    description: "Slack messages",
-                    searchable_text: "slack rest messages",
-                },
-            ),
+            document(DocumentInput {
+                doc_id: "catalog:table:github_v4.issues",
+                doc_kind: CatalogIndexDocumentKind::CatalogTable,
+                source_name: "github_v4",
+                surface_kind: "table",
+                surface_name: "issues",
+                field_name: "",
+                field_role: "",
+                qualified_name: "github_v4.issues",
+                title: "issues",
+                description: "GitHub issues",
+                searchable_text: "github rest issues",
+            }),
+            document(DocumentInput {
+                doc_id: "catalog:function:github_mcp_v4.search_issues",
+                doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+                source_name: "github_mcp_v4",
+                surface_kind: "table_function",
+                surface_name: "search_issues",
+                field_name: "",
+                field_role: "",
+                qualified_name: "github_mcp_v4.search_issues",
+                title: "search_issues",
+                description: "Search GitHub issues",
+                searchable_text: "github mcp search issues",
+            }),
         ],
     };
     store
         .refresh_catalog_projection(&snapshot)
         .expect("refresh catalog");
-    drop(store);
 
-    let reopened = catalog_store(&temp);
-    let result = reopened
+    let result = store
         .clear_catalog_source("github_v4")
-        .expect("clear installed source");
+        .expect("clear one installed source");
 
-    assert_eq!(result.deleted_document_count, 2);
+    // The REST and MCP interfaces are independent sources: no ownership
+    // indirection can strand one when the other is cleared.
+    assert_eq!(result.deleted_document_count, 1);
+    assert_eq!(store.catalog_document_count().expect("document count"), 1);
+    assert_eq!(catalog_fts_document_count(&store), 1);
+    let hits = store
+        .search_catalog(
+            &["search_issues".to_string()],
+            10,
+            CatalogDocumentClass::Entries,
+        )
+        .expect("search remaining source");
     assert_eq!(
-        reopened.catalog_document_count().expect("document count"),
-        1
+        hits.hits.first().expect("remaining hit").source_name,
+        "github_mcp_v4"
     );
-    assert_eq!(catalog_fts_document_count(&reopened), 1);
-    let connection = reopened.connect_for_test().expect("connect");
-    let github_owner_count: i64 = connection
+}
+
+#[test]
+fn clear_source_keeps_its_workspace_guard_on_the_fts_delete() {
+    // `doc_id` is not workspace-qualified. Production runs one sidecar per
+    // workspace, so this guards test layouts and defence in depth, not a live
+    // corruption path -- but the schema is workspace-keyed, so it stays.
+    let temp = tempdir().expect("tempdir");
+    let path = temp.path().join("search.sqlite3");
+    let other_workspace = WorkspaceName::parse("other").expect("workspace");
+    let shared_documents = vec![document(DocumentInput {
+        doc_id: "catalog:table:github_v4.issues",
+        doc_kind: CatalogIndexDocumentKind::CatalogTable,
+        source_name: "github_v4",
+        surface_kind: "table",
+        surface_name: "issues",
+        field_name: "",
+        field_role: "",
+        qualified_name: "github_v4.issues",
+        title: "issues",
+        description: "GitHub issues",
+        searchable_text: "github rest issues",
+    })];
+    for workspace_name in [WorkspaceName::default(), other_workspace.clone()] {
+        SqliteSearchStore::open(&path, workspace_name)
+            .expect("store")
+            .refresh_catalog_projection(&CatalogIndexSnapshot {
+                fingerprint: "shared-doc-id-v1".to_string(),
+                documents: shared_documents.clone(),
+            })
+            .expect("refresh catalog");
+    }
+
+    SqliteSearchStore::open(&path, WorkspaceName::default())
+        .expect("store")
+        .clear_catalog_source("github_v4")
+        .expect("clear source in one workspace");
+
+    let other_store = SqliteSearchStore::open(&path, other_workspace).expect("other store");
+    assert_eq!(
+        other_store
+            .catalog_document_count()
+            .expect("document count"),
+        1,
+        "clearing one workspace must not delete another workspace's rows"
+    );
+    let connection = other_store.connect_for_test().expect("connect");
+    let other_fts_rows: i64 = connection
         .query_row(
-            "SELECT COUNT(*) FROM catalog_source_owners WHERE workspace = 'default' AND owner_source_name = 'github_v4'",
+            "SELECT COUNT(*) FROM catalog_documents_fts WHERE workspace = 'other'",
             [],
             |row| row.get(0),
         )
-        .expect("GitHub owner count");
-    let slack_owner_count: i64 = connection
-        .query_row(
-            "SELECT COUNT(*) FROM catalog_source_owners WHERE workspace = 'default' AND owner_source_name = 'slack_v4'",
-            [],
-            |row| row.get(0),
-        )
-        .expect("Slack owner count");
-    assert_eq!(github_owner_count, 0);
-    assert_eq!(slack_owner_count, 1);
+        .expect("other workspace FTS rows");
+    assert_eq!(other_fts_rows, 1);
 }
 
 #[test]
@@ -527,40 +545,6 @@ fn refresh_rechecks_fingerprint_after_writer_lock() {
 }
 
 #[test]
-fn missing_catalog_ownership_invalidates_and_repairs_the_projection() {
-    let temp = tempdir().expect("tempdir");
-    let store = catalog_store(&temp);
-    let snapshot = catalog_index_snapshot();
-    store
-        .refresh_catalog_projection(&snapshot)
-        .expect("refresh catalog");
-    let connection = store.connect_for_test().expect("connect");
-    connection
-        .execute(
-            "DELETE FROM catalog_source_owners WHERE workspace = 'default' AND source_name = 'github'",
-            [],
-        )
-        .expect("corrupt source ownership");
-    drop(connection);
-
-    assert!(
-        !store
-            .catalog_projection_is_current(&snapshot.fingerprint)
-            .expect("projection current check")
-    );
-    let refresh = store
-        .refresh_catalog_projection(&snapshot)
-        .expect("repair catalog projection");
-
-    assert!(refresh.refreshed);
-    assert!(
-        store
-            .catalog_projection_is_current(&snapshot.fingerprint)
-            .expect("repaired projection current")
-    );
-}
-
-#[test]
 fn search_terms_are_normalized_before_retrieval() {
     let temp = tempdir().expect("tempdir");
     let store = catalog_store(&temp);
@@ -685,24 +669,10 @@ fn catalog_fts_document_count(store: &SqliteSearchStore) -> u32 {
     u32::try_from(count).expect("FTS count should fit")
 }
 
-fn catalog_source_owner_count(store: &SqliteSearchStore) -> u32 {
-    let connection = store.connect_for_test().expect("connect");
-    let workspace_name = WorkspaceName::default();
-    let count: i64 = connection
-        .query_row(
-            "SELECT count(*) FROM catalog_source_owners WHERE workspace = ?1",
-            [workspace_name.as_str()],
-            |row| row.get(0),
-        )
-        .expect("source owner count");
-    u32::try_from(count).expect("source owner count should fit")
-}
-
 #[derive(Debug, PartialEq, Eq)]
 struct CatalogProjectionStorageState {
     documents: Vec<(String, String, String)>,
     fts_documents: Vec<(String, String, String, String, String)>,
-    source_owners: Vec<(String, String, String)>,
     fingerprint: String,
 }
 
@@ -749,23 +719,6 @@ fn catalog_projection_storage_state(store: &SqliteSearchStore) -> CatalogProject
             .collect::<Result<Vec<_>, _>>()
             .expect("read catalog FTS state")
     };
-    let source_owners = {
-        let mut statement = connection
-            .prepare(
-                "SELECT source_name, owner_source_name, snapshot_fingerprint
-                 FROM catalog_source_owners
-                 WHERE workspace = ?1
-                 ORDER BY source_name",
-            )
-            .expect("prepare catalog ownership state");
-        statement
-            .query_map([workspace_name.as_str()], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-            })
-            .expect("query catalog ownership state")
-            .collect::<Result<Vec<_>, _>>()
-            .expect("read catalog ownership state")
-    };
     let fingerprint = connection
         .query_row(
             "SELECT value FROM search_meta WHERE key = ?1",
@@ -780,7 +733,6 @@ fn catalog_projection_storage_state(store: &SqliteSearchStore) -> CatalogProject
     CatalogProjectionStorageState {
         documents,
         fts_documents,
-        source_owners,
         fingerprint,
     }
 }
@@ -940,14 +892,9 @@ struct DocumentInput<'a> {
 }
 
 fn document(input: DocumentInput<'_>) -> CatalogIndexDocument {
-    owned_document(input.source_name, input)
-}
-
-fn owned_document(owner_source_name: &str, input: DocumentInput<'_>) -> CatalogIndexDocument {
     CatalogIndexDocument {
         doc_id: input.doc_id.to_string(),
         doc_kind: input.doc_kind,
-        owner_source_name: owner_source_name.to_string(),
         source_name: input.source_name.to_string(),
         surface_kind: input.surface_kind.to_string(),
         surface_name: input.surface_name.to_string(),

--- a/crates/coral-app/src/search/engine.rs
+++ b/crates/coral-app/src/search/engine.rs
@@ -214,7 +214,7 @@ mod tests {
     use tokio::time::timeout;
     use tracing::Instrument as _;
 
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeSet;
 
     use coral_engine::{CatalogInfo, TableInfo};
 
@@ -664,7 +664,6 @@ mod tests {
                 table_functions: Vec::new(),
             },
             failed_source_names: BTreeSet::new(),
-            runtime_schema_owners: BTreeMap::new(),
         }
     }
 

--- a/crates/coral-app/src/search/migrations/0006_catalog_source_identity.sql
+++ b/crates/coral-app/src/search/migrations/0006_catalog_source_identity.sql
@@ -1,0 +1,11 @@
+-- The catalog projection stored a second copy of the schema -> owner topology
+-- that #1791 removed: one installed source publishes one SQL namespace, so
+-- `catalog_documents.source_name` already is the installed source name.
+--
+-- Catalog documents and FTS rows are deliberately left in place. The refresh is
+-- forced by bumping `CATALOG_SEARCH_SNAPSHOT_VERSION`, which guarantees every
+-- stored fingerprint mismatches and triggers exactly one lazy refresh per
+-- workspace -- and, unlike a DELETE here, does nothing extra on repair replays.
+
+DROP INDEX IF EXISTS idx_catalog_source_owners_workspace_owner;
+DROP TABLE IF EXISTS catalog_source_owners;

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -20,7 +20,7 @@ use crate::state::AppStateLayout;
 use crate::storage::fs::create_new_file_private;
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 5;
+pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 6;
 
 struct SearchSqliteMigration {
     version: u32,
@@ -50,6 +50,10 @@ const SEARCH_SQLITE_MIGRATIONS: &[SearchSqliteMigration] = &[
     SearchSqliteMigration {
         version: 5,
         sql: include_str!("migrations/0005_observed_source_identity.sql"),
+    },
+    SearchSqliteMigration {
+        version: 6,
+        sql: include_str!("migrations/0006_catalog_source_identity.sql"),
     },
 ];
 
@@ -946,8 +950,6 @@ fn apply_migration(
 ) -> Result<(), SqliteSearchError> {
     let started_at = Instant::now();
     let transaction = connection.transaction()?;
-    let initializes_catalog_source_ownership =
-        migration.version == 4 && !tables_exist(&transaction, &["catalog_source_owners"])?;
     let legacy_observed = if migration.version == 5 {
         LegacyObservedIdentity::detect(&transaction)?
     } else {
@@ -969,17 +971,6 @@ fn apply_migration(
             duration_ms = started_at.elapsed().as_millis(),
             "migrated observed-values storage to singular source identity"
         );
-    }
-    if initializes_catalog_source_ownership {
-        // Existing catalog rows predate durable installed-owner identity. They
-        // are disposable and cannot be safely backfilled for multi-component
-        // sources without loading source artifacts during migration.
-        transaction.execute("DELETE FROM catalog_documents_fts", [])?;
-        transaction.execute("DELETE FROM catalog_documents", [])?;
-        transaction.execute(
-            "DELETE FROM search_meta WHERE key GLOB 'catalog_snapshot_fingerprint:*'",
-            [],
-        )?;
     }
     transaction.execute(
         "
@@ -1009,13 +1000,13 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
 fn catalog_schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError> {
     if !tables_exist(
         connection,
-        &[
-            "search_meta",
-            "catalog_documents",
-            "catalog_documents_fts",
-            "catalog_source_owners",
-        ],
+        &["search_meta", "catalog_documents", "catalog_documents_fts"],
     )? {
+        return Ok(false);
+    }
+    // 0006 removed the ownership projection for good, so its presence means the
+    // schema predates v6 no matter what version it claims to be.
+    if tables_exist(connection, &["catalog_source_owners"])? {
         return Ok(false);
     }
     let search_meta_is_valid = schema_query_is_valid(
@@ -1058,26 +1049,7 @@ fn catalog_schema_is_current(connection: &Connection) -> Result<bool, SqliteSear
         LIMIT 0
         ",
     )?;
-    let catalog_source_owners_is_valid = schema_query_is_valid(
-        connection,
-        "
-        SELECT
-            workspace,
-            source_name,
-            owner_source_name,
-            snapshot_fingerprint,
-            updated_at
-        FROM catalog_source_owners
-        LIMIT 0
-        ",
-    )?;
-    let catalog_source_owner_index_is_valid =
-        indexes_exist(connection, &["idx_catalog_source_owners_workspace_owner"])?;
-    Ok(search_meta_is_valid
-        && catalog_table_is_valid
-        && catalog_fts_is_valid
-        && catalog_source_owners_is_valid
-        && catalog_source_owner_index_is_valid)
+    Ok(search_meta_is_valid && catalog_table_is_valid && catalog_fts_is_valid)
 }
 
 fn observed_values_schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError> {
@@ -1318,7 +1290,7 @@ mod tests {
     }
 
     #[test]
-    fn opening_v3_invalidates_catalog_rows_without_durable_source_ownership() {
+    fn opening_v3_preserves_catalog_rows_and_removes_the_ownership_table() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("search.sqlite3");
         let mut connection = Connection::open(&path).expect("raw v3 connection");
@@ -1337,26 +1309,20 @@ mod tests {
         drop(connection);
 
         let connection = open_current_search_connection(&path);
-        let catalog_fingerprint = connection
-            .query_row(
-                "SELECT value FROM search_meta WHERE key = 'catalog_snapshot_fingerprint:default'",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()
-            .expect("catalog fingerprint query");
 
-        assert_eq!(catalog_document_count(&connection), 0);
+        // Catalog documents are preserved, not wiped: the snapshot-version bump
+        // is what stops them being trusted, and it forces exactly one refresh.
+        assert_eq!(catalog_document_count(&connection), 1);
         assert_eq!(observed_queue_job_count(&connection), 1);
-        assert_eq!(catalog_fingerprint, None);
-        assert!(index_exists(
+        assert!(!tables_exist_for_test(&connection, "catalog_source_owners"));
+        assert!(!index_exists(
             &connection,
             "idx_catalog_source_owners_workspace_owner"
         ));
     }
 
     #[test]
-    fn opening_v1_repairs_missing_search_meta_and_discards_unowned_catalog() {
+    fn opening_v1_repairs_missing_search_meta_and_keeps_untrusted_catalog() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("search.sqlite3");
         let connection = v1_search_connection(&path);
@@ -1367,7 +1333,12 @@ mod tests {
         drop(connection);
 
         let connection = open_current_search_connection(&path);
-        assert_eq!(catalog_document_count(&connection), 0);
+
+        // Pre-v6 documents survive the repair. They are not trusted: no stored
+        // fingerprint can match one recomputed under the bumped snapshot
+        // version, so the next search refreshes the whole workspace.
+        assert_eq!(catalog_document_count(&connection), 1);
+        assert!(!catalog_projection_is_current_for_test(&path));
     }
 
     #[test]
@@ -1385,7 +1356,7 @@ mod tests {
     }
 
     #[test]
-    fn opening_v1_repairs_missing_catalog_fts_and_discards_unowned_catalog() {
+    fn opening_v1_repairs_missing_catalog_fts_and_keeps_untrusted_catalog() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("search.sqlite3");
         let connection = v1_search_connection(&path);
@@ -1396,7 +1367,12 @@ mod tests {
         drop(connection);
 
         let connection = open_current_search_connection(&path);
-        assert_eq!(catalog_document_count(&connection), 0);
+
+        // The document survives without its FTS row, which is safe precisely
+        // because the projection cannot be current: the refresh that follows
+        // replaces every workspace row.
+        assert_eq!(catalog_document_count(&connection), 1);
+        assert!(!catalog_projection_is_current_for_test(&path));
     }
 
     #[test]
@@ -1646,12 +1622,6 @@ mod tests {
             .expect("seed catalog document");
         connection
             .execute(
-                "INSERT INTO catalog_source_owners (workspace, source_name, owner_source_name, snapshot_fingerprint) VALUES ('default', 'github', 'github', 'fingerprint')",
-                [],
-            )
-            .expect("seed catalog source owner");
-        connection
-            .execute(
                 "INSERT INTO observed_values (workspace, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation) VALUES ('default', 'github', 'scope', 'table', 'issues', 'title', 'value', 'Payment issue', 'payment issue', 0, 0)",
                 [],
             )
@@ -1682,13 +1652,6 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("observed count");
-        let catalog_owner_count: i64 = connection
-            .query_row(
-                "SELECT COUNT(*) FROM catalog_source_owners WHERE workspace = 'default' AND owner_source_name = 'github'",
-                [],
-                |row| row.get(0),
-            )
-            .expect("catalog owner count");
         let generation_count: i64 = connection
             .query_row(
                 "SELECT COUNT(*) FROM observed_source_generations WHERE workspace = 'default' AND source_name = 'github'",
@@ -1698,7 +1661,6 @@ mod tests {
             .expect("generation count");
         assert_eq!(catalog_count, 1);
         assert_eq!(observed_count, 1);
-        assert_eq!(catalog_owner_count, 1);
         assert_eq!(generation_count, 0);
     }
 
@@ -1728,18 +1690,18 @@ mod tests {
     }
 
     #[test]
-    fn source_all_clear_uses_persisted_catalog_ownership_after_restart() {
+    fn source_all_clear_removes_only_that_source_after_restart() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("search.sqlite3");
         let workspace = WorkspaceName::parse("default").expect("workspace");
         let store = SqliteSearchStore::open(&path, workspace.clone()).expect("store");
         store
             .refresh_catalog_projection(&CatalogIndexSnapshot {
-                fingerprint: "multi-component-v1".to_string(),
+                fingerprint: "singular-identity-v1".to_string(),
                 documents: vec![
-                    catalog_document("github_v4", "github_v4_rest", "issues"),
-                    catalog_document("github_v4", "github_v4_mcp", "search_issues"),
-                    catalog_document("slack_v4", "slack_v4_rest", "messages"),
+                    catalog_document("github_v4", "issues"),
+                    catalog_document("github_mcp_v4", "search_issues"),
+                    catalog_document("slack_v4", "messages"),
                 ],
             })
             .expect("refresh catalog projection");
@@ -1758,12 +1720,14 @@ mod tests {
         drop(connection);
         drop(store);
 
+        // Source clear is a direct delete now -- no persisted ownership table to
+        // consult, so a restart changes nothing about what it removes.
         let reopened = SqliteSearchStore::open(&path, workspace).expect("reopen store");
         let (catalog, observed) = reopened
             .clear_source_all("github_v4")
             .expect("clear installed source");
 
-        assert_eq!(catalog.deleted_document_count, 2);
+        assert_eq!(catalog.deleted_document_count, 1);
         assert_eq!(observed.values, 1);
         let connection = reopened.connect_for_test().expect("reconnect");
         let remaining_catalog_sources = connection
@@ -1784,7 +1748,7 @@ mod tests {
             .expect("query observed sources")
             .collect::<Result<Vec<_>, _>>()
             .expect("observed sources");
-        assert_eq!(remaining_catalog_sources, ["slack_v4_rest"]);
+        assert_eq!(remaining_catalog_sources, ["github_mcp_v4", "slack_v4"]);
         assert_eq!(remaining_observed_sources, ["slack_v4"]);
     }
 
@@ -1831,12 +1795,7 @@ mod tests {
         let store =
             SqliteSearchStore::open(&path, WorkspaceName::default()).expect("repair schema");
         let connection = store.connect_for_test().expect("connect");
-        for table_name in [
-            "search_meta",
-            "catalog_documents",
-            "catalog_documents_fts",
-            "catalog_source_owners",
-        ] {
+        for table_name in ["search_meta", "catalog_documents", "catalog_documents_fts"] {
             let exists: bool = connection
                 .query_row(
                     "
@@ -1855,7 +1814,7 @@ mod tests {
     }
 
     #[test]
-    fn opening_current_version_repairs_missing_catalog_ownership_and_invalidates_rows() {
+    fn repair_replay_on_a_healthy_schema_preserves_the_catalog() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("search.sqlite3");
         let connection = open_current_search_connection(&path);
@@ -1867,8 +1826,19 @@ mod tests {
             )
             .expect("seed catalog fingerprint");
         connection
-            .execute_batch("DROP TABLE catalog_source_owners")
-            .expect("remove ownership table");
+            .execute(
+                "
+                INSERT INTO catalog_documents_fts (workspace, doc_id, title, qualified_name, description, searchable_text)
+                VALUES ('default', 'fixture', 'Fixture', 'fixture.table', '', 'fixture')
+                ",
+                [],
+            )
+            .expect("seed catalog FTS row");
+        // Damage only the observed side, so the repair path replays the whole
+        // migration history against an intact catalog.
+        connection
+            .execute_batch("DROP TABLE observed_values")
+            .expect("damage the observed schema");
         drop(connection);
 
         let connection = open_current_search_connection(&path);
@@ -1881,12 +1851,18 @@ mod tests {
             .optional()
             .expect("catalog fingerprint query");
 
-        assert_eq!(catalog_document_count(&connection), 0);
-        assert_eq!(catalog_fingerprint, None);
-        assert!(index_exists(
-            &connection,
-            "idx_catalog_source_owners_workspace_owner"
-        ));
+        // Pins the version-4 hook neutering: with its DELETEs still in place,
+        // every post-v6 repair replay would wipe the catalog, forever.
+        assert_eq!(catalog_document_count(&connection), 1);
+        assert_eq!(
+            matching_row_count(
+                &connection,
+                "SELECT COUNT(*) FROM catalog_documents_fts",
+                "catalog FTS rows after repair",
+            ),
+            1
+        );
+        assert_eq!(catalog_fingerprint.as_deref(), Some("current"));
     }
 
     #[test]
@@ -2020,16 +1996,11 @@ mod tests {
             .expect("seed catalog document");
     }
 
-    fn catalog_document(
-        owner_source_name: &str,
-        source_name: &str,
-        surface_name: &str,
-    ) -> CatalogIndexDocument {
+    fn catalog_document(source_name: &str, surface_name: &str) -> CatalogIndexDocument {
         let qualified_name = format!("{source_name}.{surface_name}");
         CatalogIndexDocument {
             doc_id: format!("catalog:table:{qualified_name}"),
             doc_kind: CatalogIndexDocumentKind::CatalogTable,
-            owner_source_name: owner_source_name.to_string(),
             source_name: source_name.to_string(),
             surface_kind: "table".to_string(),
             surface_name: surface_name.to_string(),
@@ -2047,7 +2018,6 @@ mod tests {
     struct WorkspaceAllClearRollbackSnapshot {
         catalog_documents: i64,
         catalog_fts_documents: i64,
-        catalog_source_owners: i64,
         catalog_fingerprints: i64,
         observed_values: i64,
         observed_fts_values: i64,
@@ -2063,8 +2033,6 @@ mod tests {
                 VALUES ('default', 'doc', 'catalog_table', 'github', 'Issues', 'fingerprint');
                 INSERT INTO catalog_documents_fts (workspace, doc_id, title, qualified_name, description, searchable_text)
                 VALUES ('default', 'doc', 'Issues', 'github.issues', 'GitHub issues', 'github issues');
-                INSERT INTO catalog_source_owners (workspace, source_name, owner_source_name, snapshot_fingerprint)
-                VALUES ('default', 'github', 'github', 'fingerprint');
                 INSERT INTO search_meta (key, value)
                 VALUES ('catalog_snapshot_fingerprint:default', 'fingerprint');
                 INSERT INTO observed_values (workspace, source_name, source_scope_id, surface_kind, surface_name, column_name, value_key, display_value, search_text, source_generation, workspace_generation)
@@ -2095,11 +2063,6 @@ mod tests {
                 connection,
                 "SELECT COUNT(*) FROM catalog_documents_fts WHERE workspace = 'default' AND doc_id = 'doc' AND title = 'Issues' AND qualified_name = 'github.issues' AND description = 'GitHub issues' AND searchable_text = 'github issues'",
                 "catalog FTS document count",
-            ),
-            catalog_source_owners: matching_row_count(
-                connection,
-                "SELECT COUNT(*) FROM catalog_source_owners WHERE workspace = 'default'",
-                "catalog source owner count",
             ),
             catalog_fingerprints: matching_row_count(
                 connection,
@@ -2133,7 +2096,6 @@ mod tests {
         WorkspaceAllClearRollbackSnapshot {
             catalog_documents: 1,
             catalog_fts_documents: 1,
-            catalog_source_owners: 1,
             catalog_fingerprints: 1,
             observed_values: 1,
             observed_fts_values: 1,
@@ -2589,6 +2551,26 @@ mod tests {
                 [],
             )
             .expect("seed observed queue job");
+    }
+
+    /// Recomputes what a live catalog snapshot would fingerprint to and asks
+    /// the store whether its stored projection matches.
+    fn catalog_projection_is_current_for_test(path: &std::path::Path) -> bool {
+        let store = SqliteSearchStore::open(path, WorkspaceName::default()).expect("open store");
+        let fingerprint = crate::search::catalog::snapshot::CatalogSearchSnapshot::from_catalog(
+            &coral_engine::CatalogInfo {
+                tables: Vec::new(),
+                table_functions: Vec::new(),
+            },
+        )
+        .fingerprint;
+        store
+            .catalog_projection_is_current(&fingerprint)
+            .expect("projection current check")
+    }
+
+    fn tables_exist_for_test(connection: &Connection, table_name: &str) -> bool {
+        super::tables_exist(connection, &[table_name]).expect("table lookup")
     }
 
     fn catalog_document_count(connection: &Connection) -> i64 {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -214,7 +214,7 @@ struct SearchClearArgs {
     /// Search data scope to clear
     #[arg(long, value_enum)]
     scope: SearchClearScope,
-    /// Installed source owner whose runtime schemas and surfaces should be cleared
+    /// Installed source whose local search state is cleared
     #[arg(long, value_name = "SOURCE")]
     source: Option<String>,
     /// Set when an explicit global `--workspace NAME` selector is present.


### PR DESCRIPTION
## What

Deletes the persisted second copy of a topology that no longer exists —
`catalog_source_owners` plus the runtime `schema → owner` map — and migrates the
sidecar to schema **v6**.

Since #1791 a source publishes exactly one schema, so
`catalog_documents.source_name` already *is* the installed source name. The
ownership projection records nothing the document does not.

No catalog data loss; one forced refresh per workspace.

## Migration 0006 is pure DDL

It drops the index and the table, and deliberately leaves catalog documents and
FTS rows in place. The refresh is forced by bumping
`CATALOG_SEARCH_SNAPSHOT_VERSION`, which guarantees every stored fingerprint
mismatches its recomputed value — so each workspace refreshes exactly once
before its documents are trusted again, and unlike a `DELETE` in the migration
file it does nothing extra on later repair replays.

> **Note the version is `-v5`, not `-v4`.** `-v4` already shipped on `main` in
> #2041 for grouped catalog surfaces. Reusing it would leave workspaces that
> already refreshed under #2041 matching, and the refresh this migration depends
> on would silently never run. Git does not flag this: both sides changed that
> line to the same value, so it auto-merges with no conflict marker.

## The version-4 hook had to be neutered

Its guard is `migration.version == 4 && !tables_exist(["catalog_source_owners"])`.
After 0006 that table is *permanently absent*, so **every** post-v6 repair
replay — including the observed-only reset path whose log line promises to
preserve the catalog — would have fired the hook and deleted all catalog
documents, FTS rows, and fingerprints. Forever.

It cannot be re-gated on the stamped version, because a replay re-stamps
`user_version` to 1, 2, 3 before 0004 runs. So its three DELETEs are removed;
the snapshot-version bump subsumes their invalidation job. Pinned by a
repair-replay test.

## Validation inverts

`catalog_schema_is_current` now requires the ownership table to be **absent**.

Known bounded edge, accepted and not special-cased: a v5 database whose repair
replay fails recoverably *before* 0006 executes still has the table, fails
catalog validation, and routes to the full-schema rebuild — a
refresh-from-provider, not corruption.

## Source clear becomes a direct delete

The FTS delete keeps its own `workspace = ?1` guard because `doc_id` is not
workspace-qualified. Production runs one sidecar per workspace, so that guards
test layouts and defence in depth rather than a live corruption path — it stays
because the schema is workspace-keyed and dropping it buys nothing.

Catalog **lifecycle** invalidation remains workspace-wide by design
(`clear_catalog_projection_for_source_lifecycle_best_effort`) — a refresh cost,
not data loss. Changing it is sources-domain work and out of scope.

## Public wording

`--source` is the installed source name, which is also its SQL schema name. CLI
help and both docs pages drop the multiple-runtime-components language; #2041's
rewrite had reintroduced it in new wording. No wire, CLI-flag, or JSON changes.
