### PR TITLE
feat(reef): authenticate every Coral route client

### DIFF
--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -20,16 +20,6 @@ const routeConfigFile = path.join(appDir, 'routes.ts')
 const reefRoot = path.resolve(appDir, '..')
 const desktopRoot = path.resolve(reefRoot, '..', 'desktop')
 
-function filesUnder(directory: string, matches: (name: string) => boolean): string[] {
-  if (!fs.existsSync(directory)) return []
-
-  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = path.join(directory, entry.name)
-    if (entry.isDirectory()) return filesUnder(entryPath, matches)
-    return entry.isFile() && matches(entry.name) ? [entryPath] : []
-  })
-}
-
 function read(...segments: string[]): string {
   return fs.readFileSync(path.join(...segments), 'utf8')
 }
@@ -101,45 +91,5 @@ describe('hosted auth architecture', () => {
           !entry.startsWith("layout('routes/_protected.tsx',"),
       ),
     ).toEqual([])
-  })
-
-  // Regression: a Coral client factory called with one argument is a call that
-  // forgot the access token, and hosted requests then go out unauthenticated.
-  //
-  // Matching the literal `(request)` would make this only as good as the
-  // formatter — a call wrapped across lines, given a trailing comma, or handed
-  // `args.request` would walk straight past it. So it matches the shape: a
-  // single argument, whatever it is named and however it is spaced.
-  it('threads request auth through every server-side Coral client factory call', () => {
-    const unauthenticatedCall =
-      /\b(?:catalog|function|query|source|trace|workspace)ClientForRequest\(\s*[A-Za-z_$][\w$.]*\s*,?\s*\)/
-
-    for (const call of [
-      'sourceClientForRequest(request)',
-      'sourceClientForRequest( request )',
-      'sourceClientForRequest(request,)',
-      'queryClientForRequest(\n  request,\n)',
-      'traceClientForRequest(args.request)',
-      'workspaceClientForRequest(req)',
-    ]) {
-      expect(unauthenticatedCall.test(call), `${call} should be flagged`).toBe(true)
-    }
-    for (const call of [
-      'sourceClientForRequest(request, accessToken)',
-      'sourceClientForRequest(request, null)',
-      'queryClientForRequest(\n  request,\n  accessToken,\n)',
-    ]) {
-      expect(unauthenticatedCall.test(call), `${call} should be allowed`).toBe(false)
-    }
-
-    const sources = filesUnder(
-      appDir,
-      (name) => /\.tsx?$/.test(name) && !name.includes('.test.') && !name.includes('.stories.'),
-    )
-    const violations = sources
-      .filter((file) => unauthenticatedCall.test(fs.readFileSync(file, 'utf8')))
-      .map((file) => path.relative(appDir, file))
-
-    expect(violations).toEqual([])
   })
 })

--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -20,6 +20,16 @@ const routeConfigFile = path.join(appDir, 'routes.ts')
 const reefRoot = path.resolve(appDir, '..')
 const desktopRoot = path.resolve(reefRoot, '..', 'desktop')
 
+function filesUnder(directory: string, matches: (name: string) => boolean): string[] {
+  if (!fs.existsSync(directory)) return []
+
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) return filesUnder(entryPath, matches)
+    return entry.isFile() && matches(entry.name) ? [entryPath] : []
+  })
+}
+
 function read(...segments: string[]): string {
   return fs.readFileSync(path.join(...segments), 'utf8')
 }
@@ -91,5 +101,45 @@ describe('hosted auth architecture', () => {
           !entry.startsWith("layout('routes/_protected.tsx',"),
       ),
     ).toEqual([])
+  })
+
+  // Regression: a Coral client factory called with one argument is a call that
+  // forgot the access token, and hosted requests then go out unauthenticated.
+  //
+  // Matching the literal `(request)` would make this only as good as the
+  // formatter — a call wrapped across lines, given a trailing comma, or handed
+  // `args.request` would walk straight past it. So it matches the shape: a
+  // single argument, whatever it is named and however it is spaced.
+  it('threads request auth through every server-side Coral client factory call', () => {
+    const unauthenticatedCall =
+      /\b(?:catalog|function|query|source|trace|workspace)ClientForRequest\(\s*[A-Za-z_$][\w$.]*\s*,?\s*\)/
+
+    for (const call of [
+      'sourceClientForRequest(request)',
+      'sourceClientForRequest( request )',
+      'sourceClientForRequest(request,)',
+      'queryClientForRequest(\n  request,\n)',
+      'traceClientForRequest(args.request)',
+      'workspaceClientForRequest(req)',
+    ]) {
+      expect(unauthenticatedCall.test(call), `${call} should be flagged`).toBe(true)
+    }
+    for (const call of [
+      'sourceClientForRequest(request, accessToken)',
+      'sourceClientForRequest(request, null)',
+      'queryClientForRequest(\n  request,\n  accessToken,\n)',
+    ]) {
+      expect(unauthenticatedCall.test(call), `${call} should be allowed`).toBe(false)
+    }
+
+    const sources = filesUnder(
+      appDir,
+      (name) => /\.tsx?$/.test(name) && !name.includes('.test.') && !name.includes('.stories.'),
+    )
+    const violations = sources
+      .filter((file) => unauthenticatedCall.test(fs.readFileSync(file, 'utf8')))
+      .map((file) => path.relative(appDir, file))
+
+    expect(violations).toEqual([])
   })
 })

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -14,27 +14,27 @@ import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
 import { isExplicitLoopbackUrl } from './loopback.server'
 import { isLocalDevOrigin, trimTrailingSlash } from './utils'
 
-export function sourceClientForRequest(request: Request, accessToken: string | null = null) {
+export function sourceClientForRequest(request: Request, accessToken: string | null) {
   return createClient(SourceService, coralTransportForRequest(request, accessToken))
 }
 
-export function workspaceClientForRequest(request: Request, accessToken: string | null = null) {
+export function workspaceClientForRequest(request: Request, accessToken: string | null) {
   return createClient(WorkspaceService, coralTransportForRequest(request, accessToken))
 }
 
-export function catalogClientForRequest(request: Request, accessToken: string | null = null) {
+export function catalogClientForRequest(request: Request, accessToken: string | null) {
   return createClient(CatalogService, coralTransportForRequest(request, accessToken))
 }
 
-export function functionClientForRequest(request: Request, accessToken: string | null = null) {
+export function functionClientForRequest(request: Request, accessToken: string | null) {
   return createClient(FunctionService, coralTransportForRequest(request, accessToken))
 }
 
-export function queryClientForRequest(request: Request, accessToken: string | null = null) {
+export function queryClientForRequest(request: Request, accessToken: string | null) {
   return createClient(QueryService, coralTransportForRequest(request, accessToken))
 }
 
-export function traceClientForRequest(request: Request, accessToken: string | null = null) {
+export function traceClientForRequest(request: Request, accessToken: string | null) {
   return createClient(TraceService, coralTransportForRequest(request, accessToken))
 }
 

--- a/apps/reef/app/routes/functions.server.test.ts
+++ b/apps/reef/app/routes/functions.server.test.ts
@@ -1,10 +1,15 @@
 import { create } from '@bufbuild/protobuf'
 import { describe, expect, it, vi } from 'vitest'
 
-const { deleteFunction } = vi.hoisted(() => ({ deleteFunction: vi.fn() }))
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+
+const { deleteFunction, functionClientForRequest } = vi.hoisted(() => ({
+  deleteFunction: vi.fn(),
+  functionClientForRequest: vi.fn(),
+}))
 
 vi.mock('@/lib/coral-request.server', () => ({
-  functionClientForRequest: () => ({ deleteFunction }),
+  functionClientForRequest,
 }))
 
 import {
@@ -87,12 +92,12 @@ describe('functions route mapping', () => {
 describe('functions route action', () => {
   it('deletes a function from the route workspace', async () => {
     deleteFunction.mockResolvedValue({})
+    functionClientForRequest.mockReturnValue({ deleteFunction })
+    const request = deleteRequest('review_queue')
 
-    const result = await action({
-      params: { workspaceId: 'analytics' },
-      request: deleteRequest('review_queue'),
-    } as Parameters<typeof action>[0])
+    const result = await action(authRouteTestArgs(request, { workspaceId: 'analytics' }))
 
+    expect(functionClientForRequest).toHaveBeenCalledWith(request, 'test-coral-token')
     expect(deleteFunction).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'review_queue',

--- a/apps/reef/app/routes/functions.tsx
+++ b/apps/reef/app/routes/functions.tsx
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/functions'
 
+import { requestAuthContext } from '@/auth/server-context'
 import type { FunctionDetailsProps } from '@/components/functions'
 import {
   DeleteFunctionRequestSchema,
@@ -22,7 +23,11 @@ export type FunctionsActionData =
   | { message: string; name: string; status: 'error' }
   | { name: string; status: 'success' }
 
-export async function action({ params, request }: Route.ActionArgs): Promise<FunctionsActionData> {
+export async function action({
+  context,
+  params,
+  request,
+}: Route.ActionArgs): Promise<FunctionsActionData> {
   const formData = await request.formData()
   const nameValue = formData.get('name')
   const name = typeof nameValue === 'string' ? nameValue : ''
@@ -30,23 +35,29 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Fun
 
   try {
     const workspace = workspaceFromParams(params)
-    await functionClientForRequest(request).deleteFunction(
-      create(DeleteFunctionRequestSchema, { name, workspace }),
-      { signal: request.signal },
-    )
+    await functionClientForRequest(
+      request,
+      context.get(requestAuthContext).accessToken,
+    ).deleteFunction(create(DeleteFunctionRequestSchema, { name, workspace }), {
+      signal: request.signal,
+    })
     return { name, status: 'success' }
   } catch (error) {
     return { message: errorMessage(error), name, status: 'error' }
   }
 }
 
-export async function loader({ params, request }: Route.LoaderArgs): Promise<FunctionsRouteData> {
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<FunctionsRouteData> {
   try {
     const workspace = workspaceFromParams(params)
-    const response = await functionClientForRequest(request).listFunctions(
-      create(ListFunctionsRequestSchema, { workspace }),
-      { signal: request.signal },
-    )
+    const response = await functionClientForRequest(
+      request,
+      context.get(requestAuthContext).accessToken,
+    ).listFunctions(create(ListFunctionsRequestSchema, { workspace }), { signal: request.signal })
     return {
       functions: response.functions
         .map(toFunctionDetails)

--- a/apps/reef/app/routes/schema-table.tsx
+++ b/apps/reef/app/routes/schema-table.tsx
@@ -1,4 +1,5 @@
 import { fetchTableColumnsFromCoral } from '@/lib/schema-explorer'
+import { requestAuthContext } from '@/auth/server-context'
 import { catalogClientForRequest } from '@/lib/coral-request.server'
 import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaTableError, SchemaTableView } from '@/views/schema-explorer/schema-table'
@@ -12,11 +13,11 @@ import type { Route } from './+types/schema-table'
 // The abort signal matters: large tables fan out concurrent paginated
 // ListColumns calls, so switching tables quickly would otherwise pile up
 // orphaned requests.
-export async function loader({ params, request }: Route.LoaderArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const workspace = workspaceFromParams(params)
   return {
     columns: await fetchTableColumnsFromCoral(
-      catalogClientForRequest(request),
+      catalogClientForRequest(request, context.get(requestAuthContext).accessToken),
       workspace,
       params.schemaName,
       params.tableName,

--- a/apps/reef/app/routes/schema.tsx
+++ b/apps/reef/app/routes/schema.tsx
@@ -1,4 +1,5 @@
 import { fetchSchemaFromCoral } from '@/lib/schema-explorer'
+import { requestAuthContext } from '@/auth/server-context'
 import { catalogClientForRequest } from '@/lib/coral-request.server'
 import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaExplorer, SchemaExplorerError } from '@/views/schema-explorer/schema'
@@ -9,10 +10,14 @@ import type { Route } from './+types/schema'
 // global navigation progress bar is the pending UI and a failure lands in the
 // route ErrorBoundary. The abort signal cancels the catalog request when the
 // navigation is superseded.
-export async function loader({ params, request }: Route.LoaderArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const workspace = workspaceFromParams(params)
   return {
-    schema: await fetchSchemaFromCoral(catalogClientForRequest(request), workspace, request.signal),
+    schema: await fetchSchemaFromCoral(
+      catalogClientForRequest(request, context.get(requestAuthContext).accessToken),
+      workspace,
+      request.signal,
+    ),
   }
 }
 

--- a/apps/reef/app/routes/source-detail.server.test.tsx
+++ b/apps/reef/app/routes/source-detail.server.test.tsx
@@ -1,0 +1,52 @@
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSource, getSourceInfo, sourceClientForRequest } = vi.hoisted(() => {
+  const getSourceMock = vi.fn()
+  const getSourceInfoMock = vi.fn()
+  return {
+    getSource: getSourceMock,
+    getSourceInfo: getSourceInfoMock,
+    sourceClientForRequest: vi.fn(() => ({
+      getSource: getSourceMock,
+      getSourceInfo: getSourceInfoMock,
+    })),
+  }
+})
+
+vi.mock('@/lib/coral-request.server', () => ({ sourceClientForRequest }))
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+import { SourceInfoSchema, SourceOrigin } from '@/generated/coral/v1/sources_pb'
+
+import { loader } from './source-detail'
+
+describe('source detail loader authentication', () => {
+  beforeEach(() => {
+    getSource.mockReset()
+    getSourceInfo.mockReset()
+    sourceClientForRequest.mockClear()
+    getSource.mockResolvedValue({ source: undefined })
+    getSourceInfo.mockResolvedValue({
+      sourceInfo: create(SourceInfoSchema, {
+        installed: false,
+        name: 'github',
+        origin: SourceOrigin.BUNDLED,
+      }),
+    })
+  })
+
+  it.each([
+    ['hosted', 'coral-access-token'],
+    ['local', null],
+  ])('passes the %s request token to Coral', async (_mode, accessToken) => {
+    const request = new Request('http://reef.test/workspaces/analytics/sources/github')
+
+    const result = await loader(
+      authRouteTestArgs(request, { sourceName: 'github', workspaceId: 'analytics' }, accessToken),
+    )
+
+    expect(sourceClientForRequest).toHaveBeenCalledWith(request, accessToken)
+    expect(result.entry).toMatchObject({ installed: false, name: 'github' })
+  })
+})

--- a/apps/reef/app/routes/source-detail.tsx
+++ b/apps/reef/app/routes/source-detail.tsx
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import type { Route } from './+types/source-detail'
 import { action as sourcesAction, type SourcesActionData } from './sources-action'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   GetSourceInfoRequestSchema,
   GetSourceRequestSchema,
@@ -28,6 +29,7 @@ interface SourceDetailRouteData {
 }
 
 export async function loader({
+  context,
   params,
   request,
 }: Route.LoaderArgs): Promise<SourceDetailRouteData> {
@@ -40,7 +42,7 @@ export async function loader({
     }
   }
 
-  const sourceClient = sourceClientForRequest(request)
+  const sourceClient = sourceClientForRequest(request, context.get(requestAuthContext).accessToken)
   const [sourceResult, infoResult] = await Promise.allSettled([
     getInstalledSource(sourceClient, workspace, name),
     getSourceInfo(sourceClient, workspace, name),

--- a/apps/reef/app/routes/source-oauth-import.server.test.ts
+++ b/apps/reef/app/routes/source-oauth-import.server.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+
+const { importSource, sourceClientForRequest } = vi.hoisted(() => ({
+  importSource: vi.fn(),
+  sourceClientForRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({ sourceClientForRequest }))
+
+import { action } from './source-oauth-import'
+
+describe('source OAuth import action', () => {
+  beforeEach(() => {
+    importSource.mockReset()
+    sourceClientForRequest.mockReset()
+  })
+
+  it('threads the server-held access token into the source client', async () => {
+    importSource.mockReturnValue(emptyStream())
+    sourceClientForRequest.mockReturnValue({ importSource })
+    const request = new Request(
+      'https://reef.example.test/workspaces/analytics/sources/oauth-import',
+      {
+        body: new URLSearchParams({
+          manifest_yaml: 'name: github',
+          oauth_input_key: 'GITHUB_TOKEN',
+          oauth_method_index: '0',
+        }),
+        method: 'POST',
+      },
+    )
+
+    const response = await action(authRouteTestArgs(request, { workspaceId: 'analytics' }))
+    await response.text()
+
+    expect(sourceClientForRequest).toHaveBeenCalledWith(request, 'test-coral-token')
+    expect(importSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifestYaml: 'name: github',
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+      expect.objectContaining({ signal: request.signal }),
+    )
+  })
+})
+
+async function* emptyStream() {}

--- a/apps/reef/app/routes/source-oauth-import.ts
+++ b/apps/reef/app/routes/source-oauth-import.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/source-oauth-import'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   ImportSourceRequestSchema,
   OAuthCredentialRetrievalSchema,
@@ -15,7 +16,7 @@ import { formValue } from '@/lib/source-install-form'
 import { errorMessage } from '@/lib/utils'
 import { workspaceFromParams } from '@/lib/workspace-routing'
 
-export async function action({ params, request }: Route.ActionArgs): Promise<Response> {
+export async function action({ context, params, request }: Route.ActionArgs): Promise<Response> {
   const formData = await request.formData()
   const manifestYaml = formData.get('manifest_yaml')
   const inputKey = formValue(formData, 'oauth_input_key')
@@ -31,7 +32,10 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
   }
 
   try {
-    const stream = sourceClientForRequest(request).importSource(
+    const stream = sourceClientForRequest(
+      request,
+      context.get(requestAuthContext).accessToken,
+    ).importSource(
       create(ImportSourceRequestSchema, {
         manifestYaml,
         oauthCredentialRetrievals: [

--- a/apps/reef/app/routes/source-oauth-install.server.test.ts
+++ b/apps/reef/app/routes/source-oauth-install.server.test.ts
@@ -1,6 +1,8 @@
 import { create } from '@bufbuild/protobuf'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+
 const { createBundledSourceWithOAuth, getSourceInfo } = vi.hoisted(() => ({
   createBundledSourceWithOAuth: vi.fn(),
   getSourceInfo: vi.fn(),
@@ -84,10 +86,9 @@ describe('action', () => {
       },
     )
 
-    const response = await action({
-      params: { sourceName: 'github', workspaceId: 'analytics' },
-      request,
-    } as Parameters<typeof action>[0])
+    const response = await action(
+      authRouteTestArgs(request, { sourceName: 'github', workspaceId: 'analytics' }),
+    )
     await response.text()
 
     expect(getSourceInfo).toHaveBeenCalledWith(

--- a/apps/reef/app/routes/source-oauth-install.ts
+++ b/apps/reef/app/routes/source-oauth-install.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/source-oauth-install'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   CreateBundledSourceWithOAuthRequestSchema,
   GetSourceInfoRequestSchema,
@@ -29,7 +30,7 @@ import { workspaceFromParams } from '@/lib/workspace-routing'
 // interactive OAuth/device-code installs need browser-visible server-streaming
 // progress. The browser fetches this same-origin endpoint; it never imports or
 // calls Coral's gRPC-Web client directly.
-export async function action({ params, request }: Route.ActionArgs): Promise<Response> {
+export async function action({ context, params, request }: Route.ActionArgs): Promise<Response> {
   const formData = await request.formData()
   let name: string
   try {
@@ -40,7 +41,7 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
     return oauthStreamErrorResponse(errorMessage(error), 400)
   }
 
-  const sourceClient = sourceClientForRequest(request)
+  const sourceClient = sourceClientForRequest(request, context.get(requestAuthContext).accessToken)
   try {
     const workspace = workspaceFromParams(params)
     const info = await getSourceInfo(sourceClient, name, workspace)

--- a/apps/reef/app/routes/trace-detail-loader.ts
+++ b/apps/reef/app/routes/trace-detail-loader.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/trace-detail'
 
+import { requestAuthContext } from '@/auth/server-context'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { GetTraceRequestSchema, TraceView } from '@/generated/coral/v1/traces_pb'
 import { traceClientForRequest } from '@/lib/coral-request.server'
@@ -19,23 +20,34 @@ export type GetTraceForRequest = (
   traceId: string,
   workspace: Workspace,
   view: TraceView,
+  accessToken: string | null,
 ) => Promise<TraceDetailData>
 
-export async function loader({ params, request }: Route.LoaderArgs): Promise<TraceDetailRouteData> {
-  return loadTraceDetailRouteData(request, params.traceId, workspaceFromParams(params))
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<TraceDetailRouteData> {
+  return loadTraceDetailRouteData(
+    request,
+    params.traceId,
+    workspaceFromParams(params),
+    context.get(requestAuthContext).accessToken,
+  )
 }
 
 export async function loadTraceDetailRouteData(
   request: Request,
   traceId: string | undefined,
   workspace: Workspace,
+  accessToken: string | null,
   getTrace: GetTraceForRequest = getTraceForRequest,
 ): Promise<TraceDetailRouteData> {
   if (!traceId) return { detail: null, loadError: 'Missing trace ID' }
 
   try {
     return {
-      detail: await getTrace(request, traceId, workspace, TraceView.QUERY_STREAM),
+      detail: await getTrace(request, traceId, workspace, TraceView.QUERY_STREAM, accessToken),
       loadError: null,
     }
   } catch (error) {
@@ -48,8 +60,9 @@ async function getTraceForRequest(
   traceId: string,
   workspace: Workspace,
   view: TraceView,
+  accessToken: string | null,
 ): Promise<TraceDetailData> {
-  return traceClientForRequest(request).getTrace(
+  return traceClientForRequest(request, accessToken).getTrace(
     create(GetTraceRequestSchema, { traceId, view, workspace }),
   )
 }

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -65,13 +65,22 @@ describe('traces list loader', () => {
       traces: [summary('query'), search, futureTool],
     })
 
-    await expect(loadTracesRouteData(request, workspace, listPage)).resolves.toEqual({
+    await expect(
+      loadTracesRouteData(request, workspace, 'coral-access-token', listPage),
+    ).resolves.toEqual({
       endpointLabel: 'reef.test',
       loadError: null,
       referenceTimeMs: 123_456,
       traces: [summary('query'), search, futureTool],
     })
-    expect(listPage).toHaveBeenCalledWith(request, workspace, 100, '', TraceView.QUERY_STREAM)
+    expect(listPage).toHaveBeenCalledWith(
+      request,
+      workspace,
+      100,
+      '',
+      TraceView.QUERY_STREAM,
+      'coral-access-token',
+    )
   })
 
   it('uses one bounded Query Stream page', async () => {
@@ -81,9 +90,9 @@ describe('traces list loader', () => {
       traces,
     })
 
-    await expect(listQueryTraces(request, workspace, listPage)).resolves.toEqual(
-      traces.slice(0, 80),
-    )
+    await expect(
+      listQueryTraces(request, workspace, 'coral-access-token', listPage),
+    ).resolves.toEqual(traces.slice(0, 80))
     expect(listPage).toHaveBeenCalledOnce()
   })
 })

--- a/apps/reef/app/routes/traces-loader.ts
+++ b/apps/reef/app/routes/traces-loader.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/traces'
 
+import { requestAuthContext } from '@/auth/server-context'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { ListTracesRequestSchema, TraceView } from '@/generated/coral/v1/traces_pb'
 import { traceClientForRequest } from '@/lib/coral-request.server'
@@ -25,15 +26,25 @@ export type ListTracePage = (
   pageSize: number,
   pageToken: string,
   view: TraceView,
+  accessToken: string | null,
 ) => Promise<{ nextPageToken: string; traces: TraceSummaryData[] }>
 
-export async function loader({ params, request }: Route.LoaderArgs): Promise<TracesRouteData> {
-  return loadTracesRouteData(request, workspaceFromParams(params))
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<TracesRouteData> {
+  return loadTracesRouteData(
+    request,
+    workspaceFromParams(params),
+    context.get(requestAuthContext).accessToken,
+  )
 }
 
 export async function loadTracesRouteData(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TracesRouteData> {
   const referenceTimeMs = Date.now()
@@ -42,7 +53,7 @@ export async function loadTracesRouteData(
       endpointLabel: traceEndpointLabel(request),
       loadError: null,
       referenceTimeMs,
-      traces: await listQueryTraces(request, workspace, listPage),
+      traces: await listQueryTraces(request, workspace, accessToken, listPage),
     }
   } catch (error) {
     return {
@@ -57,6 +68,7 @@ export async function loadTracesRouteData(
 export async function listQueryTraces(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TraceSummaryData[]> {
   const response = await listPage(
@@ -65,6 +77,7 @@ export async function listQueryTraces(
     TRACE_LIST_PAGE_SIZE,
     '',
     TraceView.QUERY_STREAM,
+    accessToken,
   )
   return response.traces.slice(0, MAX_QUERY_TRACES)
 }
@@ -83,8 +96,9 @@ async function listTracePageForRequest(
   pageSize: number,
   pageToken: string,
   view: TraceView,
+  accessToken: string | null,
 ): Promise<{ nextPageToken: string; traces: TraceSummaryData[] }> {
-  return traceClientForRequest(request).listTraces(
+  return traceClientForRequest(request, accessToken).listTraces(
     create(ListTracesRequestSchema, { pageSize, pageToken, view, workspace }),
   )
 }


### PR DESCRIPTION
> Reef hosted-auth stack: layer 9 of 11. Base: PR #2065.

## Intent

Complete bearer-token threading across schema, source, trace, query, and function routes, including call sites added after the original authentication work. Add an architecture guard against unauthenticated one-argument client construction.

## What it enables

Every browser-triggered Coral operation stays behind a server route and reaches Coral with the current protected request's credentials. New routes fail the architecture test if they forget the auth argument.

## Usage examples

Create a route client with both request context values, for example `sourceClientForRequest(request, requestAuth.accessToken)`. In disabled mode the token is `null`; in required mode it is the session's server-held bearer token.