### PR TITLE
docs: lead with Desktop and MCP

### DIFF
--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Installation"
-description: "Install the Coral CLI"
+description: "Install Coral Desktop or the Coral CLI"
 ---
 
-Coral ships as a single local CLI. Once installed, the same binary is used for source management, SQL queries, and the MCP stdio server.
+Install Coral Desktop on macOS. Use the CLI on Linux, Windows, servers, or for automation.
 
 <Note>
   Coral publishes macOS, Linux, and x86_64 Windows artifacts. Windows support
@@ -14,6 +14,12 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
 ## Install Coral
 
 <Tabs>
+  <Tab title="macOS Desktop">
+    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg),
+    open the DMG, and move Coral to your Applications folder. Coral Desktop
+    includes the Coral runtime.
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew install withcoral/tap/coral
@@ -128,7 +134,8 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
 </Tabs>
 
 <Tip>
-  Once installed, run `coral onboard` to start the interactive wizard to complete the setup.
+  Continue with the [quickstart](/getting-started/quickstart) to connect a
+  source and your agent.
 </Tip>
 
 ## Upgrade

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -88,8 +88,6 @@ Ask your agent of choice:
 
 > "Use Coral to search ..."
 
-We would suggest asking it to search a source you have connected.
-
 If you use Coral Desktop, you can view **Traces** there.
 
 ## Next steps

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -86,7 +86,7 @@ Or
 
 Ask your agent of choice:
 
-> "Use Coral to search ..."
+> "Use Coral to search for my pull requests."
 
 If you use Coral Desktop, you can view **Traces** there.
 

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -1,60 +1,96 @@
 ---
 title: "Quickstart"
-description: "Set up Coral in minutes: run the onboarding flow, connect your first sources, and start querying your data."
+description: "Install Coral, connect a source and an AI agent, then try your first search."
 ---
 
-This tutorial gets you from a fresh [install](/getting-started/installation) of Coral, to your first SQL query.
+export const CopyMcpGuide = () => {
+  const [copyStatus, setCopyStatus] = useState("ready")
 
-<Tip>
-  Prefer the CLI experience? Run `coral onboard` for an interactive wizard that
-  walks you through the whole setup described in this page.
-</Tip>
+  const copyGuide = async (event) => {
+    event.preventDefault()
 
-## 1. Discover bundled sources
+    try {
+      const response = await fetch("/guides/use-coral-over-mcp")
+      const guide = new DOMParser().parseFromString(await response.text(), "text/html")
+      const content = guide.querySelector("#content")?.textContent
+      if (!content) throw new Error("MCP guide content not found")
+      await navigator.clipboard.writeText(content.trim())
+      setCopyStatus("copied")
+    } catch {
+      setCopyStatus("failed")
+    }
+  }
 
-```shellscript
-coral source discover
-```
+  const copyLabel =
+    copyStatus === "copied"
+      ? "Copied MCP setup guide"
+      : copyStatus === "failed"
+        ? "Copy failed; click to retry"
+        : "Copy the content of our setup guide for your agent"
 
-This lists the bundled sources available in your build. Coral comes with [bundled sources](/reference/bundled-sources) for GitHub, Slack, Datadog, Linear, Sentry, and more.
+  return <a href="/guides/use-coral-over-mcp" onClick={copyGuide} aria-live="polite">{copyLabel}</a>
+}
 
-## 2. Add a source
+Choose Coral Desktop or the CLI, then connect one source before you set up MCP.
 
-For example, add GitHub. Pass `--interactive` and Coral will prompt you for each required input:
+<Tabs>
+  <Tab title="Coral Desktop (macOS only)">
+    ## 1. Install Coral Desktop
 
-```shellscript
-coral source add --interactive github
-```
+    [Install for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg),
+    open the DMG, and move Coral to your Applications folder. Open Coral and
+    complete the onboarding flow.
 
-Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
+    ## 2. Add a source
 
-<Tip>
-  For scripted setups, omit `--interactive` and Coral reads each input from an
-  environment variable of the same name — e.g. `GITHUB_TOKEN=ghp_... coral
-  source add github`.
-</Tip>
+    Open **Sources** in Coral Desktop and connect GitHub, Slack, Datadog, or
+    another [bundled source](/reference/bundled-sources).
+  </Tab>
 
-## 3. Query your data
+  <Tab title="Coral CLI">
+    ## 1. Install the Coral CLI
 
-You can now query any connected source using SQL.
+    [See CLI installation options](/getting-started/installation), then list
+    the bundled sources in your build:
 
-Use `coral.tables` to see all available tables:
+    ```shellscript
+    coral source discover
+    ```
 
-```shellscript
-coral sql "SELECT schema_name, table_name FROM coral.tables ORDER BY 1, 2"
-```
+    ## 2. Add a source
 
-Assuming you've connected GitHub, try listing open issues for a repo:
+    For example, add GitHub. Pass `--interactive` and Coral will prompt you for
+    each required input:
 
-```shellscript
-coral sql "
-  SELECT number, title, state, created_at
-  FROM github.issues
-  WHERE owner = 'withcoral' AND repo = 'coral' AND state = 'open'
-  ORDER BY created_at DESC
-  LIMIT 10
-"
-```
+    ```shellscript
+    coral source add --interactive github
+    ```
+
+    <Tip>
+      For scripted setups, omit `--interactive` and Coral reads each input from
+      an environment variable of the same name — e.g. `GITHUB_TOKEN=ghp_...
+      coral source add github`.
+    </Tip>
+  </Tab>
+</Tabs>
+
+## 3. Connect your agent over MCP
+
+[Read our setup guide](/guides/use-coral-over-mcp)
+
+Or
+
+<CopyMcpGuide />
+
+## 4. Try it out
+
+Ask your agent of choice:
+
+> "Use Coral to search ..."
+
+We would suggest asking it to search a source you have connected.
+
+If you use Coral Desktop, you can view **Traces** there.
 
 ## Next steps
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -11,40 +11,75 @@ Coral supports a number of [popular data sources](/reference/bundled-sources) bu
 
 ## Get started
 
-<Steps titleSize="h3">
-  <Step title="Install Coral">
-    Install the Coral CLI to get started.
+<Tabs>
+  <Tab title="Coral Desktop (macOS only)">
+    <Steps titleSize="h3">
+      <Step title="Install Coral">
+        Coral Desktop includes the Coral runtime.
 
-    ```shellscript
-    brew install withcoral/tap/coral
-    ```
+        [Install for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
 
-    [See all installation options](/getting-started/installation)
+      </Step>
 
-  </Step>
+      <Step title="Add your sources">
+        Open Coral Desktop and connect GitHub, Slack, Datadog, or another [bundled source](/reference/bundled-sources) to your workspace.
 
-  <Step title="Add your sources">
-   Connect GitHub, Slack, Datadog, and other [bundled sources](/reference/bundled-sources) to your workspace. For example:
+      </Step>
 
-    ```shellscript
-    coral source add --interactive github
-    ```
+      <Step title="Connect your agent over MCP">
+        [Read our setup guide](/guides/use-coral-over-mcp)
 
-    [Go to the quickstart](/getting-started/quickstart)
+      </Step>
 
-  </Step>
+      <Step title="Try it out">
+        Ask your agent of choice:
 
-  <Step title="Start querying">
-    Write SQL directly or let your AI agent query on your behalf.
+        > "Use Coral to search ..."
 
-    ```shellscript
-    coral sql "SELECT name, stargazers_count FROM github.org_repos WHERE org = 'withcoral' ORDER BY stargazers_count DESC"
-    ```
+        We would suggest asking it to search a source you have connected.
 
-    [Or use Coral over MCP](/guides/use-coral-over-mcp)
+        You can view **Traces** in Coral Desktop.
 
-  </Step>
-</Steps>
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="Coral CLI">
+    <Steps titleSize="h3">
+      <Step title="Install Coral">
+        Use the CLI on macOS, Linux, Windows, servers, or for automation.
+
+        [See CLI installation options](/getting-started/installation)
+
+      </Step>
+
+      <Step title="Add your sources">
+        For example, add GitHub:
+
+        ```shellscript
+        coral source add --interactive github
+        ```
+
+        See all [bundled sources](/reference/bundled-sources).
+
+      </Step>
+
+      <Step title="Connect your agent over MCP">
+        [Read our setup guide](/guides/use-coral-over-mcp)
+
+      </Step>
+
+      <Step title="Try it out">
+        Ask your agent of choice:
+
+        > "Use Coral to search ..."
+
+        We would suggest asking it to search a source you have connected.
+
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
 
 ## Why Coral
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -34,7 +34,7 @@ Coral supports a number of [popular data sources](/reference/bundled-sources) bu
       <Step title="Try it out">
         Ask your agent of choice:
 
-        > "Use Coral to search ..."
+        > "Use Coral to search for my pull requests."
 
         You can view **Traces** in Coral Desktop.
 
@@ -70,7 +70,7 @@ Coral supports a number of [popular data sources](/reference/bundled-sources) bu
       <Step title="Try it out">
         Ask your agent of choice:
 
-        > "Use Coral to search ..."
+        > "Use Coral to search for my pull requests."
 
       </Step>
     </Steps>

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -36,8 +36,6 @@ Coral supports a number of [popular data sources](/reference/bundled-sources) bu
 
         > "Use Coral to search ..."
 
-        We would suggest asking it to search a source you have connected.
-
         You can view **Traces** in Coral Desktop.
 
       </Step>
@@ -73,8 +71,6 @@ Coral supports a number of [popular data sources](/reference/bundled-sources) bu
         Ask your agent of choice:
 
         > "Use Coral to search ..."
-
-        We would suggest asking it to search a source you have connected.
 
       </Step>
     </Steps>


### PR DESCRIPTION
## Summary

- make Coral Desktop the main macOS setup path
- keep a separate Coral CLI path for Linux, Windows, servers, and automation
- make MCP the main agent path on the home page and in Quickstart
- replace the manual SQL example with an agent search and Desktop trace inspection
- let users copy the MCP setup guide for their agent

## Why

The docs led with the CLI and asked users to write SQL directly. The updated flow starts with the product surface users should use, then connects their agent over MCP. The CLI remains available where Desktop is not supported or automation needs it.

## Screenshots

**Coral Desktop**

<img width="1200" alt="The Get started section with the Coral Desktop path selected" src="https://gist.githubusercontent.com/Bradley-Butcher/1968797d743b827a45ed21d301136289/raw/e752a21ecb879d5f3b2b999adf658f7734895aac/coral-desktop-path.svg">

**Coral CLI**

<img width="1200" alt="The Get started section with the Coral CLI path selected" src="https://gist.githubusercontent.com/Bradley-Butcher/1968797d743b827a45ed21d301136289/raw/829262fd34125df2d1e4092c338b8c7ce73bf591/coral-cli-path.svg">

## Validation

- `make docs-check`
- `cd apps/docs && npx --yes mint@4.2.772 broken-links`
- `git diff --check`
- visually checked the home page, installation page, and Quickstart
- checked Desktop and CLI tabs at desktop and 390 px widths
- tested the MCP guide copy action

## Not in this PR

- broader consolidation of overlapping introduction and Quickstart content

