### PR TITLE
feat(traces): add bounded Query Stream listing

### DIFF
--- a/crates/coral-api/proto/coral/v1/traces.proto
+++ b/crates/coral-api/proto/coral/v1/traces.proto
@@ -100,6 +100,8 @@ message ListTracesRequest {
   // Optional workspace that scopes returned traces. Omit to list all local
   // traces visible to the local server.
   Workspace workspace = 3;
+  // Projection to return. The default preserves one-summary-per-trace behavior.
+  TraceView view = 4;
 }
 
 // Page of locally captured traces.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1017,7 +1017,7 @@ mod tests {
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
         EndTaskRequest, ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse,
-        ListSourcesRequest, ListTracesRequest, StartTaskRequest, TaskStatus, Workspace,
+        ListSourcesRequest, ListTracesRequest, StartTaskRequest, TaskStatus, TraceView, Workspace,
         import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
@@ -1538,6 +1538,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
                 page_size: 10,
                 page_token: String::new(),
                 workspace: None,
+                view: TraceView::Unspecified as i32,
             }))
             .await
             .expect_err("trace service should be disabled");
@@ -1797,6 +1798,7 @@ backend = "unsupported"
                 page_size: 10,
                 page_token: String::new(),
                 workspace: None,
+                view: TraceView::Unspecified as i32,
             }))
             .await
             .expect("list traces")

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -642,6 +642,20 @@ impl TraceStore {
         .map_err(|source| TraceStoreError::Worker { source })?
     }
 
+    pub(crate) async fn list_query_stream(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: Option<String>,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || {
+            traces.list_query_stream_sync(limit, offset, workspace_name.as_deref())
+        })
+        .await
+        .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
     pub(crate) async fn get_trace(
         &self,
         trace_id: String,
@@ -760,6 +774,15 @@ impl TraceStore {
         sort_summaries(&mut summaries);
 
         Ok(summaries.into_iter().take(limit).collect())
+    }
+
+    fn list_query_stream_sync(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: Option<&str>,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        query_stream::list(self, limit, offset, workspace_name)
     }
 
     fn get_trace_sync(&self, trace_id: &str) -> Result<TraceDetailRecord, TraceStoreError> {
@@ -2922,20 +2945,20 @@ mod tests {
             .count()
     }
 
-    fn timestamped_jsonl_path(timestamp: SystemTime) -> String {
+    pub(super) fn timestamped_jsonl_path(timestamp: SystemTime) -> String {
         format!(
             "spans-{:020}-test-0000000000000000.jsonl",
             unix_nanos(timestamp)
         )
     }
 
-    fn write_record_file(path: &Path, record: &TraceSpanRecord) {
+    pub(super) fn write_record_file(path: &Path, record: &TraceSpanRecord) {
         let mut line = serde_json::to_string(record).expect("serialize record");
         line.push('\n');
         fs::write(path, line).expect("write trace record");
     }
 
-    fn write_record_file_lines(path: &Path, records: &[TraceSpanRecord]) {
+    pub(super) fn write_record_file_lines(path: &Path, records: &[TraceSpanRecord]) {
         let mut lines = String::new();
         for record in records {
             lines.push_str(&serde_json::to_string(record).expect("serialize record"));
@@ -2944,7 +2967,7 @@ mod tests {
         fs::write(path, lines).expect("write trace records");
     }
 
-    fn set_modified_time(path: &Path, modified: SystemTime) {
+    pub(super) fn set_modified_time(path: &Path, modified: SystemTime) {
         let file = fs::OpenOptions::new()
             .write(true)
             .open(path)

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -1,6 +1,6 @@
-//! Query Stream operation projection over locally captured spans.
+//! Query Stream operation projection over locally captured JSONL spans.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 mod classification;
 
@@ -11,11 +11,66 @@ use classification::{
 };
 
 use super::{
-    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceSpanRecord,
-    TraceSummaryRecord, attr_string, attr_u64, parse_attributes, status_from_attributes,
-    usize_to_u32,
+    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceSpanRecord, TraceStore,
+    TraceStoreError, TraceSummaryRecord, attr_string, attr_u64, parse_attributes,
+    read_list_spans_file, status_from_attributes, usize_to_u32,
 };
 use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+
+// Bounded LIST storage scanning.
+
+pub(super) fn list(
+    store: &TraceStore,
+    limit: usize,
+    offset: usize,
+    workspace_name: Option<&str>,
+) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    store.prune_expired()?;
+    let files = store.jsonl_files_by_modified()?;
+    let required_entry_count = offset.saturating_add(limit);
+    let mut projector = QueryStreamProjector::new(required_entry_count, workspace_name);
+    let mut scanned_all_files = true;
+    let mut remaining_files = files.as_slice();
+    while let Some(newest_bucket_file) = remaining_files.last() {
+        let bucket_start = remaining_files.partition_point(|file| {
+            file.modified_unix_nanos < newest_bucket_file.modified_unix_nanos
+        });
+        let (older_files, bucket_files) = remaining_files.split_at(bucket_start);
+        let mut spans = Vec::new();
+        // Equal-mtime files are one atomic unit for duplicate precedence and
+        // ancestry resolution. A timestamp-preserving restore can therefore
+        // make this bucket contain the entire retained store.
+        for file in bucket_files {
+            // Files are read in ascending path order so that the last record
+            // retains the existing highest-path precedence for duplicate span
+            // IDs while the projector can resolve the entire bucket at once.
+            spans.extend(read_list_spans_file(&file.path)?);
+        }
+        projector.record_file(spans);
+
+        let Some(newest_unscanned_file) = older_files.last() else {
+            break;
+        };
+        let watermark = newest_unscanned_file.span_end_upper_bound_unix_nanos;
+        projector.advance_watermark(watermark);
+        if projector.page_is_newer_than(watermark) {
+            scanned_all_files = false;
+            break;
+        }
+        remaining_files = older_files;
+    }
+
+    if scanned_all_files {
+        projector.finish();
+    }
+    Ok(projector.into_page(offset, limit))
+}
+
+// Projection shared by LIST and detail retrieval.
 
 fn sort_and_deduplicate_query_stream_summaries(summaries: &mut Vec<TraceSummaryRecord>) {
     summaries.sort_by(|left, right| {
@@ -50,11 +105,12 @@ fn summaries(spans: &[TraceSpanRecord], workspace_name: Option<&str>) -> Vec<Tra
             end_time_unix_nanos: span.end_time_unix_nanos,
             attributes_json: span.attributes_json.clone(),
         })
-        .collect();
-    let mut projector = QueryStreamProjector::new(workspace_name);
+        .collect::<Vec<_>>();
+    let required_entry_count = records.len();
+    let mut projector = QueryStreamProjector::new(required_entry_count, workspace_name);
     projector.record_file(records);
     projector.finish();
-    projector.into_summaries()
+    projector.into_page(0, required_entry_count)
 }
 
 type QueryStreamSpanKey = (String, String);
@@ -125,6 +181,7 @@ impl ProjectedQueryStreamSpan {
 
 #[derive(Debug, Clone, Copy)]
 struct QueryStreamNodeState {
+    start_time_unix_nanos: i64,
     owner: Option<u64>,
     owner_depth: Option<usize>,
     suppresses_entries: bool,
@@ -247,6 +304,13 @@ impl StreamingQueryStreamAggregate {
             .or_else(|| self.workspace_evidence.unique())
     }
 
+    fn may_match_workspace(&self, workspace_name: Option<&str>) -> bool {
+        workspace_name.is_none_or(|workspace_name| {
+            self.workspace()
+                .is_none_or(|operation_workspace| operation_workspace == workspace_name)
+        })
+    }
+
     fn into_summary(self) -> TraceSummaryRecord {
         let text_enrichment = self.text_enrichment.as_ref().filter(|enrichment| {
             operation_text_is_semantic(
@@ -285,25 +349,36 @@ impl StreamingQueryStreamAggregate {
     }
 }
 
-/// Projects completed spans into their outer Query Stream operations.
+/// Projects completed spans while scanning files from newest to oldest.
 ///
-/// A completed child with an unresolved local parent remains hidden until that
-/// owning ancestry is available, avoiding an incomplete row that would later
-/// need to be replaced by its outer operation.
+/// The local exporter writes a span only after it ends, so a parent is written
+/// no earlier than its descendants. File mtimes plus the store tolerance form
+/// the same conservative span-end watermark used by the normal trace list. Once
+/// that watermark moves before a span's start, no older file can contain one of
+/// its descendants (or a valid duplicate), and its compact ancestry state can
+/// be discarded. A completed child with an unresolved local parent remains
+/// hidden until that owning ancestry is exported, avoiding an incomplete row
+/// that would later need to be replaced by its outer operation.
 struct QueryStreamProjector {
+    required_entry_count: usize,
     workspace_name: Option<String>,
     nodes: HashMap<QueryStreamSpanKey, QueryStreamNodeState>,
+    node_starts: BTreeMap<i64, Vec<QueryStreamSpanKey>>,
     aggregates: HashMap<u64, StreamingQueryStreamAggregate>,
+    aggregate_starts: BTreeMap<i64, Vec<u64>>,
     finalized: Vec<TraceSummaryRecord>,
     next_operation_id: u64,
 }
 
 impl QueryStreamProjector {
-    fn new(workspace_name: Option<&str>) -> Self {
+    fn new(required_entry_count: usize, workspace_name: Option<&str>) -> Self {
         Self {
+            required_entry_count,
             workspace_name: workspace_name.map(str::to_string),
             nodes: HashMap::new(),
+            node_starts: BTreeMap::new(),
             aggregates: HashMap::new(),
+            aggregate_starts: BTreeMap::new(),
             finalized: Vec::new(),
             next_operation_id: 0,
         }
@@ -367,6 +442,10 @@ impl QueryStreamProjector {
         let (owner, owner_depth) = if let Some(metadata) = visible_metadata {
             let operation_id = self.next_operation_id;
             self.next_operation_id = self.next_operation_id.saturating_add(1);
+            self.aggregate_starts
+                .entry(span.start_time_unix_nanos)
+                .or_default()
+                .push(operation_id);
             self.aggregates.insert(
                 operation_id,
                 StreamingQueryStreamAggregate::new(QueryStreamEntrySnapshot::from_span(
@@ -390,10 +469,15 @@ impl QueryStreamProjector {
                 .as_ref()
                 .is_some_and(|metadata| metadata.explicit);
         let node = QueryStreamNodeState {
+            start_time_unix_nanos: span.start_time_unix_nanos,
             owner,
             owner_depth,
             suppresses_entries,
         };
+        self.node_starts
+            .entry(node.start_time_unix_nanos)
+            .or_default()
+            .push(key.clone());
         self.nodes.insert(key, node);
         if let Some((owner, depth)) = owner.zip(owner_depth)
             && let Some(aggregate) = self.aggregates.get_mut(&owner)
@@ -402,12 +486,25 @@ impl QueryStreamProjector {
         }
     }
 
+    fn advance_watermark(&mut self, watermark: i64) {
+        for operation_id in take_indexed_values_after(&mut self.aggregate_starts, watermark) {
+            self.finalize_operation(operation_id);
+        }
+        for key in take_indexed_values_after(&mut self.node_starts, watermark) {
+            self.nodes.remove(&key);
+        }
+        self.trim_finalized();
+    }
+
     fn finish(&mut self) {
         let operation_ids = self.aggregates.keys().copied().collect::<Vec<_>>();
         for operation_id in operation_ids {
             self.finalize_operation(operation_id);
         }
+        self.aggregate_starts.clear();
         self.nodes.clear();
+        self.node_starts.clear();
+        self.trim_finalized();
     }
 
     fn finalize_operation(&mut self, operation_id: u64) {
@@ -423,13 +520,46 @@ impl QueryStreamProjector {
         }
     }
 
-    fn into_summaries(mut self) -> Vec<TraceSummaryRecord> {
+    fn trim_finalized(&mut self) {
+        sort_and_deduplicate_query_stream_summaries(&mut self.finalized);
+        self.finalized.truncate(self.required_entry_count);
+    }
+
+    fn page_is_newer_than(&self, watermark: i64) -> bool {
+        let Some(boundary) = self
+            .finalized
+            .get(self.required_entry_count.saturating_sub(1))
+        else {
+            return false;
+        };
+        boundary.end_time_unix_nanos > watermark
+            && self
+                .aggregates
+                .values()
+                .filter(|aggregate| aggregate.may_match_workspace(self.workspace_name.as_deref()))
+                .all(|aggregate| aggregate.entry.end_time_unix_nanos < boundary.end_time_unix_nanos)
+    }
+
+    fn into_page(mut self, offset: usize, limit: usize) -> Vec<TraceSummaryRecord> {
         sort_and_deduplicate_query_stream_summaries(&mut self.finalized);
         self.finalized
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect()
     }
+}
+
+fn take_indexed_values_after<T>(index: &mut BTreeMap<i64, Vec<T>>, watermark: i64) -> Vec<T> {
+    let Some(split_at) = watermark.checked_add(1) else {
+        return Vec::new();
+    };
+    index.split_off(&split_at).into_values().flatten().collect()
 }
 
 #[cfg(test)]
 mod semantics_tests;
+#[cfg(test)]
+mod storage_tests;
 #[cfg(test)]
 mod test_support;

--- a/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
@@ -1,0 +1,399 @@
+//! LIST storage scanning, pagination, and projector lifecycle tests.
+
+use std::time::{Duration, SystemTime};
+
+use serde_json::json;
+
+use super::super::{
+    StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord,
+    unix_nanos,
+};
+use super::QueryStreamProjector;
+use super::test_support::{TraceFiles, span};
+
+#[test]
+fn query_stream_resolves_equal_mtime_files_as_one_bucket() {
+    let files = TraceFiles::new();
+    let base_time = SystemTime::now() - Duration::from_secs(10);
+    let common_modified = base_time + Duration::from_secs(1);
+
+    let parent = span("equal-mtime-trace", "local-parent")
+        .named("http.request")
+        .times(
+            unix_nanos(base_time),
+            unix_nanos(base_time + Duration::from_millis(900)),
+        )
+        .build();
+    let root = span("equal-mtime-trace", "selected-tool")
+        .named("coral.mcp.call_tool")
+        .child_of(&parent)
+        .entry("tool", "sql", "alpha")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "sql",
+        }))
+        .times(
+            unix_nanos(base_time + Duration::from_millis(100)),
+            unix_nanos(base_time + Duration::from_millis(800)),
+        )
+        .build();
+    let child = span("equal-mtime-trace", "nested-query")
+        .child_of(&root)
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 42", "row_count": 1}))
+        .times(
+            unix_nanos(base_time + Duration::from_millis(200)),
+            unix_nanos(base_time + Duration::from_millis(700)),
+        )
+        .build();
+
+    for (name, span) in [
+        ("spans-a-parent.jsonl", &parent),
+        ("spans-b-root.jsonl", &root),
+        ("spans-c-child.jsonl", &child),
+    ] {
+        files.write_named_at(name, span, common_modified);
+    }
+
+    let summaries = files.list(10, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("equal-mtime summary");
+    assert_eq!(summary.root_span_id, "selected-tool");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Query);
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Mcp);
+    assert_eq!(summary.query, "SELECT 42");
+    assert_eq!(summary.row_count, 1);
+    assert!(summary.row_count_recorded);
+    assert_eq!(summary.span_count, 2);
+}
+
+#[test]
+fn query_stream_filters_workspace_before_pagination() {
+    let files = TraceFiles::new();
+    let mut records = Vec::new();
+    for (trace_id, span_id, workspace, end_time) in [
+        ("alpha-new-trace", "alpha-new", "alpha", 30),
+        ("beta-trace", "beta", "beta", 20),
+        ("alpha-old-trace", "alpha-old", "alpha", 10),
+    ] {
+        records.push(
+            span(trace_id, span_id)
+                .remote_root()
+                .entry("query", "sql", workspace)
+                .attrs(json!({"sql": format!("SELECT '{span_id}'")}))
+                .times(end_time - 1, end_time)
+                .build(),
+        );
+    }
+    files.write("spans-pagination.jsonl", &records);
+
+    let first = files.list(1, 0, Some("alpha"));
+    let second = files.list(1, 1, Some("alpha"));
+    assert_eq!(
+        first.first().expect("first entry").root_span_id,
+        "alpha-new"
+    );
+    assert_eq!(
+        second.first().expect("second entry").root_span_id,
+        "alpha-old"
+    );
+}
+
+#[test]
+fn query_stream_stops_after_a_complete_recent_page() {
+    let files = TraceFiles::new();
+    let now = SystemTime::now();
+    let recent_time = now - Duration::from_secs(1);
+    let old_time = now - Duration::from_hours(2);
+
+    let recent = span("recent-trace", "recent-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'recent'"}))
+        .times(
+            unix_nanos(recent_time),
+            unix_nanos(recent_time + Duration::from_millis(1)),
+        )
+        .build();
+    files.write_at(&recent, recent_time);
+    files.write_invalid_at(old_time);
+
+    let summaries = files.list(1, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("recent summary").root_span_id,
+        "recent-entry"
+    );
+}
+
+#[test]
+fn query_stream_ignores_known_other_workspaces_when_stopping() {
+    let files = TraceFiles::new();
+    let now = SystemTime::now();
+    let unreadable_time = now - Duration::from_hours(2);
+
+    let alpha = span("alpha-recent-trace", "alpha-recent-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'alpha'"}))
+        .times(
+            unix_nanos(now - Duration::from_secs(2)),
+            unix_nanos(now - Duration::from_secs(1)),
+        )
+        .build();
+    let beta = span("beta-long-trace", "beta-long-entry")
+        .entry("query", "sql", "beta")
+        .attrs(json!({"sql": "SELECT 'beta'"}))
+        .times(
+            unix_nanos(now - Duration::from_hours(3)),
+            unix_nanos(now - Duration::from_millis(500)),
+        )
+        .build();
+    files.write("spans-recent-workspaces.jsonl", &[alpha, beta]);
+    files.write_invalid_at(unreadable_time);
+
+    let summaries = files.list(1, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("alpha summary").root_span_id,
+        "alpha-recent-entry"
+    );
+}
+
+#[test]
+fn query_stream_ignores_descendant_workspace_mismatches_when_stopping() {
+    let files = TraceFiles::new();
+    let now = SystemTime::now();
+    let unreadable_time = now - Duration::from_hours(2);
+
+    let alpha = span("alpha-recent-trace", "alpha-recent-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'alpha'"}))
+        .times(
+            unix_nanos(now - Duration::from_secs(2)),
+            unix_nanos(now - Duration::from_secs(1)),
+        )
+        .build();
+    let beta_tool = span("beta-tool-trace", "beta-tool-entry")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "legacy_tool",
+        }))
+        .times(
+            unix_nanos(now - Duration::from_hours(3)),
+            unix_nanos(now - Duration::from_millis(500)),
+        )
+        .build();
+    let beta_child = span("beta-tool-trace", "beta-child")
+        .named("internal.beta")
+        .child_of(&beta_tool)
+        .attrs(json!({"workspace": "beta"}))
+        .times(
+            unix_nanos(now - Duration::from_secs(10)),
+            unix_nanos(now - Duration::from_secs(9)),
+        )
+        .build();
+    files.write(
+        "spans-recent-descendant-workspace.jsonl",
+        &[alpha, beta_tool, beta_child],
+    );
+    files.write_invalid_at(unreadable_time);
+
+    let summaries = files.list(1, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("alpha summary").root_span_id,
+        "alpha-recent-entry"
+    );
+}
+
+#[test]
+fn query_stream_offset_page_reads_enough_recent_files_then_stops() {
+    let files = TraceFiles::new();
+    let now = SystemTime::now();
+    let newest_time = now - Duration::from_secs(1);
+    let second_time = now - Duration::from_secs(5);
+    let unreadable_time = now - Duration::from_hours(2);
+
+    let newest = span("newest-trace", "newest-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'newest'"}))
+        .times(
+            unix_nanos(newest_time),
+            unix_nanos(newest_time + Duration::from_millis(1)),
+        )
+        .build();
+    files.write_at(&newest, newest_time);
+
+    let second = span("second-trace", "second-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'second'"}))
+        .times(
+            unix_nanos(second_time),
+            unix_nanos(second_time + Duration::from_millis(1)),
+        )
+        .build();
+    files.write_at(&second, second_time);
+    files.write_invalid_at(unreadable_time);
+
+    let summaries = files.list(1, 1, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("offset summary").root_span_id,
+        "second-entry"
+    );
+}
+
+#[test]
+fn query_stream_completes_returned_operations_from_older_files() {
+    let files = TraceFiles::new();
+    let operation_start = SystemTime::now() - Duration::from_secs(20);
+    let child_end = operation_start + Duration::from_secs(2);
+    let operation_end = operation_start + Duration::from_secs(10);
+
+    let root = span("split-trace", "tool-root")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("tool", "sql", "alpha")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "sql",
+        }))
+        .times(unix_nanos(operation_start), unix_nanos(operation_end))
+        .build();
+
+    let child = span("split-trace", "query-child")
+        .child_of(&root)
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 42", "row_count": 1}))
+        .times(
+            unix_nanos(operation_start + Duration::from_secs(1)),
+            unix_nanos(child_end),
+        )
+        .build();
+    files.write_at(&child, child_end);
+    files.write_at(&root, operation_end);
+
+    let summaries = files.list(1, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("completed operation summary");
+    assert_eq!(summary.root_span_id, "tool-root");
+    assert_eq!(summary.query, "SELECT 42");
+    assert_eq!(summary.row_count, 1);
+    assert!(summary.row_count_recorded);
+    assert_eq!(summary.span_count, 2);
+}
+
+#[test]
+fn query_stream_projector_releases_completed_discovery_trees() {
+    let mut projector = QueryStreamProjector::new(1, Some("alpha"));
+
+    for index in (0..128_i64).rev() {
+        let base = index * 10;
+        let protocol_span_id = format!("protocol-{index}");
+        let protocol = TraceListSpanRecord {
+            trace_id: "shared-discovery-trace".to_string(),
+            span_id: protocol_span_id.clone(),
+            parent_span_id: Some("remote-parent".to_string()),
+            parent_span_is_remote: true,
+            name: "coral.mcp.list_tools".to_string(),
+            status: StoredTraceStatus::Ok,
+            start_time_unix_nanos: base,
+            end_time_unix_nanos: base + 4,
+            attributes_json: r#"{"mcp.method":"tools/list"}"#.to_string(),
+        };
+        let child = TraceListSpanRecord {
+            trace_id: "shared-discovery-trace".to_string(),
+            span_id: format!("discovery-query-{index}"),
+            parent_span_id: Some(protocol_span_id),
+            parent_span_is_remote: false,
+            name: "coral.query".to_string(),
+            status: StoredTraceStatus::Ok,
+            start_time_unix_nanos: base + 1,
+            end_time_unix_nanos: base + 2,
+            attributes_json: json!({
+                "coral.stream.entry": true,
+                "coral.stream.kind": "query",
+                "coral.stream.name": "list_catalog",
+                "workspace": "alpha",
+                "sql": "LIST CATALOG",
+            })
+            .to_string(),
+        };
+
+        projector.record_file(vec![child, protocol]);
+        projector.advance_watermark(base - 1);
+        assert!(projector.nodes.is_empty());
+        assert!(projector.aggregates.is_empty());
+        assert!(projector.finalized.is_empty());
+    }
+}
+
+#[test]
+fn query_stream_keeps_newer_duplicate_span_across_files() {
+    let files = TraceFiles::new();
+    let base_time = SystemTime::now() - Duration::from_secs(10);
+
+    let older = span("duplicate-query-stream", "duplicate-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'old'"}))
+        .times(
+            unix_nanos(base_time + Duration::from_millis(500)),
+            unix_nanos(base_time + Duration::from_millis(600)),
+        )
+        .build();
+    files.write_at(&older, base_time);
+
+    let newer_modified = base_time + Duration::from_millis(10);
+    let newer = span("duplicate-query-stream", "duplicate-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'new'"}))
+        .times(
+            unix_nanos(base_time + Duration::from_millis(500)),
+            unix_nanos(base_time + Duration::from_millis(700)),
+        )
+        .build();
+    files.write_at(&newer, newer_modified);
+
+    let summaries = files.list(1, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("newer duplicate summary").query,
+        "SELECT 'new'"
+    );
+}
+
+#[test]
+fn query_stream_keeps_scanning_when_file_mtime_is_coarse() {
+    let files = TraceFiles::new();
+    let base_time = SystemTime::now() - Duration::from_secs(10);
+    let hidden_modified = base_time;
+    let visible_modified = base_time + Duration::from_millis(10);
+
+    let hidden_newer = span("hidden-newer", "hidden-newer-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'newer'"}))
+        .times(
+            unix_nanos(base_time),
+            unix_nanos(base_time + Duration::from_millis(900)),
+        )
+        .build();
+    files.write_at(&hidden_newer, hidden_modified);
+
+    let visible_older = span("visible-older", "visible-older-entry")
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 'older'"}))
+        .times(
+            unix_nanos(base_time),
+            unix_nanos(base_time + Duration::from_millis(100)),
+        )
+        .build();
+    files.write_at(&visible_older, visible_modified);
+
+    let summaries = files.list(1, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("newest summary").trace_id,
+        "hidden-newer"
+    );
+}

--- a/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
@@ -1,7 +1,14 @@
-use serde_json::{Map, Value, json};
+use std::fs;
+use std::time::SystemTime;
 
-use super::super::tests::trace_record;
-use super::super::{StoredTraceStatus, TraceSpanRecord, TraceSummaryRecord};
+use serde_json::{Map, Value, json};
+use tempfile::TempDir;
+
+use super::super::tests::{
+    set_modified_time, timestamped_jsonl_path, trace_record, write_record_file,
+    write_record_file_lines,
+};
+use super::super::{StoredTraceStatus, TraceSpanRecord, TraceStore, TraceSummaryRecord};
 
 pub(super) fn span(trace_id: &str, span_id: &str) -> TestSpan {
     TestSpan {
@@ -77,4 +84,52 @@ pub(super) fn project(
     workspace_name: Option<&str>,
 ) -> Vec<TraceSummaryRecord> {
     super::summaries(records, workspace_name)
+}
+
+pub(super) struct TraceFiles {
+    temp: TempDir,
+}
+
+impl TraceFiles {
+    pub(super) fn new() -> Self {
+        Self {
+            temp: TempDir::new().expect("temp dir"),
+        }
+    }
+
+    pub(super) fn write(&self, name: &str, records: &[TraceSpanRecord]) {
+        write_record_file_lines(&self.temp.path().join(name), records);
+    }
+
+    pub(super) fn write_at(&self, record: &TraceSpanRecord, modified: SystemTime) {
+        self.write_named_at(&timestamped_jsonl_path(modified), record, modified);
+    }
+
+    pub(super) fn write_named_at(
+        &self,
+        name: &str,
+        record: &TraceSpanRecord,
+        modified: SystemTime,
+    ) {
+        let path = self.temp.path().join(name);
+        write_record_file(&path, record);
+        set_modified_time(&path, modified);
+    }
+
+    pub(super) fn write_invalid_at(&self, modified: SystemTime) {
+        let path = self.temp.path().join(timestamped_jsonl_path(modified));
+        fs::write(&path, [0xff]).expect("write unreadable JSONL text");
+        set_modified_time(&path, modified);
+    }
+
+    pub(super) fn list(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: Option<&str>,
+    ) -> Vec<TraceSummaryRecord> {
+        TraceStore::new(self.temp.path().to_path_buf())
+            .list_query_stream_sync(limit, offset, workspace_name)
+            .expect("list query stream")
+    }
 }

--- a/crates/coral-app/src/telemetry/manager.rs
+++ b/crates/coral-app/src/telemetry/manager.rs
@@ -14,6 +14,7 @@ pub(crate) enum TraceListView {
 
 #[derive(Debug)]
 pub(crate) struct ListTracesQuery {
+    pub(crate) view: TraceListView,
     pub(crate) workspace: Option<WorkspaceName>,
     pub(crate) page_size: usize,
     pub(crate) offset: usize,
@@ -66,18 +67,27 @@ impl TraceManager {
         query: ListTracesQuery,
     ) -> Result<TraceListPage, TraceManagerError> {
         let ListTracesQuery {
+            view,
             workspace,
             page_size,
             offset,
         } = query;
+        let workspace = workspace.map(|workspace| workspace.as_str().to_string());
         let fetch_limit = page_size.saturating_add(1);
-        let mut traces = match workspace {
-            Some(workspace) => {
+        let mut traces = match view {
+            TraceListView::All => match workspace {
+                Some(workspace) => {
+                    self.traces
+                        .list_traces_for_workspace(fetch_limit, offset, workspace)
+                        .await
+                }
+                None => self.traces.list_traces(fetch_limit, offset).await,
+            },
+            TraceListView::QueryStream => {
                 self.traces
-                    .list_traces_for_workspace(fetch_limit, offset, workspace.as_str().to_string())
+                    .list_query_stream(fetch_limit, offset, workspace)
                     .await
             }
-            None => self.traces.list_traces(fetch_limit, offset).await,
         }?;
         let next_offset = (traces.len() > page_size).then(|| offset.saturating_add(page_size));
         if next_offset.is_some() {
@@ -129,12 +139,22 @@ mod tests {
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
-    async fn manager_scopes_and_paginates_trace_lists() {
+    async fn manager_scopes_and_paginates_all_trace_lists() {
+        assert_manager_scopes_and_paginates_trace_lists(TraceListView::All).await;
+    }
+
+    #[tokio::test]
+    async fn manager_scopes_and_paginates_query_stream_trace_lists() {
+        assert_manager_scopes_and_paginates_trace_lists(TraceListView::QueryStream).await;
+    }
+
+    async fn assert_manager_scopes_and_paginates_trace_lists(view: TraceListView) {
         let (_temp, manager) = trace_manager_fixture();
         let alpha = WorkspaceName::parse("alpha").expect("alpha workspace");
 
         let first_page = manager
             .list_traces(ListTracesQuery {
+                view,
                 workspace: Some(alpha.clone()),
                 page_size: 1,
                 offset: 0,
@@ -150,6 +170,7 @@ mod tests {
 
         let second_page = manager
             .list_traces(ListTracesQuery {
+                view,
                 workspace: Some(alpha),
                 page_size: 1,
                 offset: 1,
@@ -230,6 +251,9 @@ mod tests {
             "end_time_unix_nanos": end_time_unix_nanos,
             "duration_nanos": end_time_unix_nanos - start_time_unix_nanos,
             "attributes_json": json!({
+                "coral.stream.entry": true,
+                "coral.stream.kind": "query",
+                "coral.stream.name": trace_id,
                 "workspace": workspace,
                 "sql": format!("SELECT '{trace_id}'"),
                 "status": "ok",

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -47,8 +47,10 @@ impl TraceServiceApi for TraceService {
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
             let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let view = trace_list_view_from_proto(request.view)?;
             let page = traces
                 .list_traces(ListTracesQuery {
+                    view,
                     workspace,
                     page_size,
                     offset,
@@ -297,6 +299,7 @@ mod tests {
                 page_size: 10,
                 page_token: String::new(),
                 workspace: Some(workspace("alpha")),
+                view: TraceView::Unspecified as i32,
             }),
         )
         .await
@@ -363,6 +366,28 @@ mod tests {
         write_query_stream_trace_fixture(&trace_store);
         let service = TraceService::new(TraceManager::new(trace_store, Duration::from_mins(1)));
 
+        let response = TraceServiceApi::list_traces(
+            &service,
+            Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+                workspace: Some(workspace("alpha")),
+                view: TraceView::QueryStream as i32,
+            }),
+        )
+        .await
+        .expect("list query stream")
+        .into_inner();
+        assert_eq!(response.traces.len(), 1);
+        let summary = response.traces.first().expect("tool summary");
+        assert_eq!(summary.root_span_id, "tool-span");
+        assert_eq!(summary.operation_kind, TraceOperationKind::Query as i32);
+        assert_eq!(summary.operation_name, "sql");
+        assert_eq!(summary.invocation_kind, TraceInvocationKind::Mcp as i32);
+        assert_eq!(summary.query, "SELECT 42");
+        assert_eq!(summary.start_time_unix_nanos, 10);
+        assert_eq!(summary.end_time_unix_nanos, 40);
+
         let detail = TraceServiceApi::get_trace(
             &service,
             Request::new(GetTraceRequest {
@@ -374,20 +399,15 @@ mod tests {
         .await
         .expect("get query stream trace")
         .into_inner();
-        let summary = detail.summary.expect("query stream detail summary");
-        assert_eq!(summary.root_span_id, "tool-span");
-        assert_eq!(summary.operation_kind, TraceOperationKind::Query as i32);
-        assert_eq!(summary.operation_name, "sql");
-        assert_eq!(summary.invocation_kind, TraceInvocationKind::Mcp as i32);
-        assert_eq!(summary.query, "SELECT 42");
-        assert_eq!(summary.start_time_unix_nanos, 10);
-        assert_eq!(summary.end_time_unix_nanos, 40);
+        let detail_summary = detail.summary.expect("query stream detail summary");
+        assert_eq!(detail_summary, *summary);
         assert_eq!(detail.spans.len(), 2);
 
-        let unknown_view = TraceServiceApi::get_trace(
+        let unknown_view = TraceServiceApi::list_traces(
             &service,
-            Request::new(GetTraceRequest {
-                trace_id: "shared-trace".to_string(),
+            Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
                 workspace: None,
                 view: 999,
             }),

--- a/crates/coral-app/tests/telemetry_host_subscriber.rs
+++ b/crates/coral-app/tests/telemetry_host_subscriber.rs
@@ -22,7 +22,7 @@
 )]
 
 use coral_api::v1::trace_service_client::TraceServiceClient;
-use coral_api::v1::{ListSourcesRequest, ListTracesRequest, SearchRequest};
+use coral_api::v1::{ListSourcesRequest, ListTracesRequest, SearchRequest, TraceView};
 use coral_client::{AppClient, default_workspace, local::ServerBuilder};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
@@ -104,6 +104,7 @@ async fn host_subscriber_keeps_server_available_without_local_only_attributes() 
             page_size: 10,
             page_token: String::new(),
             workspace: None,
+            view: TraceView::Unspecified as i32,
         }))
         .await
         .expect_err("host-owned subscriber should leave trace service disabled");

--- a/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
+++ b/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
@@ -7,8 +7,8 @@
 
 use std::path::{Path, PathBuf};
 
-use coral_api::v1::ListTracesRequest;
 use coral_api::v1::trace_service_client::TraceServiceClient;
+use coral_api::v1::{ListTracesRequest, TraceView};
 use coral_client::local::ServerBuilder;
 use serde_json::json;
 use tempfile::TempDir;
@@ -123,6 +123,7 @@ async fn list_trace_ids(endpoint_uri: &str) -> Vec<String> {
             page_size: 10,
             page_token: String::new(),
             workspace: None,
+            view: TraceView::Unspecified as i32,
         }))
         .await
         .expect("list traces")


### PR DESCRIPTION
## TL;DR

This PR adds the efficient list side of Query Stream on top of #1876's operation contract.

It scans locally retained trace files from newest to oldest, returns at most one Query Stream row per distributed trace, and stops once the requested page is known to be complete. List and detail return the same semantic capability, invocation provenance, operation name, and operation text.

## Summary

- add `ListTraces(view = QUERY_STREAM)` without changing the default diagnostic list
- reuse #1876's projector so list and detail apply the same capability, invocation, privacy, text, and nesting rules
- preserve Query/Search capability independently of direct or MCP invocation
- add projector indexes and pagination state used only by bounded listing
- scan JSONL files newest-first with a conservative completion watermark
- resolve files with identical modification times as one atomic bucket, including restored stores where every file has the same timestamp
- filter by workspace before pagination, including operations whose workspace is established by unique descendant evidence
- deduplicate by trace ID and return deterministic newest-first pages
- bound retained ancestry and aggregate state while scanning
- cover both manager list views, pagination, offsets, workspace-aware early stopping, older-file completion, duplicate spans, coarse mtimes, equal-mtime files, and list/detail parity

## Stack boundary

- Layer 3 of 4 in the Query Stream stack
- Depends on: #1876
- Next: #1904
- This PR owns bounded projection state, backend listing, and storage traversal. Capability and invocation semantics and detail projection are in #1876; Reef consumption and presentation are in #1904.

## Validation

- `make rust-checks` at the stack tip: passed (format, Clippy, 2,485 tests, rustdoc)
- `make lint-proto`: passed
- `cargo test --locked -p coral-app telemetry::local_store::query_stream --lib`: passed (25 tests)
- `cargo test --locked -p coral-app telemetry::service::tests --lib`: passed (5 tests)
- `git diff --check`: passed
