### PR TITLE
feat(reef): connect MCP clients during onboarding

### DIFF
--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.css.ts
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.css.ts
@@ -103,24 +103,6 @@ export const commandInput = style({
   ...theme.typography.code,
 })
 
-export const mcpConfig = style([
-  baseInput,
-  {
-    boxSizing: 'border-box',
-    color: theme.content.primary,
-    margin: 0,
-    paddingBlock: 12,
-    paddingInlineEnd: 52,
-    paddingInlineStart: 16,
-    whiteSpace: 'pre-wrap',
-    ...theme.typography.code,
-  },
-])
-
-export const mcpConfigField = style({
-  position: 'relative',
-})
-
 export const copyButton = style({
   insetBlockStart: 8,
   insetInlineEnd: 8,

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.stories.tsx
@@ -7,11 +7,9 @@ import { getOnboardingStepState } from './onboarding-steps'
 
 const meta = {
   args: {
-    mcpClients: { clients: [], onWorkspaceChange: fn() },
     onContinue: fn(),
     runtime: 'web',
     step: getOnboardingStepState('next-steps'),
-    workspaces: [{ name: 'default' }, { name: 'analytics' }],
   },
   component: OnboardingNextStepsPage,
   parameters: {
@@ -26,20 +24,18 @@ type Story = StoryObj<typeof meta>
 
 export const Web: Story = {}
 
-// Enough clients that the list scrolls under its sticky header.
+// Desktop connects clients in place of the manual instructions. The list's own
+// scrolling and pending states are covered by Components/McpClientsList.
 export const Desktop: Story = {
   args: {
     mcpClients: {
-      clients: ['Claude Code', 'Claude Desktop', 'Codex', 'Cursor', 'VS Code', 'Zed'].map(
-        (name, index) => ({
-          configuredWorkspace: index === 0 ? 'default' : undefined,
-          id: name.toLowerCase().replaceAll(' ', '-'),
-          name,
-        }),
-      ),
+      clients: [
+        { configuredWorkspace: 'default', id: 'claude-code', name: 'Claude Code' },
+        { id: 'codex', name: 'Codex' },
+      ],
       onWorkspaceChange: fn(),
-      pendingClientIds: ['codex'],
     },
     runtime: 'desktop',
+    workspaces: [{ name: 'default' }, { name: 'analytics' }],
   },
 }

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.stories.tsx
@@ -7,10 +7,11 @@ import { getOnboardingStepState } from './onboarding-steps'
 
 const meta = {
   args: {
-    mcpLaunchConfig: { status: 'unavailable' },
+    mcpClients: { clients: [], onWorkspaceChange: fn() },
     onContinue: fn(),
     runtime: 'web',
     step: getOnboardingStepState('next-steps'),
+    workspaces: [{ name: 'default' }, { name: 'analytics' }],
   },
   component: OnboardingNextStepsPage,
   parameters: {
@@ -25,14 +26,19 @@ type Story = StoryObj<typeof meta>
 
 export const Web: Story = {}
 
+// Enough clients that the list scrolls under its sticky header.
 export const Desktop: Story = {
   args: {
-    mcpLaunchConfig: {
-      config: {
-        args: ['mcp-stdio'],
-        command: '/Applications/Coral.app/Contents/Resources/coral/coral',
-      },
-      status: 'success',
+    mcpClients: {
+      clients: ['Claude Code', 'Claude Desktop', 'Codex', 'Cursor', 'VS Code', 'Zed'].map(
+        (name, index) => ({
+          configuredWorkspace: index === 0 ? 'default' : undefined,
+          id: name.toLowerCase().replaceAll(' ', '-'),
+          name,
+        }),
+      ),
+      onWorkspaceChange: fn(),
+      pendingClientIds: ['codex'],
     },
     runtime: 'desktop',
   },

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.test.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.test.tsx
@@ -1,5 +1,5 @@
 import { createRoutesStub } from 'react-router'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import {
@@ -10,6 +10,8 @@ import {
 import { getOnboardingStepState } from './onboarding-steps'
 
 const nextStepsStep = getOnboardingStepState('next-steps')
+
+const WORKSPACES = [{ name: 'default' }, { name: 'analytics' }]
 
 describe('OnboardingNextStepsPage', () => {
   it('defaults to AI-assisted setup and offers manual setup', async () => {
@@ -27,16 +29,14 @@ describe('OnboardingNextStepsPage', () => {
       {
         Component: () => (
           <OnboardingNextStepsPage
-            mcpLaunchConfig={{
-              config: {
-                args: ['mcp-stdio'],
-                command: '/Applications/Coral.app/Contents/Resources/coral/coral',
-              },
-              status: 'success',
+            mcpClients={{
+              clients: [{ id: 'codex', name: 'Codex' }],
+              onWorkspaceChange: vi.fn(),
             }}
             onContinue={() => undefined}
             runtime="desktop"
             step={nextStepsStep}
+            workspaces={WORKSPACES}
           />
         ),
         path: '/',
@@ -90,27 +90,21 @@ describe('OnboardingNextStepsPage', () => {
     await expect
       .element(screen.getByRole('heading', { name: '2. Install the Coral skill' }))
       .toBeVisible()
-    expect(
-      screen.getByLabelText('Coral MCP server configuration', { exact: true }).element()
-        .textContent,
-    ).toBe('command: "/Applications/Coral.app/Contents/Resources/coral/coral"\nargs: ["mcp-stdio"]')
-    await expect
-      .element(screen.getByRole('button', { name: 'Copy Coral MCP server configuration' }))
-      .toBeVisible()
+    await expect.element(screen.getByRole('button', { name: 'Not configured' })).toBeVisible()
     await expect
       .element(screen.getByRole('link', { name: 'MCP setup guide' }))
       .toHaveAttribute('href', 'https://withcoral.com/docs/guides/use-coral-over-mcp')
-    await expect.element(screen.getByText(/Restart your agent or open a new chat/)).toBeVisible()
   })
 
-  it('does not invent a local executable path on the web', async () => {
+  it('does not offer to connect a client on the web', async () => {
     const Stub = createRoutesStub([
       {
         Component: () => (
           <OnboardingNextStepsPage
-            mcpLaunchConfig={{ status: 'unavailable' }}
+            mcpClients={{ clients: [], onWorkspaceChange: vi.fn() }}
             runtime="web"
             step={nextStepsStep}
+            workspaces={WORKSPACES}
           />
         ),
         path: '/',
@@ -125,10 +119,10 @@ describe('OnboardingNextStepsPage', () => {
     await screen.getByRole('tab', { name: 'Manual' }).click()
 
     await expect
-      .element(screen.getByText(/web agents cannot launch a local stdio MCP server/))
+      .element(screen.getByText(/Open this step in Coral Desktop to connect a client/))
       .toBeVisible()
     await expect
-      .element(screen.getByLabelText('Coral MCP server configuration', { exact: true }))
+      .element(screen.getByRole('button', { name: 'Not configured' }))
       .not.toBeInTheDocument()
   })
 })

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.test.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.test.tsx
@@ -96,17 +96,47 @@ describe('OnboardingNextStepsPage', () => {
       .toHaveAttribute('href', 'https://withcoral.com/docs/guides/use-coral-over-mcp')
   })
 
-  it('does not offer to connect a client on the web', async () => {
+  it('connects and disconnects a client from the workspace menu', async () => {
+    const onWorkspaceChange = vi.fn()
     const Stub = createRoutesStub([
       {
         Component: () => (
           <OnboardingNextStepsPage
-            mcpClients={{ clients: [], onWorkspaceChange: vi.fn() }}
-            runtime="web"
+            mcpClients={{
+              clients: [
+                { configuredWorkspace: 'default', id: 'claude-code', name: 'Claude Code' },
+                { id: 'codex', name: 'Codex' },
+              ],
+              onWorkspaceChange,
+            }}
+            runtime="desktop"
             step={nextStepsStep}
             workspaces={WORKSPACES}
           />
         ),
+        path: '/',
+      },
+    ])
+    const screen = await render(<Stub />)
+
+    await screen.getByRole('tab', { name: 'Manual' }).click()
+
+    await screen.getByRole('button', { name: 'Not configured' }).click()
+    await screen.getByRole('menuitemradio', { name: 'analytics' }).click()
+    expect(onWorkspaceChange).toHaveBeenCalledWith('codex', 'analytics')
+
+    await screen.getByRole('button', { name: 'default' }).click()
+    await expect
+      .element(screen.getByRole('menuitemradio', { name: 'default' }))
+      .toHaveAttribute('aria-checked', 'true')
+    await screen.getByRole('menuitemradio', { name: 'Not configured' }).click()
+    expect(onWorkspaceChange).toHaveBeenLastCalledWith('claude-code', undefined)
+  })
+
+  it('does not offer to connect a client on the web', async () => {
+    const Stub = createRoutesStub([
+      {
+        Component: () => <OnboardingNextStepsPage runtime="web" step={nextStepsStep} />,
         path: '/',
       },
     ])

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
@@ -1,4 +1,4 @@
-import type { McpLaunchConfig } from '@/lib/coral-desktop'
+import { McpClientsList, type DesktopMcpClientsState } from '@/components/mcp-clients-list'
 import { Inputs, ScrollArea, Tabs, Typography } from '@/wax/components'
 import { CopyButton } from '@/wax/components/button'
 
@@ -53,17 +53,19 @@ export function coralAgentSetupPrompt(runtime: 'desktop' | 'web'): string {
 }
 
 export interface OnboardingNextStepsPageProps {
-  mcpLaunchConfig: McpLaunchConfigState
+  mcpClients: DesktopMcpClientsState
   onContinue?: () => void
   runtime: 'desktop' | 'web'
   step: OnboardingStepState
+  workspaces: ReadonlyArray<{ name: string }>
 }
 
 export function OnboardingNextStepsPage({
-  mcpLaunchConfig,
+  mcpClients,
   onContinue,
   runtime,
   step,
+  workspaces,
 }: OnboardingNextStepsPageProps) {
   const agentSetupPrompt = coralAgentSetupPrompt(runtime)
 
@@ -105,31 +107,12 @@ export function OnboardingNextStepsPage({
                 <Typography.HeadingXSmall as="h2">
                   1. Connect your agent over MCP
                 </Typography.HeadingXSmall>
-                <Typography.Body variant="tertiary">
-                  In your agent&apos;s MCP settings, add a local stdio server named{' '}
-                  <Typography.CodeInline as="code">coral</Typography.CodeInline>.
-                </Typography.Body>
               </header>
 
-              <ManualMcpConfig state={mcpLaunchConfig} />
-
-              {mcpLaunchConfig.status === 'success' ? (
-                <Typography.Body variant="tertiary">
-                  Copy these values into your client&apos;s MCP configuration. Restart your agent or
-                  open a new chat, then ask it to list the tables available in Coral. See the{' '}
-                  <OnboardingLink href="https://withcoral.com/docs/guides/use-coral-over-mcp">
-                    MCP setup guide
-                  </OnboardingLink>{' '}
-                  for client-specific instructions.
-                </Typography.Body>
+              {runtime === 'desktop' ? (
+                <ConnectClients mcpClients={mcpClients} workspaces={workspaces} />
               ) : (
-                <Typography.Body variant="tertiary">
-                  See the{' '}
-                  <OnboardingLink href="https://withcoral.com/docs/guides/use-coral-over-mcp">
-                    MCP setup guide
-                  </OnboardingLink>{' '}
-                  for supported clients and troubleshooting.
-                </Typography.Body>
+                <ManualConnectInstructions />
               )}
             </section>
 
@@ -192,55 +175,50 @@ export function OnboardingNextStepsPage({
   )
 }
 
-export type McpLaunchConfigState =
-  | { status: 'error'; message: string }
-  | { status: 'loading' }
-  | { status: 'success'; config: McpLaunchConfig }
-  | { status: 'unavailable' }
-
-function ManualMcpConfig({ state }: { state: McpLaunchConfigState }) {
-  if (state.status === 'loading') {
-    return (
-      <Typography.BodySmall role="status" variant="tertiary">
-        Finding Coral Desktop&apos;s bundled executable…
-      </Typography.BodySmall>
-    )
-  }
-
-  if (state.status === 'unavailable') {
-    return (
-      <Typography.BodySmall variant="tertiary">
-        Open this step in Coral Desktop to see the exact command for its bundled runtime. This
-        browser cannot provide a local executable path, and web agents cannot launch a local stdio
-        MCP server.
-      </Typography.BodySmall>
-    )
-  }
-
-  if (state.status === 'error') {
-    return (
-      <Typography.BodySmall variant="error">
-        Coral Desktop could not find its bundled executable: {state.message}
-      </Typography.BodySmall>
-    )
-  }
-
-  const configText = formatMcpLaunchConfig(state.config)
+function ConnectClients({
+  mcpClients,
+  workspaces,
+}: Pick<OnboardingNextStepsPageProps, 'mcpClients' | 'workspaces'>) {
   return (
-    <div className={styles.mcpConfigField}>
-      <pre aria-label="Coral MCP server configuration" className={styles.mcpConfig}>
-        {configText}
-      </pre>
-      <CopyButton
-        ariaLabel="Copy Coral MCP server configuration"
-        className={styles.copyButton}
-        textToCopy={configText}
-        variant="bare"
-      />
-    </div>
+    <>
+      <Typography.Body variant="tertiary">
+        Connecting a client lets it query your sources over MCP.
+      </Typography.Body>
+
+      {/* Bounded so a long client list scrolls instead of pushing step 2 out of the panel. */}
+      <McpClientsList {...mcpClients} maxHeight={260} workspaces={workspaces} />
+
+      <Typography.Body variant="tertiary">
+        Only global MCP configurations appear here. See the{' '}
+        <OnboardingLink href="https://withcoral.com/docs/guides/use-coral-over-mcp">
+          MCP setup guide
+        </OnboardingLink>{' '}
+        for supported clients and troubleshooting.
+      </Typography.Body>
+    </>
   )
 }
 
-function formatMcpLaunchConfig(config: McpLaunchConfig): string {
-  return `command: ${JSON.stringify(config.command)}\nargs: ${JSON.stringify(config.args)}`
+function ManualConnectInstructions() {
+  return (
+    <>
+      <Typography.Body variant="tertiary">
+        In your agent&apos;s MCP settings, add a local stdio server named{' '}
+        <Typography.CodeInline as="code">coral</Typography.CodeInline>.
+      </Typography.Body>
+
+      <Typography.BodySmall variant="tertiary">
+        Open this step in Coral Desktop to connect a client for you. This browser cannot configure a
+        local MCP server, and web agents cannot launch a local stdio one.
+      </Typography.BodySmall>
+
+      <Typography.Body variant="tertiary">
+        See the{' '}
+        <OnboardingLink href="https://withcoral.com/docs/guides/use-coral-over-mcp">
+          MCP setup guide
+        </OnboardingLink>{' '}
+        for supported clients and troubleshooting.
+      </Typography.Body>
+    </>
+  )
 }

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
@@ -52,13 +52,19 @@ export function coralAgentSetupPrompt(runtime: 'desktop' | 'web'): string {
   ].join('\n')
 }
 
-export interface OnboardingNextStepsPageProps {
+interface ConnectClientsProps {
   mcpClients: DesktopMcpClientsState
-  onContinue?: () => void
-  runtime: 'desktop' | 'web'
-  step: OnboardingStepState
   workspaces: ReadonlyArray<{ name: string }>
 }
+
+/** Only Desktop can write a client's config, so only Desktop carries the clients. */
+export type OnboardingNextStepsPageProps = {
+  onContinue?: () => void
+  step: OnboardingStepState
+} & (
+  | ({ runtime: 'desktop' } & ConnectClientsProps)
+  | ({ runtime: 'web' } & Partial<Record<keyof ConnectClientsProps, never>>)
+)
 
 export function OnboardingNextStepsPage({
   mcpClients,
@@ -175,10 +181,7 @@ export function OnboardingNextStepsPage({
   )
 }
 
-function ConnectClients({
-  mcpClients,
-  workspaces,
-}: Pick<OnboardingNextStepsPageProps, 'mcpClients' | 'workspaces'>) {
+function ConnectClients({ mcpClients, workspaces }: ConnectClientsProps) {
   return (
     <>
       <Typography.Body variant="tertiary">

--- a/apps/reef/app/routes/onboarding.tsx
+++ b/apps/reef/app/routes/onboarding.tsx
@@ -4,14 +4,22 @@ import type { SourcesActionData } from './sources-action'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
-import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
+import { firstWorkspaceForRequest, listWorkspacesForRequest } from '@/lib/workspaces.server'
 import { OnboardingView } from '@/views/onboarding/onboarding'
 
 import { runSourcesAction } from './sources-action'
 import { loadSourcesRouteData } from './sources-loader'
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const workspace = await firstWorkspaceForRequest(request)
+  const workspaces = await listWorkspacesForRequest(request)
+  const [workspace] = workspaces
+  if (!workspace) {
+    throw new Response('No Coral workspace is configured.', {
+      status: 404,
+      statusText: 'Workspace Not Found',
+    })
+  }
+
   const sources = await loadSourcesRouteData(request, workspace)
   const step = getOnboardingStepState(new URL(request.url).searchParams.get('step'))
   const shouldRunSampleQuery =
@@ -25,6 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     sampleQuery: shouldRunSampleQuery ? loadOnboardingSampleQuery(request, workspace.name) : null,
     step,
     workspaceId: workspace.name,
+    workspaces: workspaces.map(({ name }) => ({ name })),
   }
 }
 

--- a/apps/reef/app/views/onboarding/onboarding.tsx
+++ b/apps/reef/app/views/onboarding/onboarding.tsx
@@ -3,18 +3,18 @@ import { Await, useNavigate, useNavigation, useRevalidator } from 'react-router'
 
 import type { SourcesActionData } from '@/routes/sources-action'
 
+import { useDesktopMcpClients } from '@/components/mcp-clients-list'
 import { OnboardingNextStepsPage } from '@/components/onboarding/onboarding-next-steps-page'
-import type { McpLaunchConfigState } from '@/components/onboarding/onboarding-next-steps-page'
 import { OnboardingSampleQueryPage } from '@/components/onboarding/onboarding-sample-query-page'
 import type { SampleQueryLoadState } from '@/components/onboarding/onboarding-sample-query-page'
 import { OnboardingSourcesPage } from '@/components/onboarding/onboarding-sources-page'
 import type { OnboardingStepState } from '@/components/onboarding/onboarding-steps'
-import { coralDesktopApi, desktopErrorMessage } from '@/lib/coral-desktop'
 import type { OnboardingSampleQueryResult } from '@/lib/onboarding-query'
 import type { CatalogEntry } from '@/lib/sources'
 import { routePath } from '@/routing/routemap'
 import { SourceDetailDialog } from '@/views/sources/source-detail'
 import { SourceInstallDialog } from '@/views/sources/source-install'
+import { ToastContainer } from '@/wax/components/toast'
 
 export function OnboardingView({
   actionData,
@@ -28,6 +28,7 @@ export function OnboardingView({
     sampleQuery: OnboardingSampleQueryResult | Promise<OnboardingSampleQueryResult> | null
     step: OnboardingStepState
     workspaceId: string
+    workspaces: ReadonlyArray<{ name: string }>
   }
 }) {
   const navigate = useNavigate()
@@ -88,6 +89,7 @@ export function OnboardingView({
           }
           runtime={loaderData.runtime}
           step={step}
+          workspaces={loaderData.workspaces}
         />
       )
     default: {
@@ -101,48 +103,31 @@ function OnboardingNextStepsStep({
   onContinue,
   runtime,
   step,
+  workspaces,
 }: {
   onContinue: () => void
   runtime: 'desktop' | 'web'
   step: OnboardingStepState
+  workspaces: ReadonlyArray<{ name: string }>
 }) {
-  const [mcpLaunchConfig, setMcpLaunchConfig] = useState<McpLaunchConfigState>(
-    runtime === 'desktop' ? { status: 'loading' } : { status: 'unavailable' },
-  )
-
-  useEffect(() => {
-    if (runtime !== 'desktop') return
-
-    const desktop = coralDesktopApi()
-    if (!desktop) {
-      setMcpLaunchConfig({ status: 'unavailable' })
-      return
-    }
-
-    let cancelled = false
-    desktop
-      .getMcpLaunchConfig()
-      .then((config) => {
-        if (!cancelled) setMcpLaunchConfig({ config, status: 'success' })
-      })
-      .catch((error: unknown) => {
-        if (!cancelled) {
-          setMcpLaunchConfig({ message: desktopErrorMessage(error), status: 'error' })
-        }
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [runtime])
+  const mcpClients = useDesktopMcpClients(runtime === 'desktop')
 
   return (
-    <OnboardingNextStepsPage
-      mcpLaunchConfig={mcpLaunchConfig}
-      onContinue={onContinue}
-      runtime={runtime}
-      step={step}
-    />
+    <>
+      <OnboardingNextStepsPage
+        mcpClients={mcpClients}
+        onContinue={onContinue}
+        runtime={runtime}
+        step={step}
+        workspaces={workspaces}
+      />
+      {/*
+        Onboarding renders outside the app shell, which is where the rest of the app
+        mounts its toast host. Without one here, connecting a client would silently
+        drop both its confirmation and its failures.
+      */}
+      <ToastContainer />
+    </>
   )
 }
 

--- a/apps/reef/app/views/onboarding/onboarding.tsx
+++ b/apps/reef/app/views/onboarding/onboarding.tsx
@@ -114,13 +114,17 @@ function OnboardingNextStepsStep({
 
   return (
     <>
-      <OnboardingNextStepsPage
-        mcpClients={mcpClients}
-        onContinue={onContinue}
-        runtime={runtime}
-        step={step}
-        workspaces={workspaces}
-      />
+      {runtime === 'desktop' ? (
+        <OnboardingNextStepsPage
+          mcpClients={mcpClients}
+          onContinue={onContinue}
+          runtime="desktop"
+          step={step}
+          workspaces={workspaces}
+        />
+      ) : (
+        <OnboardingNextStepsPage onContinue={onContinue} runtime="web" step={step} />
+      )}
       {/*
         Onboarding renders outside the app shell, which is where the rest of the app
         mounts its toast host. Without one here, connecting a client would silently


### PR DESCRIPTION
## Summary

Extending the onboarding with our MCP client auto-setup UI.

## Test plan

Manual step now has the same UI as our settings

<img width="1068" height="635" alt="image" src="https://github.com/user-attachments/assets/00166585-9d77-4c2e-9421-393300c1c4e4" />
