### PR TITLE
feat(app): allow additional server auth audiences

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -96,9 +96,10 @@ bind = "127.0.0.1:14556"
 
 The unauthenticated MCP listener is restricted to loopback addresses.
 
-Within a configured `[auth]` section, use `allowed_audiences` to register
-additional public surfaces that front the private gRPC API, such as a hosted
-Reef deployment:
+Add `allowed_audiences` to the top-level `[auth]` table of an otherwise complete
+auth configuration to register public surfaces that front the private gRPC API,
+such as a hosted Reef deployment. The required `[auth.session]`,
+`[auth.authorization_server]`, and `[auth.provider]` tables are omitted here:
 
 ```toml
 [auth]

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -82,7 +82,7 @@ bind_addr = "127.0.0.1:14555"
 ```
 
 <Warning>
-  The native gRPC server does not authenticate clients. A non-loopback bind exposes Coral and its configured sources to any client that can reach the port. Protect access with a trusted network boundary or authenticating proxy.
+  Without `[auth]`, the native gRPC server does not authenticate clients. A non-loopback bind exposes Coral and its configured sources to any client that can reach the port. Protect access with a trusted network boundary or authenticating proxy.
 </Warning>
 
 MCP Streamable HTTP is disabled by default. Enable its companion listener under
@@ -95,6 +95,23 @@ bind = "127.0.0.1:14556"
 ```
 
 The unauthenticated MCP listener is restricted to loopback addresses.
+
+Within a configured `[auth]` section, use `allowed_audiences` to register
+additional public surfaces that front the private gRPC API, such as a hosted
+Reef deployment:
+
+```toml
+[auth]
+allowed_audiences = ["https://reef.example.com"]
+```
+
+Each URL becomes both an OAuth resource clients may request a token for and an
+accepted audience on the private gRPC API, like
+`server.mcp_http.public_url`. MCP HTTP still accepts only tokens minted for its
+own `public_url`; a token for another allowed audience cannot be replayed there.
+Coral canonicalizes these URLs and rejects duplicates. When authentication is
+configured, provide at least one `allowed_audiences` entry or enable MCP HTTP
+with a `public_url`.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -82,7 +82,7 @@ bind_addr = "127.0.0.1:14555"
 ```
 
 <Warning>
-  Without `[auth]`, the native gRPC server does not authenticate clients. A non-loopback bind exposes Coral and its configured sources to any client that can reach the port. Protect access with a trusted network boundary or authenticating proxy.
+  The native gRPC server does not authenticate clients. A non-loopback bind exposes Coral and its configured sources to any client that can reach the port. Protect access with a trusted network boundary or authenticating proxy.
 </Warning>
 
 MCP Streamable HTTP is disabled by default. Enable its companion listener under
@@ -95,24 +95,6 @@ bind = "127.0.0.1:14556"
 ```
 
 The unauthenticated MCP listener is restricted to loopback addresses.
-
-Add `allowed_audiences` to the top-level `[auth]` table of an otherwise complete
-auth configuration to register public surfaces that front the private gRPC API,
-such as a hosted Reef deployment. The required `[auth.session]`,
-`[auth.authorization_server]`, and `[auth.provider]` tables are omitted here:
-
-```toml
-[auth]
-allowed_audiences = ["https://reef.example.com"]
-```
-
-Each URL becomes both an OAuth resource clients may request a token for and an
-accepted audience on the private gRPC API, like
-`server.mcp_http.public_url`. MCP HTTP still accepts only tokens minted for its
-own `public_url`; a token for another allowed audience cannot be replayed there.
-Coral canonicalizes these URLs and rejects duplicates. When authentication is
-configured, provide at least one `allowed_audiences` entry or enable MCP HTTP
-with a `public_url`.
 
 ## Runtime features
 

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -56,17 +56,25 @@ impl CoralAuthorizationServer {
     /// # Errors
     ///
     /// Returns an error when the provider secret cannot be resolved from its
-    /// environment variable, the session signing key cannot be resolved, or
-    /// the session-token key material is invalid.
+    /// environment variable, the session signing key cannot be resolved, the
+    /// session-token key material is invalid, or a configured authorization
+    /// resource is invalid.
     pub fn from_settings(
         config_path: &Path,
         settings: AuthSettings,
     ) -> Result<Self, AuthServerError> {
+        let authorization_resources = settings.allowed_audiences().to_vec();
         let (settings, session_tokens) = settings
             .resolve_runtime_dependencies(config_path, &|name| {
                 crate::bootstrap::env_var(name).map_err(|error| signing_key_env_error(&error))
             })?;
-        Self::from_resolved_settings(settings, session_tokens)
+        let mut server = Self::from_resolved_settings(settings, session_tokens)?;
+        for resource in authorization_resources {
+            server = server
+                .with_authorization_resource(resource)
+                .map_err(AuthServerError::Config)?;
+        }
+        Ok(server)
     }
 
     pub(crate) fn from_resolved_settings(
@@ -110,6 +118,12 @@ impl CoralAuthorizationServer {
                 .map_err(|error| format!("authorization resource {error}"))?,
         );
         Ok(self)
+    }
+
+    /// Returns registered resources for assertions outside this module.
+    #[cfg(test)]
+    pub(crate) fn authorization_resources(&self) -> &BTreeSet<String> {
+        &self.authorization_resources
     }
 
     /// Starts the HTTP listener.
@@ -348,8 +362,8 @@ mod tests {
         dir
     }
 
-    fn authorization_server(extra: &str) -> tempfile::TempDir {
-        config(&format!("{AUTHORIZATION_SERVER}{extra}\n{PROVIDER}"))
+    fn authorization_server(auth_fields: &str) -> tempfile::TempDir {
+        config(&format!("{auth_fields}{AUTHORIZATION_SERVER}\n{PROVIDER}"))
     }
 
     fn server(dir: &tempfile::TempDir) -> CoralAuthorizationServer {
@@ -434,6 +448,17 @@ mod tests {
                 .expect("invalid resource");
             assert!(error.contains("authorization resource"));
         }
+    }
+
+    #[test]
+    fn registers_configured_authorization_resources() {
+        let dir = authorization_server("allowed_audiences = ['https://REEF.example.test/']\n");
+        let prepared = server(&dir);
+
+        assert_eq!(
+            prepared.authorization_resources,
+            ["https://reef.example.test".to_string()].into()
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -217,7 +217,9 @@ async fn resolve_client(
         .client_metadata_resolver
         .resolve(client_id)
         .await
-        .map_err(|_error| ())
+        .map_err(|error| {
+            tracing::warn!(%error, "OAuth client metadata resolution failed");
+        })
 }
 
 /// Resolves the redirect URI a request names, under [`BrowserRedirect`].

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -61,6 +61,10 @@ struct RawAuthSettings {
         deserialize_with = "deserialize_bind_addr"
     )]
     http_bind_addr: SocketAddr,
+    /// Additional public-surface resource identifiers accepted by the private
+    /// gRPC API and registered with the authorization server.
+    #[serde(default)]
+    allowed_audiences: Vec<String>,
     session: SessionTokenSettings,
     authorization_server: AuthorizationServerSettings,
     provider: OidcProviderSettings,
@@ -81,6 +85,14 @@ impl AuthSettings {
         };
         settings.validate()?;
         Ok(Some(Self(settings)))
+    }
+
+    /// Returns the additional public-surface audiences exactly as configured.
+    ///
+    /// Server bootstrap owns their URL canonicalization alongside the other
+    /// public-surface identifiers it composes.
+    pub(crate) fn allowed_audiences(&self) -> &[String] {
+        &self.0.allowed_audiences
     }
 
     /// Fetches the secrets the config only points at — the provider client

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -84,6 +84,7 @@ impl LoadedServerConfig {
                 session_auth: None,
             });
         };
+        let allowed_audiences = auth_settings.allowed_audiences().to_vec();
         let (auth_settings, session) = auth_settings
             .resolve_runtime_dependencies(&self.config_path, &|name| {
                 AppEnvironment::env_var(name).map_err(|error| match error {
@@ -103,7 +104,7 @@ impl LoadedServerConfig {
             Some(auth_settings.authorization_server().issuer()),
         )?;
         let mcp_http = self.resolve_mcp_http(Some(&authorization_server))?;
-        let public_audiences = public_surface_audiences(mcp_http.as_ref())?;
+        let public_audiences = public_surface_audiences(mcp_http.as_ref(), &allowed_audiences)?;
         Ok(ServeSettings {
             mcp_http,
             session_auth: Some(SessionAuthSettings {
@@ -345,28 +346,37 @@ impl SessionAuthSettings {
     }
 }
 
-/// Collects the resource identifiers of the instance's public surfaces.
+/// Collects the resource identifiers that front the instance's private API.
 ///
-/// Only a public surface has a resource identity: it is the audience of the tokens
-/// minted for it and the authorization resource clients name when requesting one.
-/// The gRPC API is private — reached through the surfaces that front it, MCP HTTP
-/// today and the UI BFF later — so it has no identifier of its own and instead
-/// accepts every identifier returned here.
+/// Each identifier is both the audience of tokens minted for a public surface
+/// and the authorization resource clients name when requesting one. Some are
+/// derived from a surface Coral serves, while others are explicitly registered
+/// for external fronting surfaces such as a hosted UI BFF.
 ///
-/// At least one public surface is therefore required: with none, no token can be
-/// minted for anything and every login would fail at the authorization endpoint.
-/// The requirement is deliberately surface-agnostic, so adding the BFF satisfies
-/// it without revisiting this code.
+/// The gRPC API has no resource identity of its own and instead accepts every
+/// identifier returned here. At least one is therefore required: with none, no
+/// token can be minted for anything and every login would fail at authorization.
 fn public_surface_audiences(
     mcp_http: Option<&McpHttpServeConfig>,
+    allowed_audiences: &[String],
 ) -> Result<Vec<String>, AppError> {
-    let audiences = match mcp_http {
+    let mut audiences = match mcp_http {
         Some(McpHttpServeConfig::Authenticated { public_url, .. }) => vec![public_url.clone()],
         _ => Vec::new(),
     };
+    for (index, configured) in allowed_audiences.iter().enumerate() {
+        let label = format!("auth.allowed_audiences[{index}]");
+        let audience = required_oauth_url(&label, Some(configured))?;
+        if audiences.iter().any(|existing| existing == &audience) {
+            return Err(AppError::FailedPrecondition(format!(
+                "{label} duplicates another configured public surface audience"
+            )));
+        }
+        audiences.push(audience);
+    }
     if audiences.is_empty() {
         return Err(AppError::FailedPrecondition(
-            "configured [auth] requires at least one public surface with a public_url, such as an enabled server.mcp_http"
+            "configured [auth] requires at least one public surface: an enabled server.mcp_http with a public_url, or a non-empty auth.allowed_audiences"
                 .to_string(),
         ));
     }
@@ -405,6 +415,14 @@ mod tests {
     use crate::state::AppStateLayout;
 
     fn write_authenticated_config(layout: &AppStateLayout, mcp_http: &str) {
+        write_authenticated_config_with_auth(layout, mcp_http, "");
+    }
+
+    fn write_authenticated_config_with_auth(
+        layout: &AppStateLayout,
+        mcp_http: &str,
+        auth_fields: &str,
+    ) {
         layout.ensure().expect("config dir");
         fs::write(layout.config_dir().join("session.key"), test_signing_key())
             .expect("session key");
@@ -412,6 +430,9 @@ mod tests {
             layout.config_file(),
             format!(
                 "{mcp_http}
+[auth]
+{auth_fields}
+
 [auth.authorization_server]
 issuer = 'https://AUTH.example.test/'
 
@@ -533,12 +554,13 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
     }
 
     #[test]
-    fn authenticated_companions_share_one_canonical_mcp_audience() {
+    fn authenticated_companions_canonicalize_public_audiences_in_surface_order() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-        write_authenticated_config(
+        write_authenticated_config_with_auth(
             &layout,
             "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://MCP.example.test/'\n",
+            "allowed_audiences = ['https://REEF.example.test/']",
         );
 
         let companions = LoadedServerConfig::load(&layout)
@@ -557,7 +579,69 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         // providers and the authorization server from it is the composition
         // root's job, covered in `bootstrap::server`.
         let session_auth = companions.session_auth.expect("session auth");
-        assert_eq!(session_auth.public_audiences, ["https://mcp.example.test"]);
+        assert_eq!(
+            session_auth.public_audiences,
+            ["https://mcp.example.test", "https://reef.example.test"]
+        );
+    }
+
+    #[test]
+    fn authenticated_reef_only_config_uses_its_allowed_audience() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        write_authenticated_config_with_auth(
+            &layout,
+            "",
+            "allowed_audiences = ['https://REEF.example.test/']",
+        );
+
+        let companions = LoadedServerConfig::load(&layout)
+            .expect("load")
+            .companion_settings()
+            .expect("Reef-only companions");
+        assert!(companions.mcp_http.is_none());
+        assert_eq!(
+            companions
+                .session_auth
+                .expect("session auth")
+                .public_audiences,
+            ["https://reef.example.test"]
+        );
+    }
+
+    #[test]
+    fn allowed_audiences_reject_invalid_and_duplicate_entries() {
+        let cases = [
+            (
+                "",
+                "allowed_audiences = ['https://reef.example.test/?tenant=one']",
+                "auth.allowed_audiences[0] must not include a query",
+            ),
+            (
+                "[server.mcp_http]\nenabled = true\npublic_url = 'https://MCP.example.test/'\n",
+                "allowed_audiences = ['https://mcp.example.test']",
+                "auth.allowed_audiences[0] duplicates another configured public surface audience",
+            ),
+            (
+                "",
+                "allowed_audiences = ['https://REEF.example.test/', 'https://reef.example.test']",
+                "auth.allowed_audiences[1] duplicates another configured public surface audience",
+            ),
+        ];
+
+        for (mcp_http, auth_fields, expected) in cases {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+            write_authenticated_config_with_auth(&layout, mcp_http, auth_fields);
+
+            let error = LoadedServerConfig::load(&layout)
+                .expect("load")
+                .companion_settings()
+                .err()
+                .expect("invalid audience must fail");
+            assert!(error.to_string().contains(expected), "error: {error}");
+        }
     }
 
     /// Parsing `[auth]` validates the section without touching what it points
@@ -581,14 +665,13 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
     }
 
     /// The private gRPC API has no resource identity of its own, so an
-    /// authenticated instance needs a public surface for anything to be minted
-    /// for. The message names no specific surface, so adding the UI BFF satisfies
-    /// it without touching this check.
+    /// authenticated instance needs at least one public surface for anything to
+    /// be minted for. An empty allowlist behaves exactly like an absent one.
     #[test]
     fn configured_auth_requires_a_public_surface() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-        write_authenticated_config(&layout, "");
+        write_authenticated_config_with_auth(&layout, "", "allowed_audiences = []");
         let error = LoadedServerConfig::load(&layout)
             .expect("load")
             .companion_settings()
@@ -597,7 +680,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         assert!(
             error
                 .to_string()
-                .contains("requires at least one public surface with a public_url"),
+                .contains("requires at least one public surface"),
             "error: {error}"
         );
     }

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -586,7 +586,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
     }
 
     #[test]
-    fn authenticated_reef_only_config_uses_its_allowed_audience() {
+    fn authenticated_reef_only_config_registers_its_allowed_audience() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
         write_authenticated_config_with_auth(
@@ -600,12 +600,15 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             .companion_settings()
             .expect("Reef-only companions");
         assert!(companions.mcp_http.is_none());
+        let session_auth = companions.session_auth.expect("session auth");
+        assert_eq!(session_auth.public_audiences, ["https://reef.example.test"]);
+
+        let authorization_server = session_auth
+            .into_authorization_server()
+            .expect("authorization server");
         assert_eq!(
-            companions
-                .session_auth
-                .expect("session auth")
-                .public_audiences,
-            ["https://reef.example.test"]
+            authorization_server.authorization_resources(),
+            &["https://reef.example.test".to_string()].into()
         );
     }
 

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -22,6 +22,7 @@ const OAUTH_ISSUER: &str = "http://localhost:9080";
 const OAUTH_RESOURCE: &str = "http://localhost:1457";
 const SESSION_ISSUER: &str = "https://auth.example";
 const SESSION_RESOURCE: &str = "https://coral.example/mcp";
+const REEF_RESOURCE: &str = "https://reef.example";
 
 fn write_config(temp: &TempDir, config: &str) {
     std::fs::write(temp.path().join("config.toml"), config).expect("write config");
@@ -107,6 +108,18 @@ async fn assert_unauthorized(base: &str, authorization: &str) {
         .await
         .expect("MCP response");
     assert_eq!(rejected.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        rejected.headers().get_all(WWW_AUTHENTICATE).iter().count(),
+        1
+    );
+    assert!(
+        rejected
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("Bearer ")),
+        "MCP rejection must include one bearer challenge"
+    );
 }
 
 /// Asserts the private gRPC data plane refuses a call carrying no credentials.
@@ -196,19 +209,37 @@ fn signed_session_token(
 }
 
 fn write_session_config(temp: &TempDir, signing_key: &[u8]) {
-    std::fs::write(temp.path().join("session.key"), signing_key).expect("session key");
-    // The uppercase host is deliberate: the advertised-resource assertion only
-    // proves canonicalization if the configured URL actually needs canonicalizing.
-    write_config(
+    write_session_config_with_mcp(
         temp,
+        signing_key,
         r"
-[trace_history]
-enabled = false
-
 [server.mcp_http]
 enabled = true
 bind = '127.0.0.1:0'
 public_url = 'https://CORAL.example/mcp'
+",
+    );
+}
+
+fn write_reef_only_session_config(temp: &TempDir, signing_key: &[u8]) {
+    write_session_config_with_mcp(temp, signing_key, "");
+}
+
+fn write_session_config_with_mcp(temp: &TempDir, signing_key: &[u8], mcp_http: &str) {
+    std::fs::write(temp.path().join("session.key"), signing_key).expect("session key");
+    // The uppercase hosts are deliberate: the assertions only prove
+    // canonicalization if the configured URLs actually need it.
+    write_config(
+        temp,
+        &format!(
+            r"
+[trace_history]
+enabled = false
+
+{mcp_http}
+
+[auth]
+allowed_audiences = ['https://REEF.example/']
 
 [auth.session]
 signing_key_file = 'session.key'
@@ -222,10 +253,11 @@ client_id = 'upstream-client'
 client_secret = 'test-secret'
 redirect_uri = 'https://auth.example/auth/oidc/callback'
 ",
+        ),
     );
 }
 
-async fn assert_authenticated_data(server: &RunningServer, mcp_endpoint: &str, token: &str) {
+async fn assert_grpc_authenticated(server: &RunningServer, token: &str) {
     let authenticated = connect_with_loopback_bearer(
         server.endpoint_uri(),
         BearerToken::new(token).expect("bearer token"),
@@ -237,6 +269,10 @@ async fn assert_authenticated_data(server: &RunningServer, mcp_endpoint: &str, t
         .list_catalog(Request::new(catalog_request()))
         .await
         .expect("authenticated catalog call");
+}
+
+async fn assert_authenticated_data(server: &RunningServer, mcp_endpoint: &str, token: &str) {
+    assert_grpc_authenticated(server, token).await;
     assert_catalog_tool(mcp_endpoint.to_string(), Some(token)).await;
 }
 
@@ -513,6 +549,10 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
     let token = session_token(signing_key.as_ref(), &resource);
     assert_authenticated_data(&server, &format!("{base}/mcp"), &token).await;
 
+    let reef_token = session_token(signing_key.as_ref(), REEF_RESOURCE);
+    assert_grpc_authenticated(&server, &reef_token).await;
+    assert_unauthorized(&base, &format!("Bearer {reef_token}")).await;
+
     // Readiness observes the backend, not just the port: stopping gRPC while MCP
     // HTTP keeps serving must turn the authenticated probe unhealthy.
     let RunningServer {
@@ -540,6 +580,34 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         .shutdown()
         .await
         .expect("shutdown OAuth server");
+}
+
+#[tokio::test]
+async fn reef_only_audience_authenticates_private_grpc_without_mcp_http() {
+    let temp = TempDir::new().expect("temp dir");
+    let signing_key =
+        EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+            .expect("P-256 signing key");
+    write_reef_only_session_config(&temp, signing_key.as_ref());
+
+    let server = start(
+        ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(temp.path())
+            .with_noop_feedback_uploads(),
+        McpOptions::default(),
+    )
+    .await
+    .expect("start Reef-only authenticated server");
+
+    assert!(server.grpc_authentication_enabled());
+    assert!(server.mcp_http_addr().is_none());
+    assert!(server.oauth_addr().is_some());
+    assert_grpc_rejects_unauthenticated(server.endpoint_uri()).await;
+
+    let reef_token = session_token(signing_key.as_ref(), REEF_RESOURCE);
+    assert_grpc_authenticated(&server, &reef_token).await;
+
+    server.shutdown().await.expect("shutdown Reef-only server");
 }
 
 #[tokio::test]


### PR DESCRIPTION
> Coral server prerequisite stack: layer 1 of 2. Base: `main`.

## Intent

Allow Coral authentication to register additional public OAuth resources that front the private native-gRPC API, while preserving the MCP HTTP listener's resource-specific audience enforcement.

## What it enables

A hosted Reef deployment can request a token for its own public origin and present that token to Coral's private gRPC server. Resources derived from MCP configuration remain valid, and an MCP token cannot be replayed for a different allowed audience.

## Usage examples

Register Reef's canonical public origin in Coral configuration:

```toml
[auth]
allowed_audiences = ["https://reef.example.com"]
```

That URL becomes both an OAuth resource Coral may mint and an accepted audience on the native gRPC server.