### PR TITLE
fix(spec): allow injecting OpenAPI parameters via manifest to support…

### DIFF
--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -83,6 +83,19 @@ pub struct OpenApiRuntimeConfig {
     pub auth: AuthSpec,
     pub request_headers: Vec<HeaderSpec>,
     pub rate_limit: RateLimitSpec,
+    pub injected_parameters: Vec<InjectedParameterSpec>,
+}
+
+/// Parameter to inject into the `OpenAPI` surface when parsed.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct InjectedParameterSpec {
+    /// Optional list of operation IDs this parameter applies to. If empty or missing, it applies to all operations.
+    #[serde(default)]
+    pub operations: Option<Vec<String>>,
+    /// The `OpenAPI` parameter object to inject.
+    #[serde(flatten)]
+    pub parameter_obj: serde_json::Map<String, Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -164,6 +177,8 @@ struct RawV4Surface {
     request_headers: Vec<HeaderSpec>,
     #[serde(default)]
     rate_limit: RateLimitSpec,
+    #[serde(default)]
+    injected_parameters: Vec<InjectedParameterSpec>,
     #[serde(default)]
     server: Option<McpServerSpec>,
 }
@@ -270,6 +285,7 @@ fn parse_openapi_surface(
             auth: raw_surface.auth,
             request_headers: raw_surface.request_headers,
             rate_limit: raw_surface.rate_limit,
+            injected_parameters: raw_surface.injected_parameters,
         }),
     })
 }
@@ -285,7 +301,13 @@ fn parse_mcp_surface(
             "source '{source_name}' MCP surface must not declare url or file"
         )));
     }
-    for field in ["base_url", "auth", "request_headers", "rate_limit"] {
+    for field in [
+        "base_url",
+        "auth",
+        "request_headers",
+        "rate_limit",
+        "injected_parameters",
+    ] {
         if surface_value.get(field).is_some() {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' MCP surface must not declare OpenAPI field '{field}'"

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -153,6 +153,22 @@ impl OpenApiImporter<'_> {
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Vec<IrOperationInput> {
+        let injected = self
+            .surface
+            .openapi_runtime()
+            .map_or(&[] as &[_], |r| r.injected_parameters.as_slice());
+        let matching_injected = injected
+            .iter()
+            .filter(|inj| {
+                inj.operations.as_ref().is_none_or(|ops| {
+                    ops.is_empty()
+                        || ops
+                            .iter()
+                            .any(|op| normalize_identifier(op, "operation") == operation_id)
+                })
+            })
+            .map(|inj| Value::Object(inj.parameter_obj.clone()));
+
         let mut merged: BTreeMap<(IrInputLocation, String), Value> = BTreeMap::new();
         for parameter in path_item
             .get("parameters")
@@ -166,8 +182,10 @@ impl OpenApiImporter<'_> {
                     .into_iter()
                     .flatten(),
             )
+            .cloned()
+            .chain(matching_injected)
         {
-            let Some(resolved) = self.resolve_ref(parameter, operation_id, diagnostics) else {
+            let Some(resolved) = self.resolve_ref(&parameter, operation_id, diagnostics) else {
                 continue;
             };
             let Some(parameter_obj) = resolved.as_object() else {

--- a/sources/v4/microsoft_graph/manifest.yaml
+++ b/sources/v4/microsoft_graph/manifest.yaml
@@ -65,6 +65,11 @@ surface:
     - name: User-Agent
       from: literal
       value: coral-dsl-v4
+  injected_parameters:
+    - name: $orderby
+      in: query
+      schema:
+        type: string
 
 test_queries:
   - SELECT displayname, userprincipalname FROM microsoft_graph_v4.me_user_me_user_getuser LIMIT 1


### PR DESCRIPTION
**What changed**: 
Added `injected_parameters` to the V4 OpenAPI surface configuration so source authors can declare parameters missing from upstream specs. Updated the `microsoft_graph` manifest to inject `$orderby`.

**Why it changed**: 
Upstream OpenAPI specs (like Microsoft Graph) often omit OData query options, which prevented users from combining `$orderby` with date filters on endpoints like `chatMessages`.

Fixes #1990
