### PR TITLE
feat(app): allow loopback OAuth client metadata

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -269,6 +269,13 @@ impl AuthorizationServerHttpState {
         state_store: Arc<InMemoryStateStore>,
         authorization_resources: Arc<BTreeSet<String>>,
     ) -> Result<Self, AuthServerError> {
+        let client_metadata_resolver = Arc::new(
+            HttpClientMetadataResolver::new(
+                settings.authorization_server().issuer(),
+                &authorization_resources,
+            )
+            .map_err(|error| AuthServerError::ClientMetadataResolver(error.to_string()))?,
+        );
         Ok(Self {
             settings,
             session_tokens,
@@ -278,10 +285,7 @@ impl AuthorizationServerHttpState {
             provider_client: OidcProviderClient::new()
                 .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
             authorization_resources,
-            client_metadata_resolver: Arc::new(
-                HttpClientMetadataResolver::new()
-                    .map_err(|error| AuthServerError::ClientMetadataResolver(error.to_string()))?,
-            ),
+            client_metadata_resolver,
         })
     }
 

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -94,6 +94,7 @@ pub(super) async fn oauth_authorize_get(
         &callback,
         &browser_binding,
         secure_cookie,
+        &state.settings.provider().issuer,
     ) else {
         return trusted.error("server_error", "authorization failed");
     };
@@ -563,12 +564,21 @@ mod tests {
             (header::CONTENT_TYPE, "text/html; charset=utf-8"),
             (header::CACHE_CONTROL, "no-store"),
             (header::PRAGMA, "no-cache"),
+            // `form-action` names the provider's origin as well as `'self'`:
+            // a browser applies the directive to the redirect this page's own
+            // submission produces, so a bare `'self'` silently drops the
+            // hand-off to the provider. See
+            // `approval_page_allows_the_provider_redirect_it_produces`.
             (
                 header::CONTENT_SECURITY_POLICY,
-                "default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+                "default-src 'none'; base-uri 'none'; form-action 'self' https://provider.invalid; frame-ancestors 'none'",
             ),
             (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
-            (header::REFERRER_POLICY, "no-referrer"),
+            // Not `no-referrer`: that policy makes Chromium submit this page's
+            // own form with `Origin: null`, which the exact-origin check on the
+            // submission can never accept. See
+            // `approval_page_referrer_policy_preserves_the_submission_origin`.
+            (header::REFERRER_POLICY, "same-origin"),
             (header::X_FRAME_OPTIONS, "DENY"),
         ] {
             assert_eq!(response.headers()[name], value);
@@ -627,6 +637,7 @@ mod tests {
             &Url::parse("http://127.0.0.1:14554/oauth/callback").expect("loopback redirect"),
             &browser_binding(),
             false,
+            "https://provider.invalid",
         )
         .expect("page");
         let loopback_cookie = loopback.headers()[header::SET_COOKIE]
@@ -653,6 +664,7 @@ mod tests {
             &Url::parse(REDIRECT_URI).expect("redirect"),
             &browser_binding(),
             true,
+            "https://provider.invalid",
         )
         .expect("page");
         let escaped = response_body(escaped).await;
@@ -770,6 +782,70 @@ mod tests {
         assert!(
             location(&bound_browser).is_some_and(|location| location.contains("access_denied"))
         );
+    }
+
+    /// The approval page must permit the redirect its own submission produces.
+    ///
+    /// Submitting the form posts back here and this handler answers with a
+    /// redirect to the provider. Browsers apply `form-action` to every URL in
+    /// that navigation, redirects included, so a bare `'self'` delivers the
+    /// POST — consuming the approval — and then drops the redirect. The user
+    /// sees nothing happen, and a second attempt reports the now-consumed
+    /// approval as expired. Chromium blames the same-origin form action in its
+    /// console, never the provider it actually blocked.
+    #[tokio::test]
+    async fn approval_page_allows_the_provider_redirect_it_produces() {
+        let auth_state = state(
+            "https://provider.invalid",
+            Arc::new(InMemoryStateStore::new()),
+        );
+        let page = request(auth_state, &pairs()).await;
+        assert_eq!(page.status(), StatusCode::OK);
+        let policy = page.headers()[header::CONTENT_SECURITY_POLICY]
+            .to_str()
+            .expect("policy");
+        assert!(
+            policy.contains("form-action 'self' https://provider.invalid;"),
+            "form-action must name the provider origin, got: {policy}"
+        );
+        // The rest of the policy is unchanged: nothing else may load or frame.
+        assert!(policy.contains("default-src 'none'"));
+        assert!(policy.contains("base-uri 'none'"));
+        assert!(policy.contains("frame-ancestors 'none'"));
+    }
+
+    /// The approval page must not carry `no-referrer`.
+    ///
+    /// Its own form posts back to this handler, and that submission is checked
+    /// against an exact `Origin`. Chromium derives a form submission's `Origin`
+    /// from the document's referrer policy, so a page served with `no-referrer`
+    /// submits `Origin: null` and every approval fails — the whole browser
+    /// login flow, for every client. Asserting the header's presence is what
+    /// missed this: both halves were tested, their interaction was not. The
+    /// `Origin: null` case below is the submission this policy would produce.
+    #[tokio::test]
+    async fn approval_page_referrer_policy_preserves_the_submission_origin() {
+        let auth_state = state(
+            "https://provider.invalid",
+            Arc::new(InMemoryStateStore::new()),
+        );
+        let page = request(auth_state.clone(), &pairs()).await;
+        assert_eq!(page.status(), StatusCode::OK);
+        assert_eq!(page.headers()[header::CACHE_CONTROL], "no-store");
+        assert_eq!(page.headers()[header::PRAGMA], "no-cache");
+        assert_eq!(page.headers()[header::X_CONTENT_TYPE_OPTIONS], "nosniff");
+        assert_eq!(page.headers()[header::REFERRER_POLICY], "same-origin");
+
+        let ticket = ticket_from_page(&response_body(page).await);
+        let mut null_origin = submission_request(&ticket, "cancel");
+        null_origin
+            .headers_mut()
+            .insert(header::ORIGIN, "null".parse().unwrap());
+        let null_origin = oauth_authorize_post(State(auth_state.clone()), null_origin).await;
+        assert_eq!(null_origin.status(), StatusCode::BAD_REQUEST);
+
+        let bound_browser = submit(auth_state, &ticket, "cancel").await;
+        assert_eq!(bound_browser.status(), StatusCode::FOUND);
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -94,7 +94,6 @@ pub(super) async fn oauth_authorize_get(
         &callback,
         &browser_binding,
         secure_cookie,
-        &state.settings.provider().issuer,
     ) else {
         return trusted.error("server_error", "authorization failed");
     };
@@ -564,14 +563,10 @@ mod tests {
             (header::CONTENT_TYPE, "text/html; charset=utf-8"),
             (header::CACHE_CONTROL, "no-store"),
             (header::PRAGMA, "no-cache"),
-            // `form-action` names the provider's origin as well as `'self'`:
-            // a browser applies the directive to the redirect this page's own
-            // submission produces, so a bare `'self'` silently drops the
-            // hand-off to the provider. See
-            // `approval_page_allows_the_provider_redirect_it_produces`.
+            // No `form-action`: see `approval_page_does_not_restrict_form_action`.
             (
                 header::CONTENT_SECURITY_POLICY,
-                "default-src 'none'; base-uri 'none'; form-action 'self' https://provider.invalid; frame-ancestors 'none'",
+                "default-src 'none'; base-uri 'none'; frame-ancestors 'none'",
             ),
             (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
             // Not `no-referrer`: that policy makes Chromium submit this page's
@@ -637,7 +632,6 @@ mod tests {
             &Url::parse("http://127.0.0.1:14554/oauth/callback").expect("loopback redirect"),
             &browser_binding(),
             false,
-            "https://provider.invalid",
         )
         .expect("page");
         let loopback_cookie = loopback.headers()[header::SET_COOKIE]
@@ -664,7 +658,6 @@ mod tests {
             &Url::parse(REDIRECT_URI).expect("redirect"),
             &browser_binding(),
             true,
-            "https://provider.invalid",
         )
         .expect("page");
         let escaped = response_body(escaped).await;
@@ -784,17 +777,18 @@ mod tests {
         );
     }
 
-    /// The approval page must permit the redirect its own submission produces.
+    /// The approval page must not restrict `form-action`.
     ///
-    /// Submitting the form posts back here and this handler answers with a
-    /// redirect to the provider. Browsers apply `form-action` to every URL in
-    /// that navigation, redirects included, so a bare `'self'` delivers the
-    /// POST — consuming the approval — and then drops the redirect. The user
-    /// sees nothing happen, and a second attempt reports the now-consumed
-    /// approval as expired. Chromium blames the same-origin form action in its
-    /// console, never the provider it actually blocked.
+    /// Submitting the form starts a sign-in that navigates through this server,
+    /// the provider, any hop the provider adds, this server's callback, and
+    /// finally the client's redirect URI. Browsers apply `form-action` to every
+    /// one of them, so any list short of all of them blocks the login — after
+    /// the POST has already consumed the approval, leaving the user on a page
+    /// where nothing happened and a retry reporting the approval as expired.
+    /// A real sign-in through a hosted provider crossed five origins this way.
+    /// The remaining directives still deny every fetch, base URI and framing.
     #[tokio::test]
-    async fn approval_page_allows_the_provider_redirect_it_produces() {
+    async fn approval_page_does_not_restrict_form_action() {
         let auth_state = state(
             "https://provider.invalid",
             Arc::new(InMemoryStateStore::new()),
@@ -805,10 +799,9 @@ mod tests {
             .to_str()
             .expect("policy");
         assert!(
-            policy.contains("form-action 'self' https://provider.invalid;"),
-            "form-action must name the provider origin, got: {policy}"
+            !policy.contains("form-action"),
+            "form-action cannot enumerate an OAuth redirect chain, got: {policy}"
         );
-        // The rest of the policy is unchanged: nothing else may load or frame.
         assert!(policy.contains("default-src 'none'"));
         assert!(policy.contains("base-uri 'none'"));
         assert!(policy.contains("frame-ancestors 'none'"));

--- a/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
@@ -21,33 +21,26 @@ const BROWSER_BINDING_LENGTH: usize = 43;
 const APPROVAL_COOKIE_MAX_AGE_SECONDS: u64 = 5 * 60;
 const SECURE_APPROVAL_COOKIE_NAME: &str = "__Host-coral_oauth_approval";
 const LOOPBACK_APPROVAL_COOKIE_NAME: &str = "coral_oauth_approval";
-/// Builds the approval page's policy, naming where its form may end up.
+/// The approval page's policy, which deliberately omits `form-action`.
 ///
-/// Submitting the form posts back here, and this handler answers with a
-/// redirect to the upstream provider. A browser applies `form-action` to every
-/// URL in that navigation, redirects included, so a bare `'self'` blocks the
-/// hand-off to the provider — the POST is delivered and the approval consumed,
-/// then the redirect is dropped, and Chromium reports the violation against
-/// this same-origin action rather than the provider it actually blocked. The
-/// provider's origin therefore has to be named here.
+/// Submitting this page's form starts a sign-in that navigates through every
+/// origin the flow touches, and a browser applies `form-action` to all of them,
+/// redirects included. A single observed sign-in went here, to the provider, to
+/// two more provider URLs, back to this server's callback, and finally to the
+/// client's redirect URI — five origins, only some of them knowable when this
+/// page is rendered. An enumerated list is worse than none: a provider that
+/// federates to an enterprise identity provider, adds an MFA or bot-check hop,
+/// or simply changes its own redirect path silently breaks every login, and the browser
+/// blames this page's same-origin form action rather than the hop it blocked.
+/// The POST is delivered and the approval consumed before the block, so the
+/// user sees nothing happen and a retry reports the spent approval as expired.
 ///
-/// The origin comes from the configured issuer rather than the discovered
-/// `authorization_endpoint`, so rendering this page costs no discovery fetch.
-/// Discovery is only performed once the form is submitted, and naming an origin
-/// this page cannot yet know would mean fetching it on every render.
-///
-/// That leaves one provider shape unsupported: one whose `authorization_endpoint`
-/// sits on a different origin than its issuer, which the discovery policy permits
-/// today (it constrains the scheme, not the origin). Such a provider's redirect
-/// is blocked here with no error naming it — the failure this whole policy is
-/// written to avoid. No known provider is shaped that way, and constraining the
-/// endpoint to the issuer's origin at discovery is the fix if one appears.
-fn content_security_policy(provider_origin: &str) -> String {
-    format!(
-        "default-src 'none'; base-uri 'none'; form-action 'self' {provider_origin}; \
-         frame-ancestors 'none'"
-    )
-}
+/// What the directive would defend against is an injected form exfiltrating
+/// data. This page renders no script, takes no user input beyond a hidden
+/// ticket, escapes every interpolated value, and already denies every other
+/// fetch through `default-src 'none'`, so the exposure it leaves is small and
+/// bounded — where a wrong `form-action` breaks the feature outright.
+const CONTENT_SECURITY_POLICY: &str = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum ApprovalDecision {
@@ -139,8 +132,8 @@ pub(super) async fn parse_submission(
 /// `Cancel` comes before `Continue` in the form because the first submit button
 /// is the one a browser presses for a bare Enter key, and the safe decision is
 /// the better default for a keystroke nobody aimed at either button. Source
-/// order is display order here: the page has no stylesheet, and the policy from
-/// [`content_security_policy`] has no `style-src`, so it inherits
+/// order is display order here: the page has no stylesheet, and
+/// [`CONTENT_SECURITY_POLICY`] has no `style-src`, so it inherits
 /// `default-src 'none'` and no styling could reverse the two.
 pub(super) fn response(
     ticket: &OAuthAuthorizationApprovalTicket,
@@ -149,12 +142,7 @@ pub(super) fn response(
     redirect_uri: &Url,
     browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
     secure_cookie: bool,
-    provider_issuer: &str,
 ) -> Option<Response> {
-    let provider_origin = Url::parse(provider_issuer)
-        .ok()?
-        .origin()
-        .ascii_serialization();
     let client_host = Url::parse(client_id)
         .ok()?
         .host()
@@ -182,10 +170,7 @@ pub(super) fn response(
         approval_page_security_headers(),
         [
             (header::CONTENT_TYPE, "text/html; charset=utf-8"),
-            (
-                header::CONTENT_SECURITY_POLICY,
-                content_security_policy(&provider_origin).as_str(),
-            ),
+            (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
             (header::X_FRAME_OPTIONS, "DENY"),
         ],
         body,

--- a/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
@@ -13,7 +13,7 @@ use zeroize::Zeroizing;
 use super::super::super::state_store::{
     OAuthAuthorizationApprovalBrowserBinding, OAuthAuthorizationApprovalTicket,
 };
-use super::super::response::security_headers;
+use super::super::response::approval_page_security_headers;
 
 const MAX_FORM_BYTES: usize = 256;
 const TICKET_LENGTH: usize = 43;
@@ -21,8 +21,33 @@ const BROWSER_BINDING_LENGTH: usize = 43;
 const APPROVAL_COOKIE_MAX_AGE_SECONDS: u64 = 5 * 60;
 const SECURE_APPROVAL_COOKIE_NAME: &str = "__Host-coral_oauth_approval";
 const LOOPBACK_APPROVAL_COOKIE_NAME: &str = "coral_oauth_approval";
-const CONTENT_SECURITY_POLICY: &str =
-    "default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'";
+/// Builds the approval page's policy, naming where its form may end up.
+///
+/// Submitting the form posts back here, and this handler answers with a
+/// redirect to the upstream provider. A browser applies `form-action` to every
+/// URL in that navigation, redirects included, so a bare `'self'` blocks the
+/// hand-off to the provider — the POST is delivered and the approval consumed,
+/// then the redirect is dropped, and Chromium reports the violation against
+/// this same-origin action rather than the provider it actually blocked. The
+/// provider's origin therefore has to be named here.
+///
+/// The origin comes from the configured issuer rather than the discovered
+/// `authorization_endpoint`, so rendering this page costs no discovery fetch.
+/// Discovery is only performed once the form is submitted, and naming an origin
+/// this page cannot yet know would mean fetching it on every render.
+///
+/// That leaves one provider shape unsupported: one whose `authorization_endpoint`
+/// sits on a different origin than its issuer, which the discovery policy permits
+/// today (it constrains the scheme, not the origin). Such a provider's redirect
+/// is blocked here with no error naming it — the failure this whole policy is
+/// written to avoid. No known provider is shaped that way, and constraining the
+/// endpoint to the issuer's origin at discovery is the fix if one appears.
+fn content_security_policy(provider_origin: &str) -> String {
+    format!(
+        "default-src 'none'; base-uri 'none'; form-action 'self' {provider_origin}; \
+         frame-ancestors 'none'"
+    )
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum ApprovalDecision {
@@ -114,8 +139,8 @@ pub(super) async fn parse_submission(
 /// `Cancel` comes before `Continue` in the form because the first submit button
 /// is the one a browser presses for a bare Enter key, and the safe decision is
 /// the better default for a keystroke nobody aimed at either button. Source
-/// order is display order here: the page has no stylesheet, and the policy in
-/// [`CONTENT_SECURITY_POLICY`] has no `style-src`, so it inherits
+/// order is display order here: the page has no stylesheet, and the policy from
+/// [`content_security_policy`] has no `style-src`, so it inherits
 /// `default-src 'none'` and no styling could reverse the two.
 pub(super) fn response(
     ticket: &OAuthAuthorizationApprovalTicket,
@@ -124,7 +149,12 @@ pub(super) fn response(
     redirect_uri: &Url,
     browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
     secure_cookie: bool,
+    provider_issuer: &str,
 ) -> Option<Response> {
+    let provider_origin = Url::parse(provider_issuer)
+        .ok()?
+        .origin()
+        .ascii_serialization();
     let client_host = Url::parse(client_id)
         .ok()?
         .host()
@@ -149,10 +179,13 @@ pub(super) fn response(
     );
     let mut response = (
         StatusCode::OK,
-        security_headers(),
+        approval_page_security_headers(),
         [
             (header::CONTENT_TYPE, "text/html; charset=utf-8"),
-            (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
+            (
+                header::CONTENT_SECURITY_POLICY,
+                content_security_policy(&provider_origin).as_str(),
+            ),
             (header::X_FRAME_OPTIONS, "DENY"),
         ],
         body,

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -223,6 +223,11 @@ mod tests {
             Duration::from_mins(5),
         )
         .expect("session");
+        let authorization_resources = Arc::new(BTreeSet::from([RESOURCE.into()]));
+        let client_metadata_resolver = Arc::new(
+            HttpClientMetadataResolver::new(AUTH_ISSUER, &authorization_resources)
+                .expect("client metadata resolver"),
+        );
         AuthorizationServerHttpState {
             settings: Arc::new(settings(issuer)),
             session_tokens,
@@ -230,10 +235,8 @@ mod tests {
             session_store: store.clone(),
             code_store: store,
             provider_client: OidcProviderClient::new().expect("client"),
-            authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
-            client_metadata_resolver: Arc::new(
-                HttpClientMetadataResolver::new().expect("client metadata resolver"),
-            ),
+            authorization_resources,
+            client_metadata_resolver,
         }
     }
 

--- a/crates/coral-app/src/auth/authorization_server/client_metadata.rs
+++ b/crates/coral-app/src/auth/authorization_server/client_metadata.rs
@@ -1,5 +1,6 @@
 //! Client ID Metadata Document fetching and validation.
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -7,9 +8,10 @@ use serde::Deserialize;
 use thiserror::Error;
 use zeroize::Zeroizing;
 
+use crate::oauth_resource::CanonicalOauthUrl;
 use crate::outbound_url_policy::{
-    BrowserRedirect, EndpointUrl, OutboundUrlPolicyError, PublicMetadata,
-    public_metadata_http_client, read_bounded_body,
+    BrowserRedirect, ClientMetadata, Configured, EndpointUrl, OutboundUrlPolicyError,
+    client_metadata_http_client, read_bounded_body,
 };
 
 const CLIENT_METADATA_MAX_BYTES: usize = 5 * 1024;
@@ -40,25 +42,65 @@ pub(super) trait ClientMetadataResolver: Send + Sync {
     ) -> Result<OAuthClientRegistration, ClientMetadataError>;
 }
 
-/// Production resolver backed by the hardened public-metadata HTTP client.
+/// Production resolver backed by the hardened client-metadata HTTP client.
 #[derive(Clone)]
 pub(super) struct HttpClientMetadataResolver {
+    issuer: EndpointUrl<Configured>,
+    allowed_loopback_client_ids: BTreeSet<String>,
     fetcher: Arc<dyn MetadataFetcher>,
 }
 
 impl HttpClientMetadataResolver {
-    pub(super) fn new() -> Result<Self, ClientMetadataError> {
+    pub(super) fn new(
+        issuer: &str,
+        authorization_resources: &BTreeSet<String>,
+    ) -> Result<Self, ClientMetadataError> {
         let http =
-            public_metadata_http_client().map_err(|_error| ClientMetadataError::ClientBuild)?;
-        Ok(Self {
-            fetcher: Arc::new(ReqwestMetadataFetcher { http }),
-        })
+            client_metadata_http_client().map_err(|_error| ClientMetadataError::ClientBuild)?;
+        Self::with_fetcher(
+            issuer,
+            authorization_resources,
+            Arc::new(ReqwestMetadataFetcher { http }),
+        )
     }
 
-    #[cfg(test)]
-    fn with_fetcher(fetcher: Arc<dyn MetadataFetcher>) -> Self {
-        Self { fetcher }
+    fn with_fetcher(
+        issuer: &str,
+        authorization_resources: &BTreeSet<String>,
+        fetcher: Arc<dyn MetadataFetcher>,
+    ) -> Result<Self, ClientMetadataError> {
+        let issuer = EndpointUrl::<Configured>::parse(issuer)
+            .map_err(|_error| ClientMetadataError::InvalidConfiguration)?;
+        let allowed_loopback_client_ids =
+            derive_allowed_loopback_client_ids(authorization_resources)?;
+        Ok(Self {
+            issuer,
+            allowed_loopback_client_ids,
+            fetcher,
+        })
     }
+}
+
+fn derive_allowed_loopback_client_ids(
+    authorization_resources: &BTreeSet<String>,
+) -> Result<BTreeSet<String>, ClientMetadataError> {
+    authorization_resources
+        .iter()
+        .try_fold(BTreeSet::new(), |mut client_ids, value| {
+            let resource = CanonicalOauthUrl::parse(value)
+                .map_err(|_error| ClientMetadataError::InvalidConfiguration)?;
+            if resource.identifier() != value {
+                return Err(ClientMetadataError::InvalidConfiguration);
+            }
+            let url = resource.url();
+            if url.scheme() == "http" && url.path() == "/" {
+                let client_id = url
+                    .join("/.well-known/oauth-client")
+                    .map_err(|_error| ClientMetadataError::InvalidConfiguration)?;
+                client_ids.insert(client_id.to_string());
+            }
+            Ok(client_ids)
+        })
 }
 
 #[async_trait::async_trait]
@@ -67,8 +109,12 @@ impl ClientMetadataResolver for HttpClientMetadataResolver {
         &self,
         client_id: &str,
     ) -> Result<OAuthClientRegistration, ClientMetadataError> {
-        let metadata_url = EndpointUrl::<PublicMetadata>::parse(client_id)
-            .map_err(|_error| ClientMetadataError::InvalidClientId)?;
+        let metadata_url = EndpointUrl::<ClientMetadata>::parse(
+            client_id,
+            &self.issuer,
+            &self.allowed_loopback_client_ids,
+        )
+        .map_err(|_error| ClientMetadataError::InvalidClientId)?;
         // A client ID must already be the URL Coral fetches, character for
         // character. Parsing normalizes — it strips tab, CR, and LF from
         // anywhere in the input, trims surrounding spaces, lowercases the host,
@@ -89,7 +135,7 @@ impl ClientMetadataResolver for HttpClientMetadataResolver {
 trait MetadataFetcher: Send + Sync {
     async fn fetch(
         &self,
-        metadata_url: &EndpointUrl<PublicMetadata>,
+        metadata_url: &EndpointUrl<ClientMetadata>,
     ) -> Result<reqwest::Response, ClientMetadataError>;
 }
 
@@ -101,7 +147,7 @@ struct ReqwestMetadataFetcher {
 impl MetadataFetcher for ReqwestMetadataFetcher {
     async fn fetch(
         &self,
-        metadata_url: &EndpointUrl<PublicMetadata>,
+        metadata_url: &EndpointUrl<ClientMetadata>,
     ) -> Result<reqwest::Response, ClientMetadataError> {
         metadata_url
             .get(&self.http)
@@ -220,8 +266,10 @@ fn map_body_error(error: &OutboundUrlPolicyError) -> ClientMetadataError {
 /// Sanitized client metadata resolution failures.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 pub(super) enum ClientMetadataError {
-    #[error("OAuth client_id is not a valid public metadata URL")]
+    #[error("OAuth client_id is not a valid metadata document URL")]
     InvalidClientId,
+    #[error("OAuth client metadata resolver configuration is invalid")]
+    InvalidConfiguration,
     #[error("failed to build the OAuth client metadata HTTP client")]
     ClientBuild,
     #[error("OAuth client metadata fetch failed")]
@@ -256,6 +304,8 @@ mod tests {
 
     const CLIENT_ID: &str =
         "https://client.example.test/oauth/client.json?token=client-query-secret";
+    const PUBLIC_ISSUER: &str = "https://auth.example.test";
+    const LOOPBACK_ISSUER: &str = "http://localhost:9080";
 
     struct LocalFetcher {
         endpoint: String,
@@ -266,7 +316,7 @@ mod tests {
     impl MetadataFetcher for LocalFetcher {
         async fn fetch(
             &self,
-            _metadata_url: &EndpointUrl<PublicMetadata>,
+            _metadata_url: &EndpointUrl<ClientMetadata>,
         ) -> Result<reqwest::Response, ClientMetadataError> {
             self.http
                 .get(&self.endpoint)
@@ -282,7 +332,7 @@ mod tests {
     impl MetadataFetcher for PanicFetcher {
         async fn fetch(
             &self,
-            _metadata_url: &EndpointUrl<PublicMetadata>,
+            _metadata_url: &EndpointUrl<ClientMetadata>,
         ) -> Result<reqwest::Response, ClientMetadataError> {
             panic!("invalid client IDs must be rejected before fetching")
         }
@@ -293,7 +343,12 @@ mod tests {
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("test client");
-        HttpClientMetadataResolver::with_fetcher(Arc::new(LocalFetcher { endpoint, http }))
+        HttpClientMetadataResolver::with_fetcher(
+            PUBLIC_ISSUER,
+            &BTreeSet::new(),
+            Arc::new(LocalFetcher { endpoint, http }),
+        )
+        .expect("test resolver")
     }
 
     fn document() -> Value {
@@ -328,7 +383,12 @@ mod tests {
 
     #[tokio::test]
     async fn delegates_client_id_url_shape_to_public_metadata_policy() {
-        let resolver = HttpClientMetadataResolver::with_fetcher(Arc::new(PanicFetcher));
+        let resolver = HttpClientMetadataResolver::with_fetcher(
+            PUBLIC_ISSUER,
+            &BTreeSet::new(),
+            Arc::new(PanicFetcher),
+        )
+        .expect("resolver");
         for client_id in [
             "http://client.example.test/client.json",
             "https://localhost/client.json",
@@ -346,7 +406,12 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_client_ids_that_are_not_their_own_fetched_url() {
-        let resolver = HttpClientMetadataResolver::with_fetcher(Arc::new(PanicFetcher));
+        let resolver = HttpClientMetadataResolver::with_fetcher(
+            PUBLIC_ISSUER,
+            &BTreeSet::new(),
+            Arc::new(PanicFetcher),
+        )
+        .expect("resolver");
         for client_id in [
             // Each of these parses, and parsing rewrites it into a URL that
             // names a different — or differently spelled — document than the ID
@@ -366,6 +431,80 @@ mod tests {
                 ClientMetadataError::InvalidClientId
             );
         }
+    }
+
+    #[test]
+    fn derives_local_client_ids_from_every_root_loopback_resource() {
+        let resources = BTreeSet::from([
+            "http://localhost:3000".to_string(),
+            "http://127.42.0.1:4000".to_string(),
+            "http://localhost:5000/mcp".to_string(),
+            "https://reef.example.test".to_string(),
+        ]);
+
+        assert_eq!(
+            derive_allowed_loopback_client_ids(&resources).expect("validated resources"),
+            BTreeSet::from([
+                "http://localhost:3000/.well-known/oauth-client".to_string(),
+                "http://127.42.0.1:4000/.well-known/oauth-client".to_string(),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_exact_client_id_derived_from_a_local_resource() {
+        let server = MockServer::start().await;
+        let resource = server.uri();
+        let client_id = format!("{resource}/.well-known/oauth-client");
+        let mut metadata = document();
+        metadata["client_id"] = json!(client_id.clone());
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+            .mount(&server)
+            .await;
+
+        let resolver =
+            HttpClientMetadataResolver::new(LOOPBACK_ISSUER, &BTreeSet::from([resource]))
+                .expect("local resolver");
+        let registration = resolver.resolve(&client_id).await.expect("local CIMD");
+        assert_eq!(registration.redirect_uris.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rejects_unlisted_local_ids_and_mixed_topology_before_fetching() {
+        let resource = "http://localhost:3000".to_string();
+        let resources = BTreeSet::from([resource]);
+        let resolver = HttpClientMetadataResolver::with_fetcher(
+            LOOPBACK_ISSUER,
+            &resources,
+            Arc::new(PanicFetcher),
+        )
+        .expect("local resolver");
+
+        for client_id in [
+            "http://localhost:3001/.well-known/oauth-client",
+            "http://localhost:3000/other-client",
+            "http://127.0.0.1:3000/.well-known/oauth-client",
+        ] {
+            assert_eq!(
+                resolver.resolve(client_id).await.expect_err(client_id),
+                ClientMetadataError::InvalidClientId
+            );
+        }
+
+        let mixed = HttpClientMetadataResolver::with_fetcher(
+            PUBLIC_ISSUER,
+            &resources,
+            Arc::new(PanicFetcher),
+        )
+        .expect("mixed resolver");
+        assert_eq!(
+            mixed
+                .resolve("http://localhost:3000/.well-known/oauth-client")
+                .await
+                .expect_err("public issuer must reject local client ID"),
+            ClientMetadataError::InvalidClientId
+        );
     }
 
     #[tokio::test]
@@ -553,6 +692,7 @@ mod tests {
         let rendered = format!("{registration:?}");
         assert!(!rendered.contains("callback"));
         assert!(!rendered.contains("body-secret"));
-        HttpClientMetadataResolver::new().expect("hardened production client");
+        HttpClientMetadataResolver::new(PUBLIC_ISSUER, &BTreeSet::new())
+            .expect("hardened production client");
     }
 }

--- a/crates/coral-app/src/auth/authorization_server/response.rs
+++ b/crates/coral-app/src/auth/authorization_server/response.rs
@@ -129,6 +129,9 @@ pub(super) fn redirect(location: &str) -> Response {
 /// reaches every response that carries a code, a token, an error, or the
 /// approval page. The discovery metadata document is deliberately not among
 /// them: it is public and meant to be cached.
+///
+/// The approval page uses [`approval_page_security_headers`] instead, because
+/// `no-referrer` breaks the form it serves.
 pub(super) fn security_headers() -> [(header::HeaderName, &'static str); 4] {
     [
         (header::CACHE_CONTROL, "no-store"),
@@ -136,4 +139,24 @@ pub(super) fn security_headers() -> [(header::HeaderName, &'static str); 4] {
         (header::REFERRER_POLICY, "no-referrer"),
         (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
     ]
+}
+
+/// [`security_headers`] with the referrer policy the approval page needs.
+///
+/// The approval page is the one response whose own form posts back here, and
+/// that submission is checked against an exact `Origin`. Chromium derives a
+/// form submission's `Origin` from the document's referrer policy: under
+/// `no-referrer` it sends `Origin: null`, which no exact-origin check can
+/// accept, so every approval fails. `same-origin` restores a real `Origin` on
+/// the same-origin POST while still sending nothing cross-origin — so the
+/// redirect that carries the authorization code to the client still leaks no
+/// `Referer`, which is the property `no-referrer` was protecting here.
+pub(super) fn approval_page_security_headers() -> [(header::HeaderName, &'static str); 4] {
+    security_headers().map(|(name, value)| {
+        if name == header::REFERRER_POLICY {
+            (name, "same-origin")
+        } else {
+            (name, value)
+        }
+    })
 }

--- a/crates/coral-app/src/auth/authorization_server/token.rs
+++ b/crates/coral-app/src/auth/authorization_server/token.rs
@@ -367,6 +367,11 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
             })
             .expect("resolved auth settings");
         let store = Arc::new(InMemoryStateStore::new());
+        let authorization_resources = Arc::new(BTreeSet::from([RESOURCE.into()]));
+        let client_metadata_resolver = Arc::new(
+            HttpClientMetadataResolver::new(AUTH_ISSUER, &authorization_resources)
+                .expect("client metadata resolver"),
+        );
         let state = AuthorizationServerHttpState {
             settings: Arc::new(settings),
             session_tokens: session_tokens.clone(),
@@ -374,10 +379,8 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
             session_store: store.clone(),
             code_store: store.clone(),
             provider_client: OidcProviderClient::new().expect("client"),
-            authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
-            client_metadata_resolver: Arc::new(
-                HttpClientMetadataResolver::new().expect("client metadata resolver"),
-            ),
+            authorization_resources,
+            client_metadata_resolver,
         };
         (state, store, session_tokens)
     }

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -11,6 +11,9 @@
 //!   when the configured issuer already uses it.
 //! - [`PublicMetadata`] — supplied by an untrusted client and fetched. Public
 //!   HTTPS only, with a DNS resolver that rejects non-public answers.
+//! - [`ClientMetadata`] — a CIMD URL. Public HTTPS follows the same hardened
+//!   rule, while an exact operator-derived loopback URL is admitted only when
+//!   the configured authorization-server issuer also uses loopback HTTP.
 //! - [`ResourceIdentifier`] — an RFC 8707 `resource`, compared and recorded.
 //! - [`BrowserRedirect`] — an OAuth redirect target, handed to a browser.
 //!
@@ -34,6 +37,7 @@
     )
 )]
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -324,6 +328,62 @@ impl SelfContainedPolicy for PublicMetadata {
 
 impl FetchablePolicy for PublicMetadata {}
 
+/// An attacker-controlled OAuth client metadata URL with a contextual local exception.
+///
+/// Public HTTPS uses the same URL and DNS restrictions as [`PublicMetadata`].
+/// Plain HTTP is admitted only for an explicit-loopback client ID that exactly
+/// matches one derived from an operator-registered loopback resource, and only
+/// when the authorization-server issuer itself uses explicit-loopback HTTP.
+pub(crate) struct ClientMetadata;
+
+impl UrlPolicy for ClientMetadata {
+    const NAME: &'static str = "EndpointUrl<ClientMetadata>";
+
+    fn transport_error() -> OutboundUrlPolicyError {
+        OutboundUrlPolicyError::ClientMetadataTransport
+    }
+}
+
+impl FetchablePolicy for ClientMetadata {}
+
+impl EndpointUrl<ClientMetadata> {
+    /// Parses a CIMD client ID under the topology established by `issuer` and
+    /// the exact local IDs derived from operator-registered resources.
+    pub(crate) fn parse(
+        value: &str,
+        issuer: &EndpointUrl<Configured>,
+        allowed_loopback_client_ids: &BTreeSet<String>,
+    ) -> Result<Self, OutboundUrlPolicyError> {
+        PublicMetadata::check_raw(value)?;
+        let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
+        if url.path().is_empty() || url.path() == "/" {
+            return Err(OutboundUrlPolicyError::MetadataPathRequired);
+        }
+        check_shape(&url)?;
+
+        if url.scheme() == "https" {
+            if public_metadata_host_is_blocked(&url) {
+                return Err(OutboundUrlPolicyError::NonPublicHost);
+            }
+            return Ok(Self(url, PhantomData));
+        }
+
+        // Check canonical byte identity before allowlist membership. Otherwise
+        // a rewritten spelling could inherit permission from the one exact ID
+        // the operator's resource derives.
+        if url.scheme() == "http"
+            && issuer.as_url().scheme() == "http"
+            && is_explicit_loopback(&url)
+            && url.as_str() == value
+            && allowed_loopback_client_ids.contains(value)
+        {
+            return Ok(Self(url, PhantomData));
+        }
+
+        Err(ClientMetadata::transport_error())
+    }
+}
+
 /// A resource identifier Coral compares and records but never requests.
 ///
 /// # Trust
@@ -425,6 +485,11 @@ pub(crate) enum OutboundUrlPolicyError {
     /// Public metadata did not use HTTPS.
     #[error("public metadata URL must use HTTPS")]
     PublicMetadataTransport,
+    /// Client metadata used neither public HTTPS nor the contextual local exception.
+    #[error(
+        "OAuth client metadata URL must use public HTTPS or an authorized explicit-loopback HTTP endpoint"
+    )]
+    ClientMetadataTransport,
     /// A resource identifier did not use HTTPS or explicit loopback HTTP.
     #[error("resource identifier must use HTTPS or explicit loopback HTTP")]
     ResourceIdentifierTransport,
@@ -479,6 +544,22 @@ pub(crate) fn public_metadata_http_client() -> Result<reqwest::Client, OutboundU
         .connect_timeout(PUBLIC_METADATA_TIMEOUT)
         .timeout(PUBLIC_METADATA_TIMEOUT)
         .dns_resolver(PublicMetadataResolver)
+        .build()
+        .map_err(OutboundUrlPolicyError::ClientBuild)
+}
+
+/// Builds an HTTP client for CIMD URLs validated under [`ClientMetadata`].
+///
+/// The caller must still construct requests from an
+/// [`EndpointUrl<ClientMetadata>`]. Exact `localhost` DNS answers must all be
+/// loopback; every other hostname must resolve exclusively to public addresses.
+pub(crate) fn client_metadata_http_client() -> Result<reqwest::Client, OutboundUrlPolicyError> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .connect_timeout(PUBLIC_METADATA_TIMEOUT)
+        .timeout(PUBLIC_METADATA_TIMEOUT)
+        .dns_resolver(ClientMetadataDnsResolver)
         .build()
         .map_err(OutboundUrlPolicyError::ClientBuild)
 }
@@ -539,6 +620,51 @@ impl reqwest::dns::Resolve for PublicMetadataResolver {
             Ok(Box::new(addresses.into_iter()) as reqwest::dns::Addrs)
         })
     }
+}
+
+#[derive(Clone)]
+struct ClientMetadataDnsResolver;
+
+impl reqwest::dns::Resolve for ClientMetadataDnsResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let addresses = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|error| {
+                    std::io::Error::other(format!(
+                        "OAuth client metadata DNS lookup failed for {host}: {error}"
+                    ))
+                })?
+                .collect::<Vec<_>>();
+            validate_client_metadata_resolution(&host, &addresses)?;
+            Ok(Box::new(addresses.into_iter()) as reqwest::dns::Addrs)
+        })
+    }
+}
+
+fn validate_client_metadata_resolution(
+    host: &str,
+    addresses: &[SocketAddr],
+) -> std::io::Result<()> {
+    if host.trim_end_matches('.').eq_ignore_ascii_case("localhost") {
+        if addresses.is_empty() {
+            return Err(std::io::Error::other(
+                "OAuth client metadata DNS lookup returned no localhost records",
+            ));
+        }
+        if let Some(address) = addresses
+            .iter()
+            .find(|address| !is_loopback_ip(address.ip()))
+        {
+            return Err(std::io::Error::other(format!(
+                "OAuth client metadata DNS lookup resolved localhost to disallowed address {address}"
+            )));
+        }
+        return Ok(());
+    }
+
+    validate_public_resolution(host, addresses)
 }
 
 fn validate_public_resolution(host: &str, addresses: &[SocketAddr]) -> std::io::Result<()> {
@@ -729,15 +855,17 @@ fn append_bounded_chunk(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::net::SocketAddr;
 
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        BrowserRedirect, Configured, Discovered, EndpointUrl, OutboundUrlPolicyError,
-        PublicMetadata, ResourceIdentifier, append_bounded_chunk, public_metadata_http_client,
-        public_metadata_ip_is_blocked, read_bounded_body, validate_public_resolution,
+        BrowserRedirect, ClientMetadata, Configured, Discovered, EndpointUrl,
+        OutboundUrlPolicyError, PublicMetadata, ResourceIdentifier, append_bounded_chunk,
+        client_metadata_http_client, public_metadata_http_client, public_metadata_ip_is_blocked,
+        read_bounded_body, validate_client_metadata_resolution, validate_public_resolution,
     };
 
     #[test]
@@ -994,6 +1122,74 @@ mod tests {
     }
 
     #[test]
+    fn client_metadata_allows_public_https_and_exact_contextual_loopback_ids() {
+        let public_issuer =
+            EndpointUrl::<Configured>::parse("https://auth.example.test").expect("issuer");
+        let loopback_issuer =
+            EndpointUrl::<Configured>::parse("http://localhost:9080").expect("issuer");
+        let loopback_ids = BTreeSet::from([
+            "http://localhost:3000/.well-known/oauth-client".to_string(),
+            "http://127.42.0.1:3000/.well-known/oauth-client".to_string(),
+            "http://[::1]:3000/.well-known/oauth-client".to_string(),
+            "http://[::ffff:7f00:1]:3000/.well-known/oauth-client".to_string(),
+        ]);
+
+        for issuer in [&public_issuer, &loopback_issuer] {
+            EndpointUrl::<ClientMetadata>::parse(
+                "https://client.example.test/.well-known/oauth-client",
+                issuer,
+                &loopback_ids,
+            )
+            .expect("public HTTPS remains valid");
+        }
+
+        for client_id in &loopback_ids {
+            EndpointUrl::<ClientMetadata>::parse(client_id, &loopback_issuer, &loopback_ids)
+                .expect(client_id);
+        }
+    }
+
+    #[test]
+    fn client_metadata_rejects_unlisted_or_unsafe_local_urls_before_fetching() {
+        let loopback_issuer =
+            EndpointUrl::<Configured>::parse("http://localhost:9080").expect("issuer");
+        let allowed =
+            BTreeSet::from(["http://localhost:3000/.well-known/oauth-client".to_string()]);
+
+        for client_id in [
+            "http://localhost:3001/.well-known/oauth-client",
+            "http://localhost:3000/other-client",
+            "http://127.0.0.1:3000/.well-known/oauth-client",
+            "http://api.localhost:3000/.well-known/oauth-client",
+            "http://10.0.0.1:3000/.well-known/oauth-client",
+            "http://169.254.169.254/.well-known/oauth-client",
+            "http://user@localhost:3000/.well-known/oauth-client",
+            "http://localhost:3000",
+            "http://localhost:3000/.well-known/oauth-client#fragment",
+            "http://localhost:3000/a/../.well-known/oauth-client",
+            "http://localhost:3000/a/%2e%2e%2f.well-known/oauth-client",
+            "http://LOCALHOST:3000/.well-known/oauth-client",
+            "http://[::ffff:127.0.0.1]:3000/.well-known/oauth-client",
+        ] {
+            EndpointUrl::<ClientMetadata>::parse(client_id, &loopback_issuer, &allowed)
+                .expect_err(client_id);
+        }
+    }
+
+    #[test]
+    fn client_metadata_rejects_loopback_http_for_a_public_issuer() {
+        let public_issuer =
+            EndpointUrl::<Configured>::parse("https://auth.example.test").expect("issuer");
+        let client_id = "http://localhost:3000/.well-known/oauth-client";
+        let allowed = BTreeSet::from([client_id.to_string()]);
+
+        assert!(matches!(
+            EndpointUrl::<ClientMetadata>::parse(client_id, &public_issuer, &allowed),
+            Err(OutboundUrlPolicyError::ClientMetadataTransport)
+        ));
+    }
+
+    #[test]
     fn public_metadata_rejects_localhost_and_non_public_ipv4() {
         for host in [
             "localhost",
@@ -1092,6 +1288,29 @@ mod tests {
     }
 
     #[test]
+    fn client_metadata_dns_requires_loopback_localhost_and_public_other_hosts() {
+        let ipv4_loopback: SocketAddr = "127.42.0.1:0".parse().expect("IPv4 loopback");
+        let ipv6_loopback: SocketAddr = "[::1]:0".parse().expect("IPv6 loopback");
+        let mapped_loopback: SocketAddr = "[::ffff:127.0.0.1]:0".parse().expect("mapped loopback");
+        let public: SocketAddr = "93.184.216.34:0".parse().expect("public");
+        let private: SocketAddr = "10.0.0.1:0".parse().expect("private");
+
+        validate_client_metadata_resolution(
+            "localhost",
+            &[ipv4_loopback, ipv6_loopback, mapped_loopback],
+        )
+        .expect("all localhost answers are loopback");
+        validate_client_metadata_resolution("localhost.", &[public])
+            .expect_err("localhost must not resolve publicly");
+        validate_client_metadata_resolution("public.test", &[public])
+            .expect("other hosts may resolve publicly");
+        validate_client_metadata_resolution("public.test", &[public, private])
+            .expect_err("mixed public/private answers are rejected");
+        validate_client_metadata_resolution("public.test", &[ipv4_loopback])
+            .expect_err("other hosts must not resolve to loopback");
+    }
+
+    #[test]
     fn ip_classifier_keeps_public_addresses_public() {
         assert!(!public_metadata_ip_is_blocked(
             "93.184.216.34".parse().expect("IPv4")
@@ -1147,6 +1366,7 @@ mod tests {
     #[test]
     fn hardened_public_client_builds() {
         public_metadata_http_client().expect("public metadata client");
+        client_metadata_http_client().expect("client metadata client");
     }
 
     /// Refusing redirects is the hardening that matters most for SSRF: without
@@ -1155,7 +1375,7 @@ mod tests {
     /// not pin that, so drive a real 302. The mock listens on a literal IP,
     /// which hyper resolves without consulting the custom resolver.
     #[tokio::test]
-    async fn hardened_public_client_does_not_follow_redirects() {
+    async fn hardened_metadata_clients_do_not_follow_redirects() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/metadata"))
@@ -1165,21 +1385,25 @@ mod tests {
             .mount(&server)
             .await;
 
-        let response = public_metadata_http_client()
-            .expect("public metadata client")
-            .get(format!("{}/metadata", server.uri()))
-            .send()
-            .await
-            .expect("response");
+        for client in [
+            public_metadata_http_client().expect("public metadata client"),
+            client_metadata_http_client().expect("client metadata client"),
+        ] {
+            let response = client
+                .get(format!("{}/metadata", server.uri()))
+                .send()
+                .await
+                .expect("response");
 
-        assert_eq!(response.status().as_u16(), 302);
-        assert_eq!(
-            response
-                .headers()
-                .get("location")
-                .and_then(|location| location.to_str().ok()),
-            Some("http://169.254.169.254/")
-        );
+            assert_eq!(response.status().as_u16(), 302);
+            assert_eq!(
+                response
+                    .headers()
+                    .get("location")
+                    .and_then(|location| location.to_str().ok()),
+                Some("http://169.254.169.254/")
+            );
+        }
     }
 
     /// A server that omits `Content-Length` skips the declared-size early

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -515,7 +515,7 @@ pub(crate) enum OutboundUrlPolicyError {
     #[error("public metadata URL host must be public")]
     NonPublicHost,
     /// The hardened HTTP client could not be constructed.
-    #[error("failed to build public metadata HTTP client: {0}")]
+    #[error("failed to build metadata HTTP client: {0}")]
     ClientBuild(reqwest::Error),
     /// A response body could not be read.
     ///


### PR DESCRIPTION
> Coral server prerequisite stack: layer 2 of 2. Base: PR #2070.

## Intent

Permit Coral's authorization server to resolve CIMD over plain HTTP only for an explicit all-loopback topology. Derive the allowed loopback client IDs from configured loopback audiences and retain strict outbound URL checks everywhere else.

## What it enables

Developers can exercise the complete Reef-to-Coral OAuth and native-gRPC flow locally without a public HTTPS tunnel. Hosted, mixed-locality, hostname-alias, redirecting, oversized, and malformed metadata requests remain rejected.

## Usage examples

```toml
[server]
bind_addr = "127.0.0.1:14555"

[auth]
http_bind_addr = "127.0.0.1:9080"
allowed_audiences = ["http://localhost:5173"]
```

Reef then publishes CIMD at `http://localhost:5173/.well-known/oauth-client`, and Coral accepts that exact derived client ID only when its own authorization issuer is also explicit-loopback HTTP.