### PR TITLE
feat(reef): add device code copy action

### DIFF
--- a/apps/reef/app/components/sources/install/oauth-progress-dialog.css.ts
+++ b/apps/reef/app/components/sources/install/oauth-progress-dialog.css.ts
@@ -3,6 +3,7 @@ import { style } from '@vanilla-extract/css'
 import { theme } from '@/wax/theme/theme.css'
 
 export const code = style({
+  gridColumn: 2,
   letterSpacing: '0.08em',
   lineHeight: '32px',
 })
@@ -16,6 +17,13 @@ export const codePanel = style({
   flexDirection: 'column',
   gap: 4,
   padding: 16,
+})
+
+export const codeRow = style({
+  alignItems: 'center',
+  display: 'grid',
+  gridTemplateColumns: '1fr auto 1fr',
+  gap: 12,
 })
 
 export const error = style({

--- a/apps/reef/app/components/sources/install/oauth-progress-dialog.tsx
+++ b/apps/reef/app/components/sources/install/oauth-progress-dialog.tsx
@@ -48,15 +48,21 @@ export function OAuthProgressDialog({
           {awaitingOAuth?.userCode ? (
             <div className={styles.codePanel}>
               <Typography.BodySmall variant="tertiary">Enter this code</Typography.BodySmall>
-              <Typography.CodeLarge
-                as="code"
-                className={styles.code}
-                size={24}
-                variant="primary"
-                weight={700}
-              >
-                {awaitingOAuth.userCode}
-              </Typography.CodeLarge>
+              <div className={styles.codeRow}>
+                <Typography.CodeLarge
+                  as="code"
+                  className={styles.code}
+                  size={24}
+                  variant="primary"
+                  weight={700}
+                >
+                  {awaitingOAuth.userCode}
+                </Typography.CodeLarge>
+                <Button.CopyButton
+                  ariaLabel="Copy device code to clipboard"
+                  textToCopy={awaitingOAuth.userCode}
+                ></Button.CopyButton>
+              </div>
             </div>
           ) : null}
           <Dialog.Actions>


### PR DESCRIPTION
Add a compact clipboard action beside OAuth device codes so users can transfer them without retyping.

| after | before |
| --- | --- |
| ![CleanShot 2026-08-12 at 08.24.59@2x.png](https://app.graphite.com/user-attachments/assets/8c853fdc-b789-43b9-ac85-3f01ba523a43.png)<br> | ![CleanShot 2026-08-05 at 17.22.38@2x.png](https://app.graphite.com/user-attachments/assets/7b4c48d0-c435-415e-bfdf-055890495c33.png) |

Constraint: Keep the dialog compact by using the existing icon-only CopyButton pattern.

Rejected: Text label on the copy action | It made the code panel unnecessarily bulky.

Confidence: high

Scope-risk: narrow

Directive: Preserve the accessible aria label when keeping this action icon-only.

Tested: Targeted oxfmt, oxlint, typecheck, and Playwright Storybook verification.

Not-tested: Full Reef test and build suites.