### PR TITLE
feat(reef): protect hosted routes without gating local Reef

### DIFF
--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -16,11 +16,16 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const routeConfigFile = path.join(appDir, 'routes.ts')
 const reefRoot = path.resolve(appDir, '..')
 const desktopRoot = path.resolve(reefRoot, '..', 'desktop')
 
 function read(...segments: string[]): string {
   return fs.readFileSync(path.join(...segments), 'utf8')
+}
+
+function leadingIndentWidth(line: string): number {
+  return (/^\s*/.exec(line)?.[0] ?? '').length
 }
 
 describe('hosted auth architecture', () => {
@@ -47,5 +52,42 @@ describe('hosted auth architecture', () => {
     expect(desktopHelper).toMatch(/return import\.meta\.env\.CORAL_DESKTOP_APP/)
     expect(devScript.match(/CORAL_DESKTOP_APP:\s*'1'/g)).toHaveLength(1)
     expect(stageScript.match(/CORAL_DESKTOP_APP:\s*'1'/g)).toHaveLength(1)
+  })
+
+  // Regression: a route added at the top level of `routes.ts` sits outside the
+  // `_protected` boundary and is served with no session check. Comparing source
+  // positions would not catch it — a route appended after the boundary block
+  // closes still compares "later" — so this scans the top-level entries
+  // themselves, and every public one has to be named here on purpose.
+  //
+  // Depth is read from the file rather than assumed: pinning a literal
+  // two-space indent would make an auth guard only as strong as the formatter,
+  // and a reindent would drop entries out of the scan silently instead of
+  // failing.
+  it('keeps every route inside the auth boundary except the public ones named here', () => {
+    const routeConfig = read(routeConfigFile)
+    const publicTopLevelRoutes = [
+      "route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),",
+    ]
+
+    const entryLines = routeConfig
+      .slice(routeConfig.indexOf('export default ['))
+      .split('\n')
+      .filter((line) => /^\s+(?:index|layout|route)\(/.test(line))
+    const topLevelIndent = Math.min(...entryLines.map(leadingIndentWidth))
+    const topLevelEntries = entryLines
+      .filter((line) => leadingIndentWidth(line) === topLevelIndent)
+      .map((line) => line.trim())
+
+    // Guards the guard: an empty scan would make everything below it vacuous.
+    expect(entryLines.length).toBeGreaterThan(0)
+    expect(topLevelEntries).toContain("layout('routes/_protected.tsx', [")
+    expect(
+      topLevelEntries.filter(
+        (entry) =>
+          !publicTopLevelRoutes.includes(entry) &&
+          !entry.startsWith("layout('routes/_protected.tsx',"),
+      ),
+    ).toEqual([])
   })
 })

--- a/apps/reef/app/auth/server-context.ts
+++ b/apps/reef/app/auth/server-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react-router'
+
+import type { RequestAuth } from './types'
+
+export const requestAuthContext = createContext<RequestAuth>()

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -20,3 +20,7 @@ export interface AuthSession {
   expiresAt: number
   tokenType: string
 }
+
+export type RequestAuth =
+  | { accessToken: null; mode: 'disabled' }
+  | { accessToken: string; mode: 'required'; session: AuthSession }

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -5,29 +5,31 @@ import { routePattern } from './routing/routemap'
 export default [
   // Public CIMD resource: Coral fetches this before it can authorize Reef.
   route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),
-  // Action-only resource route: OAuth/device-code install streams progress over
-  // same-origin fetch. It intentionally sits outside the app shell and does not
-  // render a page.
-  route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
-  route(routePattern('onboarding'), 'routes/onboarding.tsx'),
-  layout('routes/app-shell.tsx', [
-    index('routes/index.tsx'),
-    route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
-    route(routePattern('workspaceSources'), 'routes/sources.tsx', [
-      route('discover', 'routes/source-discovery.ts'),
-      route('install', 'routes/source-install.tsx'),
-      route('oauth-import', 'routes/source-oauth-import.ts'),
-      route(':sourceName', 'routes/source-detail.tsx'),
+  layout('routes/_protected.tsx', [
+    // Action-only resource route: OAuth/device-code install streams progress over
+    // same-origin fetch. It and onboarding share the auth boundary but do not
+    // render the app shell.
+    route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
+    route(routePattern('onboarding'), 'routes/onboarding.tsx'),
+    layout('routes/app-shell.tsx', [
+      index('routes/index.tsx'),
+      route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
+      route(routePattern('workspaceSources'), 'routes/sources.tsx', [
+        route('discover', 'routes/source-discovery.ts'),
+        route('install', 'routes/source-install.tsx'),
+        route('oauth-import', 'routes/source-oauth-import.ts'),
+        route(':sourceName', 'routes/source-detail.tsx'),
+      ]),
+      route(routePattern('workspaceFunctions'), 'routes/functions.tsx'),
+      route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
+        index('routes/schema-empty.tsx'),
+        route(':schemaName/:tableName', 'routes/schema-table.tsx'),
+        route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx'),
+      ]),
+      route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
+        route(':traceId', 'routes/trace-detail.tsx'),
+      ]),
+      route(routePattern('settings'), 'routes/settings.tsx'),
     ]),
-    route(routePattern('workspaceFunctions'), 'routes/functions.tsx'),
-    route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
-      index('routes/schema-empty.tsx'),
-      route(':schemaName/:tableName', 'routes/schema-table.tsx'),
-      route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx'),
-    ]),
-    route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
-      route(':traceId', 'routes/trace-detail.tsx'),
-    ]),
-    route(routePattern('settings'), 'routes/settings.tsx'),
   ]),
 ] satisfies RouteConfig

--- a/apps/reef/app/routes/_protected.server.test.tsx
+++ b/apps/reef/app/routes/_protected.server.test.tsx
@@ -180,14 +180,29 @@ describe('optional auth boundary', () => {
     expect((thrown as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
   })
 
+  // "Only" is the half that matters and the half a placement assertion cannot
+  // reach: a descendant runs, reads the token the way a real loader does, and
+  // the response it produces is then searched for the token in every part a
+  // browser would see.
   it('keeps the token only in server request context', async () => {
     authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
     authMocks.readReefSession.mockResolvedValue(session)
     const context = new RouterContextProvider()
 
-    await runMiddleware(
+    const response = await runMiddleware(
       new Request('https://reef.example.test/workspaces/analytics/sources'),
-      async () => new Response('hosted app'),
+      async () => {
+        // Stands in for a descendant loader: it reads the token, uses it, and
+        // renders from the result — without echoing it.
+        const { accessToken } = context.get(requestAuthContext)
+        expect(accessToken).toBe('server-only-token')
+        return new Response(
+          `<main>hosted app for ${accessToken ? 'a signed-in user' : 'nobody'}</main>`,
+          {
+            headers: { 'Content-Type': 'text/html', 'X-Rendered-By': 'descendant' },
+          },
+        )
+      },
       context,
     )
 
@@ -196,6 +211,15 @@ describe('optional auth boundary', () => {
       mode: 'required',
       session,
     })
+
+    const body = await response.clone().text()
+    const headers = [...response.headers.entries()].map(([name, value]) => `${name}: ${value}`)
+
+    expect(body).toContain('hosted app for a signed-in user')
+    expect(body).not.toContain('server-only-token')
+    for (const header of headers) {
+      expect(header).not.toContain('server-only-token')
+    }
   })
 
   it('marks normal and thrown hosted responses private and non-cacheable', async () => {

--- a/apps/reef/app/routes/_protected.server.test.tsx
+++ b/apps/reef/app/routes/_protected.server.test.tsx
@@ -1,0 +1,231 @@
+import { createRequestHandler, RouterContextProvider, type ServerBuild } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({
+  clearReefSession: vi.fn(async () => 'reef_session=; Max-Age=0; Path=/; HttpOnly'),
+  readReefSession: vi.fn(),
+  reefAuthConfig: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/session.server', () => ({
+  clearReefSession: authMocks.clearReefSession,
+  readReefSession: authMocks.readReefSession,
+}))
+
+import { requestAuthContext } from '@/auth/server-context'
+
+import { middleware } from './_protected'
+
+const requiredConfig: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+const session = {
+  accessToken: 'server-only-token',
+  expiresAt: 4_102_444_800,
+  tokenType: 'Bearer',
+}
+const descendantLoader = vi.fn(() => ({ ok: true }))
+const descendantAction = vi.fn(() => ({ ok: true }))
+const routeComponent = () => null
+
+const handlerBuild = {
+  assets: {
+    entry: { imports: [], module: '' },
+    routes: {},
+    url: '',
+    version: '',
+  },
+  assetsBuildDirectory: '',
+  basename: '/',
+  entry: {
+    module: {
+      default: async () => new Response('document'),
+    },
+  },
+  future: {
+    v8_middleware: true,
+    v8_passThroughRequests: false,
+    v8_trailingSlashAwareDataRequests: false,
+  },
+  isSpaMode: false,
+  prerender: [],
+  publicPath: '/',
+  routeDiscovery: { manifestPath: '/__manifest', mode: 'lazy' },
+  routes: {
+    root: {
+      id: 'root',
+      module: { default: routeComponent },
+      path: '',
+    },
+    'routes/_protected': {
+      id: 'routes/_protected',
+      module: { default: routeComponent, middleware },
+      parentId: 'root',
+    },
+    'routes/protected': {
+      id: 'routes/protected',
+      module: {
+        action: descendantAction,
+        default: routeComponent,
+        loader: descendantLoader,
+      },
+      parentId: 'routes/_protected',
+      path: 'protected',
+    },
+  },
+  ssr: true,
+} as unknown as ServerBuild
+
+describe('optional auth boundary', () => {
+  beforeEach(() => {
+    authMocks.clearReefSession.mockClear()
+    authMocks.readReefSession.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+    descendantAction.mockClear()
+    descendantLoader.mockClear()
+  })
+
+  it('is a true no-op for disabled local and desktop requests', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+    const context = new RouterContextProvider()
+    const response = new Response('local app')
+    const next = vi.fn(async () => response)
+
+    await expect(runMiddleware(new Request('http://localhost:5173/'), next, context)).resolves.toBe(
+      response,
+    )
+    expect(next).toHaveBeenCalledOnce()
+    expect(authMocks.readReefSession).not.toHaveBeenCalled()
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+    expect(context.get(requestAuthContext)).toEqual({ accessToken: null, mode: 'disabled' })
+    expect(response.headers.has('Cache-Control')).toBe(false)
+  })
+
+  it.each([
+    ['document', 'GET', 'https://reef.example.test/workspaces/analytics/sources'],
+    ['data', 'GET', 'https://reef.example.test/workspaces/analytics/sources.data?index'],
+    ['action', 'POST', 'https://reef.example.test/workspaces'],
+    ['resource action', 'POST', 'https://reef.example.test/sources/github/oauth-install'],
+  ])(
+    'redirects an anonymous required-auth %s request before descendants',
+    async (_, method, url) => {
+      authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+      authMocks.readReefSession.mockResolvedValue(null)
+      const next = vi.fn()
+
+      const thrown = await runMiddleware(new Request(url, { method }), next).catch(
+        (error: unknown) => error,
+      )
+
+      expect(thrown).toBeInstanceOf(Response)
+      expect((thrown as Response).status).toBe(302)
+      const requested = new URL(url)
+      expect((thrown as Response).headers.get('location')).toBe(
+        `/login?returnTo=${encodeURIComponent(`${requested.pathname}${requested.search}`)}`,
+      )
+      expectPrivate(thrown as Response)
+      expect(next).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    ['document', 'GET', '/protected'],
+    ['data loader', 'GET', '/protected.data'],
+    ['data action', 'POST', '/protected.data'],
+  ])(
+    'blocks anonymous required-auth %s requests in the React Router handler',
+    async (_, method, pathname) => {
+      authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+      authMocks.readReefSession.mockResolvedValue(null)
+      const handleRequest = createRequestHandler(handlerBuild, 'test')
+
+      const response = await handleRequest(
+        new Request(`https://reef.example.test${pathname}`, { method }),
+      )
+
+      const routedPathname = pathname.replace(/\.data$/, '')
+      const loginLocation = `/login?returnTo=${encodeURIComponent(routedPathname)}`
+      if (pathname.endsWith('.data')) {
+        expect(response.status).toBe(202)
+        expect(await response.text()).toContain(loginLocation)
+      } else {
+        expect(response.status).toBe(302)
+        expect(response.headers.get('location')).toBe(loginLocation)
+      }
+      expect(descendantLoader).not.toHaveBeenCalled()
+      expect(descendantAction).not.toHaveBeenCalled()
+    },
+  )
+
+  it('clears an unreadable session cookie on the login redirect', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+
+    const thrown = await runMiddleware(
+      new Request('https://reef.example.test/', {
+        headers: { cookie: 'other=value; reef_session=unreadable' },
+      }),
+      vi.fn(),
+    ).catch((error: unknown) => error)
+
+    expect(authMocks.clearReefSession).toHaveBeenCalledWith(requiredConfig)
+    expect((thrown as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
+  })
+
+  it('keeps the token only in server request context', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+    const context = new RouterContextProvider()
+
+    await runMiddleware(
+      new Request('https://reef.example.test/workspaces/analytics/sources'),
+      async () => new Response('hosted app'),
+      context,
+    )
+
+    expect(context.get(requestAuthContext)).toEqual({
+      accessToken: 'server-only-token',
+      mode: 'required',
+      session,
+    })
+  })
+
+  it('marks normal and thrown hosted responses private and non-cacheable', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+
+    const response = await runMiddleware(
+      new Request('https://reef.example.test/'),
+      async () => new Response('ok'),
+    )
+    expectPrivate(response)
+
+    const childRedirect = new Response(null, { headers: { location: '/elsewhere' }, status: 302 })
+    const thrown = await runMiddleware(new Request('https://reef.example.test/'), async () => {
+      throw childRedirect
+    }).catch((error: unknown) => error)
+    expect(thrown).toBe(childRedirect)
+    expectPrivate(thrown as Response)
+  })
+})
+
+async function runMiddleware(
+  request: Request,
+  next: () => Promise<Response>,
+  context = new RouterContextProvider(),
+): Promise<Response> {
+  return (await middleware[0]({ context, params: {}, request } as never, next)) as Response
+}
+
+function expectPrivate(response: Response): void {
+  expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  expect(response.headers.get('Vary')).toContain('Cookie')
+}

--- a/apps/reef/app/routes/_protected.tsx
+++ b/apps/reef/app/routes/_protected.tsx
@@ -1,0 +1,68 @@
+import { Outlet, redirect } from 'react-router'
+
+import type { Route } from './+types/_protected'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { requestAuthContext } from '@/auth/server-context'
+import { clearReefSession, readReefSession } from '@/auth/session.server'
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const PRIVATE_RESPONSE_HEADERS = {
+  'Cache-Control': 'private, no-store',
+  Vary: 'Cookie',
+} as const
+
+export const middleware: Route.MiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    const config = reefAuthConfig()
+
+    if (config.mode === 'disabled') {
+      context.set(requestAuthContext, { accessToken: null, mode: 'disabled' })
+      return next()
+    }
+
+    const session = await readReefSession(request, config)
+    if (!session) throw await loginRedirect(request, config)
+    context.set(requestAuthContext, {
+      accessToken: session.accessToken,
+      mode: 'required',
+      session,
+    })
+
+    try {
+      const response = await next()
+      applyPrivateHeaders(response)
+      return response
+    } catch (error) {
+      if (error instanceof Response) applyPrivateHeaders(error)
+      throw error
+    }
+  },
+]
+
+export default function Protected() {
+  return <Outlet />
+}
+
+async function loginRedirect(request: Request, config: RequiredAuthConfig): Promise<Response> {
+  const url = new URL(request.url)
+  const returnTo = `${url.pathname}${url.search}`
+  const headers = new Headers()
+  if (hasSessionCookie(request, config.cookieName)) {
+    headers.append('Set-Cookie', await clearReefSession(config))
+  }
+
+  const response = redirect(`/login?returnTo=${encodeURIComponent(returnTo)}`, { headers })
+  applyPrivateHeaders(response)
+  return response
+}
+
+function hasSessionCookie(request: Request, name: string): boolean {
+  const cookie = request.headers.get('cookie')
+  return cookie?.split(';').some((part) => part.trim().startsWith(`${name}=`)) ?? false
+}
+
+function applyPrivateHeaders(response: Response): void {
+  response.headers.set('Cache-Control', PRIVATE_RESPONSE_HEADERS['Cache-Control'])
+  response.headers.append('Vary', PRIVATE_RESPONSE_HEADERS.Vary)
+}


### PR DESCRIPTION
> Reef hosted-auth stack: layer 5 of 11. Base: PR #2061.

## Intent

Add a server-side protected route boundary that guards documents, loaders, actions, and resource routes only when Reef authentication is required. Keep the same route tree open for local development and Desktop.

## What it enables

Hosted requests are authenticated before any Coral-backed work runs, without hydration flashes or gaps around non-document requests. Local Reef still starts and navigates without an issuer or session secret.

## Usage examples

With `REEF_AUTH_MODE=required`, requesting a protected path without a valid session redirects through login and preserves the original destination. With authentication disabled, the same path loads normally and no auth issuer is contacted.