### PR TITLE
feat(reef): link to onboarding from the sidebar

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -351,8 +351,8 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain(
         "route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts')",
       )
-      // Onboarding is a hidden, manually visited flow outside the normal app chrome.
-      expect(routeConfig).toContain("route('onboarding', 'routes/onboarding.tsx')")
+      // Onboarding renders its own full-page chrome, so it stays outside the app shell.
+      expect(routeConfig).toContain("route(routePattern('onboarding'), 'routes/onboarding.tsx')")
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
       expect(routeConfig).toContain("index('routes/index.tsx')")
       expect(routeConfig).toContain(
@@ -379,7 +379,7 @@ describe('Architectural Tests', () => {
       // outside the app shell, while canonical workspace routes and settings
       // stay inside it.
       expect(routeConfig).toMatch(
-        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
+        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\(routePattern\('onboarding'\), 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -372,6 +372,14 @@ describe('Sidebar', () => {
     await expect.element(screen.getByRole('menuitem', { name: 'No workspaces' })).toBeVisible()
   })
 
+  it('links to the onboarding flow', async () => {
+    const screen = await renderSidebar(false, routePath('home'), WORKSPACES)
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Onboarding' }))
+      .toHaveAttribute('href', routePath('onboarding'))
+  })
+
   it('keeps collapsed navigation labels available through tooltips', async () => {
     const screen = await renderSidebar(true, '/workspaces/analytics/sources', WORKSPACES)
 

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -94,6 +94,19 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
     </>
   )
 
+  // Temporary: re-entry point into the onboarding flow.
+  const onboardingButton = (
+    <SidebarButton
+      aria-label="Onboarding"
+      as={Link}
+      icon="Sparkles"
+      isMinimized={isMinimized}
+      to={routePath('onboarding')}
+    >
+      Onboarding
+    </SidebarButton>
+  )
+
   const handleToggleSidebar = (event: KeyboardEvent) => {
     event.preventDefault()
     toggleSidebar()
@@ -256,6 +269,13 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
           )
         })}
       </div>
+      {isMinimized ? (
+        <Tooltip content="Onboarding" side="right">
+          {onboardingButton}
+        </Tooltip>
+      ) : (
+        onboardingButton
+      )}
       {updateState.status !== 'idle' && updateState.status !== 'unsupported' && (
         <DesktopUpdateIndicator isMinimized={isMinimized} state={updateState} />
       )}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -7,7 +7,7 @@ export default [
   // same-origin fetch. It intentionally sits outside the app shell and does not
   // render a page.
   route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
-  route('onboarding', 'routes/onboarding.tsx'),
+  route(routePattern('onboarding'), 'routes/onboarding.tsx'),
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),
     route(routePattern('workspaces'), 'routes/workspaces-action.ts'),

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -5,6 +5,7 @@ import { routeMap, routeObjects, routePath, routePattern } from './routemap'
 
 const CANONICAL_PATTERNS = {
   home: '/',
+  onboarding: '/onboarding',
   settings: '/settings',
   workspaces: '/workspaces',
   workspaceFunctions: '/workspaces/:workspaceId/functions',
@@ -37,6 +38,7 @@ describe('route map', () => {
   it('generates canonical URLs for every mapped route', () => {
     const paths = {
       home: routePath('home'),
+      onboarding: routePath('onboarding'),
       settings: routePath('settings'),
       workspaces: routePath('workspaces'),
       workspaceFunctions: routePath('workspaceFunctions', { workspaceId: 'analytics' }),
@@ -69,6 +71,7 @@ describe('route map', () => {
 
     expect(paths).toEqual({
       home: '/',
+      onboarding: '/onboarding',
       settings: '/settings',
       workspaces: '/workspaces',
       workspaceFunctions: '/workspaces/analytics/functions',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -2,6 +2,7 @@ import { generatePath } from 'react-router'
 import type { RouteObject } from 'react-router'
 
 const HOME_PATH = '/'
+const ONBOARDING_PATH = '/onboarding'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_FUNCTIONS_PATH = '/workspaces/:workspaceId/functions'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
@@ -20,6 +21,10 @@ export const routeDefinitions = {
   home: {
     path: HOME_PATH,
     toPath: () => HOME_PATH,
+  },
+  onboarding: {
+    path: ONBOARDING_PATH,
+    toPath: () => ONBOARDING_PATH,
   },
   settings: {
     path: SETTINGS_PATH,


### PR DESCRIPTION
## Summary

Adding temporary onboarding button in the Sidebar. Temporary because ideally we'd just show you the onboarding the first time you open the app; but that requires storing that in the DB, which isn't ready yet,

## Test plan

Button is there, and clicking redirects to onboarding

<img width="185" height="817" alt="image" src="https://github.com/user-attachments/assets/ae0c7cc9-426e-47f9-affe-5cf4f9eb0764" />
