### PR TITLE
feat(reef): serve OAuth client metadata

### DIFF
--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -3,6 +3,8 @@ import { type RouteConfig, index, layout, route } from '@react-router/dev/routes
 import { routePattern } from './routing/routemap'
 
 export default [
+  // Public CIMD resource: Coral fetches this before it can authorize Reef.
+  route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),
   // Action-only resource route: OAuth/device-code install streams progress over
   // same-origin fetch. It intentionally sits outside the app shell and does not
   // render a page.

--- a/apps/reef/app/routes/oauth-client-metadata.server.test.ts
+++ b/apps/reef/app/routes/oauth-client-metadata.server.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({ reefAuthConfig: vi.fn() }))
+
+vi.mock('@/auth/config.server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/auth/config.server')>()),
+  reefAuthConfig: authMocks.reefAuthConfig,
+}))
+
+import { loader } from './oauth-client-metadata'
+
+const requiredConfig: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('OAuth client metadata route', () => {
+  it('serves a cacheable CIMD document derived from the canonical Reef public URL', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+
+    const response = await runLoader('https://internal-proxy/.well-known/oauth-client')
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=300')
+    expect(response.headers.has('Set-Cookie')).toBe(false)
+    expect(Buffer.byteLength(JSON.stringify(body))).toBeLessThanOrEqual(5 * 1024)
+    expect(body).toEqual({
+      client_id: 'https://reef.example.test/.well-known/oauth-client',
+      client_name: 'Coral Reef',
+      grant_types: ['authorization_code'],
+      redirect_uris: ['https://reef.example.test/auth/callback'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    })
+  })
+
+  it('serves the same document over the accepted all-loopback HTTP topology', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({
+      ...requiredConfig,
+      issuer: 'http://127.0.0.1:3000',
+      publicUrl: 'http://localhost:5173',
+    })
+
+    const body = await (await runLoader('http://localhost:5173/.well-known/oauth-client')).json()
+
+    expect(body.client_id).toBe('http://localhost:5173/.well-known/oauth-client')
+    expect(body.redirect_uris).toEqual(['http://localhost:5173/auth/callback'])
+  })
+
+  it('does not publish OAuth client metadata when auth is disabled', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+
+    const error = await runLoader('http://localhost:5173/.well-known/oauth-client').catch(
+      (caught: unknown) => caught,
+    )
+
+    expect(error).toBeInstanceOf(Response)
+    expect((error as Response).status).toBe(404)
+  })
+})
+
+function runLoader(url: string): Promise<Response> {
+  return loader({ request: new Request(url) } as never)
+}

--- a/apps/reef/app/routes/oauth-client-metadata.ts
+++ b/apps/reef/app/routes/oauth-client-metadata.ts
@@ -1,0 +1,29 @@
+import type { Route } from './+types/oauth-client-metadata'
+
+import { authClientId, authRedirectUri, reefAuthConfig } from '@/auth/config.server'
+
+const MAX_CLIENT_METADATA_BYTES = 5 * 1024
+
+export async function loader({ request: _request }: Route.LoaderArgs): Promise<Response> {
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') throw new Response('Not Found', { status: 404 })
+
+  const body = JSON.stringify({
+    client_id: authClientId(config),
+    client_name: 'Coral Reef',
+    grant_types: ['authorization_code'],
+    redirect_uris: [authRedirectUri(config)],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  })
+  if (Buffer.byteLength(body) > MAX_CLIENT_METADATA_BYTES) {
+    throw new Error('Reef OAuth client metadata exceeds the 5 KiB CIMD limit')
+  }
+
+  return new Response(body, {
+    headers: {
+      'Cache-Control': 'public, max-age=300',
+      'Content-Type': 'application/json',
+    },
+  })
+}


### PR DESCRIPTION
> Reef hosted-auth stack: layer 4 of 11. Base: PR #2060.

## Intent

Publish Reef's Client ID Metadata Document at the client ID derived from `REEF_PUBLIC_URL`. Keep the endpoint server-rendered, public, small, and cacheable without introducing client registration.

## What it enables

Coral can resolve Reef as an OAuth public client and validate its exact callback URI before issuing an authorization code. Local and hosted Reef use the same derivation rule.

## Usage examples

Inspect a deployment's metadata directly:

```bash
curl -i "$REEF_PUBLIC_URL/.well-known/oauth-client"
```

The returned `client_id` is `$REEF_PUBLIC_URL/.well-known/oauth-client`, and the redirect URI is `$REEF_PUBLIC_URL/auth/callback`.