### PR TITLE
feat(release): publish official Coral Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.cargo
+.context
+.agents
+.claude
+.codex
+.playwright-cli
+.verify
+.envrc
+tasks
+target
+**/node_modules
+**/.env
+**/.env.*
+benchmarks/universal-search/runs

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,8 +17,10 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: docker-publish-${{ inputs.tag }}
-  cancel-in-progress: false
+  # Moving tags (latest and X.Y) are shared mutable state across releases, so
+  # every publish must finish before the next one evaluates and applies them.
+  group: docker-publish
+  queue: max
 
 env:
   IMAGE: ghcr.io/withcoral/coral

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,18 +147,30 @@ jobs:
           prerelease="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
           echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
 
-      - name: Read the newest stable release
+      - name: Resolve the newest stable tags
         id: newest
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
         run: |
           set -euo pipefail
-          newest="$(gh release list --repo "$GITHUB_REPOSITORY" \
-            --exclude-pre-releases --exclude-drafts --limit 1 \
-            --json tagName --jq '.[0].tagName // ""')"
-          echo "newest stable release is '${newest}'; this run packages '${TAG}'"
-          echo "tag=${newest}" >> "$GITHUB_OUTPUT"
+          # One listing, ranked by version rather than by GitHub's own ordering
+          # (which is by commit date, not by semver). "$TAG" joins the candidate
+          # set either way: the release path may not list it yet, and the CVE
+          # rebuild path already does, so both compare against the same set.
+          stable="$(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-pre-releases --exclude-drafts --limit 1000 \
+            --json tagName --jq '.[].tagName')"
+          candidates="$(printf '%s\n%s\n' "$stable" "$TAG" | grep -v '^$' | sort -u)"
+          newest="$(printf '%s\n' "$candidates" | sort -V | tail -1)"
+          # Dots are literal so the 1.2 line never absorbs 1.20.x.
+          line="$(printf '%s\n' "$candidates" | grep -E "^v${MAJOR_MINOR//./\\.}\." | sort -V | tail -1)"
+          echo "newest stable release is '${newest}'; newest in the ${MAJOR_MINOR} line is '${line}'; this run packages '${TAG}'"
+          {
+            echo "tag=${newest}"
+            echo "line-tag=${line}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Tag the pushed manifest
         id: manifest
@@ -169,14 +181,17 @@ jobs:
           MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
           PRERELEASE: ${{ steps.release.outputs.prerelease }}
           NEWEST_TAG: ${{ steps.newest.outputs.tag }}
+          NEWEST_LINE_TAG: ${{ steps.newest.outputs.line-tag }}
         run: |
           set -euo pipefail
-          tags=(--tag "${IMAGE}:${VERSION}" --tag "${IMAGE}:${MAJOR_MINOR}")
-          # `latest` never points at a prerelease, and never moves backwards: a
-          # CVE rebuild of a superseded release re-publishes its own version and
-          # line tags, but must not demote `latest` users to an older release.
-          # publish-version has already promoted the release by the time the
-          # release path reaches this job, so the newest stable tag is this one.
+          # The exact version tag always publishes. The moving tags never move
+          # backwards and never point at a prerelease: a CVE rebuild of a
+          # superseded release re-publishes its own version tag, but leaves
+          # `X.Y` and `latest` on whichever release is newest by semver.
+          tags=(--tag "${IMAGE}:${VERSION}")
+          if [ "$PRERELEASE" = "false" ] && [ "$NEWEST_LINE_TAG" = "$TAG" ]; then
+            tags+=(--tag "${IMAGE}:${MAJOR_MINOR}")
+          fi
           if [ "$PRERELEASE" = "false" ] && [ "$NEWEST_TAG" = "$TAG" ]; then
             tags+=(--tag "${IMAGE}:latest")
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,6 +147,19 @@ jobs:
           prerelease="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
           echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
 
+      - name: Read the newest stable release
+        id: newest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          newest="$(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-pre-releases --exclude-drafts --limit 1 \
+            --json tagName --jq '.[0].tagName // ""')"
+          echo "newest stable release is '${newest}'; this run packages '${TAG}'"
+          echo "tag=${newest}" >> "$GITHUB_OUTPUT"
+
       - name: Tag the pushed manifest
         id: manifest
         shell: bash
@@ -155,12 +168,16 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
           MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
           PRERELEASE: ${{ steps.release.outputs.prerelease }}
+          NEWEST_TAG: ${{ steps.newest.outputs.tag }}
         run: |
           set -euo pipefail
           tags=(--tag "${IMAGE}:${VERSION}" --tag "${IMAGE}:${MAJOR_MINOR}")
-          # `latest` never points at a prerelease; publish-version has already
-          # promoted the release by the time the release path reaches this job.
-          if [ "$PRERELEASE" = "false" ]; then
+          # `latest` never points at a prerelease, and never moves backwards: a
+          # CVE rebuild of a superseded release re-publishes its own version and
+          # line tags, but must not demote `latest` users to an older release.
+          # publish-version has already promoted the release by the time the
+          # release path reaches this job, so the newest stable tag is this one.
+          if [ "$PRERELEASE" = "false" ] && [ "$NEWEST_TAG" = "$TAG" ]; then
             tags+=(--tag "${IMAGE}:latest")
           fi
           docker buildx imagetools create "${tags[@]}" "${IMAGE}@${BUILD_DIGEST}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -172,7 +172,86 @@ jobs:
             echo "line-tag=${line}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Tag the pushed manifest
+      - name: Prepare smoke helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/wait-healthy.sh" <<'HELPER'
+          #!/usr/bin/env bash
+          # Poll the image's own grpc_health_probe from inside the container, so the
+          # probe under test is the one the HEALTHCHECK uses.
+          set -euo pipefail
+          container="$1"
+          for _ in $(seq 1 60); do
+            if docker exec "$container" /usr/local/bin/grpc_health_probe -addr=127.0.0.1:14555 >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "container ${container} never became healthy" >&2
+          docker logs "$container" >&2 || true
+          exit 1
+          HELPER
+          chmod +x "$RUNNER_TEMP/wait-healthy.sh"
+
+      - name: Smoke - first boot seeds a starter config
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker volume create coral-smoke > /dev/null
+          docker run -d --name coral-smoke -v coral-smoke:/var/lib/coral "${IMAGE}@${DIGEST}" > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke
+          docker logs coral-smoke 2>&1 | grep -F 'coral-entrypoint: seeded starter'
+          docker logs coral-smoke 2>&1 | grep -F 'Coral gRPC server listening on http://0.0.0.0:14555'
+
+      - name: Smoke - restart reuses the existing config
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker restart coral-smoke > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke
+          docker logs coral-smoke 2>&1 | grep -F 'coral-entrypoint: using existing'
+          test "$(docker logs coral-smoke 2>&1 | grep -c -F 'coral-entrypoint: seeded starter')" -eq 1
+
+      - name: Smoke - read-only volume fails fast
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          status=0
+          output="$(timeout --kill-after=5s 30s docker run --rm -v coral-smoke:/var/lib/coral:ro "${IMAGE}@${DIGEST}" 2>&1)" || status=$?
+          printf '%s\n' "$output"
+          test "$status" -eq 1
+          printf '%s\n' "$output" | grep -F 'coral-entrypoint: FATAL'
+
+      - name: Smoke - CORAL_SEED_CONFIG seeds once
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          marker='# coral-docker-smoke-marker'
+          seed="$(printf '%s\n[server]\nbind_addr = "0.0.0.0:14555"\n' "$marker")"
+          docker volume create coral-smoke-seed > /dev/null
+          docker run -d --name coral-smoke-seed \
+            -e CORAL_SEED_CONFIG="$seed" \
+            -v coral-smoke-seed:/var/lib/coral \
+            "${IMAGE}@${DIGEST}" > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
+          docker logs coral-smoke-seed 2>&1 | grep -F 'from CORAL_SEED_CONFIG'
+          expected_sha="$(printf '%s' "$seed" | sha256sum | awk '{print $1}')"
+          actual_sha="$(docker exec coral-smoke-seed sha256sum /var/lib/coral/config/config.toml | awk '{print $1}')"
+          test "$actual_sha" = "$expected_sha"
+          docker restart coral-smoke-seed > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
+          docker logs coral-smoke-seed 2>&1 | grep -F 'CORAL_SEED_CONFIG ignored'
+
+      # The digest is deliberately untagged until every smoke check passes, so
+      # a broken rebuild cannot move an existing release, line, or latest tag.
+      - name: Tag the validated manifest
         id: manifest
         shell: bash
         env:
@@ -211,79 +290,3 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes "${IMAGE}@${DIGEST}"
-
-      - name: Prepare smoke helper
-        shell: bash
-        run: |
-          set -euo pipefail
-          cat > "$RUNNER_TEMP/wait-healthy.sh" <<'HELPER'
-          #!/usr/bin/env bash
-          # Poll the image's own grpc_health_probe from inside the container, so the
-          # probe under test is the one the HEALTHCHECK uses.
-          set -euo pipefail
-          container="$1"
-          for _ in $(seq 1 60); do
-            if docker exec "$container" /usr/local/bin/grpc_health_probe -addr=127.0.0.1:14555 >/dev/null 2>&1; then
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "container ${container} never became healthy" >&2
-          docker logs "$container" >&2 || true
-          exit 1
-          HELPER
-          chmod +x "$RUNNER_TEMP/wait-healthy.sh"
-
-      - name: Smoke - first boot seeds a starter config
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
-        run: |
-          set -euo pipefail
-          docker volume create coral-smoke > /dev/null
-          docker run -d --name coral-smoke -v coral-smoke:/var/lib/coral "${IMAGE}@${DIGEST}" > /dev/null
-          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke
-          docker logs coral-smoke 2>&1 | grep -F 'coral-entrypoint: seeded starter'
-          docker logs coral-smoke 2>&1 | grep -F 'Coral gRPC server listening on http://0.0.0.0:14555'
-
-      - name: Smoke - restart reuses the existing config
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker restart coral-smoke > /dev/null
-          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke
-          docker logs coral-smoke 2>&1 | grep -F 'coral-entrypoint: using existing'
-          test "$(docker logs coral-smoke 2>&1 | grep -c -F 'coral-entrypoint: seeded starter')" -eq 1
-
-      - name: Smoke - read-only volume fails fast
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
-        run: |
-          set -euo pipefail
-          status=0
-          output="$(docker run --rm -v coral-smoke:/var/lib/coral:ro "${IMAGE}@${DIGEST}" 2>&1)" || status=$?
-          printf '%s\n' "$output"
-          test "$status" -eq 1
-          printf '%s\n' "$output" | grep -F 'coral-entrypoint: FATAL'
-
-      - name: Smoke - CORAL_SEED_CONFIG seeds once
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
-        run: |
-          set -euo pipefail
-          marker='# coral-docker-smoke-marker'
-          seed="$(printf '%s\n[server]\nbind_addr = "0.0.0.0:14555"\n' "$marker")"
-          docker volume create coral-smoke-seed > /dev/null
-          docker run -d --name coral-smoke-seed \
-            -e CORAL_SEED_CONFIG="$seed" \
-            -v coral-smoke-seed:/var/lib/coral \
-            "${IMAGE}@${DIGEST}" > /dev/null
-          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
-          docker logs coral-smoke-seed 2>&1 | grep -F 'from CORAL_SEED_CONFIG'
-          # Path is docker/Dockerfile's baked CORAL_CONFIG_DIR; expansion stays host-side.
-          docker exec coral-smoke-seed cat /var/lib/coral/config/config.toml | grep -F "$marker"
-          docker restart coral-smoke-seed > /dev/null
-          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
-          docker logs coral-smoke-seed 2>&1 | grep -F 'CORAL_SEED_CONFIG ignored'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,257 @@
+name: Publish Docker image
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Published release tag to package, e.g. v1.2.3.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Published release tag to package, e.g. v1.2.3. Rebuilds the image
+          from that release's assets (CVE rebuild) without touching the release.
+        required: true
+        type: string
+permissions:
+  contents: read
+concurrency:
+  group: docker-publish-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/withcoral/coral
+  TARBALL: coral-x86_64-unknown-linux-gnu.tar.gz
+  # Must stay in step with the runtime stage of docker/Dockerfile.
+  BASE_IMAGE: debian:trixie-slim
+  TAG: ${{ inputs.tag }}
+
+jobs:
+  publish-image:
+    name: Build, publish, and smoke the linux/amd64 image
+    # GitHub-hosted, like release.yml's Linux build matrix: the smoke battery
+    # runs real containers against the pushed digest on a stock Docker daemon.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Validate tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Docker publish tag must look like vX.Y.Z, got '${TAG}'." >&2
+            exit 1
+          fi
+
+          version="${TAG#v}"
+          {
+            echo "version=${version}"
+            echo "major-minor=${version%.*}"
+          } >> "$GITHUB_OUTPUT"
+
+      # The Dockerfile and entrypoint come from the ref this workflow runs on:
+      # the release tag under workflow_call, and whatever ref the CVE rebuild
+      # dispatch picks. Only the binary comes from the release assets.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/release"
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$RUNNER_TEMP/release" \
+            --pattern "$TARBALL" \
+            --pattern checksums.sha256
+
+      - name: Verify release checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/release"
+          # Exact filename match, reprinted in sha256sum's two-space format.
+          awk -v f="$TARBALL" '$2 == f { print $1 "  " f }' checksums.sha256 > tarball.sha256
+          test -s tarball.sha256
+          sha256sum --check --strict tarball.sha256
+
+      - name: Extract binary into the build context
+        shell: bash
+        run: |
+          set -euo pipefail
+          # dist/<TARGETARCH>/coral is the build-context layout docker/Dockerfile stages from.
+          mkdir -p dist/amd64
+          tar -xzf "$RUNNER_TEMP/release/$TARBALL" -C dist/amd64 coral
+          test -x dist/amd64/coral
+
+      - name: Check glibc floor against the base image
+        shell: bash
+        run: |
+          set -euo pipefail
+          needed="$(objdump -T dist/amd64/coral | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1)"
+          test -n "$needed"
+          # Read natively on this amd64 runner — no QEMU anywhere in this workflow.
+          base="GLIBC_$(docker run --rm --platform linux/amd64 "$BASE_IMAGE" ldd --version | head -1 | awk '{print $NF}')"
+          echo "binary requires ${needed}; ${BASE_IMAGE} provides ${base}"
+          if [ "$(printf '%s\n%s\n' "$needed" "$base" | sort -V | tail -1)" != "$base" ]; then
+            echo "Release binary requires ${needed}, newer than ${BASE_IMAGE}'s ${base}." >&2
+            exit 1
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          # A publishing workflow takes no cache input it did not build itself.
+          cache-binary: false
+
+      - name: Build and push image by digest
+        id: build
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --provenance=true \
+            --file docker/Dockerfile \
+            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file "$RUNNER_TEMP/build-metadata.json" \
+            .
+          digest="$(jq -r '."containerimage.digest" // ""' "$RUNNER_TEMP/build-metadata.json")"
+          test -n "$digest"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Read release prerelease flag
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          prerelease="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag the pushed manifest
+        id: manifest
+        shell: bash
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          tags=(--tag "${IMAGE}:${VERSION}" --tag "${IMAGE}:${MAJOR_MINOR}")
+          # `latest` never points at a prerelease; publish-version has already
+          # promoted the release by the time the release path reaches this job.
+          if [ "$PRERELEASE" = "false" ]; then
+            tags+=(--tag "${IMAGE}:latest")
+          fi
+          docker buildx imagetools create "${tags[@]}" "${IMAGE}@${BUILD_DIGEST}"
+          # Tagging republishes the index, so re-read the digest the tags resolve to.
+          digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
+          test -n "$digest"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the published manifest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Prepare smoke helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/wait-healthy.sh" <<'HELPER'
+          #!/usr/bin/env bash
+          # Poll the image's own grpc_health_probe from inside the container, so the
+          # probe under test is the one the HEALTHCHECK uses.
+          set -euo pipefail
+          container="$1"
+          for _ in $(seq 1 60); do
+            if docker exec "$container" /usr/local/bin/grpc_health_probe -addr=127.0.0.1:14555 >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "container ${container} never became healthy" >&2
+          docker logs "$container" >&2 || true
+          exit 1
+          HELPER
+          chmod +x "$RUNNER_TEMP/wait-healthy.sh"
+
+      - name: Smoke - first boot seeds a starter config
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker volume create coral-smoke > /dev/null
+          docker run -d --name coral-smoke -v coral-smoke:/var/lib/coral "${IMAGE}@${DIGEST}" > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke
+          docker logs coral-smoke 2>&1 | grep -F 'coral-entrypoint: seeded starter'
+          docker logs coral-smoke 2>&1 | grep -F 'Coral gRPC server listening on http://0.0.0.0:14555'
+
+      - name: Smoke - restart reuses the existing config
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker restart coral-smoke > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke
+          docker logs coral-smoke 2>&1 | grep -F 'coral-entrypoint: using existing'
+          test "$(docker logs coral-smoke 2>&1 | grep -c -F 'coral-entrypoint: seeded starter')" -eq 1
+
+      - name: Smoke - read-only volume fails fast
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          status=0
+          output="$(docker run --rm -v coral-smoke:/var/lib/coral:ro "${IMAGE}@${DIGEST}" 2>&1)" || status=$?
+          printf '%s\n' "$output"
+          test "$status" -eq 1
+          printf '%s\n' "$output" | grep -F 'coral-entrypoint: FATAL'
+
+      - name: Smoke - CORAL_SEED_CONFIG seeds once
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          marker='# coral-docker-smoke-marker'
+          seed="$(printf '%s\n[server]\nbind_addr = "0.0.0.0:14555"\n' "$marker")"
+          docker volume create coral-smoke-seed > /dev/null
+          docker run -d --name coral-smoke-seed \
+            -e CORAL_SEED_CONFIG="$seed" \
+            -v coral-smoke-seed:/var/lib/coral \
+            "${IMAGE}@${DIGEST}" > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
+          docker logs coral-smoke-seed 2>&1 | grep -F 'from CORAL_SEED_CONFIG'
+          # Path is docker/Dockerfile's baked CORAL_CONFIG_DIR; expansion stays host-side.
+          docker exec coral-smoke-seed cat /var/lib/coral/config/config.toml | grep -F "$marker"
+          docker restart coral-smoke-seed > /dev/null
+          "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
+          docker logs coral-smoke-seed 2>&1 | grep -F 'CORAL_SEED_CONFIG ignored'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -594,3 +594,18 @@ jobs:
                 footer: { text: "Fresh from the reef" }
               }]
             }' | curl -sf -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+
+  # Additive by design: a failure here leaves the image missing until a manual
+  # `docker-publish` dispatch, and never blocks or rewinds a published release.
+  publish-docker:
+    needs:
+      - validate-release-ref
+      - publish-version
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tag: ${{ needs.validate-release-ref.outputs.tag-name }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,4 +608,3 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag: ${{ needs.validate-release-ref.outputs.tag-name }}
-    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,12 +76,12 @@
   or the `UI build` workflow job), not by `crates/coral-cli/build.rs`. Local
   Rust builds may compile without `apps/ui/dist`, because UI development normally
   serves assets from Vite while the CLI provides the loopback API server.
-- Use `make docker-build` to build the release image locally from the latest
-  published `linux/amd64` binary. Set `DOCKER_RELEASE_TAG=vX.Y.Z` to pin the
-  release, `DOCKER_IMAGE=coral:test` to change the local tag, or
-  `DOCKER_NO_CACHE=1` for a clean build. Keep its asset staging, checksum
-  verification, platform, and provenance settings aligned with the
-  `docker-publish` workflow.
+- Use `make docker-build` to compile the current checkout in a native Linux
+  BuildKit stage and package that binary as `coral:local`. Set
+  `DOCKER_IMAGE=coral:test` to change the local tag or `DOCKER_NO_CACHE=1` to
+  bypass Docker layer caching. Keep the exported-binary layout, runtime
+  platform, and provenance settings aligned with the `docker-publish`
+  workflow; local builds must not download a published Coral binary.
 - Keep adapters thin. If CLI or MCP behavior gets complex, move it inward.
 - Keep server topology orchestration private to `coral-cli` while CLI commands
   are its only consumers. Do not extract the orchestration into a shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@
   or the `UI build` workflow job), not by `crates/coral-cli/build.rs`. Local
   Rust builds may compile without `apps/ui/dist`, because UI development normally
   serves assets from Vite while the CLI provides the loopback API server.
+- Use `make docker-build` to build the release image locally from the latest
+  published `linux/amd64` binary. Set `DOCKER_RELEASE_TAG=vX.Y.Z` to pin the
+  release, `DOCKER_IMAGE=coral:test` to change the local tag, or
+  `DOCKER_NO_CACHE=1` for a clean build. Keep its asset staging, checksum
+  verification, platform, and provenance settings aligned with the
+  `docker-publish` workflow.
 - Keep adapters thin. If CLI or MCP behavior gets complex, move it inward.
 - Keep server topology orchestration private to `coral-cli` while CLI commands
   are its only consumers. Do not extract the orchestration into a shared

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ LOCAL_POSTGRES_IMAGE ?= postgres:17
 LOCAL_POSTGRES_CONTAINER ?= coral-test-postgres
 LOCAL_POSTGRES_PORT ?=
 DOCKER_IMAGE ?= coral:local
-DOCKER_RELEASE_TAG ?=
 DOCKER_NO_CACHE ?= 0
 
 install: ui-build
@@ -21,34 +20,31 @@ ui-build:
 # ----------------------------------------------------------------------------
 # Local Coral image build
 # ----------------------------------------------------------------------------
-# Repackages the published linux/amd64 release binary exactly as the Docker
-# publishing workflow does, but loads the result into the local Docker daemon.
-# The latest published release is the default; pin a tag for reproducibility.
+# Compiles the current checkout in a native Linux BuildKit stage, then packages
+# that binary with the same runtime Dockerfile used by the publishing workflow.
+# The image platform follows the Docker daemon (arm64 or amd64), so this works
+# without cross-compilers or QEMU on both Apple Silicon and Intel machines.
 #
 #   make docker-build
-#   DOCKER_RELEASE_TAG=v1.2.3 DOCKER_IMAGE=coral:test make docker-build
+#   DOCKER_IMAGE=coral:test make docker-build
 #   DOCKER_NO_CACHE=1 make docker-build
 
 docker-build:
 	@set -eu; \
-	for command in docker gh tar awk grep; do \
-	  if ! command -v "$$command" >/dev/null 2>&1; then \
-	    echo "$$command is required to build the Coral image" >&2; \
-	    exit 1; \
-	  fi; \
-	done; \
+	if ! command -v docker >/dev/null 2>&1; then \
+	  echo "docker is required to build the Coral image" >&2; \
+	  exit 1; \
+	fi; \
 	if ! docker buildx version >/dev/null 2>&1; then \
 	  echo "docker buildx is required to build the Coral image" >&2; \
 	  exit 1; \
 	fi; \
-	release_tag="$(DOCKER_RELEASE_TAG)"; \
-	if [ -z "$$release_tag" ]; then \
-	  release_tag=$$(gh release view --repo withcoral/coral --json tagName --jq .tagName); \
-	fi; \
-	if ! printf '%s\n' "$$release_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-	  echo "DOCKER_RELEASE_TAG must look like vX.Y.Z, got '$$release_tag'" >&2; \
-	  exit 1; \
-	fi; \
+	daemon_arch=$$(docker info --format '{{.Architecture}}'); \
+	case "$$daemon_arch" in \
+	  amd64|x86_64) image_arch=amd64 ;; \
+	  arm64|aarch64) image_arch=arm64 ;; \
+	  *) echo "unsupported Docker architecture: $$daemon_arch" >&2; exit 1 ;; \
+	esac; \
 	case "$(DOCKER_NO_CACHE)" in \
 	  0|false|'') no_cache=0 ;; \
 	  1|true) no_cache=1 ;; \
@@ -57,40 +53,28 @@ docker-build:
 	tmpdir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmpdir"' EXIT HUP INT TERM; \
 	context="$$tmpdir/context"; \
-	release_dir="$$tmpdir/release"; \
-	tarball=coral-x86_64-unknown-linux-gnu.tar.gz; \
-	mkdir -p "$$context/dist/amd64" "$$context/docker" "$$release_dir"; \
-	cp docker/Dockerfile docker/entrypoint.sh "$$context/docker/"; \
-	echo "Downloading Coral $$release_tag release assets..."; \
-	gh release download "$$release_tag" \
-	  --repo withcoral/coral \
-	  --dir "$$release_dir" \
-	  --pattern "$$tarball" \
-	  --pattern checksums.sha256; \
-	checksum_line=$$(awk -v f="$$tarball" '$$2 == f { print $$1 "  " f }' "$$release_dir/checksums.sha256"); \
-	if [ -z "$$checksum_line" ]; then \
-	  echo "checksum entry for $$tarball not found" >&2; \
-	  exit 1; \
-	fi; \
-	if command -v sha256sum >/dev/null 2>&1; then \
-	  (cd "$$release_dir" && printf '%s\n' "$$checksum_line" | sha256sum -c -); \
-	elif command -v shasum >/dev/null 2>&1; then \
-	  (cd "$$release_dir" && printf '%s\n' "$$checksum_line" | shasum -a 256 -c -); \
-	else \
-	  echo "sha256sum or shasum is required to verify the release asset" >&2; \
-	  exit 1; \
-	fi; \
-	tar -xzf "$$release_dir/$$tarball" -C "$$context/dist/amd64" coral; \
-	test -x "$$context/dist/amd64/coral"; \
+	mkdir -p "$$context/dist/$$image_arch" "$$context/docker"; \
 	set -- docker buildx build \
-	  --platform linux/amd64 \
+	  --platform "linux/$$image_arch" \
+	  --provenance=false \
+	  --file docker/Dockerfile.local \
+	  --target binary \
+	  --output "type=local,dest=$$context/dist/$$image_arch"; \
+	if [ "$$no_cache" -eq 1 ]; then set -- "$$@" --no-cache; fi; \
+	set -- "$$@" .; \
+	echo "Compiling the current checkout for linux/$$image_arch..."; \
+	"$$@"; \
+	test -x "$$context/dist/$$image_arch/coral"; \
+	cp docker/Dockerfile docker/entrypoint.sh "$$context/docker/"; \
+	set -- docker buildx build \
+	  --platform "linux/$$image_arch" \
 	  --provenance=true \
 	  --file "$$context/docker/Dockerfile" \
 	  --load \
 	  --tag "$(DOCKER_IMAGE)"; \
 	if [ "$$no_cache" -eq 1 ]; then set -- "$$@" --no-cache; fi; \
 	set -- "$$@" "$$context"; \
-	echo "Building $(DOCKER_IMAGE) from Coral $$release_tag..."; \
+	echo "Building $(DOCKER_IMAGE) from the local linux/$$image_arch binary..."; \
 	"$$@"; \
 	echo "Built $(DOCKER_IMAGE)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install ui-build rust-checks perf-check
+.PHONY: install ui-build docker-build rust-checks perf-check
 .PHONY: postgres-start postgres-url postgres-stop postgres-clean postgres-tests
 .PHONY: license-check lint-proto lint-sources fix-sources
 .PHONY: docs-generate docs-check schema-generate schema-check
@@ -6,6 +6,9 @@
 LOCAL_POSTGRES_IMAGE ?= postgres:17
 LOCAL_POSTGRES_CONTAINER ?= coral-test-postgres
 LOCAL_POSTGRES_PORT ?=
+DOCKER_IMAGE ?= coral:local
+DOCKER_RELEASE_TAG ?=
+DOCKER_NO_CACHE ?= 0
 
 install: ui-build
 	cargo install --path crates/coral-cli --locked
@@ -14,6 +17,82 @@ ui-build:
 	npm ci --prefix apps/ui
 	npm run build --prefix apps/ui
 	test -s apps/ui/dist/index.html
+
+# ----------------------------------------------------------------------------
+# Local Coral image build
+# ----------------------------------------------------------------------------
+# Repackages the published linux/amd64 release binary exactly as the Docker
+# publishing workflow does, but loads the result into the local Docker daemon.
+# The latest published release is the default; pin a tag for reproducibility.
+#
+#   make docker-build
+#   DOCKER_RELEASE_TAG=v1.2.3 DOCKER_IMAGE=coral:test make docker-build
+#   DOCKER_NO_CACHE=1 make docker-build
+
+docker-build:
+	@set -eu; \
+	for command in docker gh tar awk grep; do \
+	  if ! command -v "$$command" >/dev/null 2>&1; then \
+	    echo "$$command is required to build the Coral image" >&2; \
+	    exit 1; \
+	  fi; \
+	done; \
+	if ! docker buildx version >/dev/null 2>&1; then \
+	  echo "docker buildx is required to build the Coral image" >&2; \
+	  exit 1; \
+	fi; \
+	release_tag="$(DOCKER_RELEASE_TAG)"; \
+	if [ -z "$$release_tag" ]; then \
+	  release_tag=$$(gh release view --repo withcoral/coral --json tagName --jq .tagName); \
+	fi; \
+	if ! printf '%s\n' "$$release_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+	  echo "DOCKER_RELEASE_TAG must look like vX.Y.Z, got '$$release_tag'" >&2; \
+	  exit 1; \
+	fi; \
+	case "$(DOCKER_NO_CACHE)" in \
+	  0|false|'') no_cache=0 ;; \
+	  1|true) no_cache=1 ;; \
+	  *) echo "DOCKER_NO_CACHE must be 0, 1, false, or true" >&2; exit 1 ;; \
+	esac; \
+	tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT HUP INT TERM; \
+	context="$$tmpdir/context"; \
+	release_dir="$$tmpdir/release"; \
+	tarball=coral-x86_64-unknown-linux-gnu.tar.gz; \
+	mkdir -p "$$context/dist/amd64" "$$context/docker" "$$release_dir"; \
+	cp docker/Dockerfile docker/entrypoint.sh "$$context/docker/"; \
+	echo "Downloading Coral $$release_tag release assets..."; \
+	gh release download "$$release_tag" \
+	  --repo withcoral/coral \
+	  --dir "$$release_dir" \
+	  --pattern "$$tarball" \
+	  --pattern checksums.sha256; \
+	checksum_line=$$(awk -v f="$$tarball" '$$2 == f { print $$1 "  " f }' "$$release_dir/checksums.sha256"); \
+	if [ -z "$$checksum_line" ]; then \
+	  echo "checksum entry for $$tarball not found" >&2; \
+	  exit 1; \
+	fi; \
+	if command -v sha256sum >/dev/null 2>&1; then \
+	  (cd "$$release_dir" && printf '%s\n' "$$checksum_line" | sha256sum -c -); \
+	elif command -v shasum >/dev/null 2>&1; then \
+	  (cd "$$release_dir" && printf '%s\n' "$$checksum_line" | shasum -a 256 -c -); \
+	else \
+	  echo "sha256sum or shasum is required to verify the release asset" >&2; \
+	  exit 1; \
+	fi; \
+	tar -xzf "$$release_dir/$$tarball" -C "$$context/dist/amd64" coral; \
+	test -x "$$context/dist/amd64/coral"; \
+	set -- docker buildx build \
+	  --platform linux/amd64 \
+	  --provenance=true \
+	  --file "$$context/docker/Dockerfile" \
+	  --load \
+	  --tag "$(DOCKER_IMAGE)"; \
+	if [ "$$no_cache" -eq 1 ]; then set -- "$$@" --no-cache; fi; \
+	set -- "$$@" "$$context"; \
+	echo "Building $(DOCKER_IMAGE) from Coral $$release_tag..."; \
+	"$$@"; \
+	echo "Built $(DOCKER_IMAGE)"
 
 rust-checks:
 	cargo fmt --all -- --check

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ docker-build:
 	  1|true) no_cache=1 ;; \
 	  *) echo "DOCKER_NO_CACHE must be 0, 1, false, or true" >&2; exit 1 ;; \
 	esac; \
+	git_sha=$$(git rev-parse --short HEAD); \
+	test -n "$$git_sha"; \
 	tmpdir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmpdir"' EXIT HUP INT TERM; \
 	context="$$tmpdir/context"; \
@@ -57,6 +59,7 @@ docker-build:
 	set -- docker buildx build \
 	  --platform "linux/$$image_arch" \
 	  --provenance=false \
+	  --build-arg "CORAL_GIT_SHA=$$git_sha" \
 	  --file docker/Dockerfile.local \
 	  --target binary \
 	  --output "type=local,dest=$$context/dist/$$image_arch"; \

--- a/crates/coral-cli/build.rs
+++ b/crates/coral-cli/build.rs
@@ -9,15 +9,11 @@
 use std::process::Command;
 
 fn main() {
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
+    println!("cargo:rerun-if-env-changed=CORAL_GIT_SHA");
+    let sha = std::env::var("CORAL_GIT_SHA")
         .ok()
-        .filter(|out| out.status.success())
-        .map_or_else(
-            || "unknown".to_owned(),
-            |out| String::from_utf8_lossy(&out.stdout).trim().to_owned(),
-        );
+        .filter(|sha| !sha.is_empty())
+        .unwrap_or_else(git_sha);
     println!("cargo:rustc-env=CORAL_GIT_SHA={sha}");
 
     // Trigger rebuilds when HEAD or the checked-out branch's ref moves so the
@@ -42,6 +38,18 @@ fn main() {
         println!("cargo:rerun-if-changed=../../apps/ui/dist");
         println!("cargo:rerun-if-changed=../../apps/ui/dist/index.html");
     }
+}
+
+fn git_sha() -> String {
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map_or_else(
+            || "unknown".to_owned(),
+            |out| String::from_utf8_lossy(&out.stdout).trim().to_owned(),
+        )
 }
 
 fn git_path(path: &str) -> Option<String> {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,31 +5,25 @@
 # dist/${TARGETARCH}/coral beforehand.
 FROM --platform=$BUILDPLATFORM debian:trixie-slim AS prep
 ARG TARGETARCH
-ARG TINI_VERSION=v0.19.0
 ARG GRPC_HEALTH_PROBE_VERSION=v0.4.54
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 RUN set -eu; \
     case "$TARGETARCH" in \
-    amd64) tini_sha=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c; \
-           probe_sha=e25b2f7e50176a909b9036e2c7598d8997b524a87d24af81d92b796e6dfb4897 ;; \
-    arm64) tini_sha=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81; \
-           probe_sha=bc77dba74822d2b00c2585d225b77048cdb044407a0541ebf4c12711c2fdf779 ;; \
+    amd64) probe_sha=e25b2f7e50176a909b9036e2c7598d8997b524a87d24af81d92b796e6dfb4897 ;; \
+    arm64) probe_sha=bc77dba74822d2b00c2585d225b77048cdb044407a0541ebf4c12711c2fdf779 ;; \
     *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH}"; \
-    echo "${tini_sha}  /tini" | sha256sum -c -; \
     curl -fsSL -o /grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}"; \
     echo "${probe_sha}  /grpc_health_probe" | sha256sum -c -; \
-    chmod 0755 /tini /grpc_health_probe
+    chmod 0755 /grpc_health_probe
 COPY dist/${TARGETARCH}/coral /coral
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod 0755 /coral /entrypoint.sh && mkdir -p /out/var/lib/coral
 
 FROM debian:trixie-slim
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=prep /tini /tini
 COPY --from=prep /grpc_health_probe /usr/local/bin/grpc_health_probe
 COPY --from=prep /coral /usr/local/bin/coral
 COPY --from=prep --chown=0:0 --chmod=0755 /entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -40,4 +34,4 @@ ENV CORAL_CONFIG_DIR=/var/lib/coral/config \
 USER 65532:0
 EXPOSE 14555
 HEALTHCHECK CMD ["/usr/local/bin/grpc_health_probe", "-addr=127.0.0.1:14555"]
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,43 @@
+# Coral server image. Built by repackaging a published release tarball, so the
+# runtime stage is COPY-only: every RUN lives in the $BUILDPLATFORM prep stage
+# and no target-architecture code ever executes during the build (zero QEMU).
+# Build context is the repo root, with the release binary extracted to
+# dist/${TARGETARCH}/coral beforehand.
+FROM --platform=$BUILDPLATFORM debian:trixie-slim AS prep
+ARG TARGETARCH
+ARG TINI_VERSION=v0.19.0
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.54
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN set -eu; \
+    case "$TARGETARCH" in \
+    amd64) tini_sha=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c; \
+           probe_sha=e25b2f7e50176a909b9036e2c7598d8997b524a87d24af81d92b796e6dfb4897 ;; \
+    arm64) tini_sha=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81; \
+           probe_sha=bc77dba74822d2b00c2585d225b77048cdb044407a0541ebf4c12711c2fdf779 ;; \
+    *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tini "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH}"; \
+    echo "${tini_sha}  /tini" | sha256sum -c -; \
+    curl -fsSL -o /grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}"; \
+    echo "${probe_sha}  /grpc_health_probe" | sha256sum -c -; \
+    chmod 0755 /tini /grpc_health_probe
+COPY dist/${TARGETARCH}/coral /coral
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod 0755 /coral /entrypoint.sh && mkdir -p /out/var/lib/coral
+
+FROM debian:trixie-slim
+COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=prep /tini /tini
+COPY --from=prep /grpc_health_probe /usr/local/bin/grpc_health_probe
+COPY --from=prep /coral /usr/local/bin/coral
+COPY --from=prep --chown=0:0 --chmod=0755 /entrypoint.sh /usr/local/bin/entrypoint.sh
+# g=u (0775) with GID 0 so any uid running with --user <uid>:0 can write the volume.
+COPY --from=prep --chown=0:0 --chmod=0775 /out/var/lib/coral /var/lib/coral
+ENV CORAL_CONFIG_DIR=/var/lib/coral/config \
+    HOME=/var/lib/coral
+USER 65532:0
+EXPOSE 14555
+HEALTHCHECK CMD ["/usr/local/bin/grpc_health_probe", "-addr=127.0.0.1:14555"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,5 +33,5 @@ ENV CORAL_CONFIG_DIR=/var/lib/coral/config \
     HOME=/var/lib/coral
 USER 65532:0
 EXPOSE 14555
-HEALTHCHECK CMD ["/usr/local/bin/grpc_health_probe", "-addr=127.0.0.1:14555"]
+HEALTHCHECK CMD /usr/local/bin/grpc_health_probe -addr="${CORAL_HEALTHCHECK_ADDR:-127.0.0.1:14555}"
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -4,12 +4,14 @@
 # published images continue to use checksum-verified release artifacts instead.
 FROM --platform=$TARGETPLATFORM rust:1.97-trixie AS build
 ARG TARGETARCH
+ARG CORAL_GIT_SHA
 WORKDIR /src
 COPY . .
 RUN --mount=type=cache,id=coral-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=coral-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=coral-cargo-target-${TARGETARCH},target=/src/target,sharing=locked \
-    cargo build --locked --release -p coral-cli \
+    test -n "$CORAL_GIT_SHA" \
+    && cargo build --locked --release -p coral-cli \
     && install -D -m 0755 target/release/coral /out/coral
 
 FROM scratch AS binary

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.7
+# Compile the current checkout for the Docker daemon's native Linux platform.
+# The exported binary is fed into docker/Dockerfile by `make docker-build`;
+# published images continue to use checksum-verified release artifacts instead.
+FROM --platform=$TARGETPLATFORM rust:1.97-trixie AS build
+ARG TARGETARCH
+WORKDIR /src
+COPY . .
+RUN --mount=type=cache,id=coral-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=coral-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=coral-cargo-target-${TARGETARCH},target=/src/target,sharing=locked \
+    cargo build --locked --release -p coral-cli \
+    && install -D -m 0755 target/release/coral /out/coral
+
+FROM scratch AS binary
+COPY --from=build /out/coral /coral

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,20 +36,21 @@ rm -f "$probe"
 # 3. Seed only when NOTHING exists at the path — no file, no directory, no
 #    symlink (dangling included: a dangling symlink is user intent, e.g. a
 #    not-yet-mounted secret; coral itself stats via symlink_metadata,
-#    server_config.rs:53). Atomic: mktemp in the same directory + rename(2),
-#    so a kill mid-write can never leave a half-written config.toml — the file
-#    either exists complete or does not exist. Stale temps from a previous
-#    killed write are swept first and are never visible at the config path.
+#    server_config.rs:53). Atomic: mktemp in the same directory, then hard-link
+#    the completed temporary file into place. link(2) never overwrites an
+#    existing path, so concurrent starts preserve the first complete config.
 if [ ! -e "$CONFIG_FILE" ] && [ ! -L "$CONFIG_FILE" ]; then
-    rm -f "$CORAL_CONFIG_DIR"/.config.toml.seed.*
     seed="$(mktemp "$CORAL_CONFIG_DIR/.config.toml.seed.XXXXXX")"
+    trap 'rm -f "$seed"' EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
     if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
         # Whole-file seed supplied by the operator: written VERBATIM (no
         # templating, no parsing) through the same atomic path. Once-only:
         # this branch is unreachable when any config exists.
-        printf '%s\n' "$CORAL_SEED_CONFIG" > "$seed"
-        mv "$seed" "$CONFIG_FILE"
-        echo "coral-entrypoint: seeded $CONFIG_FILE from CORAL_SEED_CONFIG" >&2
+        printf '%s' "$CORAL_SEED_CONFIG" > "$seed"
+        seed_source="CORAL_SEED_CONFIG"
     else
         cat > "$seed" <<'EOF'
 # Generated once by the Coral Docker image on first start. The image will
@@ -59,8 +60,26 @@ if [ ! -e "$CONFIG_FILE" ] && [ ! -L "$CONFIG_FILE" ]; then
 [server]
 bind_addr = "0.0.0.0:14555"
 EOF
-        mv "$seed" "$CONFIG_FILE"
-        echo "coral-entrypoint: seeded starter $CONFIG_FILE (bind_addr 0.0.0.0:14555)" >&2
+        seed_source="starter"
+    fi
+
+    if ln "$seed" "$CONFIG_FILE" 2>/dev/null; then
+        rm -f "$seed"
+        trap - EXIT HUP INT TERM
+        if [ "$seed_source" = "CORAL_SEED_CONFIG" ]; then
+            echo "coral-entrypoint: seeded $CONFIG_FILE from CORAL_SEED_CONFIG" >&2
+        else
+            echo "coral-entrypoint: seeded starter $CONFIG_FILE (bind_addr 0.0.0.0:14555)" >&2
+        fi
+    elif [ -e "$CONFIG_FILE" ] || [ -L "$CONFIG_FILE" ]; then
+        rm -f "$seed"
+        trap - EXIT HUP INT TERM
+        if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
+            echo "coral-entrypoint: $CONFIG_FILE exists; CORAL_SEED_CONFIG ignored (seed applies only to first start)" >&2
+        fi
+        echo "coral-entrypoint: using existing $CONFIG_FILE" >&2
+    else
+        fatal "cannot atomically create $CONFIG_FILE"
     fi
 else
     if [ -n "${CORAL_SEED_CONFIG:-}" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,8 +5,22 @@
 # is editing that file. See https://withcoral.com/docs/guides/self-host-with-docker
 set -eu
 
-# PID 1 ignores default-action signals on Linux. Install handlers before any
-# filesystem preparation so a stop during startup cannot strand the container.
+probe=
+seed=
+
+cleanup() {
+    if [ -n "$probe" ]; then
+        rm -f "$probe" 2>/dev/null || :
+    fi
+    if [ -n "$seed" ]; then
+        rm -f "$seed" 2>/dev/null || :
+    fi
+}
+
+# PID 1 ignores default-action signals on Linux. Install cleanup and signal
+# handlers before any filesystem preparation so a stop during startup cannot
+# strand the container or leave temporary files in its persistent state.
+trap cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
@@ -38,6 +52,7 @@ mkdir -p "$CORAL_CONFIG_DIR" 2>/dev/null || fatal "cannot create $CORAL_CONFIG_D
 probe="$(mktemp "$CORAL_CONFIG_DIR/.write-probe.XXXXXX" 2>/dev/null)" \
     || fatal "$CORAL_CONFIG_DIR is not writable"
 rm -f "$probe"
+probe=
 
 # 3. Seed only when NOTHING exists at the path — no file, no directory, no
 #    symlink (dangling included: a dangling symlink is user intent, e.g. a
@@ -47,7 +62,6 @@ rm -f "$probe"
 #    existing path, so concurrent starts preserve the first complete config.
 if [ ! -e "$CONFIG_FILE" ] && [ ! -L "$CONFIG_FILE" ]; then
     seed="$(mktemp "$CORAL_CONFIG_DIR/.config.toml.seed.XXXXXX")"
-    trap 'rm -f "$seed"' EXIT
     if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
         # Whole-file seed supplied by the operator: written VERBATIM (no
         # templating, no parsing) through the same atomic path. Once-only:
@@ -68,7 +82,7 @@ EOF
 
     if ln -T "$seed" "$CONFIG_FILE" 2>/dev/null; then
         rm -f "$seed"
-        trap - EXIT
+        seed=
         if [ "$seed_source" = "CORAL_SEED_CONFIG" ]; then
             echo "coral-entrypoint: seeded $CONFIG_FILE from CORAL_SEED_CONFIG" >&2
         else
@@ -76,7 +90,7 @@ EOF
         fi
     elif [ -e "$CONFIG_FILE" ] || [ -L "$CONFIG_FILE" ]; then
         rm -f "$seed"
-        trap - EXIT
+        seed=
         if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
             echo "coral-entrypoint: $CONFIG_FILE exists; CORAL_SEED_CONFIG ignored (seed applies only to first start)" >&2
         fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,12 @@
 # is editing that file. See https://withcoral.com/docs/guides/self-host-with-docker
 set -eu
 
+# PID 1 ignores default-action signals on Linux. Install handlers before any
+# filesystem preparation so a stop during startup cannot strand the container.
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 CONFIG_FILE="$CORAL_CONFIG_DIR/config.toml"
 
 fatal() {
@@ -42,9 +48,6 @@ rm -f "$probe"
 if [ ! -e "$CONFIG_FILE" ] && [ ! -L "$CONFIG_FILE" ]; then
     seed="$(mktemp "$CORAL_CONFIG_DIR/.config.toml.seed.XXXXXX")"
     trap 'rm -f "$seed"' EXIT
-    trap 'exit 129' HUP
-    trap 'exit 130' INT
-    trap 'exit 143' TERM
     if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
         # Whole-file seed supplied by the operator: written VERBATIM (no
         # templating, no parsing) through the same atomic path. Once-only:
@@ -63,9 +66,9 @@ EOF
         seed_source="starter"
     fi
 
-    if ln "$seed" "$CONFIG_FILE" 2>/dev/null; then
+    if ln -T "$seed" "$CONFIG_FILE" 2>/dev/null; then
         rm -f "$seed"
-        trap - EXIT HUP INT TERM
+        trap - EXIT
         if [ "$seed_source" = "CORAL_SEED_CONFIG" ]; then
             echo "coral-entrypoint: seeded $CONFIG_FILE from CORAL_SEED_CONFIG" >&2
         else
@@ -73,7 +76,7 @@ EOF
         fi
     elif [ -e "$CONFIG_FILE" ] || [ -L "$CONFIG_FILE" ]; then
         rm -f "$seed"
-        trap - EXIT HUP INT TERM
+        trap - EXIT
         if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
             echo "coral-entrypoint: $CONFIG_FILE exists; CORAL_SEED_CONFIG ignored (seed applies only to first start)" >&2
         fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Coral container entrypoint. On first start with an empty volume it seeds a
+# starter config.toml — from $CORAL_SEED_CONFIG when set (verbatim), else a
+# built-in default — and it NEVER modifies an existing one. All configuration
+# is editing that file. See https://withcoral.com/docs/guides/self-host-with-docker
+set -eu
+
+CONFIG_FILE="$CORAL_CONFIG_DIR/config.toml"
+
+fatal() {
+    echo "coral-entrypoint: FATAL: $1" >&2
+    echo "coral-entrypoint: the volume mounted at /var/lib/coral must be writable by uid $(id -u):" \
+         "run with '--user <uid>:0' (GID 0), set a Kubernetes fsGroup, or pre-chown the volume;" \
+         "read-only mounts are not supported (Coral locks and writes its state root at startup)." >&2
+    exit 1
+}
+
+# Everything we create is private to the runtime uid. mktemp creates 0600
+# regardless; this governs mkdir (0700), matching coral's own hardening
+# (ensure_private_dir chmods 0700, storage/fs.rs:22-27).
+umask 077
+
+# 1. The config dir is a SUBDIRECTORY of the volume root: docker creates named-
+#    volume roots as root:root, and coral unconditionally chmods its config dir
+#    to 0700 at startup — EPERM on a dir the runtime uid does not own (spike-1
+#    correction 1). A subdir created here is owned by the runtime uid.
+mkdir -p "$CORAL_CONFIG_DIR" 2>/dev/null || fatal "cannot create $CORAL_CONFIG_DIR"
+
+# 2. Fail fast with ONE actionable message on read-only or wrongly-owned
+#    volumes, before the binary hits a less obvious flock/DB error. Runs every
+#    start: a volume that became read-only after first boot fails here too.
+probe="$(mktemp "$CORAL_CONFIG_DIR/.write-probe.XXXXXX" 2>/dev/null)" \
+    || fatal "$CORAL_CONFIG_DIR is not writable"
+rm -f "$probe"
+
+# 3. Seed only when NOTHING exists at the path — no file, no directory, no
+#    symlink (dangling included: a dangling symlink is user intent, e.g. a
+#    not-yet-mounted secret; coral itself stats via symlink_metadata,
+#    server_config.rs:53). Atomic: mktemp in the same directory + rename(2),
+#    so a kill mid-write can never leave a half-written config.toml — the file
+#    either exists complete or does not exist. Stale temps from a previous
+#    killed write are swept first and are never visible at the config path.
+if [ ! -e "$CONFIG_FILE" ] && [ ! -L "$CONFIG_FILE" ]; then
+    rm -f "$CORAL_CONFIG_DIR"/.config.toml.seed.*
+    seed="$(mktemp "$CORAL_CONFIG_DIR/.config.toml.seed.XXXXXX")"
+    if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
+        # Whole-file seed supplied by the operator: written VERBATIM (no
+        # templating, no parsing) through the same atomic path. Once-only:
+        # this branch is unreachable when any config exists.
+        printf '%s\n' "$CORAL_SEED_CONFIG" > "$seed"
+        mv "$seed" "$CONFIG_FILE"
+        echo "coral-entrypoint: seeded $CONFIG_FILE from CORAL_SEED_CONFIG" >&2
+    else
+        cat > "$seed" <<'EOF'
+# Generated once by the Coral Docker image on first start. The image will
+# never modify this file again; edit it and restart the container.
+# Reference: https://withcoral.com/docs/reference/configuration
+
+[server]
+bind_addr = "0.0.0.0:14555"
+EOF
+        mv "$seed" "$CONFIG_FILE"
+        echo "coral-entrypoint: seeded starter $CONFIG_FILE (bind_addr 0.0.0.0:14555)" >&2
+    fi
+else
+    if [ -n "${CORAL_SEED_CONFIG:-}" ]; then
+        echo "coral-entrypoint: $CONFIG_FILE exists; CORAL_SEED_CONFIG ignored (seed applies only to first start)" >&2
+    fi
+    echo "coral-entrypoint: using existing $CONFIG_FILE" >&2
+fi
+
+exec /usr/local/bin/coral server "$@"


### PR DESCRIPTION
## Intent

Publish an official linux/amd64 Coral image from the same checksum-verified release tarball produced by the Coral release workflow. The image must preserve one writable state volume, start the long-running gRPC server safely as a non-root user, and remain independently rebuildable for base-image security updates.

## What it enables

- Run Coral as a self-hosted server from GHCR with one port and one volume.
- Build the current checkout locally through one Make target, compiling for the Docker daemon's native Linux architecture (arm64 on Apple Silicon, amd64 on Intel) without downloading a published Coral binary.
- Publish exact X.Y.Z tags plus monotonic X.Y and latest stable tags after each release.
- Verify the release checksum and glibc floor before publishing.
- Ship BuildKit provenance, keyless cosign signatures, a health check, and smoke coverage for first boot, restart reuse, read-only failure, and declarative seeding.
- Rebuild an image for an existing release through workflow dispatch without rerunning or mutating the release.

## Usage examples

Run the published image:

```bash
docker run -d -p 14555:14555 -v coral-data:/var/lib/coral ghcr.io/withcoral/coral
```

Compile the current checkout and load it as `coral:local`:

```bash
make docker-build
```

Change the local image tag or bypass the BuildKit layer cache:

```bash
DOCKER_IMAGE=coral:test make docker-build
DOCKER_NO_CACHE=1 make docker-build
```

For an image-only rebuild, dispatch the `Publish Docker image` workflow with a published tag such as `v1.2.3`.

## Validation

- `actionlint v1.7.12` passed for both changed workflows with the repository-specific Blacksmith runner-label ignore.
- YAML parsing and whitespace checks passed.
- Implementation-lane evidence records passing shellcheck, buildx, health, seed/reuse, read-only-volume, custom-UID, and graceful-stop smoke cases.
- `docker buildx build --check --platform linux/arm64 --file docker/Dockerfile.local .` passed with no warnings.
- `make docker-build DOCKER_IMAGE=coral:docker-build-local-test` compiled the checkout from a cold BuildKit cache, produced a linux/arm64 image, reached gRPC health, and stopped cleanly with exit code 0.
- A warm rebuild reused the Cargo and image layers; `DOCKER_NO_CACHE=1` completed a separate clean compile and image build.
- The resulting image runs as `65532:0` and reports `linux/arm64`, matching the Apple Silicon Docker daemon used for validation.
- No Rust source files changed, so `make rust-checks` was intentionally not run; the release `coral-cli` compilation ran inside the Docker build.

Stack: 1 of 2. User documentation follows in #2056.
