### PR TITLE
feat(reef): add Coral OAuth protocol client

### DIFF
--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { authClientId, authRedirectUri, authResource } from './config.server'
 import { completeCoralOAuthLogin, startCoralOAuthLogin } from './coral-oauth.server'
-import { readOAuthTransaction, readReefSession } from './session.server'
+import { oauthCookieName, readOAuthTransaction, readReefSession } from './session.server'
 import type { RequiredAuthConfig } from './types'
 
 const AUTH_ISSUER = 'https://coral.example.test'
@@ -40,7 +40,7 @@ describe('Coral OAuth adapter', () => {
     const location = new URL(response.headers.get('location') ?? '')
     const transaction = await readOAuthTransaction(
       new Request('https://reef.example.test/', {
-        headers: { cookie: cookieHeader(response, 'reef_oauth') },
+        headers: { cookie: cookieHeader(response, oauthCookieName(config)) },
       }),
       config,
     )
@@ -77,7 +77,7 @@ describe('Coral OAuth adapter', () => {
     const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
     const callback = await completeCoralOAuthLogin(
       new Request(`https://internal-proxy/auth/callback?code=abc123&state=${state}`, {
-        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+        headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
       }),
       config,
     )
@@ -90,7 +90,7 @@ describe('Coral OAuth adapter', () => {
     )
 
     expect(callback.headers.get('location')).toBe('/workspaces/analytics?tab=mine')
-    expect(cookies[0]).toContain('reef_oauth=')
+    expect(cookies[0]).toContain(`${oauthCookieName(config)}=`)
     expect(cookies[0]).toContain('Max-Age=0')
     expect(cookies[1]).toContain('reef_session=')
     expect(cookies[1]).not.toContain('opaque-coral-token')
@@ -164,7 +164,7 @@ describe('Coral OAuth adapter', () => {
     const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
     const callback = await completeCoralOAuthLogin(
       new Request(`https://reef.example.test/auth/callback?code=abc123&state=${state}`, {
-        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+        headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
       }),
       config,
     )
@@ -175,7 +175,7 @@ describe('Coral OAuth adapter', () => {
   it('clears OAuth state only after a callback matches the active transaction', async () => {
     const fetch = mockFetch(jsonResponse(metadata))
     const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
-    const cookie = cookieHeader(login, 'reef_oauth')
+    const cookie = cookieHeader(login, oauthCookieName(config))
     const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
 
     const providerError = await completeCoralOAuthLogin(
@@ -212,7 +212,7 @@ describe('Coral OAuth adapter', () => {
 
     const error = await completeCoralOAuthLogin(
       new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
-        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+        headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
       }),
       config,
     ).catch((caught: unknown) => caught)
@@ -278,7 +278,7 @@ describe('Coral OAuth adapter', () => {
     await expect(
       completeCoralOAuthLogin(
         new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
-          headers: { cookie: cookieHeader(login, 'reef_oauth') },
+          headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
         }),
         config,
       ),

--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -139,14 +139,26 @@ describe('Coral OAuth adapter', () => {
     expect(setCookies(response)[0]).not.toContain('Secure')
   })
 
-  it('falls back to home for an external return target', async () => {
+  // The absolute form is the one an external target is usually written as. The
+  // traversal forms are the ones that reach `Location` if the destination is
+  // normalized rather than validated — `URL` turns `/..//evil.example` into the
+  // scheme-relative path `//evil.example`, and a browser follows that off-origin
+  // exactly as it would an absolute URL. Both are checked through the whole
+  // round trip, because the value is only dangerous once it comes back out of
+  // the transaction cookie as a header.
+  it.each([
+    'https://evil.example/phish',
+    '/..//evil.example',
+    '/..//evil.example/phish',
+    '/./..//evil.example',
+  ])('falls back to home for an external return target: %s', async (returnTo) => {
     mockFetch(
       jsonResponse(metadata),
       jsonResponse(metadata),
       jsonResponse({ access_token: 'token', expires_in: 3600 }),
     )
     const login = await startCoralOAuthLogin(
-      new Request('https://reef.example.test/login?returnTo=https://evil.example/phish'),
+      new Request(`https://reef.example.test/login?returnTo=${encodeURIComponent(returnTo)}`),
       config,
     )
     const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')

--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { authClientId, authRedirectUri, authResource } from './config.server'
+import { completeCoralOAuthLogin, startCoralOAuthLogin } from './coral-oauth.server'
+import { readOAuthTransaction, readReefSession } from './session.server'
+import type { RequiredAuthConfig } from './types'
+
+const AUTH_ISSUER = 'https://coral.example.test'
+const config: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: AUTH_ISSUER,
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+const metadata = {
+  authorization_endpoint: `${AUTH_ISSUER}/authorize`,
+  issuer: AUTH_ISSUER,
+  token_endpoint: `${AUTH_ISSUER}/token`,
+}
+
+describe('Coral OAuth adapter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('starts login with PKCE and identity derived only from the Reef public URL', async () => {
+    const fetch = mockFetch(jsonResponse(metadata))
+    const response = await startCoralOAuthLogin(
+      new Request('https://internal-proxy/login?returnTo=/workspaces/analytics?tab=mine'),
+      config,
+    )
+    const location = new URL(response.headers.get('location') ?? '')
+    const transaction = await readOAuthTransaction(
+      new Request('https://reef.example.test/', {
+        headers: { cookie: cookieHeader(response, 'reef_oauth') },
+      }),
+      config,
+    )
+
+    expect(fetch).toHaveBeenCalledWith(`${AUTH_ISSUER}/.well-known/oauth-authorization-server`, {
+      headers: { accept: 'application/json' },
+    })
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(location.origin).toBe(AUTH_ISSUER)
+    expect(location.searchParams.get('client_id')).toBe(authClientId(config))
+    expect(location.searchParams.get('redirect_uri')).toBe(authRedirectUri(config))
+    expect(location.searchParams.get('resource')).toBe(authResource(config))
+    expect(location.searchParams.has('scope')).toBe(false)
+    expect(location.searchParams.get('state')).toBeTruthy()
+    expect(location.searchParams.get('code_challenge')).toBeTruthy()
+    expect(location.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(transaction).toEqual({
+      codeVerifier: expect.any(String),
+      returnTo: '/workspaces/analytics?tab=mine',
+      state: location.searchParams.get('state'),
+    })
+  })
+
+  it('completes login, clears OAuth state, and stores a bounded encrypted session', async () => {
+    const fetch = mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse({ access_token: 'opaque-coral-token', expires_in: 7200, token_type: 'Bearer' }),
+    )
+    const login = await startCoralOAuthLogin(
+      new Request('https://reef.example.test/login?returnTo=/workspaces/analytics?tab=mine'),
+      config,
+    )
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+    const callback = await completeCoralOAuthLogin(
+      new Request(`https://internal-proxy/auth/callback?code=abc123&state=${state}`, {
+        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+      }),
+      config,
+    )
+    const cookies = setCookies(callback)
+    const session = await readReefSession(
+      new Request('https://reef.example.test/', {
+        headers: { cookie: cookieHeader(callback, 'reef_session') },
+      }),
+      config,
+    )
+
+    expect(callback.headers.get('location')).toBe('/workspaces/analytics?tab=mine')
+    expect(cookies[0]).toContain('reef_oauth=')
+    expect(cookies[0]).toContain('Max-Age=0')
+    expect(cookies[1]).toContain('reef_session=')
+    expect(cookies[1]).not.toContain('opaque-coral-token')
+    expect(session).toEqual({
+      accessToken: 'opaque-coral-token',
+      expiresAt: unixTimestamp() + 3600,
+      tokenType: 'Bearer',
+    })
+
+    const tokenRequest = fetch.mock.calls[2]
+    const body = tokenRequest?.[1]?.body as URLSearchParams
+    expect(tokenRequest?.[0]).toBe(`${AUTH_ISSUER}/token`)
+    expect(body.get('grant_type')).toBe('authorization_code')
+    expect(body.get('code')).toBe('abc123')
+    expect(body.get('code_verifier')).toBeTruthy()
+    expect(body.get('client_id')).toBe(authClientId(config))
+    expect(body.get('redirect_uri')).toBe(authRedirectUri(config))
+    expect(body.get('resource')).toBe(authResource(config))
+    expect(body.has('scope')).toBe(false)
+  })
+
+  it('derives the same OAuth identity for the accepted all-loopback topology', async () => {
+    const loopbackConfig = {
+      ...config,
+      issuer: 'http://127.0.0.1:3000',
+      publicUrl: 'http://localhost:5173',
+    }
+    const loopbackMetadata = {
+      authorization_endpoint: 'http://127.0.0.1:3000/authorize',
+      issuer: loopbackConfig.issuer,
+      token_endpoint: 'http://127.0.0.1:3000/token',
+    }
+    mockFetch(jsonResponse(loopbackMetadata))
+
+    const response = await startCoralOAuthLogin(
+      new Request('http://127.0.0.1:8000/login'),
+      loopbackConfig,
+    )
+    const location = new URL(response.headers.get('location') ?? '')
+
+    expect(location.searchParams.get('client_id')).toBe(
+      'http://localhost:5173/.well-known/oauth-client',
+    )
+    expect(location.searchParams.get('redirect_uri')).toBe('http://localhost:5173/auth/callback')
+    expect(location.searchParams.get('resource')).toBe('http://localhost:5173')
+    expect(setCookies(response)[0]).not.toContain('Secure')
+  })
+
+  it('falls back to home for an external return target', async () => {
+    mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse({ access_token: 'token', expires_in: 3600 }),
+    )
+    const login = await startCoralOAuthLogin(
+      new Request('https://reef.example.test/login?returnTo=https://evil.example/phish'),
+      config,
+    )
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+    const callback = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?code=abc123&state=${state}`, {
+        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+      }),
+      config,
+    )
+
+    expect(callback.headers.get('location')).toBe('/')
+  })
+
+  it('clears OAuth state only after a callback matches the active transaction', async () => {
+    const fetch = mockFetch(jsonResponse(metadata))
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const cookie = cookieHeader(login, 'reef_oauth')
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    const providerError = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?error=access_denied&state=${state}`, {
+        headers: { cookie },
+      }),
+      config,
+    ).catch((error: unknown) => error)
+    const stateError = await completeCoralOAuthLogin(
+      new Request('https://reef.example.test/auth/callback?code=abc&state=wrong', {
+        headers: { cookie },
+      }),
+      config,
+    ).catch((error: unknown) => error)
+
+    expect(providerError).toMatchObject({ status: 400 })
+    expect((providerError as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
+    expect(stateError).toMatchObject({ status: 400 })
+    expect((stateError as Response).headers.has('Set-Cookie')).toBe(false)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('normalizes direct token-endpoint OAuth JSON into the callback error contract', async () => {
+    mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse(
+        { error: 'invalid_target', error_description: 'resource is not allowed' },
+        { status: 400 },
+      ),
+    )
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    const error = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+      }),
+      config,
+    ).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(Response)
+    expect((error as Response).status).toBe(400)
+    await expect((error as Response).text()).resolves.toBe(
+      'invalid_target: resource is not allowed',
+    )
+    expect((error as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
+  })
+
+  it('uses RFC 8414 discovery for a path issuer and requires its exact identifier', async () => {
+    const issuer = 'https://coral.example.test/tenant/'
+    const pathConfig = { ...config, issuer }
+    const pathMetadata = {
+      authorization_endpoint: `${issuer}authorize`,
+      issuer,
+      token_endpoint: `${issuer}token`,
+    }
+    const fetch = mockFetch(jsonResponse(pathMetadata))
+
+    await startCoralOAuthLogin(new Request('https://reef.example.test/login'), pathConfig)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://coral.example.test/.well-known/oauth-authorization-server/tenant/',
+      { headers: { accept: 'application/json' } },
+    )
+  })
+
+  it('ignores dynamic registration metadata and always uses the derived CIMD client ID', async () => {
+    const fetch = mockFetch(
+      jsonResponse({ ...metadata, registration_endpoint: `${AUTH_ISSUER}/register` }),
+    )
+    const response = await startCoralOAuthLogin(
+      new Request('https://reef.example.test/login'),
+      config,
+    )
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(new URL(response.headers.get('location') ?? '').searchParams.get('client_id')).toBe(
+      authClientId(config),
+    )
+  })
+
+  it('rejects metadata for a different issuer', async () => {
+    mockFetch(jsonResponse({ ...metadata, issuer: 'https://attacker.example' }))
+
+    await expect(
+      startCoralOAuthLogin(new Request('https://reef.example.test/login'), config),
+    ).rejects.toThrow('metadata issuer does not match')
+  })
+
+  it('requires a positive standards-based token expiry', async () => {
+    mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse({ access_token: 'token-with-ignored-jwt-shape' }),
+    )
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    await expect(
+      completeCoralOAuthLogin(
+        new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+          headers: { cookie: cookieHeader(login, 'reef_oauth') },
+        }),
+        config,
+      ),
+    ).rejects.toThrow('positive expires_in')
+  })
+})
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function mockFetch(...responses: Response[]) {
+  const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+    const response = responses.shift()
+    if (!response) throw new Error('unexpected fetch call')
+    return response
+  })
+  vi.stubGlobal('fetch', fetch)
+  return fetch
+}
+
+function setCookies(response: Response): string[] {
+  const headers = response.headers as Headers & { getSetCookie?: () => string[] }
+  const cookies = headers.getSetCookie?.()
+  if (cookies?.length) return cookies
+  const cookie = response.headers.get('set-cookie')
+  return cookie ? [cookie] : []
+}
+
+function cookieHeader(response: Response, name: string): string {
+  const cookie = setCookies(response).find((value) => value.startsWith(`${name}=`))
+  if (!cookie) throw new Error(`missing ${name} Set-Cookie header`)
+  return cookie.split(';', 1)[0]
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/coral-oauth.server.ts
+++ b/apps/reef/app/auth/coral-oauth.server.ts
@@ -1,0 +1,237 @@
+import { createHash } from 'node:crypto'
+
+import { redirect } from 'react-router'
+
+import { authClientId, authRedirectUri, authResource } from './config.server'
+import {
+  clearOAuthTransaction,
+  commitOAuthTransaction,
+  commitReefSession,
+  randomToken,
+  readOAuthTransaction,
+} from './session.server'
+import type { AuthSession, RequiredAuthConfig } from './types'
+
+interface AuthorizationServerMetadata {
+  authorization_endpoint: string
+  issuer: string
+  token_endpoint: string
+}
+
+interface TokenResponse {
+  access_token?: unknown
+  expires_in?: unknown
+  token_type?: unknown
+}
+
+interface OAuthErrorResponse {
+  error?: unknown
+  error_description?: unknown
+}
+
+export async function startCoralOAuthLogin(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<Response> {
+  const metadata = await authorizationServerMetadata(config)
+  const url = new URL(request.url)
+  const returnTo = safeReturnTo(url.searchParams.get('returnTo'))
+  const redirectUri = authRedirectUri(config)
+  const clientId = authClientId(config)
+  const resource = authResource(config)
+  const state = randomToken(32)
+  const codeVerifier = randomToken(32)
+  const authorizationUrl = new URL(metadata.authorization_endpoint)
+
+  authorizationUrl.searchParams.set('response_type', 'code')
+  authorizationUrl.searchParams.set('client_id', clientId)
+  authorizationUrl.searchParams.set('redirect_uri', redirectUri)
+  authorizationUrl.searchParams.set('resource', resource)
+  authorizationUrl.searchParams.set('state', state)
+  authorizationUrl.searchParams.set('code_challenge', pkceChallenge(codeVerifier))
+  authorizationUrl.searchParams.set('code_challenge_method', 'S256')
+  return redirect(authorizationUrl.toString(), {
+    headers: {
+      'Set-Cookie': await commitOAuthTransaction({ codeVerifier, returnTo, state }, config),
+    },
+  })
+}
+
+export async function completeCoralOAuthLogin(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<Response> {
+  const url = new URL(request.url)
+  const state = url.searchParams.get('state')
+  const transaction = await readOAuthTransaction(request, config)
+  if (!state || !transaction || state !== transaction.state) {
+    throw callbackError('Invalid Reef auth callback state')
+  }
+
+  const providerError = url.searchParams.get('error')
+  if (providerError) {
+    const description = url.searchParams.get('error_description')
+    throw await callbackError(
+      description ? `${providerError}: ${description}` : providerError,
+      await clearOAuthTransaction(config),
+    )
+  }
+
+  const code = url.searchParams.get('code')
+  if (!code) {
+    throw callbackError('Invalid Reef auth callback code', await clearOAuthTransaction(config))
+  }
+
+  const metadata = await authorizationServerMetadata(config)
+  let token: TokenResponse
+  try {
+    token = await exchangeAuthorizationCode(metadata, {
+      clientId: authClientId(config),
+      code,
+      codeVerifier: transaction.codeVerifier,
+      redirectUri: authRedirectUri(config),
+      resource: authResource(config),
+    })
+  } catch (error) {
+    // Coral currently reports authorize failures through redirects, while its
+    // token endpoint returns OAuth JSON directly. Keep the callback route
+    // tolerant of both shapes as the server contract evolves.
+    if (error instanceof Response) {
+      error.headers.append('Set-Cookie', await clearOAuthTransaction(config))
+    }
+    throw error
+  }
+  const session = sessionFromToken(token, config)
+  const headers = new Headers()
+  headers.append('Set-Cookie', await clearOAuthTransaction(config))
+  headers.append('Set-Cookie', await commitReefSession(session, config))
+
+  return redirect(transaction.returnTo, { headers })
+}
+
+async function authorizationServerMetadata(
+  config: RequiredAuthConfig,
+): Promise<AuthorizationServerMetadata> {
+  const response = await fetch(authorizationServerMetadataUrl(config.issuer), {
+    headers: { accept: 'application/json' },
+  })
+  if (!response.ok) {
+    throw new Error(`Coral auth metadata request failed with HTTP ${response.status}`)
+  }
+
+  const metadata = (await response.json()) as AuthorizationServerMetadata
+  if (
+    typeof metadata.authorization_endpoint !== 'string' ||
+    typeof metadata.issuer !== 'string' ||
+    typeof metadata.token_endpoint !== 'string'
+  ) {
+    throw new Error('Coral auth metadata is missing required OAuth endpoints')
+  }
+  if (metadata.issuer !== config.issuer) {
+    throw new Error('Coral auth metadata issuer does not match REEF_AUTH_ISSUER')
+  }
+
+  return metadata
+}
+
+async function exchangeAuthorizationCode(
+  metadata: AuthorizationServerMetadata,
+  input: {
+    clientId: string
+    code: string
+    codeVerifier: string
+    redirectUri: string
+    resource: string
+  },
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    client_id: input.clientId,
+    code: input.code,
+    code_verifier: input.codeVerifier,
+    grant_type: 'authorization_code',
+    redirect_uri: input.redirectUri,
+    resource: input.resource,
+  })
+  const response = await fetch(metadata.token_endpoint, {
+    body,
+    headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw await tokenExchangeError(response)
+  }
+
+  return response.json() as Promise<TokenResponse>
+}
+
+async function tokenExchangeError(response: Response): Promise<Response> {
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as OAuthErrorResponse | null
+  const error = typeof body?.error === 'string' ? body.error : null
+  const description = typeof body?.error_description === 'string' ? body.error_description : null
+  const message = error
+    ? description
+      ? `${error}: ${description}`
+      : error
+    : `Coral OAuth token exchange failed with HTTP ${response.status}`
+
+  return callbackError(message)
+}
+
+function sessionFromToken(token: TokenResponse, config: RequiredAuthConfig): AuthSession {
+  if (typeof token.access_token !== 'string' || !token.access_token) {
+    throw new Error('Coral OAuth token response did not include access_token')
+  }
+  if (
+    typeof token.expires_in !== 'number' ||
+    !Number.isFinite(token.expires_in) ||
+    !Number.isInteger(token.expires_in) ||
+    token.expires_in <= 0
+  ) {
+    throw new Error('Coral OAuth token response did not include a positive expires_in')
+  }
+
+  return {
+    accessToken: token.access_token,
+    expiresAt: unixTimestamp() + Math.min(token.expires_in, config.sessionMaxAgeSeconds),
+    tokenType:
+      typeof token.token_type === 'string' && token.token_type ? token.token_type : 'Bearer',
+  }
+}
+
+function safeReturnTo(value: string | null): string {
+  if (!value) return '/'
+  try {
+    const parsed = new URL(value, 'http://reef.local')
+    if (parsed.origin !== 'http://reef.local') return '/'
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return '/'
+  }
+}
+
+function pkceChallenge(codeVerifier: string): string {
+  return createHash('sha256').update(codeVerifier).digest('base64url')
+}
+
+function authorizationServerMetadataUrl(issuer: string): string {
+  const url = new URL(issuer)
+  const issuerPath = url.pathname.replace(/^\/+/, '')
+  url.pathname = `/.well-known/oauth-authorization-server${issuerPath ? `/${issuerPath}` : ''}`
+  return url.toString()
+}
+
+function callbackError(message: string, clearTransaction?: string): Response {
+  const headers = new Headers()
+  if (clearTransaction) headers.set('Set-Cookie', clearTransaction)
+  return new Response(message, {
+    headers,
+    status: 400,
+  })
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/coral-oauth.server.ts
+++ b/apps/reef/app/auth/coral-oauth.server.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto'
 import { redirect } from 'react-router'
 
 import { authClientId, authRedirectUri, authResource } from './config.server'
+import { safeInternalPath } from './safe-path.server'
 import {
   clearOAuthTransaction,
   commitOAuthTransaction,
@@ -35,7 +36,7 @@ export async function startCoralOAuthLogin(
 ): Promise<Response> {
   const metadata = await authorizationServerMetadata(config)
   const url = new URL(request.url)
-  const returnTo = safeReturnTo(url.searchParams.get('returnTo'))
+  const returnTo = safeInternalPath(url.searchParams.get('returnTo'))
   const redirectUri = authRedirectUri(config)
   const clientId = authClientId(config)
   const resource = authResource(config)
@@ -198,17 +199,6 @@ function sessionFromToken(token: TokenResponse, config: RequiredAuthConfig): Aut
     expiresAt: unixTimestamp() + Math.min(token.expires_in, config.sessionMaxAgeSeconds),
     tokenType:
       typeof token.token_type === 'string' && token.token_type ? token.token_type : 'Bearer',
-  }
-}
-
-function safeReturnTo(value: string | null): string {
-  if (!value) return '/'
-  try {
-    const parsed = new URL(value, 'http://reef.local')
-    if (parsed.origin !== 'http://reef.local') return '/'
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`
-  } catch {
-    return '/'
   }
 }
 

--- a/apps/reef/app/auth/safe-path.server.test.ts
+++ b/apps/reef/app/auth/safe-path.server.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { safeInternalPath } from './safe-path.server'
+
+describe('safeInternalPath', () => {
+  it.each([
+    ['/', '/'],
+    ['/workspaces/analytics', '/workspaces/analytics'],
+    ['/workspaces/analytics?tab=mine#top', '/workspaces/analytics?tab=mine#top'],
+    [
+      '/sources/new?step=oauth&next=%2F%2Fevil.example',
+      '/sources/new?step=oauth&next=%2F%2Fevil.example',
+    ],
+    // Traversal that stays inside the origin is normalized, not rejected: the
+    // rule is where the path lands, not how it was spelled.
+    ['/workspaces/../traces', '/traces'],
+  ])('keeps an internal destination: %s', (value, expected) => {
+    expect(safeInternalPath(value)).toBe(expected)
+  })
+
+  // The class both predecessors of this helper let through. `URL` normalization
+  // turns each of these into a `//`-leading path, which is a scheme-relative URL
+  // — so emitting it as `Location` hands the visitor to another host. Every
+  // input here starts `/.`, so an input-side `startsWith('//')` check never
+  // sees it.
+  it.each([
+    '/..//evil.example',
+    '/..//evil.example/phish',
+    '/./..//evil.example',
+    '/workspaces/../..//evil.example',
+    '/..//evil.example?next=/workspaces',
+    '/..//\\evil.example',
+    '/.//\\\\evil.example',
+  ])('rejects a destination normalization sends off-origin: %s', (value) => {
+    expect(safeInternalPath(value)).toBe('/')
+  })
+
+  it.each([
+    ['a protocol-relative URL', '//evil.example'],
+    ['a backslash-relative URL', '/\\evil.example'],
+    ['an absolute URL', 'https://evil.example/phish'],
+    ['an absolute URL naming the sentinel origin', 'https://reef.invalid/phish'],
+    ['a credentialed URL borrowing the sentinel host', 'https://reef.invalid@evil.example/'],
+    ['a javascript: URL', 'javascript:alert(1)'],
+    ['a data: URL', 'data:text/html,<script>alert(1)</script>'],
+    ['a bare relative path', 'workspaces/analytics'],
+    ['an empty string', ''],
+    ['null', null],
+    ['undefined', undefined],
+  ])('rejects %s', (_label, value) => {
+    expect(safeInternalPath(value)).toBe('/')
+  })
+
+  it('rejects a destination past the length bound', () => {
+    expect(safeInternalPath(`/${'a'.repeat(2048)}`)).toBe('/')
+    expect(safeInternalPath(`/${'a'.repeat(2046)}`)).toBe(`/${'a'.repeat(2046)}`)
+  })
+})

--- a/apps/reef/app/auth/safe-path.server.ts
+++ b/apps/reef/app/auth/safe-path.server.ts
@@ -1,0 +1,56 @@
+// Reduction of a caller-supplied return target to a path this origin can safely
+// redirect to.
+//
+// Login and session expiry both take a destination from the request and hand it
+// back as a `Location` once the round trip completes. That destination is
+// attacker-supplied — `/login?returnTo=…` is public — so it is a redirect target
+// only after it has been proven internal.
+
+// The longest return target worth preserving. A destination this long is not a
+// real Reef route, and a bound keeps a hostile input from being carried through
+// a cookie and back out into a header.
+const MAX_LENGTH = 2048
+
+// Parsing needs a base, and the base must be an origin no input can also name —
+// otherwise an absolute URL naming it would be accepted as internal. `.invalid`
+// is reserved by RFC 2606 precisely so it can never resolve.
+const SENTINEL_ORIGIN = 'https://reef.invalid'
+
+// A path that stays on this origin: one leading slash, and the next character
+// neither a slash nor a backslash.
+//
+// Applied to the *output*, which is the whole point. `//evil.example` is a
+// scheme-relative URL, and a browser sends `Location: //evil.example` to
+// evil.example over the current scheme — so a leading `//` is an off-origin
+// redirect wearing a path's clothing. Backslash is included because browsers
+// fold it to a slash before resolving.
+const INTERNAL_PATH = /^\/(?![/\\])/
+
+/**
+ * Returns `value` as an internal path, or `/` when it is not one.
+ *
+ * The order matters, and it is the order an earlier pair of near-identical
+ * helpers got wrong. Both rejected a literal leading `//` on the *input* and
+ * then returned `URL`'s normalized pathname unexamined — but normalization is
+ * itself capable of *producing* a leading `//`: in `/..//evil.example` the `..`
+ * pops the empty first segment, leaving `//evil.example`. The input passed every
+ * check, because at input time the value was genuinely a relative path.
+ *
+ * So the origin check proves the *input* names no other host, and
+ * `INTERNAL_PATH` proves the *output* still names none after `URL` has had its
+ * say. Neither check subsumes the other.
+ */
+export function safeInternalPath(value: string | null | undefined): string {
+  if (!value || value.length > MAX_LENGTH || !value.startsWith('/')) return '/'
+
+  let path: string
+  try {
+    const parsed = new URL(value, SENTINEL_ORIGIN)
+    if (parsed.origin !== SENTINEL_ORIGIN) return '/'
+    path = `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return '/'
+  }
+
+  return INTERNAL_PATH.test(path) ? path : '/'
+}


### PR DESCRIPTION
> Reef hosted-auth stack: layer 3 of 11. Base: PR #2059.

## Intent

Implement Reef's provider-neutral OAuth authorization-code client against Coral's authorization server, using PKCE, CIMD client identity, and the Reef-derived resource on both authorization and token requests.

## What it enables

Server loaders can start and complete a Coral login without dynamic client registration, scopes, an MCP URL, or provider-specific browser state. Both redirect-form and direct JSON OAuth errors are handled.

## Usage examples

The login loader starts the protocol with `startCoralOAuthLogin(request, config)`. The callback loader completes it with `completeCoralOAuthLogin(request, config)`, validates the transaction state, exchanges the code, and commits the Reef session.