### PR TITLE
feat(reef): keep Coral OAuth tokens in encrypted sessions

### DIFF
--- a/apps/reef/app/auth/session.server.test.ts
+++ b/apps/reef/app/auth/session.server.test.ts
@@ -1,3 +1,6 @@
+import { createCipheriv, createHash, randomBytes } from 'node:crypto'
+
+import { createCookie } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -7,6 +10,11 @@ import {
   readReefSession,
 } from './session.server'
 import type { RequiredAuthConfig } from './types'
+
+// Mirrors CLOCK_SKEW_SECONDS in session.server.ts, which is deliberately not
+// exported — the tests below assert the behaviour at its edges, so the number
+// has to be stated somewhere they can see it.
+const CLOCK_SKEW_SECONDS = 30
 
 const config: RequiredAuthConfig = {
   cookieName: 'reef_session',
@@ -92,22 +100,125 @@ describe('Reef auth sessions', () => {
     expect(transactionCookie).not.toContain('Secure')
   })
 
-  it('ignores absent, malformed, tampered, and expired sessions', async () => {
+  // Previously one case named four rejections and demonstrated two of them. It
+  // is split up because each of these is a distinct guard that can regress on
+  // its own, and because two of the four were not being reached at all: the
+  // "tampered" case supplied a wrong *key* rather than altered ciphertext, and
+  // the "expired" case used a timestamp inside the clock-skew window, so the
+  // skew guard rejected it before the expiry check ever ran.
+  it('ignores a request carrying no session cookie', async () => {
     await expect(
       readReefSession(new Request('https://reef.example.test/'), config),
     ).resolves.toBeNull()
+  })
+
+  it('ignores a session cookie that is not validly signed', async () => {
     await expect(
       readReefSession(requestWith('reef_session=not-a-session'), config),
     ).resolves.toBeNull()
+  })
 
-    const cookie = await commitReefSession(
-      { accessToken: 'token', expiresAt: unixTimestamp() + 20, tokenType: 'Bearer' },
-      config,
-    )
-    await expect(readReefSession(requestWith(cookie), config)).resolves.toBeNull()
+  // Correctly signed, so the cookie layer hands each of these through to the
+  // decryptor rather than turning it away first — the only way to exercise what
+  // the decryptor does with a payload it cannot use.
+  //
+  // These pin the rejection, not the line that performs it: removing the
+  // three-part guard in `decryptSession` leaves them all passing, because the
+  // surrounding try/catch already rejects the same inputs. That guard is
+  // redundancy, and no test can tell it apart from the catch.
+  it.each([
+    ['a payload that is not three parts', 'aGVsbG8.d29ybGQ'],
+    ['a payload with an empty part', 'aGVsbG8..d29ybGQ'],
+    ['parts that are not valid ciphertext', 'aGVsbG8.d29ybGQ.YnJva2Vu'],
+  ])('ignores %s', async (_label, payload) => {
+    await expect(
+      readReefSession(requestWith(await signedCookie(payload)), config),
+    ).resolves.toBeNull()
+  })
 
+  it('ignores a session whose ciphertext was altered under the right key', async () => {
+    const cookie = await commitReefSession(validSession(), config)
+    const [iv, tag, ciphertext] = cookieValue(cookie).split('.')
+    const flipped = ciphertext.slice(0, -1) + (ciphertext.endsWith('A') ? 'B' : 'A')
+
+    await expect(
+      readReefSession(requestWith(await signedCookie(`${iv}.${tag}.${flipped}`)), config),
+    ).resolves.toBeNull()
+  })
+
+  it('ignores a session encrypted under a different secret', async () => {
+    const cookie = await commitReefSession(validSession(), config)
     const wrongSecret = { ...config, sessionSecret: 'abcdef0123456789abcdef0123456789' }
+
     await expect(readReefSession(requestWith(cookie), wrongSecret)).resolves.toBeNull()
+  })
+
+  // Decrypts cleanly and is still not a session. Nothing else in this file
+  // reaches the shape check, because everything else fails before the plaintext
+  // exists.
+  it.each([
+    ['is missing a token', { expiresAt: 4_102_444_800, tokenType: 'Bearer' }],
+    ['carries an empty token', { accessToken: '', expiresAt: 4_102_444_800, tokenType: 'Bearer' }],
+    ['carries a non-numeric expiry', { accessToken: 't', expiresAt: 'soon', tokenType: 'Bearer' }],
+    ['is missing a token type', { accessToken: 't', expiresAt: 4_102_444_800 }],
+    ['is not an object at all', 'a string'],
+  ])('ignores a decryptable payload that %s', async (_label, payload) => {
+    const cookie = await signedCookie(encryptForTest(payload))
+
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toBeNull()
+  })
+
+  it('ignores a session once it has genuinely expired', async () => {
+    const cookie = await commitReefSession(validSession(), config)
+    await expect(readReefSession(requestWith(cookie), config)).resolves.not.toBeNull()
+
+    // Well past expiry, so the skew window plays no part in the rejection.
+    advanceSeconds(1800 + CLOCK_SKEW_SECONDS + 60)
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toBeNull()
+  })
+
+  it('ignores a session that is still valid but inside the clock-skew window', async () => {
+    const cookie = await commitReefSession(validSession(), config)
+
+    // 20s of life left: not expired, but too close to hand to a request.
+    advanceSeconds(1800 - 20)
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toBeNull()
+  })
+
+  // The other half of that guard. A session this short is unreadable the instant
+  // it is written, and the resulting `/login` → callback → `/login` loop reports
+  // no error anywhere, so the refusal has to happen on the way in.
+  it('refuses to commit a session that expires inside the clock-skew window', async () => {
+    await expect(
+      commitReefSession(
+        {
+          accessToken: 'token',
+          expiresAt: unixTimestamp() + CLOCK_SKEW_SECONDS,
+          tokenType: 'Bearer',
+        },
+        config,
+      ),
+    ).rejects.toThrow('Refusing to establish a Reef session that expires within 30s')
+
+    await expect(
+      commitReefSession(
+        { accessToken: 'token', expiresAt: unixTimestamp() - 1, tokenType: 'Bearer' },
+        config,
+      ),
+    ).rejects.toThrow('Refusing to establish a Reef session that expires within 30s')
+  })
+
+  it('commits a session that clears the clock-skew window by a second', async () => {
+    await expect(
+      commitReefSession(
+        {
+          accessToken: 'token',
+          expiresAt: unixTimestamp() + CLOCK_SKEW_SECONDS + 1,
+          tokenType: 'Bearer',
+        },
+        config,
+      ),
+    ).resolves.toContain('reef_session=')
   })
 })
 
@@ -119,6 +230,45 @@ function requestWith(setCookie: string): Request {
 
 function unixTimestamp(): number {
   return Math.floor(Date.now() / 1000)
+}
+
+function advanceSeconds(seconds: number): void {
+  vi.setSystemTime(new Date(Date.now() + seconds * 1000))
+}
+
+function validSession() {
+  return {
+    accessToken: 'coral-access-token',
+    expiresAt: unixTimestamp() + 1800,
+    tokenType: 'Bearer',
+  }
+}
+
+function cookieValue(setCookie: string): string {
+  const value = setCookie.split(';', 1)[0].split('=').slice(1).join('=')
+  // react-router signs a cookie as `<base64 payload>.<signature>`, and the
+  // payload itself is the base64 of what was serialized.
+  return Buffer.from(decodeURIComponent(value).split('.')[0], 'base64').toString('utf8')
+}
+
+// Signs an arbitrary payload the way the session cookie is signed, so a
+// hand-built value reaches the decryptor instead of being turned away by the
+// cookie layer. Only `secrets` matters for that.
+async function signedCookie(payload: string): Promise<string> {
+  return createCookie(config.cookieName, { secrets: [config.sessionSecret] }).serialize(payload)
+}
+
+// Mirrors the module's own AES-256-GCM envelope. Reproduced rather than exported
+// from the source, because the point is to feed the reader something that
+// decrypts perfectly and is still not a session — the one case that cannot be
+// built out of the public API.
+function encryptForTest(payload: unknown): string {
+  const iv = randomBytes(12)
+  const key = createHash('sha256').update(config.sessionSecret).digest()
+  const cipher = createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(payload), 'utf8'), cipher.final()])
+
+  return [iv, cipher.getAuthTag(), ciphertext].map((part) => part.toString('base64url')).join('.')
 }
 
 function representativeSessionToken(): string {

--- a/apps/reef/app/auth/session.server.test.ts
+++ b/apps/reef/app/auth/session.server.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  commitOAuthTransaction,
+  commitReefSession,
+  readOAuthTransaction,
+  readReefSession,
+} from './session.server'
+import type { RequiredAuthConfig } from './types'
+
+const config: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('Reef auth sessions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('round trips an encrypted server session with secure cookie attributes', async () => {
+    const session = {
+      accessToken: 'coral-access-token',
+      expiresAt: unixTimestamp() + 1800,
+      tokenType: 'Bearer',
+    }
+    const cookie = await commitReefSession(session, config)
+
+    expect(cookie).toContain('reef_session=')
+    expect(cookie).not.toContain('coral-access-token')
+    expect(cookie).toContain('HttpOnly')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Secure')
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toEqual(session)
+  })
+
+  it('keeps a representative opaque access token below the cookie size limit', async () => {
+    const cookie = await commitReefSession(
+      {
+        accessToken: representativeSessionToken(),
+        expiresAt: unixTimestamp() + 1800,
+        tokenType: 'Bearer',
+      },
+      config,
+    )
+
+    expect(Buffer.byteLength(cookie)).toBeLessThan(4096)
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toMatchObject({
+      accessToken: representativeSessionToken(),
+    })
+  })
+
+  it('stores only PKCE, return path, and state in an OAuth transaction', async () => {
+    const transaction = {
+      codeVerifier: 'verifier',
+      returnTo: '/workspaces/analytics',
+      state: 'state',
+    }
+    const cookie = await commitOAuthTransaction(transaction, config)
+
+    expect(cookie).toContain('reef_oauth=')
+    expect(cookie).toContain('Secure')
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toEqual(transaction)
+  })
+
+  it('omits Secure only for the accepted all-loopback HTTP topology', async () => {
+    const loopbackConfig = {
+      ...config,
+      issuer: 'http://127.0.0.1:3000',
+      publicUrl: 'http://localhost:5173',
+    }
+
+    const sessionCookie = await commitReefSession(
+      { accessToken: 'token', expiresAt: unixTimestamp() + 1800, tokenType: 'Bearer' },
+      loopbackConfig,
+    )
+    const transactionCookie = await commitOAuthTransaction(
+      { codeVerifier: 'verifier', returnTo: '/', state: 'state' },
+      loopbackConfig,
+    )
+
+    expect(sessionCookie).not.toContain('Secure')
+    expect(transactionCookie).not.toContain('Secure')
+  })
+
+  it('ignores absent, malformed, tampered, and expired sessions', async () => {
+    await expect(
+      readReefSession(new Request('https://reef.example.test/'), config),
+    ).resolves.toBeNull()
+    await expect(
+      readReefSession(requestWith('reef_session=not-a-session'), config),
+    ).resolves.toBeNull()
+
+    const cookie = await commitReefSession(
+      { accessToken: 'token', expiresAt: unixTimestamp() + 20, tokenType: 'Bearer' },
+      config,
+    )
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toBeNull()
+
+    const wrongSecret = { ...config, sessionSecret: 'abcdef0123456789abcdef0123456789' }
+    await expect(readReefSession(requestWith(cookie), wrongSecret)).resolves.toBeNull()
+  })
+})
+
+function requestWith(setCookie: string): Request {
+  return new Request('https://reef.example.test/', {
+    headers: { cookie: setCookie.split(';', 1)[0] },
+  })
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+function representativeSessionToken(): string {
+  const header = base64UrlJson({
+    alg: 'ES256',
+    kid: '8n83UnqxWBGpQWJmVpkam9SuO9AmOoa3ik4fdurN7N0',
+    typ: 'at+jwt',
+  })
+  const claims = base64UrlJson({
+    aud: 'https://reef.example.test',
+    client_id: 'https://reef.example.test/.well-known/oauth-client',
+    exp: 1_767_226_800,
+    iat: 1_767_225_600,
+    iss: 'https://coral.example.test',
+    jti: '4b9677e0-2a75-4227-b1e2-45e8584f940e',
+    sub: 'opaque:subject/123',
+  })
+  const signature = 's'.repeat(86)
+  return `${header}.${claims}.${signature}`
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url')
+}

--- a/apps/reef/app/auth/session.server.test.ts
+++ b/apps/reef/app/auth/session.server.test.ts
@@ -6,15 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   commitOAuthTransaction,
   commitReefSession,
+  oauthCookieName,
   readOAuthTransaction,
   readReefSession,
 } from './session.server'
 import type { RequiredAuthConfig } from './types'
 
-// Mirrors CLOCK_SKEW_SECONDS in session.server.ts, which is deliberately not
-// exported — the tests below assert the behaviour at its edges, so the number
-// has to be stated somewhere they can see it.
+// Mirrors CLOCK_SKEW_SECONDS and OAUTH_MAX_AGE_SECONDS in session.server.ts,
+// which are deliberately not exported — the tests below assert the behaviour at
+// their edges, so the numbers have to be stated somewhere they can see them.
 const CLOCK_SKEW_SECONDS = 30
+const OAUTH_MAX_AGE_SECONDS = 10 * 60
 
 const config: RequiredAuthConfig = {
   cookieName: 'reef_session',
@@ -23,6 +25,14 @@ const config: RequiredAuthConfig = {
   publicUrl: 'https://reef.example.test',
   sessionMaxAgeSeconds: 3600,
   sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+// The one topology that serves Reef over HTTP: loopback throughout, so neither
+// cookie can carry `Secure` and the transaction cookie cannot carry `__Host-`.
+const loopbackConfig: RequiredAuthConfig = {
+  ...config,
+  issuer: 'http://127.0.0.1:3000',
+  publicUrl: 'http://localhost:5173',
 }
 
 describe('Reef auth sessions', () => {
@@ -67,6 +77,9 @@ describe('Reef auth sessions', () => {
     })
   })
 
+  // `toEqual` and not `toMatchObject`: the reader is also expected to strip the
+  // `issuedAt` it stamps on the way in, so a caller sees the three fields it
+  // committed and nothing else.
   it('stores only PKCE, return path, and state in an OAuth transaction', async () => {
     const transaction = {
       codeVerifier: 'verifier',
@@ -75,18 +88,89 @@ describe('Reef auth sessions', () => {
     }
     const cookie = await commitOAuthTransaction(transaction, config)
 
-    expect(cookie).toContain('reef_oauth=')
+    expect(cookie).toContain('__Host-reef_oauth=')
     expect(cookie).toContain('Secure')
     await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toEqual(transaction)
   })
 
-  it('omits Secure only for the accepted all-loopback HTTP topology', async () => {
-    const loopbackConfig = {
-      ...config,
-      issuer: 'http://127.0.0.1:3000',
-      publicUrl: 'http://localhost:5173',
-    }
+  // The prefix is only meaningful alongside the `Path=/` and absent `Domain`
+  // that this cookie already had, so all three are pinned together.
+  it('names the OAuth transaction cookie so a sibling host cannot toss one', async () => {
+    const cookie = await commitOAuthTransaction(validTransaction(), config)
 
+    expect(cookie).toContain('__Host-reef_oauth=')
+    expect(cookie).toContain('Path=/')
+    expect(cookie).not.toContain('Domain=')
+  })
+
+  // `__Host-` requires `Secure`, and a browser discards a cookie carrying the
+  // prefix without it — so over loopback HTTP the prefix would cost every login
+  // rather than protect it.
+  it('drops the __Host- prefix where the browser would refuse it', async () => {
+    const cookie = await commitOAuthTransaction(validTransaction(), loopbackConfig)
+
+    expect(cookie).toContain('reef_oauth=')
+    expect(cookie).not.toContain('__Host-')
+    await expect(readOAuthTransaction(requestWith(cookie), loopbackConfig)).resolves.toEqual(
+      validTransaction(),
+    )
+  })
+
+  // `Max-Age` bounds the cookie in a browser and nowhere else. These two pin the
+  // server-side bound that makes a captured transaction stop working.
+  it('ignores an OAuth transaction issued outside its lifetime', async () => {
+    const cookie = await commitOAuthTransaction(validTransaction(), config)
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.not.toBeNull()
+
+    advanceSeconds(OAUTH_MAX_AGE_SECONDS + CLOCK_SKEW_SECONDS + 1)
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toBeNull()
+  })
+
+  it('still reads an OAuth transaction inside the skew slack', async () => {
+    const cookie = await commitOAuthTransaction(validTransaction(), config)
+
+    advanceSeconds(OAUTH_MAX_AGE_SECONDS + CLOCK_SKEW_SECONDS)
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toEqual(
+      validTransaction(),
+    )
+  })
+
+  // A clock that runs ahead of the one that wrote the cookie is the only thing
+  // that produces this, since the value cannot be forged. Rejecting it would
+  // break those logins and stop no attack.
+  it('reads an OAuth transaction dated in the future', async () => {
+    const cookie = await commitOAuthTransaction(validTransaction(), config)
+
+    advanceSeconds(-300)
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toEqual(
+      validTransaction(),
+    )
+  })
+
+  // Correctly signed and correct in every field the callback reads, so only the
+  // missing timestamp turns it away. This is also the shape written by any
+  // version of this module before `issuedAt` existed: an in-flight login across
+  // the deploy fails once and works on retry.
+  it('ignores an OAuth transaction carrying no issue time', async () => {
+    const cookie = await signedOAuthCookie(validTransaction())
+
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toBeNull()
+  })
+
+  // `Number.isFinite` in the guard is deliberately not among these: JSON has no
+  // infinity, so no signed cookie can carry one. It is redundancy of the same
+  // kind as the three-part check in `decryptSession`, and no test reaches it.
+  it.each([
+    ['a non-numeric issue time', { ...validTransaction(), issuedAt: 'recently' }],
+    ['no state', { codeVerifier: 'verifier', issuedAt: 0, returnTo: '/' }],
+    ['no transaction at all', 'a string'],
+  ])('ignores an OAuth transaction with %s', async (_label, payload) => {
+    const cookie = await signedOAuthCookie(payload)
+
+    await expect(readOAuthTransaction(requestWith(cookie), config)).resolves.toBeNull()
+  })
+
+  it('omits Secure only for the accepted all-loopback HTTP topology', async () => {
     const sessionCookie = await commitReefSession(
       { accessToken: 'token', expiresAt: unixTimestamp() + 1800, tokenType: 'Bearer' },
       loopbackConfig,
@@ -242,6 +326,20 @@ function validSession() {
     expiresAt: unixTimestamp() + 1800,
     tokenType: 'Bearer',
   }
+}
+
+function validTransaction() {
+  return { codeVerifier: 'verifier', returnTo: '/workspaces/analytics', state: 'state' }
+}
+
+// Signs an arbitrary payload under the transaction cookie's name and secret, so
+// a hand-built value reaches the shape and age checks instead of being turned
+// away by the cookie layer. The name is asked for rather than written out
+// because it moves with `REEF_PUBLIC_URL`.
+async function signedOAuthCookie(payload: unknown): Promise<string> {
+  return createCookie(oauthCookieName(config), { secrets: [config.sessionSecret] }).serialize(
+    payload,
+  )
 }
 
 function cookieValue(setCookie: string): string {

--- a/apps/reef/app/auth/session.server.ts
+++ b/apps/reef/app/auth/session.server.ts
@@ -1,0 +1,149 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+import { createCookie } from 'react-router'
+
+import { authCookieSecure } from './config.server'
+import type { AuthSession, RequiredAuthConfig } from './types'
+
+const OAUTH_COOKIE_NAME = 'reef_oauth'
+const OAUTH_MAX_AGE_SECONDS = 10 * 60
+const CLOCK_SKEW_SECONDS = 30
+
+export interface OAuthTransaction {
+  codeVerifier: string
+  returnTo: string
+  state: string
+}
+
+export async function commitOAuthTransaction(
+  transaction: OAuthTransaction,
+  config: RequiredAuthConfig,
+): Promise<string> {
+  return oauthCookie(config).serialize(transaction)
+}
+
+export async function readOAuthTransaction(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<OAuthTransaction | null> {
+  const value = await oauthCookie(config).parse(request.headers.get('cookie'))
+  return isOAuthTransaction(value) ? value : null
+}
+
+export async function clearOAuthTransaction(config: RequiredAuthConfig): Promise<string> {
+  return oauthCookie(config).serialize('', { maxAge: 0 })
+}
+
+export async function commitReefSession(
+  session: AuthSession,
+  config: RequiredAuthConfig,
+): Promise<string> {
+  return sessionCookie(config).serialize(encryptSession(session, config.sessionSecret))
+}
+
+export async function readReefSession(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<AuthSession | null> {
+  const encrypted = await sessionCookie(config).parse(request.headers.get('cookie'))
+  if (typeof encrypted !== 'string' || !encrypted) return null
+  const session = decryptSession(encrypted, config.sessionSecret)
+  if (!session || session.expiresAt <= unixTimestamp() + CLOCK_SKEW_SECONDS) return null
+
+  return session
+}
+
+export async function clearReefSession(config: RequiredAuthConfig): Promise<string> {
+  return sessionCookie(config).serialize('', { maxAge: 0 })
+}
+
+export function randomToken(byteCount: number): string {
+  return randomBytes(byteCount).toString('base64url')
+}
+
+function oauthCookie(config: RequiredAuthConfig) {
+  return createCookie(OAUTH_COOKIE_NAME, {
+    httpOnly: true,
+    maxAge: OAUTH_MAX_AGE_SECONDS,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [config.sessionSecret],
+    secure: authCookieSecure(config),
+  })
+}
+
+function sessionCookie(config: RequiredAuthConfig) {
+  return createCookie(config.cookieName, {
+    httpOnly: true,
+    maxAge: config.sessionMaxAgeSeconds,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [config.sessionSecret],
+    secure: authCookieSecure(config),
+  })
+}
+
+function encryptSession(session: AuthSession, secret: string): string {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(secret), iv)
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(session), 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+
+  return [iv, tag, ciphertext].map((part) => part.toString('base64url')).join('.')
+}
+
+function decryptSession(value: string, secret: string): AuthSession | null {
+  const [ivPart, tagPart, ciphertextPart] = value.split('.')
+  if (!ivPart || !tagPart || !ciphertextPart) return null
+
+  try {
+    const decipher = createDecipheriv(
+      'aes-256-gcm',
+      encryptionKey(secret),
+      Buffer.from(ivPart, 'base64url'),
+    )
+    decipher.setAuthTag(Buffer.from(tagPart, 'base64url'))
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ciphertextPart, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8')
+    const session = JSON.parse(plaintext) as unknown
+
+    return isAuthSession(session) ? session : null
+  } catch {
+    return null
+  }
+}
+
+function encryptionKey(secret: string): Buffer {
+  return createHash('sha256').update(secret).digest()
+}
+
+function isOAuthTransaction(value: unknown): value is OAuthTransaction {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<OAuthTransaction>
+
+  return (
+    typeof candidate.codeVerifier === 'string' &&
+    typeof candidate.returnTo === 'string' &&
+    typeof candidate.state === 'string'
+  )
+}
+
+function isAuthSession(value: unknown): value is AuthSession {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<AuthSession>
+
+  return (
+    typeof candidate.accessToken === 'string' &&
+    candidate.accessToken.length > 0 &&
+    typeof candidate.expiresAt === 'number' &&
+    Number.isFinite(candidate.expiresAt) &&
+    typeof candidate.tokenType === 'string' &&
+    candidate.tokenType.length > 0
+  )
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/session.server.ts
+++ b/apps/reef/app/auth/session.server.ts
@@ -34,10 +34,28 @@ export async function clearOAuthTransaction(config: RequiredAuthConfig): Promise
   return oauthCookie(config).serialize('', { maxAge: 0 })
 }
 
+/**
+ * Writes a session cookie, refusing to write one that cannot be read back.
+ *
+ * `readReefSession` treats a session expiring within [`CLOCK_SKEW_SECONDS`] as
+ * already gone, so a shorter-lived one is unreadable from the moment it is
+ * committed. Left to itself that is not an error anywhere: the callback
+ * succeeds, redirects to a protected route, the route finds no session and
+ * sends the visitor back to `/login` — a loop with no failure in it. Two
+ * unrelated settings can cause it, a Coral token with a tiny `expires_in` and a
+ * small `REEF_SESSION_MAX_AGE_SECONDS`, so the message names both rather than
+ * guessing.
+ */
 export async function commitReefSession(
   session: AuthSession,
   config: RequiredAuthConfig,
 ): Promise<string> {
+  if (session.expiresAt <= unixTimestamp() + CLOCK_SKEW_SECONDS) {
+    throw new Error(
+      `Refusing to establish a Reef session that expires within ${CLOCK_SKEW_SECONDS}s: check the Coral access token lifetime and REEF_SESSION_MAX_AGE_SECONDS`,
+    )
+  }
+
   return sessionCookie(config).serialize(encryptSession(session, config.sessionSecret))
 }
 

--- a/apps/reef/app/auth/session.server.ts
+++ b/apps/reef/app/auth/session.server.ts
@@ -15,19 +15,55 @@ export interface OAuthTransaction {
   state: string
 }
 
+/**
+ * What actually goes in the cookie: the transaction plus the moment it was
+ * issued.
+ *
+ * `issuedAt` is stamped here rather than accepted from the caller, and stripped
+ * again on the way out, so a transaction stays the three fields a login flow
+ * cares about at both ends.
+ */
+interface StoredOAuthTransaction extends OAuthTransaction {
+  issuedAt: number
+}
+
 export async function commitOAuthTransaction(
   transaction: OAuthTransaction,
   config: RequiredAuthConfig,
 ): Promise<string> {
-  return oauthCookie(config).serialize(transaction)
+  const stored: StoredOAuthTransaction = { ...transaction, issuedAt: unixTimestamp() }
+
+  return oauthCookie(config).serialize(stored)
 }
 
+/**
+ * Reads a transaction, treating one issued too long ago as absent.
+ *
+ * The signature proves the payload came from this server; it says nothing about
+ * when. Without `issuedAt` the blob verifies forever, because it carries no
+ * timestamp and nothing else in the value varies — `Max-Age` is the only bound,
+ * and that one is the browser's to enforce. Anything replaying the cookie
+ * outside a browser is not bound by it, so a captured `codeVerifier` would stay
+ * usable for as long as its authorization code did. PKCE assumes the verifier
+ * is short-lived as well as secret, so the server checks the age itself.
+ *
+ * A cookie dated in the future is *not* rejected. It cannot be forged without
+ * the secret, so the only thing that produces one is a clock that disagrees
+ * between the instance that wrote it and the instance reading it — which is why
+ * the past side carries [`CLOCK_SKEW_SECONDS`] of slack too. Rejecting a
+ * future-dated cookie would fail those logins and prevent no attack.
+ */
 export async function readOAuthTransaction(
   request: Request,
   config: RequiredAuthConfig,
 ): Promise<OAuthTransaction | null> {
   const value = await oauthCookie(config).parse(request.headers.get('cookie'))
-  return isOAuthTransaction(value) ? value : null
+  if (!isStoredOAuthTransaction(value)) return null
+  if (unixTimestamp() - value.issuedAt > OAUTH_MAX_AGE_SECONDS + CLOCK_SKEW_SECONDS) return null
+
+  const { codeVerifier, returnTo, state } = value
+
+  return { codeVerifier, returnTo, state }
 }
 
 export async function clearOAuthTransaction(config: RequiredAuthConfig): Promise<string> {
@@ -79,8 +115,33 @@ export function randomToken(byteCount: number): string {
   return randomBytes(byteCount).toString('base64url')
 }
 
+/**
+ * The OAuth transaction cookie's name, which carries a `__Host-` prefix wherever
+ * the browser will accept one.
+ *
+ * A signature keeps the value from being forged; it does nothing about a cookie
+ * of the same name arriving from somewhere else. `Domain` is what makes that
+ * possible: this cookie is host-only, so a sibling host never *receives* it, but
+ * any host under the same registrable domain can *set* a domain-scoped
+ * `reef_oauth` that the browser will then send here. Both arrive, and
+ * `parse` keeps whichever the browser listed first — which is the more specific
+ * `Path`, and that is the attacker's to choose. The transaction the callback
+ * validates its `state` against would be one the attacker started.
+ *
+ * `__Host-` forbids `Domain` at the browser, so the tossed cookie is refused at
+ * the source rather than disambiguated here. It also requires `Secure`, hence
+ * the fallback: the accepted all-loopback HTTP topology cannot carry the prefix,
+ * and a cookie named with one there is silently discarded on every response.
+ * `REEF_SESSION_COOKIE_NAME` is validated against the same rule in
+ * `config.server.ts` — this is that reasoning applied to the cookie whose name
+ * is not configurable.
+ */
+export function oauthCookieName(config: RequiredAuthConfig): string {
+  return authCookieSecure(config) ? `__Host-${OAUTH_COOKIE_NAME}` : OAUTH_COOKIE_NAME
+}
+
 function oauthCookie(config: RequiredAuthConfig) {
-  return createCookie(OAUTH_COOKIE_NAME, {
+  return createCookie(oauthCookieName(config), {
     httpOnly: true,
     maxAge: OAUTH_MAX_AGE_SECONDS,
     path: '/',
@@ -137,14 +198,16 @@ function encryptionKey(secret: string): Buffer {
   return createHash('sha256').update(secret).digest()
 }
 
-function isOAuthTransaction(value: unknown): value is OAuthTransaction {
+function isStoredOAuthTransaction(value: unknown): value is StoredOAuthTransaction {
   if (!value || typeof value !== 'object') return false
-  const candidate = value as Partial<OAuthTransaction>
+  const candidate = value as Partial<StoredOAuthTransaction>
 
   return (
     typeof candidate.codeVerifier === 'string' &&
     typeof candidate.returnTo === 'string' &&
-    typeof candidate.state === 'string'
+    typeof candidate.state === 'string' &&
+    typeof candidate.issuedAt === 'number' &&
+    Number.isFinite(candidate.issuedAt)
   )
 }
 

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -14,3 +14,9 @@ export interface RequiredAuthConfig {
 }
 
 export type AuthConfig = DisabledAuthConfig | RequiredAuthConfig
+
+export interface AuthSession {
+  accessToken: string
+  expiresAt: number
+  tokenType: string
+}


### PR DESCRIPTION
&gt; Reef hosted-auth stack: layer 2 of 11. Base: PR #2058.

## Intent

Give the Reef server somewhere to keep a Coral access token that browser JavaScript cannot reach.

The session cookie is encrypted with AES-256-GCM under a key derived from `REEF_SESSION_SECRET`, then signed. The OAuth transaction cookie beside it is **signed but not encrypted** — its `codeVerifier`, `state`, and return path are readable by anything that can read the cookie itself, and `HttpOnly`, `SameSite=Lax`, and a ten-minute lifetime are what stand in front of that. Both cookies derive `Secure` from `REEF_PUBLIC_URL`, so an all-loopback HTTP setup works without another configuration switch.

## What it enables

Later routes can establish and read authenticated sessions without a bearer token ever reaching the browser.

A session is now checked on the way in as well as on the way out. `readReefSession` turns away a cookie whose signature does not verify, whose ciphertext was altered under the right key, whose payload decrypts to something that is not a session, or that has expired. `commitReefSession` refuses to write one that expires inside the 30-second clock-skew window: such a session is unreadable the moment it exists, and the result is a `/login` → callback → `/login` loop with no error reported anywhere. Two unrelated settings can cause it — a Coral token with a small `expires_in`, or a small `REEF_SESSION_MAX_AGE_SECONDS` — so the refusal names both.

The transaction cookie is bounded and namespaced on the same principle: what protects it has to be something the server enforces, not something it hopes the browser did.

Its ten-minute lifetime used to be `Max-Age` alone. The signature proves a payload came from this server and says nothing about when, and the value carried no timestamp and nothing else that varied — so the blob verified indefinitely, and only a browser was ever bound by the ten minutes. `commitOAuthTransaction` now stamps an `issuedAt` and `readOAuthTransaction` checks the age, so a captured `codeVerifier` stops working even when replayed by something that is not a browser. PKCE assumes the verifier is short-lived as well as secret. The field is added and stripped inside the module, so `OAuthTransaction` stays the three fields a login flow passes and receives. A cookie dated in the *future* is accepted: it cannot be forged without the secret, so the only thing that produces one is a clock disagreeing between instances, and rejecting it would fail those logins and prevent no attack — which is why the past side carries 30 seconds of slack too.

The cookie is also named `__Host-reef_oauth` wherever the browser accepts the prefix. A signature does not stop a cookie of the *same name* arriving from somewhere else. This cookie is host-only, so a sibling host never receives it — but any host under the same registrable domain can set a domain-scoped `reef_oauth`, both then arrive, and `parse` keeps whichever the browser lists first: the more specific `Path`, which is the attacker's to choose. The transaction whose `state` the callback validates against would be one the attacker started. `__Host-` forbids `Domain` at the browser, refusing the tossed cookie at the source rather than disambiguating it here. It also requires `Secure`, so the prefix follows the same `REEF_PUBLIC_URL` derivation as everything else and the accepted all-loopback HTTP topology keeps the bare name — the rule `REEF_SESSION_COOKIE_NAME` is already validated against, applied to the cookie whose name is not configurable.

## Usage examples

Configure a high-entropy server secret and an optional session lifetime:

```bash
REEF_SESSION_SECRET=replace-with-at-least-32-random-characters
REEF_SESSION_MAX_AGE_SECONDS=3600
```

Keep `REEF_SESSION_MAX_AGE_SECONDS` comfortably above 30; at or below it, every login fails with `Refusing to establish a Reef session that expires within 30s`.

A callback stores the resulting `AuthSession` with `commitReefSession`; protected loaders recover it with `readReefSession`.

## Note for the layers above this one

The transaction cookie's name now moves with `REEF_PUBLIC_URL`, so it is exported as `oauthCookieName(config)` rather than spelled out. Anything that looks the cookie up by name needs to ask for it — in the stack as it stands that is `coral-oauth.server.test.ts`, whose `cookieHeader` helper matches on `startsWith(`${name}=`)` and so does not find `__Host-reef_oauth` under a literal `reef_oauth`. No non-test caller is affected: `OAuthTransaction` is unchanged at both ends.

An in-flight login spanning the deploy fails once and succeeds on retry — the cookie name changes and the old payload has no `issuedAt`.
