### PR TITLE
feat(reef): add secure hosted logout

### DIFF
--- a/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
+++ b/apps/reef/app/__tests__/hosted-auth-architecture.test.ts
@@ -70,6 +70,7 @@ describe('hosted auth architecture', () => {
       "route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),",
       "route(routePattern('login'), 'routes/login.tsx'),",
       "route('auth/callback', 'routes/auth.callback.tsx'),",
+      "route('logout', 'routes/logout.tsx'),",
     ]
 
     const entryLines = routeConfig

--- a/apps/reef/app/auth/csrf.server.test.ts
+++ b/apps/reef/app/auth/csrf.server.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { clearCsrfToken, csrfTokenForRequest, validateCsrfToken } from './csrf.server'
+import type { AuthSession, RequiredAuthConfig } from './types'
+
+const config: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+const session: AuthSession = {
+  accessToken: 'first-coral-access-token',
+  expiresAt: 4_102_444_800,
+  tokenType: 'Bearer',
+}
+const otherSession: AuthSession = {
+  ...session,
+  accessToken: 'second-coral-access-token',
+}
+
+describe('Reef CSRF tokens', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('creates and reuses a signed, HTTP-only token bound to the active session', async () => {
+    const created = await csrfTokenForRequest(
+      new Request('https://reef.example.test/'),
+      config,
+      session,
+    )
+
+    expect(created.setCookie).toContain('reef_session_csrf=')
+    expect(created.setCookie).not.toContain(session.accessToken)
+    expect(created.setCookie).toContain('Secure')
+
+    const reused = await csrfTokenForRequest(requestWithCookie(created.setCookie!), config, session)
+    expect(reused).toEqual({ setCookie: null, token: created.token })
+  })
+
+  it('rotates a CSRF cookie inherited from a different authenticated session', async () => {
+    const created = await csrfTokenForRequest(
+      new Request('https://reef.example.test/'),
+      config,
+      session,
+    )
+
+    const rotated = await csrfTokenForRequest(
+      requestWithCookie(created.setCookie!),
+      config,
+      otherSession,
+    )
+
+    expect(rotated.token).not.toBe(created.token)
+    expect(rotated.setCookie).toContain('reef_session_csrf=')
+  })
+
+  it('accepts only a fresh form token bound to the current authenticated session', async () => {
+    const created = await csrfTokenForRequest(
+      new Request('https://reef.example.test/'),
+      config,
+      session,
+    )
+
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, created.token), config, session),
+    ).resolves.toBe(true)
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, created.token), config, otherSession),
+    ).resolves.toBe(false)
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, 'wrong-token'), config, session),
+    ).resolves.toBe(false)
+    await expect(
+      validateCsrfToken(postRequest('reef_session_csrf=tampered', created.token), config, session),
+    ).resolves.toBe(false)
+
+    vi.advanceTimersByTime((config.sessionMaxAgeSeconds + 1) * 1000)
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, created.token), config, session),
+    ).resolves.toBe(false)
+  })
+
+  it('derives the cookie name and Secure attribute from the auth configuration', async () => {
+    const loopbackConfig = {
+      ...config,
+      cookieName: 'custom_auth',
+      issuer: 'http://127.0.0.1:3000',
+      publicUrl: 'http://localhost:5173',
+    }
+    const created = await csrfTokenForRequest(
+      new Request('http://localhost:5173/'),
+      loopbackConfig,
+      session,
+    )
+    const cleared = await clearCsrfToken(loopbackConfig)
+
+    expect(created.setCookie).toContain('custom_auth_csrf=')
+    expect(created.setCookie).not.toContain('Secure')
+    expect(cleared).toContain('custom_auth_csrf=')
+  })
+})
+
+function requestWithCookie(setCookie: string): Request {
+  return new Request('https://reef.example.test/', {
+    headers: { cookie: setCookie.split(';', 1)[0] },
+  })
+}
+
+function postRequest(setCookie: string, csrf: string): Request {
+  return new Request('https://reef.example.test/logout', {
+    body: new URLSearchParams({ csrf }),
+    headers: { cookie: setCookie.split(';', 1)[0] },
+    method: 'POST',
+  })
+}

--- a/apps/reef/app/auth/csrf.server.test.ts
+++ b/apps/reef/app/auth/csrf.server.test.ts
@@ -41,6 +41,11 @@ describe('Reef CSRF tokens', () => {
     expect(created.setCookie).toContain('reef_session_csrf=')
     expect(created.setCookie).not.toContain(session.accessToken)
     expect(created.setCookie).toContain('Secure')
+    // The two attributes the name of this test promises and its body did not
+    // check. `SameSite` comes along because it is the attribute a CSRF cookie
+    // most depends on, and it was asserted nowhere in this file either.
+    expect(created.setCookie).toContain('HttpOnly')
+    expect(created.setCookie).toContain('SameSite=Lax')
 
     const reused = await csrfTokenForRequest(requestWithCookie(created.setCookie!), config, session)
     expect(reused).toEqual({ setCookie: null, token: created.token })

--- a/apps/reef/app/auth/csrf.server.ts
+++ b/apps/reef/app/auth/csrf.server.ts
@@ -1,0 +1,125 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+
+import { createCookie } from 'react-router'
+
+import { authCookieSecure } from './config.server'
+import { randomToken } from './session.server'
+import type { AuthSession, RequiredAuthConfig } from './types'
+
+const CLOCK_SKEW_SECONDS = 30
+
+interface CsrfCookieValue {
+  createdAt: number
+  sessionBinding: string
+  token: string
+}
+
+interface CsrfTokenResult {
+  setCookie: string | null
+  token: string
+}
+
+export async function csrfTokenForRequest(
+  request: Request,
+  config: RequiredAuthConfig,
+  session: AuthSession,
+): Promise<CsrfTokenResult> {
+  const existing = await readCsrfCookie(request, config)
+  const binding = sessionBinding(session)
+  if (existing && isFresh(existing, config) && safeEqual(existing.sessionBinding, binding)) {
+    return { setCookie: null, token: existing.token }
+  }
+
+  const value = {
+    createdAt: unixTimestamp(),
+    sessionBinding: binding,
+    token: randomToken(32),
+  } satisfies CsrfCookieValue
+  return {
+    setCookie: await csrfCookie(config).serialize(value),
+    token: value.token,
+  }
+}
+
+export async function validateCsrfToken(
+  request: Request,
+  config: RequiredAuthConfig,
+  session: AuthSession,
+): Promise<boolean> {
+  const cookie = await readCsrfCookie(request, config)
+  if (
+    !cookie ||
+    !isFresh(cookie, config) ||
+    !safeEqual(cookie.sessionBinding, sessionBinding(session))
+  ) {
+    return false
+  }
+
+  let formData: FormData
+  try {
+    formData = await request.clone().formData()
+  } catch {
+    return false
+  }
+
+  const submitted = formData.get('csrf')
+  return typeof submitted === 'string' && safeEqual(submitted, cookie.token)
+}
+
+export async function clearCsrfToken(config: RequiredAuthConfig): Promise<string> {
+  return csrfCookie(config).serialize('', { maxAge: 0 })
+}
+
+function csrfCookie(config: RequiredAuthConfig) {
+  return createCookie(`${config.cookieName}_csrf`, {
+    httpOnly: true,
+    maxAge: config.sessionMaxAgeSeconds,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [config.sessionSecret],
+    secure: authCookieSecure(config),
+  })
+}
+
+async function readCsrfCookie(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<CsrfCookieValue | null> {
+  const value = await csrfCookie(config).parse(request.headers.get('cookie'))
+  return isCsrfCookieValue(value) ? value : null
+}
+
+function isCsrfCookieValue(value: unknown): value is CsrfCookieValue {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<CsrfCookieValue>
+  return (
+    typeof candidate.createdAt === 'number' &&
+    Number.isFinite(candidate.createdAt) &&
+    typeof candidate.sessionBinding === 'string' &&
+    candidate.sessionBinding.length > 0 &&
+    typeof candidate.token === 'string' &&
+    candidate.token.length > 0
+  )
+}
+
+function isFresh(value: CsrfCookieValue, config: RequiredAuthConfig): boolean {
+  const now = unixTimestamp()
+  return (
+    value.createdAt <= now + CLOCK_SKEW_SECONDS &&
+    now - value.createdAt <= config.sessionMaxAgeSeconds
+  )
+}
+
+function sessionBinding(session: AuthSession): string {
+  return createHash('sha256').update(session.accessToken).digest('hex')
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer)
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/server-context.test-helper.ts
+++ b/apps/reef/app/auth/server-context.test-helper.ts
@@ -14,6 +14,7 @@ export function authTestContext(accessToken: string | null = 'test-coral-token')
 
   context.set(requestAuthContext, {
     accessToken,
+    csrfToken: 'test-csrf-token',
     mode: 'required',
     session: {
       accessToken,

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -21,6 +21,8 @@ export interface AuthSession {
   tokenType: string
 }
 
+export type BrowserAuth = { mode: 'disabled' } | { csrfToken: string; mode: 'required' }
+
 export type RequestAuth =
   | { accessToken: null; mode: 'disabled' }
-  | { accessToken: string; mode: 'required'; session: AuthSession }
+  | { accessToken: string; csrfToken: string; mode: 'required'; session: AuthSession }

--- a/apps/reef/app/components/sidebar/sidebar.css.ts
+++ b/apps/reef/app/components/sidebar/sidebar.css.ts
@@ -99,6 +99,10 @@ export const toggleButton = style({
   justifyContent: 'center',
 })
 
+export const workspaceMenuForm = style({
+  display: 'contents',
+})
+
 export const nav = style({
   display: 'flex',
   flex: 1,

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames'
 import { useEffect, useRef, useState } from 'react'
-import { Link, NavLink, useLocation, useMatch, useParams } from 'react-router'
+import { Form, Link, NavLink, useLocation, useMatch, useParams } from 'react-router'
 
+import type { BrowserAuth } from '@/auth/types'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import {
   Container as ButtonContainer,
@@ -29,13 +30,18 @@ import * as styles from './sidebar.css'
 import { useSidebarState } from './use-sidebar-state'
 
 interface SidebarProps {
+  auth?: BrowserAuth
   initialIsMinimized: boolean
   workspaces: ReadonlyArray<Pick<Workspace, 'name'>>
 }
 
 type NavItem = { icon: IconName; label: string; paths: string[]; to: string }
 
-export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
+export function Sidebar({
+  auth = { mode: 'disabled' },
+  initialIsMinimized,
+  workspaces,
+}: SidebarProps) {
   const location = useLocation()
   const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
@@ -43,6 +49,7 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const updateState = useDesktopUpdateState(desktop)
   const [createWorkspaceDialogOpen, setCreateWorkspaceDialogOpen] = useState(false)
   const createWorkspaceDialogSession = useRef(0)
+  const logoutForm = useRef<HTMLFormElement>(null)
   const createWorkspaceFetcherKey = `create-workspace-${createWorkspaceDialogSession.current}`
   const currentWorkspace = workspaces.find((workspace) => workspace.name === workspaceId)
   const workspaceNavTarget = currentWorkspace ?? workspaces[0]
@@ -208,6 +215,25 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
                   <Menu.Item icon="Settings" to={settingsPath}>
                     Settings
                   </Menu.Item>
+                  {auth.mode === 'required' && (
+                    <>
+                      <Menu.Separator />
+                      <Form
+                        action="/logout"
+                        className={styles.workspaceMenuForm}
+                        method="post"
+                        ref={logoutForm}
+                      >
+                        <input name="csrf" type="hidden" value={auth.csrfToken} />
+                        <Menu.Item
+                          icon="LogOut"
+                          onClick={() => logoutForm.current?.requestSubmit()}
+                        >
+                          Sign out
+                        </Menu.Item>
+                      </Form>
+                    </>
+                  )}
                 </Menu.Content>
               </Menu.Container>
 

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -4,10 +4,11 @@ import { routePattern } from './routing/routemap'
 
 export default [
   // Public auth resources: Coral needs CIMD before authorization, and the
-  // browser needs login/callback before Reef can establish a session.
+  // browser needs login/callback/logout outside the session boundary.
   route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),
   route(routePattern('login'), 'routes/login.tsx'),
   route('auth/callback', 'routes/auth.callback.tsx'),
+  route('logout', 'routes/logout.tsx'),
   layout('routes/_protected.tsx', [
     // Action-only resource route: OAuth/device-code install streams progress over
     // same-origin fetch. It and onboarding share the auth boundary but do not

--- a/apps/reef/app/routes/_protected.server.test.tsx
+++ b/apps/reef/app/routes/_protected.server.test.tsx
@@ -5,11 +5,13 @@ import type { RequiredAuthConfig } from '@/auth/types'
 
 const authMocks = vi.hoisted(() => ({
   clearReefSession: vi.fn(async () => 'reef_session=; Max-Age=0; Path=/; HttpOnly'),
+  csrfTokenForRequest: vi.fn(),
   readReefSession: vi.fn(),
   reefAuthConfig: vi.fn(),
 }))
 
 vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/csrf.server', () => ({ csrfTokenForRequest: authMocks.csrfTokenForRequest }))
 vi.mock('@/auth/session.server', () => ({
   clearReefSession: authMocks.clearReefSession,
   readReefSession: authMocks.readReefSession,
@@ -87,6 +89,8 @@ const handlerBuild = {
 describe('optional auth boundary', () => {
   beforeEach(() => {
     authMocks.clearReefSession.mockClear()
+    authMocks.csrfTokenForRequest.mockReset()
+    authMocks.csrfTokenForRequest.mockResolvedValue({ setCookie: null, token: 'csrf-token' })
     authMocks.readReefSession.mockReset()
     authMocks.reefAuthConfig.mockReset()
     descendantAction.mockClear()
@@ -105,6 +109,7 @@ describe('optional auth boundary', () => {
     expect(next).toHaveBeenCalledOnce()
     expect(authMocks.readReefSession).not.toHaveBeenCalled()
     expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+    expect(authMocks.csrfTokenForRequest).not.toHaveBeenCalled()
     expect(context.get(requestAuthContext)).toEqual({ accessToken: null, mode: 'disabled' })
     expect(response.headers.has('Cache-Control')).toBe(false)
   })
@@ -208,9 +213,15 @@ describe('optional auth boundary', () => {
 
     expect(context.get(requestAuthContext)).toEqual({
       accessToken: 'server-only-token',
+      csrfToken: 'csrf-token',
       mode: 'required',
       session,
     })
+    expect(authMocks.csrfTokenForRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      requiredConfig,
+      session,
+    )
 
     const body = await response.clone().text()
     const headers = [...response.headers.entries()].map(([name, value]) => `${name}: ${value}`)
@@ -220,6 +231,28 @@ describe('optional auth boundary', () => {
     for (const header of headers) {
       expect(header).not.toContain('server-only-token')
     }
+  })
+
+  it('commits a fresh CSRF cookie on the protected response', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+    authMocks.csrfTokenForRequest.mockResolvedValue({
+      setCookie: 'reef_session_csrf=signed; Path=/; HttpOnly; SameSite=Lax',
+      token: 'fresh-csrf-token',
+    })
+
+    const response = await runMiddleware(
+      new Request('https://reef.example.test/'),
+      async () => new Response('ok'),
+    )
+
+    expect(response.headers.get('Set-Cookie')).toContain('reef_session_csrf=signed')
+
+    const childError = new Response('failed', { status: 500 })
+    const thrown = await runMiddleware(new Request('https://reef.example.test/'), async () => {
+      throw childError
+    }).catch((error: unknown) => error)
+    expect((thrown as Response).headers.get('Set-Cookie')).toContain('reef_session_csrf=signed')
   })
 
   it('marks normal and thrown hosted responses private and non-cacheable', async () => {

--- a/apps/reef/app/routes/_protected.tsx
+++ b/apps/reef/app/routes/_protected.tsx
@@ -3,6 +3,7 @@ import { Outlet, redirect } from 'react-router'
 import type { Route } from './+types/_protected'
 
 import { reefAuthConfig } from '@/auth/config.server'
+import { csrfTokenForRequest } from '@/auth/csrf.server'
 import { markAuthResponsePrivate } from '@/auth/response.server'
 import { requestAuthContext } from '@/auth/server-context'
 import { clearReefSession, readReefSession } from '@/auth/session.server'
@@ -19,17 +20,23 @@ export const middleware: Route.MiddlewareFunction[] = [
 
     const session = await readReefSession(request, config)
     if (!session) throw await loginRedirect(request, config)
+    const csrf = await csrfTokenForRequest(request, config, session)
     context.set(requestAuthContext, {
       accessToken: session.accessToken,
+      csrfToken: csrf.token,
       mode: 'required',
       session,
     })
 
     try {
       const response = await next()
+      appendSetCookie(response, csrf.setCookie)
       return markAuthResponsePrivate(response)
     } catch (error) {
-      if (error instanceof Response) markAuthResponsePrivate(error)
+      if (error instanceof Response) {
+        appendSetCookie(error, csrf.setCookie)
+        markAuthResponsePrivate(error)
+      }
       throw error
     }
   },
@@ -54,4 +61,8 @@ async function loginRedirect(request: Request, config: RequiredAuthConfig): Prom
 function hasSessionCookie(request: Request, name: string): boolean {
   const cookie = request.headers.get('cookie')
   return cookie?.split(';').some((part) => part.trim().startsWith(`${name}=`)) ?? false
+}
+
+function appendSetCookie(response: Response, value: string | null): void {
+  if (value) response.headers.append('Set-Cookie', value)
 }

--- a/apps/reef/app/routes/app-shell.tsx
+++ b/apps/reef/app/routes/app-shell.tsx
@@ -8,6 +8,7 @@ import { requestAuthContext } from '@/auth/server-context'
 import { listWorkspacesForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 import { ToastContainer } from '@/wax/components/toast'
+import type { BrowserAuth, RequestAuth } from '@/auth/types'
 
 import * as styles from './app-shell.css'
 
@@ -16,10 +17,12 @@ interface RootLoaderData {
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {
-  if (isWorkspaceRedirectRoute(request)) return { workspaces: [] }
+  const auth = browserAuth(context.get(requestAuthContext))
+  if (isWorkspaceRedirectRoute(request)) return { auth, workspaces: [] }
 
   try {
     return {
+      auth,
       workspaces: await listWorkspacesForRequest(
         request,
         context.get(requestAuthContext).accessToken,
@@ -27,8 +30,14 @@ export async function loader({ context, request }: Route.LoaderArgs) {
     }
   } catch (error) {
     console.error('Failed to load sidebar workspaces:', error)
-    return { workspaces: [] }
+    return { auth, workspaces: [] }
   }
+}
+
+function browserAuth(auth: RequestAuth): BrowserAuth {
+  return auth.mode === 'required'
+    ? { csrfToken: auth.csrfToken, mode: 'required' }
+    : { mode: 'disabled' }
 }
 
 function isWorkspaceRedirectRoute(request: Request): boolean {
@@ -41,6 +50,7 @@ export default function AppShell({ loaderData }: Route.ComponentProps) {
   return (
     <div className={styles.layout}>
       <Sidebar
+        auth={loaderData.auth}
         initialIsMinimized={rootData?.sidebarIsMinimized ?? false}
         workspaces={loaderData.workspaces}
       />

--- a/apps/reef/app/routes/logout.server.test.tsx
+++ b/apps/reef/app/routes/logout.server.test.tsx
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  clearCsrfToken: vi.fn(),
+  clearOAuthTransaction: vi.fn(),
+  clearReefSession: vi.fn(),
+  readReefSession: vi.fn(),
+  reefAuthConfig: vi.fn(),
+  validateCsrfToken: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/csrf.server', () => ({
+  clearCsrfToken: authMocks.clearCsrfToken,
+  validateCsrfToken: authMocks.validateCsrfToken,
+}))
+vi.mock('@/auth/session.server', () => ({
+  clearOAuthTransaction: authMocks.clearOAuthTransaction,
+  clearReefSession: authMocks.clearReefSession,
+  readReefSession: authMocks.readReefSession,
+}))
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+import type { RequiredAuthConfig } from '@/auth/types'
+
+import { action } from './logout'
+
+const requiredConfig: RequiredAuthConfig = {
+  cookieName: 'reef_session',
+  issuer: 'https://coral.example.test',
+  mode: 'required',
+  publicUrl: 'https://reef.example.test',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+const session = {
+  accessToken: 'server-only-token',
+  expiresAt: 4_102_444_800,
+  tokenType: 'Bearer',
+}
+
+describe('logout route', () => {
+  beforeEach(() => {
+    authMocks.clearCsrfToken.mockReset()
+    authMocks.clearOAuthTransaction.mockReset()
+    authMocks.clearReefSession.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+    authMocks.readReefSession.mockReset()
+    authMocks.validateCsrfToken.mockReset()
+    authMocks.clearCsrfToken.mockResolvedValue('reef_session_csrf=; Max-Age=0; Path=/')
+    authMocks.clearOAuthTransaction.mockResolvedValue('reef_oauth=; Max-Age=0; Path=/')
+    authMocks.clearReefSession.mockResolvedValue('reef_session=; Max-Age=0; Path=/')
+  })
+
+  it('keeps disabled local and desktop logout inert', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+    const request = logoutRequest('local-token')
+
+    const response = await action(authRouteTestArgs(request, {}, null))
+
+    expect(response.headers.get('Location')).toBe('/')
+    expect(authMocks.validateCsrfToken).not.toHaveBeenCalled()
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-POST mutations', async () => {
+    const request = new Request('https://reef.example.test/logout', { method: 'DELETE' })
+
+    await expect(action(authRouteTestArgs(request, {}))).rejects.toMatchObject({ status: 405 })
+    expect(authMocks.reefAuthConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a hosted logout with an invalid CSRF token', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+    authMocks.validateCsrfToken.mockResolvedValue(false)
+    const request = logoutRequest('invalid-token')
+
+    await expect(action(authRouteTestArgs(request, {}))).rejects.toMatchObject({ status: 403 })
+    expect(authMocks.validateCsrfToken).toHaveBeenCalledWith(request, requiredConfig, session)
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects a hosted logout without an active session', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+    const request = logoutRequest('orphaned-token')
+
+    await expect(action(authRouteTestArgs(request, {}))).rejects.toMatchObject({ status: 403 })
+    expect(authMocks.validateCsrfToken).not.toHaveBeenCalled()
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+  })
+
+  it('clears hosted auth cookies and lands on the signed-out screen', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+    authMocks.validateCsrfToken.mockResolvedValue(true)
+    const request = logoutRequest('valid-token')
+
+    const response = await action(authRouteTestArgs(request, {}))
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe('/login?signedOut=1')
+    expect(response.headers.getSetCookie()).toEqual([
+      'reef_session_csrf=; Max-Age=0; Path=/',
+      'reef_oauth=; Max-Age=0; Path=/',
+      'reef_session=; Max-Age=0; Path=/',
+    ])
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(authMocks.validateCsrfToken).toHaveBeenCalledWith(request, requiredConfig, session)
+  })
+})
+
+function logoutRequest(csrf: string): Request {
+  return new Request('https://reef.example.test/logout', {
+    body: new URLSearchParams({ csrf }),
+    method: 'POST',
+  })
+}

--- a/apps/reef/app/routes/logout.tsx
+++ b/apps/reef/app/routes/logout.tsx
@@ -1,0 +1,39 @@
+import { redirect } from 'react-router'
+
+import type { Route } from './+types/logout'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { clearCsrfToken, validateCsrfToken } from '@/auth/csrf.server'
+import { markAuthResponsePrivate } from '@/auth/response.server'
+import { clearOAuthTransaction, clearReefSession, readReefSession } from '@/auth/session.server'
+
+export async function loader() {
+  return markAuthResponsePrivate(redirect('/'))
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  if (request.method !== 'POST') {
+    throw markAuthResponsePrivate(new Response('Method Not Allowed', { status: 405 }))
+  }
+
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') return markAuthResponsePrivate(redirect('/'))
+  const session = await readReefSession(request, config)
+  if (!session || !(await validateCsrfToken(request, config, session))) {
+    throw markAuthResponsePrivate(new Response('Invalid CSRF token', { status: 403 }))
+  }
+
+  const headers = new Headers()
+  headers.append('Set-Cookie', await clearCsrfToken(config))
+  headers.append('Set-Cookie', await clearOAuthTransaction(config))
+  headers.append('Set-Cookie', await clearReefSession(config))
+
+  // Coral Cloud does not currently advertise a provider-neutral browser logout
+  // or revocation endpoint. Keep logout local and stop automatic SSO bounce by
+  // landing on the signed-out login screen.
+  return markAuthResponsePrivate(redirect('/login?signedOut=1', { headers }))
+}
+
+export default function Logout() {
+  return null
+}

--- a/apps/reef/app/routes/logout.tsx
+++ b/apps/reef/app/routes/logout.tsx
@@ -6,6 +6,7 @@ import { reefAuthConfig } from '@/auth/config.server'
 import { clearCsrfToken, validateCsrfToken } from '@/auth/csrf.server'
 import { markAuthResponsePrivate } from '@/auth/response.server'
 import { clearOAuthTransaction, clearReefSession, readReefSession } from '@/auth/session.server'
+import { routePath } from '@/routing/routemap'
 
 export async function loader() {
   return markAuthResponsePrivate(redirect('/'))
@@ -31,7 +32,7 @@ export async function action({ request }: Route.ActionArgs) {
   // Coral Cloud does not currently advertise a provider-neutral browser logout
   // or revocation endpoint. Keep logout local and stop automatic SSO bounce by
   // landing on the signed-out login screen.
-  return markAuthResponsePrivate(redirect('/login?signedOut=1', { headers }))
+  return markAuthResponsePrivate(redirect(`${routePath('login')}?signedOut=1`, { headers }))
 }
 
 export default function Logout() {


### PR DESCRIPTION
> Reef hosted-auth stack: layer 10 of 11. Base: PR #2066.

## Intent

Add a hosted-only sign-out action that requires POST plus a signed, user-bound CSRF token. Clear the Reef session, OAuth transaction, and CSRF cookies before showing the signed-out screen.

## What it enables

Hosted users can end their Reef session from the sidebar without accepting cross-site GET or cookie-only logout attacks. Local and Desktop Reef remain free of auth controls.

## Usage examples

Choose **Sign out** in the hosted sidebar. Reef posts the signed CSRF value to `/logout`, clears local auth cookies, and lands on `/login?signedOut`. Direct GET requests and invalid CSRF submissions do not log the user out.