### PR TITLE
feat(reef): configure optional hosted authentication

### DIFF
--- a/apps/reef/.env.example
+++ b/apps/reef/.env.example
@@ -4,13 +4,9 @@
 # Hosted Reef should set REEF_AUTH_MODE=required and configure these server-only
 # values. Never expose the session secret through a VITE_ variable.
 # REEF_SESSION_SECRET=
-# REEF_AUTH_ISSUER=https://login.example.com
-# Optional when the issuer advertises an OAuth dynamic registration endpoint.
-# REEF_AUTH_CLIENT_ID=coral-cloud-ui
-# REEF_AUTH_REDIRECT_URI=https://reef.example.com/auth/callback
-# REEF_AUTH_SCOPE=coral:mcp
+# REEF_AUTH_ISSUER=https://coral.example.com
+# REEF_PUBLIC_URL=https://reef.example.com
 
 # Optional session overrides.
 # REEF_SESSION_COOKIE_NAME=reef_session
 # REEF_SESSION_MAX_AGE_SECONDS=3600
-# REEF_COOKIE_SECURE=true

--- a/apps/reef/.env.example
+++ b/apps/reef/.env.example
@@ -1,0 +1,16 @@
+# Reef authentication is optional. Local development defaults to disabled.
+# REEF_AUTH_MODE=disabled
+
+# Hosted Reef should set REEF_AUTH_MODE=required and configure these server-only
+# values. Never expose the session secret through a VITE_ variable.
+# REEF_SESSION_SECRET=
+# REEF_AUTH_ISSUER=https://login.example.com
+# Optional when the issuer advertises an OAuth dynamic registration endpoint.
+# REEF_AUTH_CLIENT_ID=coral-cloud-ui
+# REEF_AUTH_REDIRECT_URI=https://reef.example.com/auth/callback
+# REEF_AUTH_SCOPE=coral:mcp
+
+# Optional session overrides.
+# REEF_SESSION_COOKIE_NAME=reef_session
+# REEF_SESSION_MAX_AGE_SECONDS=3600
+# REEF_COOKIE_SECURE=true

--- a/apps/reef/.env.example
+++ b/apps/reef/.env.example
@@ -7,6 +7,10 @@
 # REEF_AUTH_ISSUER=https://coral.example.com
 # REEF_PUBLIC_URL=https://reef.example.com
 
-# Optional session overrides.
+# Optional session overrides. The cookie name must be an RFC 6265 token —
+# letters, digits, or !#$%&'*+-.^_`|~ — and a __Host- or __Secure- prefix works
+# only when REEF_PUBLIC_URL is HTTPS, since browsers discard those without
+# Secure. Reef rejects both at startup rather than serving a session the browser
+# will silently drop.
 # REEF_SESSION_COOKIE_NAME=reef_session
 # REEF_SESSION_MAX_AGE_SECONDS=3600

--- a/apps/reef/README.md
+++ b/apps/reef/README.md
@@ -18,6 +18,15 @@ npm run dev
 
 Open `http://localhost:5173` unless the dev server prints a different URL.
 
+Authentication is disabled by default for local development and for Coral
+Desktop. No auth environment variables are needed for those modes.
+
+Hosted Reef must choose its auth behavior explicitly. Set
+`REEF_AUTH_MODE=required` together with the server-only issuer, callback, and
+session values documented in `.env.example`. A non-desktop production server
+without an explicit mode fails closed rather than accidentally publishing an
+unauthenticated app.
+
 Run checks:
 
 ```bash

--- a/apps/reef/README.md
+++ b/apps/reef/README.md
@@ -22,9 +22,11 @@ Authentication is disabled by default for local development and for Coral
 Desktop. No auth environment variables are needed for those modes.
 
 Hosted Reef must choose its auth behavior explicitly. Set
-`REEF_AUTH_MODE=required` together with the server-only issuer, callback, and
-session values documented in `.env.example`. A non-desktop production server
-without an explicit mode fails closed rather than accidentally publishing an
+`REEF_AUTH_MODE=required` together with the server-only Coral authorization
+issuer, Reef public URL, and session values documented in `.env.example`. Reef
+derives its OAuth resource, client metadata URL, callback URL, and cookie
+security from `REEF_PUBLIC_URL`. A non-desktop production server without an
+explicit mode fails closed rather than accidentally publishing an
 unauthenticated app.
 
 Run checks:

--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -26,20 +26,19 @@ function read(...segments: string[]): string {
 describe('hosted auth architecture', () => {
   // Regression: `reefAuthConfig` gated the Desktop bypass on
   // `import.meta.env.VITE_CORAL_DESKTOP_APP`, a variable nothing in the repo
-  // sets, so the branch was dead. A guard already banned that spelling — but
-  // only across the files that *define* the marker, never the one that consumes
-  // it, so it stayed green while the bug shipped. The consumer is in the list
-  // now, and the delegation is asserted positively: banning the string alone
-  // would still accept an inlined `import.meta.env.CORAL_DESKTOP_APP === '1'`,
-  // which is equally broken because `define` compiles the marker to a boolean.
+  // sets, so the branch was dead.
+  //
+  // Scoped to the four places that *define* the marker, because those are what
+  // no test executes — a Vite config and two Desktop build scripts. How the auth
+  // config reads it is covered for real in `config.server.test.ts`, which mocks
+  // the helper: any consumer that bypasses it, however spelled, fails there.
   it('derives Desktop behavior from one build marker, read through one helper', () => {
     const viteConfig = read(reefRoot, 'vite.config.ts')
     const desktopHelper = read(appDir, 'lib', 'coral-desktop.ts')
     const devScript = read(desktopRoot, 'scripts', 'dev.mjs')
     const stageScript = read(desktopRoot, 'scripts', 'stage-coral.mjs')
-    const authConfig = read(appDir, 'auth', 'config.server.ts')
 
-    for (const source of [viteConfig, desktopHelper, devScript, stageScript, authConfig]) {
+    for (const source of [viteConfig, desktopHelper, devScript, stageScript]) {
       expect(source).not.toContain('VITE_CORAL_DESKTOP_APP')
     }
     expect(viteConfig).toMatch(
@@ -48,7 +47,5 @@ describe('hosted auth architecture', () => {
     expect(desktopHelper).toMatch(/return import\.meta\.env\.CORAL_DESKTOP_APP/)
     expect(devScript.match(/CORAL_DESKTOP_APP:\s*'1'/g)).toHaveLength(1)
     expect(stageScript.match(/CORAL_DESKTOP_APP:\s*'1'/g)).toHaveLength(1)
-    expect(authConfig).toContain('isDesktopBuild: isCoralDesktopBuild(),')
-    expect(authConfig).not.toMatch(/import\.meta\.env\.\w*CORAL_DESKTOP_APP/)
   })
 })

--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Structural invariants for hosted authentication.
+ *
+ * These are deliberately separate from `architecture.test.ts`, which covers
+ * component and styling conventions. Each case here pins a specific regression
+ * this stack fixed, and exists because the defect it guards was invisible to
+ * every other kind of test — a marker nothing sets, a route outside the auth
+ * boundary, a client built without a token. Per AGENTS.md, Reef keeps
+ * architectural invariants only where they protect a named contract; the named
+ * contract is recorded on each case below.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const reefRoot = path.resolve(appDir, '..')
+const desktopRoot = path.resolve(reefRoot, '..', 'desktop')
+
+function read(...segments: string[]): string {
+  return fs.readFileSync(path.join(...segments), 'utf8')
+}
+
+describe('hosted auth architecture', () => {
+  // Regression: `reefAuthConfig` gated the Desktop bypass on
+  // `import.meta.env.VITE_CORAL_DESKTOP_APP`, a variable nothing in the repo
+  // sets, so the branch was dead. A guard already banned that spelling — but
+  // only across the files that *define* the marker, never the one that consumes
+  // it, so it stayed green while the bug shipped. The consumer is in the list
+  // now, and the delegation is asserted positively: banning the string alone
+  // would still accept an inlined `import.meta.env.CORAL_DESKTOP_APP === '1'`,
+  // which is equally broken because `define` compiles the marker to a boolean.
+  it('derives Desktop behavior from one build marker, read through one helper', () => {
+    const viteConfig = read(reefRoot, 'vite.config.ts')
+    const desktopHelper = read(appDir, 'lib', 'coral-desktop.ts')
+    const devScript = read(desktopRoot, 'scripts', 'dev.mjs')
+    const stageScript = read(desktopRoot, 'scripts', 'stage-coral.mjs')
+    const authConfig = read(appDir, 'auth', 'config.server.ts')
+
+    for (const source of [viteConfig, desktopHelper, devScript, stageScript, authConfig]) {
+      expect(source).not.toContain('VITE_CORAL_DESKTOP_APP')
+    }
+    expect(viteConfig).toMatch(
+      /'import\.meta\.env\.CORAL_DESKTOP_APP':\s*JSON\.stringify\(\s*process\.env\.CORAL_DESKTOP_APP === '1',?\s*\)/,
+    )
+    expect(desktopHelper).toMatch(/return import\.meta\.env\.CORAL_DESKTOP_APP/)
+    expect(devScript.match(/CORAL_DESKTOP_APP:\s*'1'/g)).toHaveLength(1)
+    expect(stageScript.match(/CORAL_DESKTOP_APP:\s*'1'/g)).toHaveLength(1)
+    expect(authConfig).toContain('isDesktopBuild: isCoralDesktopBuild(),')
+    expect(authConfig).not.toMatch(/import\.meta\.env\.\w*CORAL_DESKTOP_APP/)
+  })
+})

--- a/apps/reef/app/auth/config.server.test.ts
+++ b/apps/reef/app/auth/config.server.test.ts
@@ -1,8 +1,35 @@
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, it } from 'vitest'
 
-import { resolveAuthConfig } from './config.server'
+import {
+  authClientId,
+  authCookieSecure,
+  authRedirectUri,
+  authResource,
+  resolveAuthConfig,
+} from './config.server'
+import type { RequiredAuthConfig } from './types'
 
 const SESSION_SECRET = '0123456789abcdef0123456789abcdef'
+
+function requiredEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: 'production',
+    REEF_AUTH_ISSUER: 'https://coral.example.test',
+    REEF_AUTH_MODE: 'required',
+    REEF_PUBLIC_URL: 'https://reef.example.test',
+    REEF_SESSION_SECRET: SESSION_SECRET,
+    ...overrides,
+  }
+}
+
+function requiredConfig(overrides: NodeJS.ProcessEnv = {}): RequiredAuthConfig {
+  const config = resolveAuthConfig({ env: requiredEnv(overrides), isDesktopBuild: false })
+  expect(config.mode).toBe('required')
+  if (config.mode !== 'required') throw new Error('expected required auth config')
+  return config
+}
 
 describe('Reef auth config', () => {
   it('defaults local development and tests to disabled auth', () => {
@@ -17,12 +44,7 @@ describe('Reef auth config', () => {
   it('keeps desktop builds disabled regardless of ambient hosted config', () => {
     expect(
       resolveAuthConfig({
-        env: {
-          NODE_ENV: 'production',
-          REEF_AUTH_ISSUER: 'https://login.example.test',
-          REEF_AUTH_MODE: 'required',
-          REEF_SESSION_SECRET: SESSION_SECRET,
-        },
+        env: requiredEnv(),
         isDesktopBuild: true,
       }),
     ).toEqual({ mode: 'disabled' })
@@ -43,96 +65,148 @@ describe('Reef auth config', () => {
     ).toEqual({ mode: 'disabled' })
   })
 
-  it('validates required auth config without changing exact OAuth identifiers', () => {
-    expect(
-      resolveAuthConfig({
-        env: {
-          NODE_ENV: 'production',
-          REEF_AUTH_CLIENT_ID: 'coral-cloud-ui',
-          REEF_AUTH_ISSUER: 'https://login.example.test:443/tenant/',
-          REEF_AUTH_MODE: 'required',
-          REEF_AUTH_REDIRECT_URI: 'https://reef.example.test:443/auth/callback?tenant=coral',
-          REEF_AUTH_SCOPE: 'coral:mcp',
-          REEF_SESSION_COOKIE_NAME: 'custom_session',
-          REEF_SESSION_MAX_AGE_SECONDS: '1800',
-          REEF_SESSION_SECRET: SESSION_SECRET,
-        },
-        isDesktopBuild: false,
-      }),
-    ).toEqual({
-      clientId: 'coral-cloud-ui',
+  it('derives every OAuth identifier and cookie security from the canonical public URL', () => {
+    const config = requiredConfig({
+      REEF_AUTH_CLIENT_ID: 'ignored-client-id',
+      REEF_AUTH_ISSUER: 'https://coral.example.test:443/tenant/',
+      REEF_AUTH_REDIRECT_URI: 'https://ignored.example.test/callback',
+      REEF_AUTH_RESOURCE: 'https://ignored.example.test',
+      REEF_AUTH_SCOPE: 'ignored:scope',
+      REEF_COOKIE_SECURE: 'false',
+      REEF_MCP_URL: 'https://ignored.example.test/mcp',
+      REEF_PUBLIC_URL: 'https://REEF.Example.test:443/',
+      REEF_SESSION_COOKIE_NAME: 'custom_session',
+      REEF_SESSION_MAX_AGE_SECONDS: '1800',
+    })
+
+    expect(config).toEqual({
       cookieName: 'custom_session',
-      cookieSecure: true,
-      issuer: 'https://login.example.test:443/tenant/',
+      issuer: 'https://coral.example.test:443/tenant/',
       mode: 'required',
-      redirectUri: 'https://reef.example.test:443/auth/callback?tenant=coral',
-      scope: 'coral:mcp',
+      publicUrl: 'https://reef.example.test',
       sessionMaxAgeSeconds: 1800,
       sessionSecret: SESSION_SECRET,
     })
+    expect(authResource(config)).toBe('https://reef.example.test')
+    expect(authClientId(config)).toBe('https://reef.example.test/.well-known/oauth-client')
+    expect(authRedirectUri(config)).toBe('https://reef.example.test/auth/callback')
+    expect(authCookieSecure(config)).toBe(true)
   })
 
-  it('rejects insecure hosted production cookies', () => {
-    expect(() =>
-      resolveAuthConfig({
-        env: {
-          NODE_ENV: 'production',
-          REEF_AUTH_ISSUER: 'https://login.example.test',
-          REEF_AUTH_MODE: 'required',
-          REEF_AUTH_REDIRECT_URI: 'https://reef.example.test/auth/callback',
-          REEF_COOKIE_SECURE: 'false',
-          REEF_SESSION_SECRET: SESSION_SECRET,
-        },
-        isDesktopBuild: false,
-      }),
-    ).toThrow('REEF_COOKIE_SECURE cannot be false in production')
+  it('allows plain HTTP only when Reef and Coral are both explicit loopback URLs', () => {
+    const config = requiredConfig({
+      REEF_AUTH_ISSUER: 'http://127.42.0.1:3000',
+      REEF_PUBLIC_URL: 'http://[::1]:5173',
+    })
+
+    expect(config.publicUrl).toBe('http://[::1]:5173')
+    expect(authResource(config)).toBe('http://[::1]:5173')
+    expect(authClientId(config)).toBe('http://[::1]:5173/.well-known/oauth-client')
+    expect(authRedirectUri(config)).toBe('http://[::1]:5173/auth/callback')
+    expect(authCookieSecure(config)).toBe(false)
   })
 
   it.each([
-    [{ REEF_AUTH_MODE: 'sometimes' }, 'REEF_AUTH_MODE must be set to disabled or required'],
+    ['http://localhost:5173', 'http://localhost:3000'],
+    ['http://localhost.:5173', 'http://localhost.:3000'],
+    ['http://127.255.1.2:5173', 'http://127.0.0.1:3000'],
+    ['http://[::1]:5173', 'http://[::1]:3000'],
+    ['http://[::ffff:127.0.0.1]:5173', 'http://[::ffff:127.0.0.2]:3000'],
+  ])('accepts explicit loopback pair %s and %s', (publicUrl, issuer) => {
+    expect(() =>
+      requiredConfig({ REEF_AUTH_ISSUER: issuer, REEF_PUBLIC_URL: publicUrl }),
+    ).not.toThrow()
+  })
+
+  it('rejects an HTTP Reef URL when the Coral issuer is not also loopback HTTP', () => {
+    expect(() => requiredConfig({ REEF_PUBLIC_URL: 'http://127.0.0.1:5173' })).toThrow(
+      'REEF_PUBLIC_URL may use HTTP only when REEF_AUTH_ISSUER also uses explicit-loopback HTTP',
+    )
+  })
+
+  it.each([
+    'http://192.168.1.10:5173',
+    'http://10.0.0.10:5173',
+    'http://169.254.1.10:5173',
+    'http://reef.internal:5173',
+    'http://preview.localhost:5173',
+  ])('rejects a non-loopback HTTP public URL: %s', (publicUrl) => {
+    expect(() => requiredConfig({ REEF_PUBLIC_URL: publicUrl })).toThrow(
+      'REEF_PUBLIC_URL must be an HTTPS or explicit-loopback HTTP origin',
+    )
+  })
+
+  it.each([
+    'https://user:password@reef.example.test',
+    'https://reef.example.test/a/path',
+    'https://reef.example.test?tenant=coral',
+    'https://reef.example.test#fragment',
+    'ftp://reef.example.test',
+  ])('rejects a public URL that is not a clean HTTP(S) origin: %s', (publicUrl) => {
+    expect(() => requiredConfig({ REEF_PUBLIC_URL: publicUrl })).toThrow(
+      'REEF_PUBLIC_URL must be an HTTPS or explicit-loopback HTTP origin',
+    )
+  })
+
+  it.each([
+    'http://192.168.1.10:3000',
+    'http://10.0.0.10:3000',
+    'http://169.254.1.10:3000',
+    'http://coral.internal:3000',
+    'http://preview.localhost:3000',
+  ])('rejects a non-loopback HTTP Coral issuer: %s', (issuer) => {
+    expect(() => requiredConfig({ REEF_AUTH_ISSUER: issuer })).toThrow(
+      'REEF_AUTH_ISSUER must use HTTPS or explicit-loopback HTTP',
+    )
+  })
+
+  it.each([
+    ['sometimes', 'REEF_AUTH_MODE must be set to disabled or required'],
+    ['', 'REEF_AUTH_MODE must be set to disabled or required'],
+  ])('rejects invalid auth mode %s', (mode, message) => {
+    expect(() =>
+      resolveAuthConfig({
+        env: requiredEnv({ REEF_AUTH_MODE: mode }),
+        isDesktopBuild: false,
+      }),
+    ).toThrow(message)
+  })
+
+  it.each([
+    [{ REEF_SESSION_SECRET: 'too-short' }, 'REEF_SESSION_SECRET must be at least 32 characters'],
+    [{ REEF_AUTH_ISSUER: '' }, 'REEF_AUTH_ISSUER must be set'],
+    [{ REEF_PUBLIC_URL: '' }, 'REEF_PUBLIC_URL must be set'],
     [
-      { REEF_AUTH_ISSUER: 'https://login.example.test', REEF_AUTH_MODE: 'required' },
-      'REEF_SESSION_SECRET must be at least 32 characters',
-    ],
-    [
-      { REEF_AUTH_MODE: 'required', REEF_SESSION_SECRET: SESSION_SECRET },
-      'REEF_AUTH_ISSUER must be set',
-    ],
-    [
-      {
-        REEF_AUTH_ISSUER: 'file:///tmp/issuer',
-        REEF_AUTH_MODE: 'required',
-        REEF_SESSION_SECRET: SESSION_SECRET,
-      },
+      { REEF_AUTH_ISSUER: 'file:///tmp/issuer' },
       'REEF_AUTH_ISSUER must be an absolute HTTP(S) URL',
     ],
     [
-      {
-        REEF_AUTH_ISSUER: 'https://login.example.test/tenant?region=us',
-        REEF_AUTH_MODE: 'required',
-        REEF_SESSION_SECRET: SESSION_SECRET,
-      },
+      { REEF_AUTH_ISSUER: 'https://user:password@coral.example.test' },
+      'REEF_AUTH_ISSUER must not include credentials',
+    ],
+    [
+      { REEF_AUTH_ISSUER: 'https://coral.example.test/tenant?region=us' },
       'REEF_AUTH_ISSUER must not include a query string or fragment',
     ],
     [
-      {
-        REEF_AUTH_ISSUER: 'https://login.example.test',
-        REEF_AUTH_MODE: 'required',
-        REEF_AUTH_REDIRECT_URI: 'https://reef.example.test/auth/callback#done',
-        REEF_SESSION_SECRET: SESSION_SECRET,
-      },
-      'REEF_AUTH_REDIRECT_URI must not include a fragment',
-    ],
-    [
-      {
-        REEF_AUTH_ISSUER: 'https://login.example.test',
-        REEF_AUTH_MODE: 'required',
-        REEF_SESSION_MAX_AGE_SECONDS: '0',
-        REEF_SESSION_SECRET: SESSION_SECRET,
-      },
+      { REEF_SESSION_MAX_AGE_SECONDS: '0' },
       'REEF_SESSION_MAX_AGE_SECONDS must be a positive integer',
     ],
-  ])('rejects invalid config %#', (env, message) => {
-    expect(() => resolveAuthConfig({ env, isDesktopBuild: false })).toThrow(message)
+  ])('rejects invalid required config %#', (overrides, message) => {
+    expect(() => requiredConfig(overrides)).toThrow(message)
+  })
+
+  it('keeps redundant auth settings out of the documented environment contract', () => {
+    const example = readFileSync(new URL('../../.env.example', import.meta.url), 'utf8')
+    for (const removedName of [
+      'REEF_AUTH_CLIENT_ID',
+      'REEF_AUTH_REDIRECT_URI',
+      'REEF_AUTH_RESOURCE',
+      'REEF_AUTH_SCOPE',
+      'REEF_COOKIE_SECURE',
+      'REEF_MCP_URL',
+    ]) {
+      expect(example).not.toContain(removedName)
+    }
   })
 })

--- a/apps/reef/app/auth/config.server.test.ts
+++ b/apps/reef/app/auth/config.server.test.ts
@@ -1,15 +1,19 @@
 import { readFileSync } from 'node:fs'
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import {
   authClientId,
   authCookieSecure,
   authRedirectUri,
   authResource,
+  reefAuthConfig,
   resolveAuthConfig,
 } from './config.server'
 import type { RequiredAuthConfig } from './types'
+
+vi.mock('@/lib/coral-desktop', () => ({ isCoralDesktopBuild: vi.fn(() => false) }))
 
 const SESSION_SECRET = '0123456789abcdef0123456789abcdef'
 
@@ -208,5 +212,40 @@ describe('Reef auth config', () => {
     ]) {
       expect(example).not.toContain(removedName)
     }
+  })
+})
+
+// Every case above hands `resolveAuthConfig` an explicit `isDesktopBuild`, which
+// is exactly the wiring that let a Desktop branch reading a variable nothing
+// sets pass for as long as it did. These exercise `reefAuthConfig` itself.
+//
+// Both cases run under the same hosted environment on purpose. Without it the
+// pair is vacuous: with no REEF_AUTH_MODE, `resolveAuthConfig` returns disabled
+// down either branch, so a permanently-false marker would still look correct.
+describe('reefAuthConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.mocked(isCoralDesktopBuild).mockReturnValue(false)
+  })
+
+  function stubHostedEnv(): void {
+    vi.stubEnv('REEF_AUTH_ISSUER', 'https://coral.example.test')
+    vi.stubEnv('REEF_AUTH_MODE', 'required')
+    vi.stubEnv('REEF_PUBLIC_URL', 'https://reef.example.test')
+    vi.stubEnv('REEF_SESSION_SECRET', SESSION_SECRET)
+  }
+
+  it('disables auth for a Desktop build even under a hosted environment', () => {
+    stubHostedEnv()
+    vi.mocked(isCoralDesktopBuild).mockReturnValue(true)
+
+    expect(reefAuthConfig()).toEqual({ mode: 'disabled' })
+  })
+
+  it('keeps that same environment authenticated when the build is not Desktop', () => {
+    stubHostedEnv()
+    vi.mocked(isCoralDesktopBuild).mockReturnValue(false)
+
+    expect(reefAuthConfig().mode).toBe('required')
   })
 })

--- a/apps/reef/app/auth/config.server.test.ts
+++ b/apps/reef/app/auth/config.server.test.ts
@@ -196,9 +196,64 @@ describe('Reef auth config', () => {
       { REEF_SESSION_MAX_AGE_SECONDS: '0' },
       'REEF_SESSION_MAX_AGE_SECONDS must be a positive integer',
     ],
+    // Each of these serializes into `Set-Cookie` without complaint and is then
+    // dropped by the browser, so the only symptom is a session that never
+    // persists. A separator, whitespace, and a control character cover the three
+    // ways a name leaves the token grammar.
+    [
+      { REEF_SESSION_COOKIE_NAME: 'reef session' },
+      'REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name',
+    ],
+    [
+      { REEF_SESSION_COOKIE_NAME: 'reef=session' },
+      'REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name',
+    ],
+    [
+      { REEF_SESSION_COOKIE_NAME: 'reef;session' },
+      'REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name',
+    ],
+    [
+      { REEF_SESSION_COOKIE_NAME: 'reef\tsession' },
+      'REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name',
+    ],
+    [
+      { REEF_SESSION_COOKIE_NAME: 'reef,session' },
+      'REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name',
+    ],
+    [
+      { REEF_SESSION_COOKIE_NAME: 'reef"session"' },
+      'REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name',
+    ],
   ])('rejects invalid required config %#', (overrides, message) => {
     expect(() => requiredConfig(overrides)).toThrow(message)
   })
+
+  it('accepts every character the cookie-name grammar allows', () => {
+    const name = "reef_session-0.9!#$%&'*+^`|~"
+    expect(requiredConfig({ REEF_SESSION_COOKIE_NAME: name }).cookieName).toBe(name)
+  })
+
+  // A `__Host-`/`__Secure-` name is well-formed but browser-enforced: without
+  // `Secure` the cookie is discarded, and Reef derives `Secure` from the public
+  // URL rather than from a switch. So the same name is correct on HTTPS and
+  // unusable on loopback HTTP, and only the config knows which it is.
+  it.each(['__Host-reef_session', '__Secure-reef_session'])(
+    'accepts %s over HTTPS and rejects it over loopback HTTP',
+    (name) => {
+      expect(requiredConfig({ REEF_SESSION_COOKIE_NAME: name }).cookieName).toBe(name)
+
+      expect(() =>
+        resolveAuthConfig({
+          env: requiredEnv({
+            REEF_AUTH_ISSUER: 'http://127.0.0.1:9080',
+            REEF_PUBLIC_URL: 'http://127.0.0.1:5173',
+            REEF_SESSION_COOKIE_NAME: name,
+          }),
+          isDesktopBuild: false,
+        }),
+      ).toThrow('REEF_SESSION_COOKIE_NAME may use a __Host- or __Secure- prefix only')
+    },
+  )
 
   it('keeps redundant auth settings out of the documented environment contract', () => {
     const example = readFileSync(new URL('../../.env.example', import.meta.url), 'utf8')

--- a/apps/reef/app/auth/config.server.test.ts
+++ b/apps/reef/app/auth/config.server.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAuthConfig } from './config.server'
+
+const SESSION_SECRET = '0123456789abcdef0123456789abcdef'
+
+describe('Reef auth config', () => {
+  it('defaults local development and tests to disabled auth', () => {
+    expect(resolveAuthConfig({ env: { NODE_ENV: 'development' }, isDesktopBuild: false })).toEqual({
+      mode: 'disabled',
+    })
+    expect(resolveAuthConfig({ env: { NODE_ENV: 'test' }, isDesktopBuild: false })).toEqual({
+      mode: 'disabled',
+    })
+  })
+
+  it('keeps desktop builds disabled regardless of ambient hosted config', () => {
+    expect(
+      resolveAuthConfig({
+        env: {
+          NODE_ENV: 'production',
+          REEF_AUTH_ISSUER: 'https://login.example.test',
+          REEF_AUTH_MODE: 'required',
+          REEF_SESSION_SECRET: SESSION_SECRET,
+        },
+        isDesktopBuild: true,
+      }),
+    ).toEqual({ mode: 'disabled' })
+  })
+
+  it('fails closed when a non-desktop production server has no explicit mode', () => {
+    expect(() =>
+      resolveAuthConfig({ env: { NODE_ENV: 'production' }, isDesktopBuild: false }),
+    ).toThrow('REEF_AUTH_MODE must be set to disabled or required in production')
+  })
+
+  it('allows production to explicitly disable auth', () => {
+    expect(
+      resolveAuthConfig({
+        env: { NODE_ENV: 'production', REEF_AUTH_MODE: 'disabled' },
+        isDesktopBuild: false,
+      }),
+    ).toEqual({ mode: 'disabled' })
+  })
+
+  it('validates required auth config without changing exact OAuth identifiers', () => {
+    expect(
+      resolveAuthConfig({
+        env: {
+          NODE_ENV: 'production',
+          REEF_AUTH_CLIENT_ID: 'coral-cloud-ui',
+          REEF_AUTH_ISSUER: 'https://login.example.test:443/tenant/',
+          REEF_AUTH_MODE: 'required',
+          REEF_AUTH_REDIRECT_URI: 'https://reef.example.test:443/auth/callback?tenant=coral',
+          REEF_AUTH_SCOPE: 'coral:mcp',
+          REEF_SESSION_COOKIE_NAME: 'custom_session',
+          REEF_SESSION_MAX_AGE_SECONDS: '1800',
+          REEF_SESSION_SECRET: SESSION_SECRET,
+        },
+        isDesktopBuild: false,
+      }),
+    ).toEqual({
+      clientId: 'coral-cloud-ui',
+      cookieName: 'custom_session',
+      cookieSecure: true,
+      issuer: 'https://login.example.test:443/tenant/',
+      mode: 'required',
+      redirectUri: 'https://reef.example.test:443/auth/callback?tenant=coral',
+      scope: 'coral:mcp',
+      sessionMaxAgeSeconds: 1800,
+      sessionSecret: SESSION_SECRET,
+    })
+  })
+
+  it('rejects insecure hosted production cookies', () => {
+    expect(() =>
+      resolveAuthConfig({
+        env: {
+          NODE_ENV: 'production',
+          REEF_AUTH_ISSUER: 'https://login.example.test',
+          REEF_AUTH_MODE: 'required',
+          REEF_AUTH_REDIRECT_URI: 'https://reef.example.test/auth/callback',
+          REEF_COOKIE_SECURE: 'false',
+          REEF_SESSION_SECRET: SESSION_SECRET,
+        },
+        isDesktopBuild: false,
+      }),
+    ).toThrow('REEF_COOKIE_SECURE cannot be false in production')
+  })
+
+  it.each([
+    [{ REEF_AUTH_MODE: 'sometimes' }, 'REEF_AUTH_MODE must be set to disabled or required'],
+    [
+      { REEF_AUTH_ISSUER: 'https://login.example.test', REEF_AUTH_MODE: 'required' },
+      'REEF_SESSION_SECRET must be at least 32 characters',
+    ],
+    [
+      { REEF_AUTH_MODE: 'required', REEF_SESSION_SECRET: SESSION_SECRET },
+      'REEF_AUTH_ISSUER must be set',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'file:///tmp/issuer',
+        REEF_AUTH_MODE: 'required',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_AUTH_ISSUER must be an absolute HTTP(S) URL',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'https://login.example.test/tenant?region=us',
+        REEF_AUTH_MODE: 'required',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_AUTH_ISSUER must not include a query string or fragment',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'https://login.example.test',
+        REEF_AUTH_MODE: 'required',
+        REEF_AUTH_REDIRECT_URI: 'https://reef.example.test/auth/callback#done',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_AUTH_REDIRECT_URI must not include a fragment',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'https://login.example.test',
+        REEF_AUTH_MODE: 'required',
+        REEF_SESSION_MAX_AGE_SECONDS: '0',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_SESSION_MAX_AGE_SECONDS must be a positive integer',
+    ],
+  ])('rejects invalid config %#', (env, message) => {
+    expect(() => resolveAuthConfig({ env, isDesktopBuild: false })).toThrow(message)
+  })
+})

--- a/apps/reef/app/auth/config.server.test.ts
+++ b/apps/reef/app/auth/config.server.test.ts
@@ -283,11 +283,13 @@ describe('reefAuthConfig', () => {
     vi.mocked(isCoralDesktopBuild).mockReturnValue(false)
   })
 
+  // Derived from the same fixture the rest of the file uses. Spelling the keys
+  // out again would be a second definition of "a hosted environment", free to
+  // drift from the first the moment either gains a variable.
   function stubHostedEnv(): void {
-    vi.stubEnv('REEF_AUTH_ISSUER', 'https://coral.example.test')
-    vi.stubEnv('REEF_AUTH_MODE', 'required')
-    vi.stubEnv('REEF_PUBLIC_URL', 'https://reef.example.test')
-    vi.stubEnv('REEF_SESSION_SECRET', SESSION_SECRET)
+    for (const [key, value] of Object.entries(requiredEnv())) {
+      if (value !== undefined) vi.stubEnv(key, value)
+    }
   }
 
   it('disables auth for a Desktop build even under a hosted environment', () => {

--- a/apps/reef/app/auth/config.server.ts
+++ b/apps/reef/app/auth/config.server.ts
@@ -6,6 +6,12 @@ import type { AuthConfig, RequiredAuthConfig } from './types'
 const DEFAULT_COOKIE_NAME = 'reef_session'
 const DEFAULT_SESSION_MAX_AGE_SECONDS = 60 * 60
 
+// RFC 6265 gives a cookie name the RFC 9110 `token` grammar: letters, digits,
+// and `!#$%&'*+-.^_`|~`. Serialization does not enforce it — a name outside the
+// grammar is written into `Set-Cookie` faithfully and rejected by the browser,
+// so the only symptom is a session that never persists.
+const COOKIE_NAME_TOKEN = /^[\w!#$%&'*+.^`|~-]+$/
+
 interface AuthConfigInput {
   env: NodeJS.ProcessEnv
   isDesktopBuild: boolean
@@ -63,7 +69,7 @@ function requiredAuthConfig(env: NodeJS.ProcessEnv): RequiredAuthConfig {
   }
 
   return {
-    cookieName: optionalString(env.REEF_SESSION_COOKIE_NAME) ?? DEFAULT_COOKIE_NAME,
+    cookieName: cookieNameEnv(env.REEF_SESSION_COOKIE_NAME, publicUrl),
     issuer,
     mode: 'required',
     publicUrl,
@@ -89,7 +95,11 @@ export function authRedirectUri(config: RequiredAuthConfig): string {
 }
 
 export function authCookieSecure(config: RequiredAuthConfig): boolean {
-  return new URL(config.publicUrl).protocol === 'https:'
+  return isSecureOrigin(config.publicUrl)
+}
+
+function isSecureOrigin(publicUrl: string): boolean {
+  return new URL(publicUrl).protocol === 'https:'
 }
 
 function requiredString(value: string | undefined, name: string): string {
@@ -161,6 +171,34 @@ function unbracketedHostname(hostname: string): string {
 
 function isLocalhostSubdomain(hostname: string): boolean {
   return unbracketedHostname(hostname).toLowerCase().replace(/\.$/, '').endsWith('.localhost')
+}
+
+// Validated here rather than left to `Set-Cookie`, because every way this value
+// can be wrong fails silently and late. The name reaches serialization unchecked,
+// the browser drops the cookie without telling anyone, and the first symptom is a
+// callback that authenticated successfully and then landed on a page with no
+// session — a login loop with nothing in any log to explain it. A configuration
+// error belongs at boot.
+function cookieNameEnv(value: string | undefined, publicUrl: string): string {
+  const configured = optionalString(value)
+  if (!configured) return DEFAULT_COOKIE_NAME
+
+  if (!COOKIE_NAME_TOKEN.test(configured)) {
+    throw new Error(
+      "REEF_SESSION_COOKIE_NAME must be an RFC 6265 cookie name: letters, digits, or !#$%&'*+-.^_`|~",
+    )
+  }
+  // `__Host-` and `__Secure-` are enforced prefixes, not decoration: a browser
+  // discards a cookie carrying either unless it was set with `Secure`. Reef
+  // derives `Secure` from REEF_PUBLIC_URL, so over loopback HTTP such a name is
+  // accepted by the grammar above and then silently discarded on every response.
+  if (/^__(?:Host|Secure)-/.test(configured) && !isSecureOrigin(publicUrl)) {
+    throw new Error(
+      'REEF_SESSION_COOKIE_NAME may use a __Host- or __Secure- prefix only when REEF_PUBLIC_URL is HTTPS',
+    )
+  }
+
+  return configured
 }
 
 function positiveIntegerEnv(value: string | undefined, name: string, fallback: number): number {

--- a/apps/reef/app/auth/config.server.ts
+++ b/apps/reef/app/auth/config.server.ts
@@ -1,5 +1,6 @@
 import { isIP } from 'node:net'
 
+import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import type { AuthConfig, RequiredAuthConfig } from './types'
 
 const DEFAULT_COOKIE_NAME = 'reef_session'
@@ -13,7 +14,7 @@ interface AuthConfigInput {
 export function reefAuthConfig(): AuthConfig {
   return resolveAuthConfig({
     env: process.env,
-    isDesktopBuild: import.meta.env.VITE_CORAL_DESKTOP_APP === '1',
+    isDesktopBuild: isCoralDesktopBuild(),
   })
 }
 

--- a/apps/reef/app/auth/config.server.ts
+++ b/apps/reef/app/auth/config.server.ts
@@ -1,0 +1,122 @@
+import type { AuthConfig, RequiredAuthConfig } from './types'
+
+const DEFAULT_COOKIE_NAME = 'reef_session'
+const DEFAULT_SESSION_MAX_AGE_SECONDS = 60 * 60
+
+interface AuthConfigInput {
+  env: NodeJS.ProcessEnv
+  isDesktopBuild: boolean
+}
+
+export function reefAuthConfig(): AuthConfig {
+  return resolveAuthConfig({
+    env: process.env,
+    isDesktopBuild: import.meta.env.VITE_CORAL_DESKTOP_APP === '1',
+  })
+}
+
+export function resolveAuthConfig({ env, isDesktopBuild }: AuthConfigInput): AuthConfig {
+  if (isDesktopBuild) return { mode: 'disabled' }
+
+  const configuredMode = env.REEF_AUTH_MODE?.trim().toLowerCase()
+  if (!configuredMode) {
+    if (env.NODE_ENV === 'production') {
+      throw new Error('REEF_AUTH_MODE must be set to disabled or required in production')
+    }
+
+    return { mode: 'disabled' }
+  }
+  if (configuredMode === 'disabled') return { mode: 'disabled' }
+  if (configuredMode !== 'required') {
+    throw new Error('REEF_AUTH_MODE must be set to disabled or required')
+  }
+
+  return requiredAuthConfig(env)
+}
+
+function requiredAuthConfig(env: NodeJS.ProcessEnv): RequiredAuthConfig {
+  const sessionSecret = env.REEF_SESSION_SECRET?.trim()
+  if (!sessionSecret || sessionSecret.length < 32) {
+    throw new Error('REEF_SESSION_SECRET must be at least 32 characters when auth is required')
+  }
+
+  const issuer = requiredString(env.REEF_AUTH_ISSUER, 'REEF_AUTH_ISSUER')
+  const issuerUrl = httpUrl(issuer, 'REEF_AUTH_ISSUER')
+  if (issuerUrl.search || issuerUrl.hash) {
+    throw new Error('REEF_AUTH_ISSUER must not include a query string or fragment')
+  }
+
+  const redirectUri = optionalString(env.REEF_AUTH_REDIRECT_URI)
+  const redirectUrl = redirectUri ? httpUrl(redirectUri, 'REEF_AUTH_REDIRECT_URI') : null
+  if (redirectUrl?.hash) throw new Error('REEF_AUTH_REDIRECT_URI must not include a fragment')
+
+  const cookieSecure = booleanEnv(env.REEF_COOKIE_SECURE) ?? redirectUrl?.protocol === 'https:'
+  if (env.NODE_ENV === 'production') {
+    if (issuerUrl.protocol !== 'https:')
+      throw new Error('REEF_AUTH_ISSUER must use HTTPS in production')
+    if (!redirectUrl) throw new Error('REEF_AUTH_REDIRECT_URI must be set in production')
+    if (redirectUrl.protocol !== 'https:') {
+      throw new Error('REEF_AUTH_REDIRECT_URI must use HTTPS in production')
+    }
+    if (!cookieSecure) throw new Error('REEF_COOKIE_SECURE cannot be false in production')
+  }
+
+  return {
+    clientId: optionalString(env.REEF_AUTH_CLIENT_ID),
+    cookieName: optionalString(env.REEF_SESSION_COOKIE_NAME) ?? DEFAULT_COOKIE_NAME,
+    cookieSecure,
+    issuer,
+    mode: 'required',
+    redirectUri,
+    scope: optionalString(env.REEF_AUTH_SCOPE),
+    sessionMaxAgeSeconds: positiveIntegerEnv(
+      env.REEF_SESSION_MAX_AGE_SECONDS,
+      'REEF_SESSION_MAX_AGE_SECONDS',
+      DEFAULT_SESSION_MAX_AGE_SECONDS,
+    ),
+    sessionSecret,
+  }
+}
+
+function requiredString(value: string | undefined, name: string): string {
+  const configured = optionalString(value)
+  if (!configured) throw new Error(`${name} must be set when auth is required`)
+  return configured
+}
+
+function httpUrl(value: string, name: string): URL {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be an absolute HTTP(S) URL`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`${name} must be an absolute HTTP(S) URL`)
+  }
+
+  return url
+}
+
+function booleanEnv(value: string | undefined): boolean | null {
+  const configured = optionalString(value)?.toLowerCase()
+  if (!configured) return null
+  if (['1', 'true', 'yes'].includes(configured)) return true
+  if (['0', 'false', 'no'].includes(configured)) return false
+  throw new Error('REEF_COOKIE_SECURE must be true or false')
+}
+
+function positiveIntegerEnv(value: string | undefined, name: string, fallback: number): number {
+  const configured = optionalString(value)
+  if (!configured) return fallback
+  const parsed = Number.parseInt(configured, 10)
+  if (!/^[0-9]+$/.test(configured) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+function optionalString(value: string | undefined): string | null {
+  return value?.trim() || null
+}

--- a/apps/reef/app/auth/config.server.ts
+++ b/apps/reef/app/auth/config.server.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net'
+
 import type { AuthConfig, RequiredAuthConfig } from './types'
 
 const DEFAULT_COOKIE_NAME = 'reef_session'
@@ -42,33 +44,28 @@ function requiredAuthConfig(env: NodeJS.ProcessEnv): RequiredAuthConfig {
 
   const issuer = requiredString(env.REEF_AUTH_ISSUER, 'REEF_AUTH_ISSUER')
   const issuerUrl = httpUrl(issuer, 'REEF_AUTH_ISSUER')
+  if (issuerUrl.username || issuerUrl.password) {
+    throw new Error('REEF_AUTH_ISSUER must not include credentials')
+  }
   if (issuerUrl.search || issuerUrl.hash) {
     throw new Error('REEF_AUTH_ISSUER must not include a query string or fragment')
   }
+  if (issuerUrl.protocol === 'http:' && !isExplicitLoopback(issuerUrl)) {
+    throw new Error('REEF_AUTH_ISSUER must use HTTPS or explicit-loopback HTTP')
+  }
 
-  const redirectUri = optionalString(env.REEF_AUTH_REDIRECT_URI)
-  const redirectUrl = redirectUri ? httpUrl(redirectUri, 'REEF_AUTH_REDIRECT_URI') : null
-  if (redirectUrl?.hash) throw new Error('REEF_AUTH_REDIRECT_URI must not include a fragment')
-
-  const cookieSecure = booleanEnv(env.REEF_COOKIE_SECURE) ?? redirectUrl?.protocol === 'https:'
-  if (env.NODE_ENV === 'production') {
-    if (issuerUrl.protocol !== 'https:')
-      throw new Error('REEF_AUTH_ISSUER must use HTTPS in production')
-    if (!redirectUrl) throw new Error('REEF_AUTH_REDIRECT_URI must be set in production')
-    if (redirectUrl.protocol !== 'https:') {
-      throw new Error('REEF_AUTH_REDIRECT_URI must use HTTPS in production')
-    }
-    if (!cookieSecure) throw new Error('REEF_COOKIE_SECURE cannot be false in production')
+  const publicUrl = publicOrigin(requiredString(env.REEF_PUBLIC_URL, 'REEF_PUBLIC_URL'))
+  if (new URL(publicUrl).protocol === 'http:' && issuerUrl.protocol !== 'http:') {
+    throw new Error(
+      'REEF_PUBLIC_URL may use HTTP only when REEF_AUTH_ISSUER also uses explicit-loopback HTTP',
+    )
   }
 
   return {
-    clientId: optionalString(env.REEF_AUTH_CLIENT_ID),
     cookieName: optionalString(env.REEF_SESSION_COOKIE_NAME) ?? DEFAULT_COOKIE_NAME,
-    cookieSecure,
     issuer,
     mode: 'required',
-    redirectUri,
-    scope: optionalString(env.REEF_AUTH_SCOPE),
+    publicUrl,
     sessionMaxAgeSeconds: positiveIntegerEnv(
       env.REEF_SESSION_MAX_AGE_SECONDS,
       'REEF_SESSION_MAX_AGE_SECONDS',
@@ -76,6 +73,22 @@ function requiredAuthConfig(env: NodeJS.ProcessEnv): RequiredAuthConfig {
     ),
     sessionSecret,
   }
+}
+
+export function authResource(config: RequiredAuthConfig): string {
+  return config.publicUrl
+}
+
+export function authClientId(config: RequiredAuthConfig): string {
+  return new URL('/.well-known/oauth-client', config.publicUrl).toString()
+}
+
+export function authRedirectUri(config: RequiredAuthConfig): string {
+  return new URL('/auth/callback', config.publicUrl).toString()
+}
+
+export function authCookieSecure(config: RequiredAuthConfig): boolean {
+  return new URL(config.publicUrl).protocol === 'https:'
 }
 
 function requiredString(value: string | undefined, name: string): string {
@@ -98,12 +111,55 @@ function httpUrl(value: string, name: string): URL {
   return url
 }
 
-function booleanEnv(value: string | undefined): boolean | null {
-  const configured = optionalString(value)?.toLowerCase()
-  if (!configured) return null
-  if (['1', 'true', 'yes'].includes(configured)) return true
-  if (['0', 'false', 'no'].includes(configured)) return false
-  throw new Error('REEF_COOKIE_SECURE must be true or false')
+function publicOrigin(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw invalidPublicUrl()
+  }
+  if (
+    (url.protocol !== 'https:' && url.protocol !== 'http:') ||
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash ||
+    isLocalhostSubdomain(url.hostname) ||
+    (url.protocol === 'http:' && !isExplicitLoopback(url))
+  ) {
+    throw invalidPublicUrl()
+  }
+
+  return url.origin
+}
+
+function invalidPublicUrl(): Error {
+  return new Error(
+    'REEF_PUBLIC_URL must be an HTTPS or explicit-loopback HTTP origin without credentials, path, query, or fragment',
+  )
+}
+
+function isExplicitLoopback(url: URL): boolean {
+  const hostname = unbracketedHostname(url.hostname).toLowerCase().replace(/\.$/, '')
+  if (hostname === 'localhost') return true
+
+  const family = isIP(hostname)
+  if (family === 4) return hostname.split('.')[0] === '127'
+  if (family !== 6) return false
+  if (hostname === '::1') return true
+
+  // WHATWG URL serialization renders IPv4-mapped loopback addresses in this
+  // canonical hexadecimal form, e.g. ::ffff:127.0.0.1 -> ::ffff:7f00:1.
+  return /^::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/i.test(hostname)
+}
+
+function unbracketedHostname(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+}
+
+function isLocalhostSubdomain(hostname: string): boolean {
+  return unbracketedHostname(hostname).toLowerCase().replace(/\.$/, '').endsWith('.localhost')
 }
 
 function positiveIntegerEnv(value: string | undefined, name: string, fallback: number): number {

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -5,13 +5,10 @@ export interface DisabledAuthConfig {
 }
 
 export interface RequiredAuthConfig {
-  clientId: string | null
   cookieName: string
-  cookieSecure: boolean
   issuer: string
   mode: 'required'
-  redirectUri: string | null
-  scope: string | null
+  publicUrl: string
   sessionMaxAgeSeconds: number
   sessionSecret: string
 }

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -1,0 +1,19 @@
+export type AuthMode = 'disabled' | 'required'
+
+export interface DisabledAuthConfig {
+  mode: 'disabled'
+}
+
+export interface RequiredAuthConfig {
+  clientId: string | null
+  cookieName: string
+  cookieSecure: boolean
+  issuer: string
+  mode: 'required'
+  redirectUri: string | null
+  scope: string | null
+  sessionMaxAgeSeconds: number
+  sessionSecret: string
+}
+
+export type AuthConfig = DisabledAuthConfig | RequiredAuthConfig

--- a/apps/reef/vitest.config.ts
+++ b/apps/reef/vitest.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
           exclude: [
             'app/**/*.server.test.{ts,tsx}',
             'app/**/*.stories.tsx',
-            'app/__tests__/architecture.test.ts',
+            'app/__tests__/*architecture.test.ts',
           ],
           environment: 'node',
           include: ['app/**/*.test.{ts,tsx}'],
@@ -50,7 +50,7 @@ export default defineConfig({
         extends: true,
         test: {
           environment: 'node',
-          include: ['app/__tests__/architecture.test.ts'],
+          include: ['app/__tests__/*architecture.test.ts'],
           name: 'architecture',
         },
       },


### PR DESCRIPTION
> Reef hosted-auth stack: layer 1 of 11. Base: `main`.

## Intent

Introduce one explicit, server-only Reef authentication configuration while preserving an auth-free local and Desktop experience. Hosted deployments derive their OAuth resource, CIMD client ID, callback URI, and cookie security from `REEF_PUBLIC_URL` instead of carrying redundant settings.

## What it enables

Local Reef remains usable with no identity provider, while hosted production deployments can require authentication and fail closed when their mode or required secrets are missing. The public URL becomes Reef's single canonical identity.

## Usage examples

Local development needs no auth configuration:

```bash
npm run dev --prefix apps/reef
```

A hosted deployment opts in explicitly:

```bash
REEF_AUTH_MODE=required
REEF_PUBLIC_URL=https://reef.example.com
REEF_AUTH_ISSUER=https://auth.coral.example.com
REEF_SESSION_SECRET=replace-with-at-least-32-random-characters
CORAL_ENDPOINT=https://coral.internal.example.com
```