### PR TITLE
refactor(traces): move trace reads behind manager

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -68,8 +68,8 @@ use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
 use crate::task::service::TaskService;
 use crate::task::store::TaskStore;
-use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
+use crate::telemetry::{TelemetryConfig, TraceManager};
 use crate::transport::GrpcRequestContextLayer;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceService};
 
@@ -491,7 +491,10 @@ fn trace_components_for_store(
     active_trace_store.map_or_else(TraceServerComponents::default, |store| {
         TraceServerComponents {
             local_trace_store_dir: Some(store.dir.clone()),
-            service: Some(TraceService::new(store.dir, store.retention)),
+            service: Some(TraceService::new(TraceManager::new(
+                store.dir,
+                store.retention,
+            ))),
         }
     })
 }
@@ -1024,7 +1027,7 @@ mod tests {
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
-    use crate::telemetry::service::TraceService;
+    use crate::telemetry::{TraceManager, service::TraceService};
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
     use crate::{
@@ -1737,8 +1740,10 @@ backend = "unsupported"
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
         );
-        let trace_service =
-            TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
+        let trace_service = TraceService::new(TraceManager::new(
+            temp.path().join("trace-store"),
+            Duration::from_mins(1),
+        ));
         let server = start_server(
             ServerDependencies {
                 source: source_manager,

--- a/crates/coral-app/src/telemetry/manager.rs
+++ b/crates/coral-app/src/telemetry/manager.rs
@@ -1,0 +1,231 @@
+//! App-level orchestration for local trace inspection.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::local_store::{TraceDetailRecord, TraceStore, TraceStoreError, TraceSummaryRecord};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug)]
+pub(crate) struct ListTracesQuery {
+    pub(crate) workspace: Option<WorkspaceName>,
+    pub(crate) page_size: usize,
+    pub(crate) offset: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct TraceListPage {
+    pub(crate) traces: Vec<TraceSummaryRecord>,
+    pub(crate) next_offset: Option<usize>,
+}
+
+#[derive(Debug)]
+pub(crate) struct GetTraceQuery {
+    pub(crate) trace_id: String,
+    pub(crate) workspace: Option<WorkspaceName>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TraceManagerError {
+    #[error("trace '{trace_id}' not found")]
+    NotFound { trace_id: String },
+    #[error(transparent)]
+    Store(TraceStoreError),
+}
+
+impl From<TraceStoreError> for TraceManagerError {
+    fn from(error: TraceStoreError) -> Self {
+        match error {
+            TraceStoreError::NotFound(trace_id) => Self::NotFound { trace_id },
+            error => Self::Store(error),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TraceManager {
+    traces: TraceStore,
+}
+
+impl TraceManager {
+    pub(crate) fn new(trace_store_dir: PathBuf, retention: Duration) -> Self {
+        Self {
+            traces: TraceStore::with_retention(trace_store_dir, retention),
+        }
+    }
+
+    pub(crate) async fn list_traces(
+        &self,
+        query: ListTracesQuery,
+    ) -> Result<TraceListPage, TraceManagerError> {
+        let ListTracesQuery {
+            workspace,
+            page_size,
+            offset,
+        } = query;
+        let fetch_limit = page_size.saturating_add(1);
+        let mut traces = match workspace {
+            Some(workspace) => {
+                self.traces
+                    .list_traces_for_workspace(fetch_limit, offset, workspace.as_str().to_string())
+                    .await
+            }
+            None => self.traces.list_traces(fetch_limit, offset).await,
+        }?;
+        let next_offset = (traces.len() > page_size).then(|| offset.saturating_add(page_size));
+        if next_offset.is_some() {
+            traces.truncate(page_size);
+        }
+        Ok(TraceListPage {
+            traces,
+            next_offset,
+        })
+    }
+
+    pub(crate) async fn get_trace(
+        &self,
+        query: GetTraceQuery,
+    ) -> Result<TraceDetailRecord, TraceManagerError> {
+        let GetTraceQuery {
+            trace_id,
+            workspace,
+        } = query;
+        match workspace {
+            Some(workspace) => {
+                self.traces
+                    .get_trace_for_workspace(trace_id, workspace.as_str().to_string())
+                    .await
+            }
+            None => self.traces.get_trace(trace_id).await,
+        }
+        .map_err(TraceManagerError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::{GetTraceQuery, ListTracesQuery, TraceManager, TraceManagerError};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn manager_scopes_and_paginates_trace_lists() {
+        let (_temp, manager) = trace_manager_fixture();
+        let alpha = WorkspaceName::parse("alpha").expect("alpha workspace");
+
+        let first_page = manager
+            .list_traces(ListTracesQuery {
+                workspace: Some(alpha.clone()),
+                page_size: 1,
+                offset: 0,
+            })
+            .await
+            .expect("first trace page");
+        assert_eq!(first_page.traces.len(), 1);
+        assert_eq!(
+            first_page.traces.first().expect("first trace").trace_id,
+            "alpha-new"
+        );
+        assert_eq!(first_page.next_offset, Some(1));
+
+        let second_page = manager
+            .list_traces(ListTracesQuery {
+                workspace: Some(alpha),
+                page_size: 1,
+                offset: 1,
+            })
+            .await
+            .expect("second trace page");
+        assert_eq!(second_page.traces.len(), 1);
+        assert_eq!(
+            second_page.traces.first().expect("second trace").trace_id,
+            "alpha-old"
+        );
+        assert_eq!(second_page.next_offset, None);
+    }
+
+    #[tokio::test]
+    async fn manager_applies_workspace_scope_to_trace_detail() {
+        let (_temp, manager) = trace_manager_fixture();
+
+        let detail = manager
+            .get_trace(GetTraceQuery {
+                trace_id: "beta".to_string(),
+                workspace: None,
+            })
+            .await
+            .expect("unscoped beta trace");
+        assert_eq!(detail.summary.trace_id, "beta");
+
+        let error = manager
+            .get_trace(GetTraceQuery {
+                trace_id: "beta".to_string(),
+                workspace: Some(WorkspaceName::parse("alpha").expect("alpha workspace")),
+            })
+            .await
+            .expect_err("beta trace must not match alpha workspace");
+        assert!(matches!(
+            error,
+            TraceManagerError::NotFound { trace_id } if trace_id == "beta"
+        ));
+    }
+
+    fn trace_manager_fixture() -> (TempDir, TraceManager) {
+        let temp = TempDir::new().expect("temp dir");
+        let trace_store = temp.path().join("trace-store");
+        std::fs::create_dir_all(&trace_store).expect("trace store dir");
+        let records = [
+            trace_record("alpha-old", "alpha", 10, 20),
+            trace_record("alpha-new", "alpha", 30, 40),
+            trace_record("beta", "beta", 50, 60),
+        ];
+        let lines = records
+            .into_iter()
+            .map(|record| record.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(trace_store.join("spans-test.jsonl"), format!("{lines}\n"))
+            .expect("write trace records");
+        (temp, TraceManager::new(trace_store, Duration::from_mins(1)))
+    }
+
+    fn trace_record(
+        trace_id: &str,
+        workspace: &str,
+        start_time_unix_nanos: i64,
+        end_time_unix_nanos: i64,
+    ) -> serde_json::Value {
+        json!({
+            "trace_id": trace_id,
+            "span_id": format!("{trace_id}-span"),
+            "parent_span_id": null,
+            "parent_span_is_remote": false,
+            "name": "coral.query",
+            "kind": "internal",
+            "status": "ok",
+            "status_message": null,
+            "start_time_unix_nanos": start_time_unix_nanos,
+            "end_time_unix_nanos": end_time_unix_nanos,
+            "duration_nanos": end_time_unix_nanos - start_time_unix_nanos,
+            "attributes_json": json!({
+                "workspace": workspace,
+                "sql": format!("SELECT '{trace_id}'"),
+                "status": "ok",
+            }).to_string(),
+            "events_json": "[]",
+            "links_json": "[]",
+            "resource_json": "{}",
+            "scope_name": "test",
+            "scope_version": null,
+            "scope_schema_url": null,
+            "scope_attributes_json": "{}",
+            "trace_flags": 0,
+            "trace_state": "",
+            "is_remote": false
+        })
+    }
+}

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -28,6 +28,7 @@ use tracing_subscriber::{EnvFilter, Registry};
 
 pub mod config;
 mod local_store;
+mod manager;
 pub mod metrics;
 pub(crate) mod service;
 
@@ -38,6 +39,7 @@ use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTE
 pub(crate) use local_store::{
     TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage, TraceStoreError,
 };
+pub(crate) use manager::TraceManager;
 
 static INIT: OnceLock<Result<TracingInitState, String>> = OnceLock::new();
 static PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,8 +1,5 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
-use std::path::PathBuf;
-use std::time::Duration;
-
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
     GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceSpan,
@@ -12,9 +9,9 @@ use tonic::{Code, Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::telemetry::local_store::{
-    StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceStore, TraceStoreError,
-    TraceSummaryRecord,
+    StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceSummaryRecord,
 };
+use crate::telemetry::manager::{GetTraceQuery, ListTracesQuery, TraceManager, TraceManagerError};
 use crate::transport::{grpc_span, instrument_grpc};
 use crate::workspaces::WorkspaceName;
 
@@ -23,13 +20,13 @@ const MAX_TRACE_PAGE_SIZE: usize = 200;
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
-    traces: TraceStore,
+    traces: TraceManager,
 }
 
 impl TraceService {
-    pub(crate) fn new(trace_store_file: PathBuf, retention: Duration) -> Self {
+    pub(crate) fn new(trace_manager: TraceManager) -> Self {
         Self {
-            traces: TraceStore::with_retention(trace_store_file, retention),
+            traces: trace_manager,
         }
     }
 }
@@ -46,33 +43,24 @@ impl TraceServiceApi for TraceService {
             let request = request.into_inner();
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
-            let workspace_name = workspace_filter_from_proto(request.workspace.as_ref())?;
-            let mut summaries = match workspace_name {
-                Some(workspace_name) => {
-                    traces
-                        .list_traces_for_workspace(
-                            page_size.saturating_add(1),
-                            offset,
-                            workspace_name,
-                        )
-                        .await
-                }
-                None => {
-                    traces
-                        .list_traces(page_size.saturating_add(1), offset)
-                        .await
-                }
-            }
-            .map_err(trace_store_status)?;
-            let next_page_token = if summaries.len() > page_size {
-                summaries.truncate(page_size);
-                offset.saturating_add(page_size).to_string()
-            } else {
-                String::new()
-            };
+            let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let page = traces
+                .list_traces(ListTracesQuery {
+                    workspace,
+                    page_size,
+                    offset,
+                })
+                .await
+                .map_err(trace_manager_status)?;
             Ok(Response::new(ListTracesResponse {
-                traces: summaries.into_iter().map(trace_summary_to_proto).collect(),
-                next_page_token,
+                traces: page
+                    .traces
+                    .into_iter()
+                    .map(trace_summary_to_proto)
+                    .collect(),
+                next_page_token: page
+                    .next_offset
+                    .map_or_else(String::new, |offset| offset.to_string()),
             }))
         })
         .await
@@ -92,16 +80,14 @@ impl TraceServiceApi for TraceService {
                     "invalid input: missing trace_id",
                 ));
             }
-            let workspace_name = workspace_filter_from_proto(request.workspace.as_ref())?;
-            let trace = match workspace_name {
-                Some(workspace_name) => {
-                    traces
-                        .get_trace_for_workspace(request.trace_id, workspace_name)
-                        .await
-                }
-                None => traces.get_trace(request.trace_id).await,
-            }
-            .map_err(trace_store_status)?;
+            let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let trace = traces
+                .get_trace(GetTraceQuery {
+                    trace_id: request.trace_id,
+                    workspace,
+                })
+                .await
+                .map_err(trace_manager_status)?;
             Ok(Response::new(trace_detail_to_proto(trace)))
         })
         .await
@@ -130,33 +116,20 @@ fn parse_page_token(page_token: &str) -> Result<usize, Status> {
     })
 }
 
-fn workspace_filter_from_proto(workspace: Option<&Workspace>) -> Result<Option<String>, Status> {
+fn workspace_filter_from_proto(
+    workspace: Option<&Workspace>,
+) -> Result<Option<WorkspaceName>, Status> {
     workspace
-        .map(|workspace| {
-            WorkspaceName::parse(&workspace.name)
-                .map(|workspace_name| workspace_name.as_str().to_string())
-                .map_err(app_status)
-        })
+        .map(|workspace| WorkspaceName::parse(&workspace.name).map_err(app_status))
         .transpose()
 }
 
-fn trace_store_status(error: TraceStoreError) -> Status {
+fn trace_manager_status(error: TraceManagerError) -> Status {
     match error {
-        TraceStoreError::NotFound(trace_id) => {
+        TraceManagerError::NotFound { trace_id } => {
             Status::new(Code::NotFound, format!("trace '{trace_id}' not found"))
         }
-        TraceStoreError::ReadDir { .. }
-        | TraceStoreError::OpenFile { .. }
-        | TraceStoreError::FileMetadata { .. }
-        | TraceStoreError::WriteFile { .. }
-        | TraceStoreError::RemoveFile { .. }
-        | TraceStoreError::RestoreFile { .. }
-        | TraceStoreError::WriterRegistryPoisoned
-        | TraceStoreError::WriterPoisoned
-        | TraceStoreError::CloseActiveWriter { .. }
-        | TraceStoreError::ReadFile { .. }
-        | TraceStoreError::PruneExpired { .. }
-        | TraceStoreError::Worker { .. } => Status::new(Code::Internal, error.to_string()),
+        TraceManagerError::Store(error) => Status::new(Code::Internal, error.to_string()),
     }
 }
 
@@ -229,6 +202,7 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{TraceService, normalize_page_size, parse_page_token};
+    use crate::telemetry::TraceManager;
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -257,7 +231,7 @@ mod tests {
                 trace_record_json("beta-trace", "beta-span", "beta", 30, 40),
             ],
         );
-        let service = TraceService::new(trace_store, Duration::from_mins(1));
+        let service = TraceService::new(TraceManager::new(trace_store, Duration::from_mins(1)));
 
         let response = TraceServiceApi::list_traces(
             &service,


### PR DESCRIPTION
## Summary

- introduce a transport-free `TraceManager` for local trace inspection
- move existing trace list/get storage access, workspace scoping, pagination, and store-error classification out of the gRPC service
- inject the manager from server bootstrap so the service remains a thin protocol adapter
- preserve the existing trace API and one-summary-per-trace behavior

## Stack boundary

- Layer 1 of 4 in the open Query Stream stack
- Depends on: `main`
- Next: #1876
- This is an application-layer refactor only. It adds no Query Stream view, marker interpretation, protobuf fields, or Reef changes.

## Validation

- `cargo test -p coral-app telemetry::manager --lib --locked`: passed
- `cargo test -p coral-app telemetry::service --lib --locked`: passed
- `cargo check -p coral-app --locked`: passed
- `make rust-checks`: passed at the stack tip
- `git diff --check`: passed
