### PR TITLE
feat(reef): add hosted login and callback routes

### DIFF
--- a/apps/reef/.gitignore
+++ b/apps/reef/.gitignore
@@ -12,6 +12,11 @@
 /.react-router/
 /build/
 
+# Vitest failure artifacts: screenshots and attachments are written on a failing
+# run and are never inputs to one.
+/.vitest-attachments/
+**/__screenshots__/
+
 /storybook-static/
 /build-storybook.log
 /.playwright-cli/

--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -68,6 +68,8 @@ describe('hosted auth architecture', () => {
     const routeConfig = read(routeConfigFile)
     const publicTopLevelRoutes = [
       "route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),",
+      "route('login', 'routes/login.tsx'),",
+      "route('auth/callback', 'routes/auth.callback.tsx'),",
     ]
 
     const entryLines = routeConfig

--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -68,7 +68,7 @@ describe('hosted auth architecture', () => {
     const routeConfig = read(routeConfigFile)
     const publicTopLevelRoutes = [
       "route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),",
-      "route('login', 'routes/login.tsx'),",
+      "route(routePattern('login'), 'routes/login.tsx'),",
       "route('auth/callback', 'routes/auth.callback.tsx'),",
     ]
 

--- a/apps/reef/app/auth/response.server.test.ts
+++ b/apps/reef/app/auth/response.server.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { markAuthResponsePrivate } from './response.server'
+
+describe('markAuthResponsePrivate', () => {
+  it('marks a bare response private and varying on the session cookie', () => {
+    const response = markAuthResponsePrivate(new Response('body'))
+
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(response.headers.get('Vary')).toBe('Cookie')
+  })
+
+  it('preserves an existing Vary list while adding the session cookie', () => {
+    const response = markAuthResponsePrivate(
+      new Response('body', { headers: { Vary: 'Accept-Encoding' } }),
+    )
+
+    expect(response.headers.get('Vary')).toBe('Accept-Encoding, Cookie')
+  })
+
+  it.each(['Cookie', 'cookie', 'Accept-Encoding, Cookie'])(
+    'does not repeat a cookie that is already declared: %s',
+    (vary) => {
+      const response = markAuthResponsePrivate(new Response('body', { headers: { Vary: vary } }))
+
+      expect(response.headers.get('Vary')).toBe(vary)
+    },
+  )
+
+  // `*` is not a field name the list can be extended with: it already says the
+  // response is unique to its request, which subsumes `Cookie`. Appending would
+  // emit `*, Cookie`, which is not a valid `Vary` value.
+  it.each(['*', ' * '])('leaves a wildcard Vary alone: %s', (vary) => {
+    const response = markAuthResponsePrivate(new Response('body', { headers: { Vary: vary } }))
+
+    expect(response.headers.get('Vary')).toBe(vary.trim())
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+})

--- a/apps/reef/app/auth/response.server.test.ts
+++ b/apps/reef/app/auth/response.server.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it } from 'vitest'
 
-import { markAuthResponsePrivate } from './response.server'
+import { authPrivateHeaders, markAuthResponsePrivate } from './response.server'
+
+// The two are one policy with two shapes: routes that build their own response
+// declare the headers, routes handed one mark it. They were separate literals,
+// which is the arrangement where a header added to one quietly misses the other
+// and nothing fails. This pins them to each other rather than to a copy of the
+// expected values, so it keeps holding when the policy changes.
+describe('authPrivateHeaders', () => {
+  it('declares exactly what marking a response applies', () => {
+    const declared = [...authPrivateHeaders().entries()]
+    const marked = markAuthResponsePrivate(new Response('body')).headers
+
+    // Every header the declaring form promises is one the marking form really
+    // sets, with the same value. Compared this way rather than as whole header
+    // sets, because a response with a body also carries a `content-type` that
+    // has nothing to do with this policy.
+    expect(declared.length).toBeGreaterThan(0)
+    for (const [name, value] of declared) {
+      expect(marked.get(name), `${name} should match the marked response`).toBe(value)
+    }
+  })
+
+  it('still says private and varies on the session cookie', () => {
+    const headers = authPrivateHeaders()
+
+    expect(headers.get('Cache-Control')).toBe('private, no-store')
+    expect(headers.get('Vary')).toBe('Cookie')
+  })
+})
 
 describe('markAuthResponsePrivate', () => {
   it('marks a bare response private and varying on the session cookie', () => {

--- a/apps/reef/app/auth/response.server.ts
+++ b/apps/reef/app/auth/response.server.ts
@@ -11,6 +11,13 @@ export function markAuthResponsePrivate(response: Response): Response {
     .get('Vary')
     ?.split(',')
     .map((value) => value.trim().toLowerCase())
-  if (!varies?.includes('cookie')) response.headers.append('Vary', 'Cookie')
+  // `*` is not a field name the list can be extended with — it means the response
+  // is unique to its request, which already covers everything `Cookie` would say.
+  // Appending would produce `*, Cookie`, which is not a valid `Vary` value, and
+  // would weaken the header rather than strengthen it.
+  if (!varies?.includes('*') && !varies?.includes('cookie')) {
+    response.headers.append('Vary', 'Cookie')
+  }
+
   return response
 }

--- a/apps/reef/app/auth/response.server.ts
+++ b/apps/reef/app/auth/response.server.ts
@@ -1,0 +1,16 @@
+export function authPrivateHeaders(): Headers {
+  return new Headers({
+    'Cache-Control': 'private, no-store',
+    Vary: 'Cookie',
+  })
+}
+
+export function markAuthResponsePrivate(response: Response): Response {
+  response.headers.set('Cache-Control', 'private, no-store')
+  const varies = response.headers
+    .get('Vary')
+    ?.split(',')
+    .map((value) => value.trim().toLowerCase())
+  if (!varies?.includes('cookie')) response.headers.append('Vary', 'Cookie')
+  return response
+}

--- a/apps/reef/app/auth/response.server.ts
+++ b/apps/reef/app/auth/response.server.ts
@@ -1,8 +1,14 @@
+/**
+ * The same headers [`markAuthResponsePrivate`] applies, for a route that
+ * declares them rather than being handed a response to mark.
+ *
+ * Derived from that function rather than restating it. Spelling the policy out
+ * twice is how the two drift: a header added to one would silently not apply to
+ * routes using the other, and nothing would fail. Running the real thing over a
+ * throwaway response costs an allocation on a path that already builds one.
+ */
 export function authPrivateHeaders(): Headers {
-  return new Headers({
-    'Cache-Control': 'private, no-store',
-    Vary: 'Cookie',
-  })
+  return markAuthResponsePrivate(new Response(null)).headers
 }
 
 export function markAuthResponsePrivate(response: Response): Response {

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -3,8 +3,11 @@ import { type RouteConfig, index, layout, route } from '@react-router/dev/routes
 import { routePattern } from './routing/routemap'
 
 export default [
-  // Public CIMD resource: Coral fetches this before it can authorize Reef.
+  // Public auth resources: Coral needs CIMD before authorization, and the
+  // browser needs login/callback before Reef can establish a session.
   route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),
+  route('login', 'routes/login.tsx'),
+  route('auth/callback', 'routes/auth.callback.tsx'),
   layout('routes/_protected.tsx', [
     // Action-only resource route: OAuth/device-code install streams progress over
     // same-origin fetch. It and onboarding share the auth boundary but do not

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -6,7 +6,7 @@ export default [
   // Public auth resources: Coral needs CIMD before authorization, and the
   // browser needs login/callback before Reef can establish a session.
   route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),
-  route('login', 'routes/login.tsx'),
+  route(routePattern('login'), 'routes/login.tsx'),
   route('auth/callback', 'routes/auth.callback.tsx'),
   layout('routes/_protected.tsx', [
     // Action-only resource route: OAuth/device-code install streams progress over

--- a/apps/reef/app/routes/_protected.tsx
+++ b/apps/reef/app/routes/_protected.tsx
@@ -3,14 +3,10 @@ import { Outlet, redirect } from 'react-router'
 import type { Route } from './+types/_protected'
 
 import { reefAuthConfig } from '@/auth/config.server'
+import { markAuthResponsePrivate } from '@/auth/response.server'
 import { requestAuthContext } from '@/auth/server-context'
 import { clearReefSession, readReefSession } from '@/auth/session.server'
 import type { RequiredAuthConfig } from '@/auth/types'
-
-const PRIVATE_RESPONSE_HEADERS = {
-  'Cache-Control': 'private, no-store',
-  Vary: 'Cookie',
-} as const
 
 export const middleware: Route.MiddlewareFunction[] = [
   async ({ context, request }, next) => {
@@ -31,10 +27,9 @@ export const middleware: Route.MiddlewareFunction[] = [
 
     try {
       const response = await next()
-      applyPrivateHeaders(response)
-      return response
+      return markAuthResponsePrivate(response)
     } catch (error) {
-      if (error instanceof Response) applyPrivateHeaders(error)
+      if (error instanceof Response) markAuthResponsePrivate(error)
       throw error
     }
   },
@@ -53,16 +48,10 @@ async function loginRedirect(request: Request, config: RequiredAuthConfig): Prom
   }
 
   const response = redirect(`/login?returnTo=${encodeURIComponent(returnTo)}`, { headers })
-  applyPrivateHeaders(response)
-  return response
+  return markAuthResponsePrivate(response)
 }
 
 function hasSessionCookie(request: Request, name: string): boolean {
   const cookie = request.headers.get('cookie')
   return cookie?.split(';').some((part) => part.trim().startsWith(`${name}=`)) ?? false
-}
-
-function applyPrivateHeaders(response: Response): void {
-  response.headers.set('Cache-Control', PRIVATE_RESPONSE_HEADERS['Cache-Control'])
-  response.headers.append('Vary', PRIVATE_RESPONSE_HEADERS.Vary)
 }

--- a/apps/reef/app/routes/auth.callback.server.test.tsx
+++ b/apps/reef/app/routes/auth.callback.server.test.tsx
@@ -1,0 +1,98 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({
+  completeCoralOAuthLogin: vi.fn(),
+  reefAuthConfig: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/coral-oauth.server', () => ({
+  completeCoralOAuthLogin: authMocks.completeCoralOAuthLogin,
+}))
+
+import { ErrorBoundary, loader } from './auth.callback'
+
+const requiredConfig: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('auth callback route', () => {
+  beforeEach(() => {
+    authMocks.completeCoralOAuthLogin.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+  })
+
+  it('is unavailable when local or desktop auth is disabled', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+
+    const thrown = await runLoader().catch((error: unknown) => error)
+
+    expect(thrown).toBeInstanceOf(Response)
+    expect((thrown as Response).status).toBe(404)
+    expect(authMocks.completeCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('preserves the hosted callback redirect and session cookie response', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    const callbackResponse = new Response(null, {
+      headers: [
+        ['location', '/workspaces/analytics/sources'],
+        ['Set-Cookie', 'reef_oauth=; Max-Age=0; Path=/; HttpOnly'],
+        ['Set-Cookie', 'reef_session=encrypted; Path=/; HttpOnly; Secure'],
+      ],
+      status: 302,
+    })
+    authMocks.completeCoralOAuthLogin.mockResolvedValue(callbackResponse)
+    const request = new Request('https://reef.example.test/auth/callback?code=code&state=state')
+
+    const response = await loader({ request } as never)
+
+    expect(authMocks.completeCoralOAuthLogin).toHaveBeenCalledWith(request, requiredConfig)
+    expect(response).toBe(callbackResponse)
+    expect(response.headers.get('location')).toBe('/workspaces/analytics/sources')
+    expect(response.headers.getSetCookie()).toHaveLength(2)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  it('marks expected callback failures private before the error boundary handles them', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    const callbackError = new Response('provider detail', { status: 400 })
+    authMocks.completeCoralOAuthLogin.mockRejectedValue(callbackError)
+
+    const thrown = await runLoader().catch((error: unknown) => error)
+
+    expect(thrown).toBe(callbackError)
+    expect(callbackError.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(callbackError.headers.get('Vary')).toContain('Cookie')
+  })
+
+  it('renders an accessible generic error without provider or token details', () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <ErrorBoundary />
+      </MemoryRouter>,
+    )
+
+    expect(markup).toContain('aria-labelledby="auth-error-title"')
+    expect(markup).toContain('Sign-in failed')
+    expect(markup).toContain('href="/login"')
+    expect(markup).toContain('Try again')
+    expect(markup).not.toContain('provider detail')
+    expect(markup).not.toContain('access_token')
+  })
+})
+
+async function runLoader() {
+  return loader({
+    request: new Request('https://reef.example.test/auth/callback?code=code&state=state'),
+  } as never)
+}

--- a/apps/reef/app/routes/auth.callback.tsx
+++ b/apps/reef/app/routes/auth.callback.tsx
@@ -1,0 +1,43 @@
+import type { Route } from './+types/auth.callback'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { completeCoralOAuthLogin } from '@/auth/coral-oauth.server'
+import { markAuthResponsePrivate } from '@/auth/response.server'
+import * as Button from '@/wax/components/button'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './login.css'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') throw new Response('Not Found', { status: 404 })
+
+  try {
+    return markAuthResponsePrivate(await completeCoralOAuthLogin(request, config))
+  } catch (error) {
+    if (error instanceof Response) markAuthResponsePrivate(error)
+    throw error
+  }
+}
+
+export default function AuthCallback() {
+  return null
+}
+
+export function ErrorBoundary() {
+  return (
+    <main className={styles.page}>
+      <section className={styles.content} aria-labelledby="auth-error-title">
+        <Typography.HeadingLarge as="h1" id="auth-error-title">
+          Sign-in failed
+        </Typography.HeadingLarge>
+        <Typography.Body>
+          Try signing in again. If the problem continues, contact your administrator.
+        </Typography.Body>
+        <div className={styles.actions}>
+          <Button.InternalLink to="/login">Try again</Button.InternalLink>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/apps/reef/app/routes/auth.callback.tsx
+++ b/apps/reef/app/routes/auth.callback.tsx
@@ -3,6 +3,7 @@ import type { Route } from './+types/auth.callback'
 import { reefAuthConfig } from '@/auth/config.server'
 import { completeCoralOAuthLogin } from '@/auth/coral-oauth.server'
 import { markAuthResponsePrivate } from '@/auth/response.server'
+import { routePath } from '@/routing/routemap'
 import * as Button from '@/wax/components/button'
 import { Typography } from '@/wax/components/typography'
 
@@ -35,7 +36,7 @@ export function ErrorBoundary() {
           Try signing in again. If the problem continues, contact your administrator.
         </Typography.Body>
         <div className={styles.actions}>
-          <Button.InternalLink to="/login">Try again</Button.InternalLink>
+          <Button.InternalLink to={routePath('login')}>Try again</Button.InternalLink>
         </div>
       </section>
     </main>

--- a/apps/reef/app/routes/login.css.ts
+++ b/apps/reef/app/routes/login.css.ts
@@ -7,7 +7,7 @@ export const page = style({
   backgroundColor: theme.surface.mainContent,
   boxSizing: 'border-box',
   display: 'flex',
-  minHeight: '100vh',
+  minHeight: '100dvh',
   padding: '24px',
 })
 

--- a/apps/reef/app/routes/login.css.ts
+++ b/apps/reef/app/routes/login.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css'
+
+import { theme } from '@/wax/theme/theme.css'
+
+export const page = style({
+  alignItems: 'center',
+  backgroundColor: theme.surface.mainContent,
+  boxSizing: 'border-box',
+  display: 'flex',
+  minHeight: '100vh',
+  padding: '24px',
+})
+
+export const content = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  margin: '0 auto',
+  maxWidth: '420px',
+  textAlign: 'center',
+})
+
+export const actions = style({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '8px',
+})

--- a/apps/reef/app/routes/login.server.test.tsx
+++ b/apps/reef/app/routes/login.server.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({
+  readReefSession: vi.fn(),
+  reefAuthConfig: vi.fn(),
+  startCoralOAuthLogin: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/coral-oauth.server', () => ({
+  startCoralOAuthLogin: authMocks.startCoralOAuthLogin,
+}))
+vi.mock('@/auth/session.server', () => ({ readReefSession: authMocks.readReefSession }))
+
+import { headers, loader } from './login'
+
+const requiredConfig: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('login route', () => {
+  beforeEach(() => {
+    authMocks.readReefSession.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+    authMocks.startCoralOAuthLogin.mockReset()
+  })
+
+  it('marks rendered login responses private at the route boundary', () => {
+    const responseHeaders = new Headers(headers())
+
+    expect(responseHeaders.get('Cache-Control')).toBe('private, no-store')
+    expect(responseHeaders.get('Vary')).toBe('Cookie')
+  })
+
+  it('returns disabled local and desktop requests home without reading auth state', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+
+    const response = await runLoader('http://localhost:5173/login')
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/')
+    expect(authMocks.readReefSession).not.toHaveBeenCalled()
+    expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('returns an existing hosted session home instead of restarting OAuth', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue({
+      accessToken: 'server-only-token',
+      expiresAt: 4_102_444_800,
+      tokenType: 'Bearer',
+    })
+
+    const response = await runLoader('https://reef.example.test/login')
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('renders the signed-out interstitial without immediately restarting SSO', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+
+    await expect(runLoaderValue('https://reef.example.test/login?signedOut=1')).resolves.toBeNull()
+    expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('starts hosted OAuth and preserves its redirect and transaction cookie', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+    const upstream = new Response(null, {
+      headers: {
+        location: 'https://coral.example.test/authorize',
+        'Set-Cookie': 'reef_oauth=transaction; Path=/; HttpOnly',
+      },
+      status: 302,
+    })
+    authMocks.startCoralOAuthLogin.mockResolvedValue(upstream)
+    const request = new Request('https://reef.example.test/login?returnTo=%2Fworkspaces')
+
+    const response = (await loader({ request } as never)) as Response
+
+    expect(authMocks.startCoralOAuthLogin).toHaveBeenCalledWith(request, requiredConfig)
+    expect(response).toBe(upstream)
+    expect(response.headers.get('location')).toBe('https://coral.example.test/authorize')
+    expect(response.headers.get('Set-Cookie')).toContain('reef_oauth=transaction')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(response.headers.get('Vary')).toContain('Cookie')
+  })
+})
+
+async function runLoader(url: string): Promise<Response> {
+  const result = await runLoaderValue(url)
+  expect(result).toBeInstanceOf(Response)
+  return result as Response
+}
+
+async function runLoaderValue(url: string) {
+  return loader({ request: new Request(url) } as never)
+}

--- a/apps/reef/app/routes/login.server.test.tsx
+++ b/apps/reef/app/routes/login.server.test.tsx
@@ -70,8 +70,34 @@ describe('login route', () => {
     authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
     authMocks.readReefSession.mockResolvedValue(null)
 
-    await expect(runLoaderValue('https://reef.example.test/login?signedOut=1')).resolves.toBeNull()
+    await expect(runLoaderValue('https://reef.example.test/login?signedOut=1')).resolves.toEqual({
+      returnTo: '/',
+    })
     expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  // The interstitial renders instead of redirecting, so unlike every other
+  // branch it has to carry the destination across the pause itself.
+  it('carries a destination through the interstitial', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+
+    await expect(
+      runLoaderValue(
+        'https://reef.example.test/login?signedOut=1&returnTo=%2Fworkspaces%2Fanalytics%3Ftab%3Dmine',
+      ),
+    ).resolves.toEqual({ returnTo: '/workspaces/analytics?tab=mine' })
+  })
+
+  it('drops a destination the interstitial should not send anyone to', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+
+    await expect(
+      runLoaderValue(
+        'https://reef.example.test/login?signedOut=1&returnTo=%2F..%2F%2Fevil.example',
+      ),
+    ).resolves.toEqual({ returnTo: '/' })
   })
 
   it('starts hosted OAuth and preserves its redirect and transaction cookie', async () => {

--- a/apps/reef/app/routes/login.tsx
+++ b/apps/reef/app/routes/login.tsx
@@ -1,0 +1,50 @@
+import { Form, redirect } from 'react-router'
+
+import type { Route } from './+types/login'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { startCoralOAuthLogin } from '@/auth/coral-oauth.server'
+import { authPrivateHeaders, markAuthResponsePrivate } from '@/auth/response.server'
+import { readReefSession } from '@/auth/session.server'
+import { getMeta } from '@/meta'
+import * as Button from '@/wax/components/button'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './login.css'
+
+export function meta(_args: Route.MetaArgs) {
+  return getMeta('Sign in')
+}
+
+export function headers() {
+  return authPrivateHeaders()
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') return redirect('/')
+
+  const session = await readReefSession(request, config)
+  if (session) return markAuthResponsePrivate(redirect('/'))
+
+  const url = new URL(request.url)
+  if (url.searchParams.has('signedOut')) return null
+
+  return markAuthResponsePrivate(await startCoralOAuthLogin(request, config))
+}
+
+export default function Login() {
+  return (
+    <main className={styles.page}>
+      <section className={styles.content} aria-labelledby="login-title">
+        <Typography.HeadingLarge as="h1" id="login-title">
+          Coral 🪸
+        </Typography.HeadingLarge>
+        <Typography.Body>You have been signed out.</Typography.Body>
+        <Form action="/login" className={styles.actions} method="get">
+          <Button.TextButton type="submit">Sign in with Coral Cloud</Button.TextButton>
+        </Form>
+      </section>
+    </main>
+  )
+}

--- a/apps/reef/app/routes/login.tsx
+++ b/apps/reef/app/routes/login.tsx
@@ -5,8 +5,10 @@ import type { Route } from './+types/login'
 import { reefAuthConfig } from '@/auth/config.server'
 import { startCoralOAuthLogin } from '@/auth/coral-oauth.server'
 import { authPrivateHeaders, markAuthResponsePrivate } from '@/auth/response.server'
+import { safeInternalPath } from '@/auth/safe-path.server'
 import { readReefSession } from '@/auth/session.server'
 import { getMeta } from '@/meta'
+import { routePath } from '@/routing/routemap'
 import * as Button from '@/wax/components/button'
 import { Typography } from '@/wax/components/typography'
 
@@ -28,12 +30,19 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (session) return markAuthResponsePrivate(redirect('/'))
 
   const url = new URL(request.url)
-  if (url.searchParams.has('signedOut')) return null
+  // The interstitial is the one branch that renders instead of starting a login,
+  // so it is also the one that has to carry the destination forward itself. It
+  // is sanitized here rather than on submit because it is about to be written
+  // into the page and handed back as a query parameter.
+  if (url.searchParams.has('signedOut')) {
+    return { returnTo: safeInternalPath(url.searchParams.get('returnTo')) }
+  }
 
   return markAuthResponsePrivate(await startCoralOAuthLogin(request, config))
 }
 
-export default function Login() {
+export default function Login({ loaderData }: Route.ComponentProps) {
+  const returnTo = loaderData?.returnTo
   return (
     <main className={styles.page}>
       <section className={styles.content} aria-labelledby="login-title">
@@ -41,7 +50,12 @@ export default function Login() {
           Coral 🪸
         </Typography.HeadingLarge>
         <Typography.Body>You have been signed out.</Typography.Body>
-        <Form action="/login" className={styles.actions} method="get">
+        {/* GET, so submitting replaces the query wholesale — `signedOut` drops
+            away and the loader starts a real login on the next pass. */}
+        <Form action={routePath('login')} className={styles.actions} method="get">
+          {returnTo && returnTo !== '/' ? (
+            <input type="hidden" name="returnTo" value={returnTo} />
+          ) : null}
           <Button.TextButton type="submit">Sign in with Coral Cloud</Button.TextButton>
         </Form>
       </section>

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -2,6 +2,7 @@ import { generatePath } from 'react-router'
 import type { RouteObject } from 'react-router'
 
 const HOME_PATH = '/'
+const LOGIN_PATH = '/login'
 const ONBOARDING_PATH = '/onboarding'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_FUNCTIONS_PATH = '/workspaces/:workspaceId/functions'
@@ -21,6 +22,14 @@ export const routeDefinitions = {
   home: {
     path: HOME_PATH,
     toPath: () => HOME_PATH,
+  },
+  // The one public route with call sites spread across the app: the interstitial
+  // form, the callback error boundary, and the redirect every expired session
+  // produces all name it, and two of those live outside `routes/`. Callers add
+  // their own query, as they do for every other route here.
+  login: {
+    path: LOGIN_PATH,
+    toPath: () => LOGIN_PATH,
   },
   onboarding: {
     path: ONBOARDING_PATH,


### PR DESCRIPTION
> Reef hosted-auth stack: layer 6 of 11. Base: PR #2062.

## Intent

Expose public `/login` and `/auth/callback` loaders that establish the protected-route session through Coral's OAuth authorization server. Keep both routes outside the protected boundary.

## What it enables

Hosted Reef can initiate PKCE login, validate the callback, exchange the authorization code, and return the user to the requested path. Local and Desktop Reef never contact an issuer.

## Usage examples

Open a protected route such as `/workspaces` while signed out. Reef redirects to `/login`, sends the browser through Coral authorization, receives the callback at `/auth/callback`, and resumes the original route after committing the encrypted session.