### PR TITLE
docs: lead with the desktop app across getting started

### DIFF
--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -1,17 +1,26 @@
 ---
 title: "Installation"
-description: "Install the Coral CLI"
+description: "Install the Coral desktop app or CLI"
 ---
 
-Coral ships as a single local CLI. Once installed, the same binary is used for source management, SQL queries, and the MCP stdio server.
-
-<Note>
-  Coral publishes macOS, Linux, and x86_64 Windows artifacts. Windows support
-  currently targets native Windows 10/11 on `x86_64-pc-windows-msvc`; ARM64
-  Windows is not released.
-</Note>
+Coral ships as a desktop app on macOS. For Linux, Windows, servers, or for automation, it is also available as a CLI.
 
 ## Install Coral
+
+<Tabs>
+<Tab title="Desktop app">
+
+The Coral desktop app is a universal macOS build that runs on both Apple silicon and Intel Macs.
+
+1. [Download the Coral desktop app](https://withcoral.com/download). You can also take a look at the [latest release's assets](https://github.com/withcoral/coral/releases/latest).
+2. Open the DMG and drag **Coral** into your Applications folder.
+3. Launch Coral and add your first [sources](/reference/bundled-sources) from the app.
+
+The desktop app bundles the `coral` binary it runs queries with, so you don't need a separate CLI install.
+
+</Tab>
+
+<Tab title="CLI">
 
 <Tabs>
   <Tab title="Homebrew">
@@ -52,6 +61,7 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     coral source discover
     coral onboard
     ```
+
   </Tab>
 
   <Tab title="Build from source">
@@ -65,6 +75,7 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     This installs Coral's source-management, SQL, and MCP surfaces. It does
     not include `coral ui`, which is compiled only when the `embedded-ui`
     feature is enabled.
+
   </Tab>
 
   <Tab title="Build for Windows">
@@ -124,14 +135,28 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     npm run build --prefix apps/ui
     cargo build --release --locked -p coral-cli --features embedded-ui
     ```
+
   </Tab>
 </Tabs>
 
 <Tip>
-  Once installed, run `coral onboard` to start the interactive wizard to complete the setup.
+  Once installed, run `coral onboard` to start the interactive wizard to
+  complete the setup.
 </Tip>
 
+</Tab>
+</Tabs>
+
 ## Upgrade
+
+<Tabs>
+<Tab title="Desktop app">
+
+When a new version is available, Coral will show a notification in the UI. You can use the menu bar to check for an update manually.
+
+</Tab>
+
+<Tab title="CLI">
 
 <Tabs>
   <Tab title="Homebrew">
@@ -146,6 +171,7 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     ```shellscript
     curl -fsSL https://withcoral.com/install.sh | sh
     ```
+
   </Tab>
 
   <Tab title="Windows ZIP">
@@ -159,10 +185,26 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     Expand-Archive -Path "coral-x86_64-pc-windows-msvc.zip" -DestinationPath "coral" -Force
     Copy-Item "coral\coral.exe" "$env:USERPROFILE\.local\bin\coral.exe"
     ```
+
   </Tab>
 </Tabs>
 
+</Tab>
+</Tabs>
+
 ## Uninstall
+
+<Tabs>
+<Tab title="Desktop app">
+
+Quit Coral and move it to the trash.
+
+Coral's [local state](#local-state) lives in the config directory and is left in place, so a reinstall keeps your sources.
+You can delete that manually if needed.
+
+</Tab>
+
+<Tab title="CLI">
 
 <Tabs>
   <Tab title="Homebrew">
@@ -184,6 +226,9 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     Remove-Item "$env:APPDATA\withcoral\coral\config" -Recurse -Force -ErrorAction SilentlyContinue
     ```
   </Tab>
+</Tabs>
+
+</Tab>
 </Tabs>
 
 ## Skills
@@ -227,5 +272,8 @@ Important files include:
 - source secrets stored separately within the same local trust boundary
 
 <Note>
-  [Bundled source](/reference/bundled-sources) specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.
+  [Bundled source](/reference/bundled-sources) specs are not copied into the
+  config directory. Coral resolves them from the current binary when you
+  validate or query a bundled source, so upgrades pick up newer bundled
+  manifests without re-adding the source.
 </Note>

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -1,63 +1,34 @@
 ---
 title: "Quickstart"
-description: "Set up Coral in minutes: run the onboarding flow, connect your first sources, and start querying your data."
+description: "Set up Coral in minutes: connect your first sources, connect your agents to Coral, and start querying your data."
 ---
 
-This tutorial gets you from a fresh [install](/getting-started/installation) of Coral, to your first SQL query.
+This tutorial gets you from a fresh [install](/getting-started/installation) of Coral, to your agents using Coral to retrieve data.
 
 <Tip>
-  Prefer the CLI experience? Run `coral onboard` for an interactive wizard that
-  walks you through the whole setup described in this page.
+  Did you install the CLI rather than the desktop app? Run `coral onboard` for
+  an interactive wizard that walks you through your first steps with the Coral
+  CLI.
 </Tip>
 
-## 1. Discover bundled sources
+## 1. Add data sources
 
-```shellscript
-coral source discover
-```
+Coral comes with [bundled sources](/reference/bundled-sources) for GitHub, Slack, Datadog, Linear, Sentry, and more.
+Coral can only retrieve data from sources you've connected.
 
-This lists the bundled sources available in your build. Coral comes with [bundled sources](/reference/bundled-sources) for GitHub, Slack, Datadog, Linear, Sentry, and more.
+The sources page in the desktop app allows you to add, remove or create new sources.
 
-## 2. Add a source
+## 2. Connect your agents
 
-For example, add GitHub. Pass `--interactive` and Coral will prompt you for each required input:
+The desktop app exposes an MCP server over stdio, that your agents can connect to. You can go to the setting in the desktop app to set up your agents, or look at the [MCP docs](/guides/use-coral-over-mcp).
 
-```shellscript
-coral source add --interactive github
-```
-
-Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
-
-<Tip>
-  For scripted setups, omit `--interactive` and Coral reads each input from an
-  environment variable of the same name — e.g. `GITHUB_TOKEN=ghp_... coral
-  source add github`.
-</Tip>
+You can also [install Coral skills](/getting-started/installation#skills) to help your agents use Coral more effectively.
 
 ## 3. Query your data
 
-You can now query any connected source using SQL.
-
-Use `coral.tables` to see all available tables:
-
-```shellscript
-coral sql "SELECT schema_name, table_name FROM coral.tables ORDER BY 1, 2"
-```
-
-Assuming you've connected GitHub, try listing open issues for a repo:
-
-```shellscript
-coral sql "
-  SELECT number, title, state, created_at
-  FROM github.issues
-  WHERE owner = 'withcoral' AND repo = 'coral' AND state = 'open'
-  ORDER BY created_at DESC
-  LIMIT 10
-"
-```
+Connected sources are now available. Try asking your agent a question about your data.
 
 ## Next steps
 
-- **[Use Coral over MCP](/guides/use-coral-over-mcp)** — expose Coral to Claude Code, Cursor, or VS Code over MCP so your agent can query sources directly
+- **[Search with Coral](/guides/search-with-coral)** — find the tables, columns, and values you need before writing SQL
 - **[Write a custom source spec](/guides/write-a-custom-source)** — connect any HTTP API or local dataset that isn't bundled yet
-- **[Install Coral skills](/getting-started/installation#skills)** — teach your coding agent how to use Coral

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -20,7 +20,7 @@ The sources page in the desktop app allows you to add, remove or create new sour
 
 ## 2. Connect your agents
 
-The desktop app exposes an MCP server over stdio, that your agents can connect to. You can go to the setting in the desktop app to set up your agents, or look at the [MCP docs](/guides/use-coral-over-mcp).
+The desktop app exposes an MCP server over stdio that your agents can connect to. You can go to the setting in the desktop app to set up your agents, or look at the [MCP docs](/guides/use-coral-over-mcp).
 
 You can also [install Coral skills](/getting-started/installation#skills) to help your agents use Coral more effectively.
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -9,7 +9,7 @@ Agents are able to make fewer, more precise tool calls with Coral than they do w
 
 Coral supports a number of [popular data sources](/reference/bundled-sources) bundled in, plus [community source specs](/reference/community-sources) you can import with `coral source add --file`. You can also extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can use our desktop app, or the [CLI](/reference/cli-reference).
 
-Coral does not store any of your data, everything is local: your data, credentials and usage history never leave your machine.
+Everything is local: your data, credentials and usage history never leave your machine.
 
 ## Get started
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -7,42 +7,28 @@ description: "Coral is a single SQL interface for APIs, files, and other data so
 
 Agents are able to make fewer, more precise tool calls with Coral than they do with data source MCP servers, CLI tools or API wrappers. For agent read tasks, SQL has a structural advantage when query complexity exceeds what a single API call can answer. It avoids pagination through large results, has cleaner, tabular responses, can bring back specific columns, and can correlate across sources more efficiently.
 
-Coral supports a number of [popular data sources](/reference/bundled-sources) bundled in, plus [community source specs](/reference/community-sources) you can import with `coral source add --file`. You can also extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can run SQL from the [CLI](/reference/cli-reference) or through [MCP](/guides/use-coral-over-mcp). And everything is local; your data, credentials and usage history never leave your machine.
+Coral supports a number of [popular data sources](/reference/bundled-sources) bundled in, plus [community source specs](/reference/community-sources) you can import with `coral source add --file`. You can also extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can use our desktop app, or the [CLI](/reference/cli-reference).
+
+Coral does not store any of your data, everything is local: your data, credentials and usage history never leave your machine.
 
 ## Get started
 
 <Steps titleSize="h3">
   <Step title="Install Coral">
-    Install the Coral CLI to get started.
-
-    ```shellscript
-    brew install withcoral/tap/coral
-    ```
-
-    [See all installation options](/getting-started/installation)
+    [Download the Coral desktop app](https://withcoral.com/download) to get started, or [see all installation options](/getting-started/installation).
 
   </Step>
 
   <Step title="Add your sources">
-   Connect GitHub, Slack, Datadog, and other [bundled sources](/reference/bundled-sources) to your workspace. For example:
-
-    ```shellscript
-    coral source add --interactive github
-    ```
+   Connect GitHub, Slack, Datadog, and other [bundled sources](/reference/bundled-sources) to your workspace.
+   Coral can only fetch data from sources you've connected.
 
     [Go to the quickstart](/getting-started/quickstart)
 
   </Step>
 
-  <Step title="Start querying">
-    Write SQL directly or let your AI agent query on your behalf.
-
-    ```shellscript
-    coral sql "SELECT name, stargazers_count FROM github.org_repos WHERE org = 'withcoral' ORDER BY stargazers_count DESC"
-    ```
-
-    [Or use Coral over MCP](/guides/use-coral-over-mcp)
-
+  <Step title="Connect your agents to Coral via MCP">
+    Configure your MCP clients (e.g. Claude Code, Codex) to use [Coral MCP](/guides/use-coral-over-mcp)
   </Step>
 </Steps>
 
@@ -77,15 +63,11 @@ Full [benchmark report](https://withcoral.com/benchmarks).
 
 Coral sits between your agents and your data sources: your agents write SQL, and Coral translates it into API calls or file reads, then returns a single query result.
 
-You can ask your agents complex questions about your data:
+You can **ask your agents complex questions about your data**:
 
 ![coral sql demo](/images/claude-query-example.png)
 
-Or run SQL queries yourself:
-
-![coral sql demo](/images/coral-sql-join.gif)
-
-A **source spec** is a YAML file that defines how to reach an API or local dataset and which tables/columns it exposes. A **source** is a data source Coral can query, created from a source spec plus your configured credentials and variables. When you run `coral source add github`, Coral installs the `github` source. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pulls` are queryable. Start with [bundled sources](/reference/bundled-sources), check [community sources](/reference/community-sources), or [write your own](/guides/write-a-custom-source).
+Coral connects to data sources using source specs. A **source spec** is a YAML file that defines how to reach an API or local dataset and which tables/columns it exposes. A **source** is a data source Coral can query, created from a source spec plus your configured credentials and variables. When you run `coral source add github`, Coral installs the `github` source. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pulls` are queryable. Start with [bundled sources](/reference/bundled-sources), check [community sources](/reference/community-sources), or [write your own](/guides/write-a-custom-source).
 
 During `source add`, Coral collects each declared variable and secret (tokens, workspace IDs, file paths, etc.) from environment variables of the same name, or prompts for them interactively when you pass `--interactive`. These values are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
 
@@ -124,7 +106,8 @@ For the full internals, crates, gRPC transport, DataFusion integration, see the 
     Set up MCP for Claude Code, Cursor, and other agents
   </Card>
   <Card title="Search with Coral" href="/guides/search-with-coral">
-    Find tables, columns, filters, and values Coral has seen before you write SQL
+    Find tables, columns, filters, and values Coral has seen before you write
+    SQL
   </Card>
   <Card title="Write a custom source" href="/guides/write-a-custom-source">
     Connect any API or dataset to Coral

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -15,7 +15,7 @@ Coral does not store any of your data, everything is local: your data, credentia
 
 <Steps titleSize="h3">
   <Step title="Install Coral">
-    [Download the Coral desktop app](https://withcoral.com/download) to get started, or [see all installation options](/getting-started/installation).
+    [Download the Coral desktop app for macOS](https://withcoral.com/download) to get started, or [see all installation options](/getting-started/installation).
 
   </Step>
 


### PR DESCRIPTION
## Summary

We want to push users to download the Desktop app; updating the docs to achieve that.

The desktop app exposes the MCP, which is now more powerful than the CLI.

## Test plan

`npx mintlify dev`, inspect new docs.