### PR TITLE
fix(reef): show database catalogs in schema explorer

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -366,6 +366,9 @@ describe('Architectural Tests', () => {
       // Schema is a layout with nested table-detail routes.
       expect(routeConfig).toContain("route(routePattern('workspaceSchema'), 'routes/schema.tsx', [")
       expect(routeConfig).toContain("index('routes/schema-empty.tsx')")
+      expect(routeConfig).toMatch(
+        /route\(\s*'catalogs\/:catalogName\/:schemaName\/:tableName',\s*'routes\/schema-catalog-table\.tsx'\s*\)/,
+      )
       expect(routeConfig).toContain("route(':schemaName/:tableName', 'routes/schema-table.tsx')")
       expect(routeConfig).toContain(
         "route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx')",

--- a/apps/reef/app/lib/schema-explorer.test.ts
+++ b/apps/reef/app/lib/schema-explorer.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { CatalogItemKind } from '@/generated/coral/v1/catalog_pb'
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 
-import { fetchSchemaFromCoral } from './schema-explorer'
+import { fetchSchemaFromCoral, fetchTableColumnsFromCoral } from './schema-explorer'
 import type { CatalogClient } from './schema-explorer'
 
 describe('fetchSchemaFromCoral', () => {
@@ -54,8 +54,9 @@ describe('fetchSchemaFromCoral', () => {
     await expect(
       fetchSchemaFromCoral({ listCatalog } as unknown as CatalogClient, workspace),
     ).resolves.toEqual({
-      connectors: [
+      namespaces: [
         {
+          kind: 'schema',
           items: [
             {
               arguments: [
@@ -95,5 +96,117 @@ describe('fetchSchemaFromCoral', () => {
       kind: CatalogItemKind.UNSPECIFIED,
       workspace,
     })
+  })
+
+  it('preserves database catalogs as catalog and schema namespaces', async () => {
+    const listCatalog = vi.fn().mockResolvedValue({
+      items: [
+        {
+          item: {
+            case: 'table',
+            value: {
+              catalogName: 'pickl_v4',
+              description: '',
+              name: 'products',
+              requiredFilters: [],
+              schemaName: 'public',
+            },
+          },
+        },
+        {
+          item: {
+            case: 'table',
+            value: {
+              catalogName: 'pickl_v4',
+              description: '',
+              name: 'sales',
+              requiredFilters: [],
+              schemaName: 'public',
+            },
+          },
+        },
+        {
+          item: {
+            case: 'table',
+            value: {
+              catalogName: 'pickl_v4',
+              description: '',
+              name: 'revenue_by_product',
+              requiredFilters: [],
+              schemaName: 'analytics',
+            },
+          },
+        },
+        {
+          item: {
+            case: 'table',
+            value: {
+              catalogName: 'warehouse',
+              description: '',
+              name: 'products',
+              requiredFilters: [],
+              schemaName: 'public',
+            },
+          },
+        },
+      ],
+    })
+    const workspace = create(WorkspaceSchema, { name: 'analytics' })
+
+    await expect(
+      fetchSchemaFromCoral({ listCatalog } as unknown as CatalogClient, workspace),
+    ).resolves.toEqual({
+      namespaces: [
+        {
+          kind: 'catalog',
+          name: 'pickl_v4',
+          schemas: [
+            {
+              items: [
+                expect.objectContaining({ kind: 'table', name: 'products' }),
+                expect.objectContaining({ kind: 'table', name: 'sales' }),
+              ],
+              name: 'public',
+            },
+            {
+              items: [expect.objectContaining({ kind: 'table', name: 'revenue_by_product' })],
+              name: 'analytics',
+            },
+          ],
+        },
+        {
+          kind: 'catalog',
+          name: 'warehouse',
+          schemas: [
+            {
+              items: [expect.objectContaining({ kind: 'table', name: 'products' })],
+              name: 'public',
+            },
+          ],
+        },
+      ],
+    })
+  })
+})
+
+describe('fetchTableColumnsFromCoral', () => {
+  it('passes the complete database table identity to ListColumns', async () => {
+    const listColumns = vi.fn().mockResolvedValue({ columns: [] })
+    const workspace = create(WorkspaceSchema, { name: 'analytics' })
+
+    await fetchTableColumnsFromCoral({ listColumns } as unknown as CatalogClient, workspace, {
+      catalogName: 'pickl_v4',
+      schemaName: 'public',
+      tableName: 'products',
+    })
+
+    expect(listColumns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        catalogName: 'pickl_v4',
+        schemaName: 'public',
+        tableName: 'products',
+      }),
+      expect.anything(),
+    )
   })
 })

--- a/apps/reef/app/lib/schema-explorer.test.ts
+++ b/apps/reef/app/lib/schema-explorer.test.ts
@@ -54,9 +54,9 @@ describe('fetchSchemaFromCoral', () => {
     await expect(
       fetchSchemaFromCoral({ listCatalog } as unknown as CatalogClient, workspace),
     ).resolves.toEqual({
-      namespaces: [
+      catalogs: [],
+      schemas: [
         {
-          kind: 'schema',
           items: [
             {
               arguments: [
@@ -98,14 +98,14 @@ describe('fetchSchemaFromCoral', () => {
     })
   })
 
-  it('preserves database catalogs as catalog and schema namespaces', async () => {
+  it('groups database tables into catalogs and provider schemas', async () => {
     const listCatalog = vi.fn().mockResolvedValue({
       items: [
         {
           item: {
             case: 'table',
             value: {
-              catalogName: 'pickl_v4',
+              catalogName: 'commerce',
               description: '',
               name: 'products',
               requiredFilters: [],
@@ -117,7 +117,7 @@ describe('fetchSchemaFromCoral', () => {
           item: {
             case: 'table',
             value: {
-              catalogName: 'pickl_v4',
+              catalogName: 'commerce',
               description: '',
               name: 'sales',
               requiredFilters: [],
@@ -129,7 +129,7 @@ describe('fetchSchemaFromCoral', () => {
           item: {
             case: 'table',
             value: {
-              catalogName: 'pickl_v4',
+              catalogName: 'commerce',
               description: '',
               name: 'revenue_by_product',
               requiredFilters: [],
@@ -156,10 +156,9 @@ describe('fetchSchemaFromCoral', () => {
     await expect(
       fetchSchemaFromCoral({ listCatalog } as unknown as CatalogClient, workspace),
     ).resolves.toEqual({
-      namespaces: [
+      catalogs: [
         {
-          kind: 'catalog',
-          name: 'pickl_v4',
+          name: 'commerce',
           schemas: [
             {
               items: [
@@ -175,7 +174,6 @@ describe('fetchSchemaFromCoral', () => {
           ],
         },
         {
-          kind: 'catalog',
           name: 'warehouse',
           schemas: [
             {
@@ -185,6 +183,7 @@ describe('fetchSchemaFromCoral', () => {
           ],
         },
       ],
+      schemas: [],
     })
   })
 })
@@ -195,14 +194,14 @@ describe('fetchTableColumnsFromCoral', () => {
     const workspace = create(WorkspaceSchema, { name: 'analytics' })
 
     await fetchTableColumnsFromCoral({ listColumns } as unknown as CatalogClient, workspace, {
-      catalogName: 'pickl_v4',
+      catalogName: 'commerce',
       schemaName: 'public',
       tableName: 'products',
     })
 
     expect(listColumns).toHaveBeenCalledWith(
       expect.objectContaining({
-        catalogName: 'pickl_v4',
+        catalogName: 'commerce',
         schemaName: 'public',
         tableName: 'products',
       }),

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -60,8 +60,26 @@ export interface SchemaGroup {
   name: string
 }
 
+export interface SchemaNamespace extends SchemaGroup {
+  kind: 'schema'
+}
+
+export interface CatalogNamespace {
+  kind: 'catalog'
+  name: string
+  schemas: SchemaGroup[]
+}
+
+export type SchemaExplorerNamespace = CatalogNamespace | SchemaNamespace
+
 export interface SchemaResponse {
-  connectors: SchemaGroup[]
+  namespaces: SchemaExplorerNamespace[]
+}
+
+export interface TableReference {
+  catalogName: string
+  schemaName: string
+  tableName: string
 }
 
 const COLUMN_PAGE_LIMIT = 200
@@ -73,16 +91,49 @@ export async function fetchSchemaFromCoral(
   signal?: AbortSignal,
 ): Promise<SchemaResponse> {
   const catalogItems = await listCatalogItems(catalogClient, workspace, signal)
-  if (catalogItems.length === 0) return { connectors: [] }
+  if (catalogItems.length === 0) return { namespaces: [] }
 
-  const schemaMap = new Map<string, SchemaItemDef[]>()
+  const namespaces: SchemaExplorerNamespace[] = []
+  const schemaNamespaces = new Map<string, SchemaNamespace>()
+  const catalogNamespaces = new Map<
+    string,
+    { namespace: CatalogNamespace; schemas: Map<string, SchemaGroup> }
+  >()
+
+  const schemaItems = (catalogName: string, schemaName: string): SchemaItemDef[] => {
+    if (!catalogName) {
+      let schema = schemaNamespaces.get(schemaName)
+      if (!schema) {
+        schema = { items: [], kind: 'schema', name: schemaName }
+        schemaNamespaces.set(schemaName, schema)
+        namespaces.push(schema)
+      }
+      return schema.items
+    }
+
+    let catalog = catalogNamespaces.get(catalogName)
+    if (!catalog) {
+      const namespace: CatalogNamespace = { kind: 'catalog', name: catalogName, schemas: [] }
+      catalog = { namespace, schemas: new Map() }
+      catalogNamespaces.set(catalogName, catalog)
+      namespaces.push(namespace)
+    }
+
+    let schema = catalog.schemas.get(schemaName)
+    if (!schema) {
+      schema = { items: [], name: schemaName }
+      catalog.schemas.set(schemaName, schema)
+      catalog.namespace.schemas.push(schema)
+    }
+    return schema.items
+  }
+
   for (const item of catalogItems) {
     if (item.item.case === 'table') {
       const table = item.item.value
       if (!table.schemaName || !table.name) continue
 
-      const schemaItems = schemaMap.get(table.schemaName) ?? []
-      schemaItems.push({
+      schemaItems(table.catalogName, table.schemaName).push({
         columns: [],
         columnsLoaded: false,
         description: optional(table.description),
@@ -90,7 +141,6 @@ export async function fetchSchemaFromCoral(
         name: table.name,
         requiredFilters: table.requiredFilters,
       })
-      schemaMap.set(table.schemaName, schemaItems)
       continue
     }
 
@@ -98,8 +148,7 @@ export async function fetchSchemaFromCoral(
       const tableFunction = item.item.value
       if (!tableFunction.schemaName || !tableFunction.name) continue
 
-      const schemaItems = schemaMap.get(tableFunction.schemaName) ?? []
-      schemaItems.push({
+      schemaItems('', tableFunction.schemaName).push({
         arguments: tableFunction.arguments.map((argument) => ({
           name: argument.name,
           required: argument.required,
@@ -115,13 +164,10 @@ export async function fetchSchemaFromCoral(
           type: column.dataType || 'unknown',
         })),
       })
-      schemaMap.set(tableFunction.schemaName, schemaItems)
     }
   }
 
-  return {
-    connectors: [...schemaMap.entries()].map(([name, items]) => ({ items, name })),
-  }
+  return { namespaces }
 }
 
 async function listCatalogItems(
@@ -143,18 +189,10 @@ async function listCatalogItems(
 export async function fetchTableColumnsFromCoral(
   catalogClient: CatalogClient,
   workspace: Workspace,
-  schemaName: string,
-  tableName: string,
+  table: TableReference,
   signal?: AbortSignal,
 ): Promise<ColumnDef[]> {
-  const firstPage = await listColumnsPage(
-    catalogClient,
-    workspace,
-    schemaName,
-    tableName,
-    0,
-    signal,
-  )
+  const firstPage = await listColumnsPage(catalogClient, workspace, table, 0, signal)
   const columns = columnsFromResponse(firstPage)
   const pagination = firstPage.pagination
   if (!pagination?.hasMore) return columns
@@ -164,21 +202,14 @@ export async function fetchTableColumnsFromCoral(
     const remainingPages = await mapWithConcurrency(
       pageOffsets(nextOffset, pagination.totalCount, COLUMN_PAGE_LIMIT),
       COLUMN_PAGE_CONCURRENCY,
-      (offset) => listColumnsPage(catalogClient, workspace, schemaName, tableName, offset, signal),
+      (offset) => listColumnsPage(catalogClient, workspace, table, offset, signal),
     )
     return columns.concat(remainingPages.flatMap(columnsFromResponse))
   }
 
   let offset = pagination.nextOffset
   while (offset > 0) {
-    const page = await listColumnsPage(
-      catalogClient,
-      workspace,
-      schemaName,
-      tableName,
-      offset,
-      signal,
-    )
+    const page = await listColumnsPage(catalogClient, workspace, table, offset, signal)
     columns.push(...columnsFromResponse(page))
     if (!page.pagination?.hasMore) break
     offset = page.pagination.nextOffset
@@ -189,19 +220,19 @@ export async function fetchTableColumnsFromCoral(
 async function listColumnsPage(
   catalogClient: CatalogClient,
   workspace: Workspace,
-  schemaName: string,
-  tableName: string,
+  table: TableReference,
   offset: number,
   signal?: AbortSignal,
 ): Promise<ListColumnsResponse> {
   return catalogClient.listColumns(
     create(ListColumnsRequestSchema, {
+      catalogName: table.catalogName,
       pagination: {
         limit: COLUMN_PAGE_LIMIT,
         offset,
       },
-      schemaName,
-      tableName,
+      schemaName: table.schemaName,
+      tableName: table.tableName,
       workspace,
     }),
     { signal },

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -60,20 +60,14 @@ export interface SchemaGroup {
   name: string
 }
 
-export interface SchemaNamespace extends SchemaGroup {
-  kind: 'schema'
-}
-
-export interface CatalogNamespace {
-  kind: 'catalog'
+export interface CatalogGroup {
   name: string
   schemas: SchemaGroup[]
 }
 
-export type SchemaExplorerNamespace = CatalogNamespace | SchemaNamespace
-
 export interface SchemaResponse {
-  namespaces: SchemaExplorerNamespace[]
+  catalogs: CatalogGroup[]
+  schemas: SchemaGroup[]
 }
 
 export interface TableReference {
@@ -91,39 +85,40 @@ export async function fetchSchemaFromCoral(
   signal?: AbortSignal,
 ): Promise<SchemaResponse> {
   const catalogItems = await listCatalogItems(catalogClient, workspace, signal)
-  if (catalogItems.length === 0) return { namespaces: [] }
+  if (catalogItems.length === 0) return { catalogs: [], schemas: [] }
 
-  const namespaces: SchemaExplorerNamespace[] = []
-  const schemaNamespaces = new Map<string, SchemaNamespace>()
-  const catalogNamespaces = new Map<
+  const catalogs: CatalogGroup[] = []
+  const schemas: SchemaGroup[] = []
+  const schemaGroups = new Map<string, SchemaGroup>()
+  const catalogGroups = new Map<
     string,
-    { namespace: CatalogNamespace; schemas: Map<string, SchemaGroup> }
+    { catalog: CatalogGroup; schemas: Map<string, SchemaGroup> }
   >()
 
   const schemaItems = (catalogName: string, schemaName: string): SchemaItemDef[] => {
     if (!catalogName) {
-      let schema = schemaNamespaces.get(schemaName)
+      let schema = schemaGroups.get(schemaName)
       if (!schema) {
-        schema = { items: [], kind: 'schema', name: schemaName }
-        schemaNamespaces.set(schemaName, schema)
-        namespaces.push(schema)
+        schema = { items: [], name: schemaName }
+        schemaGroups.set(schemaName, schema)
+        schemas.push(schema)
       }
       return schema.items
     }
 
-    let catalog = catalogNamespaces.get(catalogName)
+    let catalog = catalogGroups.get(catalogName)
     if (!catalog) {
-      const namespace: CatalogNamespace = { kind: 'catalog', name: catalogName, schemas: [] }
-      catalog = { namespace, schemas: new Map() }
-      catalogNamespaces.set(catalogName, catalog)
-      namespaces.push(namespace)
+      const catalogGroup: CatalogGroup = { name: catalogName, schemas: [] }
+      catalog = { catalog: catalogGroup, schemas: new Map() }
+      catalogGroups.set(catalogName, catalog)
+      catalogs.push(catalogGroup)
     }
 
     let schema = catalog.schemas.get(schemaName)
     if (!schema) {
       schema = { items: [], name: schemaName }
       catalog.schemas.set(schemaName, schema)
-      catalog.namespace.schemas.push(schema)
+      catalog.catalog.schemas.push(schema)
     }
     return schema.items
   }
@@ -167,7 +162,7 @@ export async function fetchSchemaFromCoral(
     }
   }
 
-  return { namespaces }
+  return { catalogs, schemas }
 }
 
 async function listCatalogItems(

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -20,6 +20,7 @@ export default [
     route(routePattern('workspaceFunctions'), 'routes/functions.tsx'),
     route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
       index('routes/schema-empty.tsx'),
+      route('catalogs/:catalogName/:schemaName/:tableName', 'routes/schema-catalog-table.tsx'),
       route(':schemaName/:tableName', 'routes/schema-table.tsx'),
       route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx'),
     ]),

--- a/apps/reef/app/routes/schema-catalog-table.tsx
+++ b/apps/reef/app/routes/schema-catalog-table.tsx
@@ -3,15 +3,8 @@ import { catalogClientForRequest } from '@/lib/coral-request.server'
 import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaTableError, SchemaTableView } from '@/views/schema-explorer/schema-table'
 
-import type { Route } from './+types/schema-table'
+import type { Route } from './+types/schema-catalog-table'
 
-// Columns are this panel's critical data: await them so the global navigation
-// progress bar is the pending UI (deferring them doesn't work here — table
-// switches re-suspend an already-revealed Suspense boundary inside the router
-// transition, so React keeps the old columns instead of showing a fallback).
-// The abort signal matters: large tables fan out concurrent paginated
-// ListColumns calls, so switching tables quickly would otherwise pile up
-// orphaned requests.
 export async function loader({ params, request }: Route.LoaderArgs) {
   const workspace = workspaceFromParams(params)
   return {
@@ -19,7 +12,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
       catalogClientForRequest(request),
       workspace,
       {
-        catalogName: '',
+        catalogName: params.catalogName,
         schemaName: params.schemaName,
         tableName: params.tableName,
       },
@@ -28,7 +21,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   }
 }
 
-export default function SchemaTableRoute({ loaderData }: Route.ComponentProps) {
+export default function SchemaCatalogTableRoute({ loaderData }: Route.ComponentProps) {
   return <SchemaTableView columns={loaderData.columns} />
 }
 

--- a/apps/reef/app/routes/schema-loaders.server.test.ts
+++ b/apps/reef/app/routes/schema-loaders.server.test.ts
@@ -25,7 +25,7 @@ describe('schema loaders', () => {
 
   it('lists catalog tables for the workspace route parameter', async () => {
     const request = new Request('http://reef.test/workspaces/analytics/schema')
-    const schema = { namespaces: [] }
+    const schema = { catalogs: [], schemas: [] }
     fetchSchemaFromCoral.mockResolvedValue(schema)
 
     await expect(
@@ -68,14 +68,14 @@ describe('schema loaders', () => {
 
   it('lists database table columns with the complete catalog identity', async () => {
     const request = new Request(
-      'http://reef.test/workspaces/analytics/schema/catalogs/pickl_v4/public/products',
+      'http://reef.test/workspaces/analytics/schema/catalogs/commerce/public/products',
     )
     fetchTableColumnsFromCoral.mockResolvedValue([])
 
     await expect(
       schemaCatalogTableLoader({
         params: {
-          catalogName: 'pickl_v4',
+          catalogName: 'commerce',
           schemaName: 'public',
           tableName: 'products',
           workspaceId: 'analytics',
@@ -87,7 +87,7 @@ describe('schema loaders', () => {
       catalogClient,
       expect.objectContaining({ name: 'analytics' }),
       {
-        catalogName: 'pickl_v4',
+        catalogName: 'commerce',
         schemaName: 'public',
         tableName: 'products',
       },

--- a/apps/reef/app/routes/schema-loaders.server.test.ts
+++ b/apps/reef/app/routes/schema-loaders.server.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/coral-request.server', () => ({ catalogClientForRequest }))
 vi.mock('@/lib/schema-explorer', () => ({ fetchSchemaFromCoral, fetchTableColumnsFromCoral }))
 
 import { loader as schemaLoader } from './schema'
+import { loader as schemaCatalogTableLoader } from './schema-catalog-table'
 import { loader as schemaTableLoader } from './schema-table'
 
 describe('schema loaders', () => {
@@ -24,7 +25,7 @@ describe('schema loaders', () => {
 
   it('lists catalog tables for the workspace route parameter', async () => {
     const request = new Request('http://reef.test/workspaces/analytics/schema')
-    const schema = { connectors: [] }
+    const schema = { namespaces: [] }
     fetchSchemaFromCoral.mockResolvedValue(schema)
 
     await expect(
@@ -56,8 +57,40 @@ describe('schema loaders', () => {
     expect(fetchTableColumnsFromCoral).toHaveBeenCalledWith(
       catalogClient,
       expect.objectContaining({ name: 'analytics' }),
-      'github',
-      'issues',
+      {
+        catalogName: '',
+        schemaName: 'github',
+        tableName: 'issues',
+      },
+      request.signal,
+    )
+  })
+
+  it('lists database table columns with the complete catalog identity', async () => {
+    const request = new Request(
+      'http://reef.test/workspaces/analytics/schema/catalogs/pickl_v4/public/products',
+    )
+    fetchTableColumnsFromCoral.mockResolvedValue([])
+
+    await expect(
+      schemaCatalogTableLoader({
+        params: {
+          catalogName: 'pickl_v4',
+          schemaName: 'public',
+          tableName: 'products',
+          workspaceId: 'analytics',
+        },
+        request,
+      } as Parameters<typeof schemaCatalogTableLoader>[0]),
+    ).resolves.toEqual({ columns: [] })
+    expect(fetchTableColumnsFromCoral).toHaveBeenCalledWith(
+      catalogClient,
+      expect.objectContaining({ name: 'analytics' }),
+      {
+        catalogName: 'pickl_v4',
+        schemaName: 'public',
+        tableName: 'products',
+      },
       request.signal,
     )
   })

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -10,6 +10,8 @@ const CANONICAL_PATTERNS = {
   workspaces: '/workspaces',
   workspaceFunctions: '/workspaces/:workspaceId/functions',
   workspaceSchema: '/workspaces/:workspaceId/schema',
+  workspaceSchemaCatalogTable:
+    '/workspaces/:workspaceId/schema/catalogs/:catalogName/:schemaName/:tableName',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
   workspaceSchemaTableFunction:
     '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName',
@@ -43,6 +45,12 @@ describe('route map', () => {
       workspaces: routePath('workspaces'),
       workspaceFunctions: routePath('workspaceFunctions', { workspaceId: 'analytics' }),
       workspaceSchema: routePath('workspaceSchema', { workspaceId: 'analytics' }),
+      workspaceSchemaCatalogTable: routePath('workspaceSchemaCatalogTable', {
+        catalogName: 'pickl?',
+        schemaName: 'public schema',
+        tableName: 'orders/2026',
+        workspaceId: 'team alpha',
+      }),
       workspaceSchemaTable: routePath('workspaceSchemaTable', {
         schemaName: 'github',
         tableName: 'issues',
@@ -76,6 +84,8 @@ describe('route map', () => {
       workspaces: '/workspaces',
       workspaceFunctions: '/workspaces/analytics/functions',
       workspaceSchema: '/workspaces/analytics/schema',
+      workspaceSchemaCatalogTable:
+        '/workspaces/team%20alpha/schema/catalogs/pickl%3F/public%20schema/orders%2F2026',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSchemaTableFunction: '/workspaces/analytics/schema/github/functions/search_issues',
       workspaceSource: '/workspaces/analytics/sources/github',

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -46,7 +46,7 @@ describe('route map', () => {
       workspaceFunctions: routePath('workspaceFunctions', { workspaceId: 'analytics' }),
       workspaceSchema: routePath('workspaceSchema', { workspaceId: 'analytics' }),
       workspaceSchemaCatalogTable: routePath('workspaceSchemaCatalogTable', {
-        catalogName: 'pickl?',
+        catalogName: 'commerce?',
         schemaName: 'public schema',
         tableName: 'orders/2026',
         workspaceId: 'team alpha',
@@ -85,7 +85,7 @@ describe('route map', () => {
       workspaceFunctions: '/workspaces/analytics/functions',
       workspaceSchema: '/workspaces/analytics/schema',
       workspaceSchemaCatalogTable:
-        '/workspaces/team%20alpha/schema/catalogs/pickl%3F/public%20schema/orders%2F2026',
+        '/workspaces/team%20alpha/schema/catalogs/commerce%3F/public%20schema/orders%2F2026',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSchemaTableFunction: '/workspaces/analytics/schema/github/functions/search_issues',
       workspaceSource: '/workspaces/analytics/sources/github',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -6,6 +6,8 @@ const ONBOARDING_PATH = '/onboarding'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_FUNCTIONS_PATH = '/workspaces/:workspaceId/functions'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
+const WORKSPACE_SCHEMA_CATALOG_TABLE_PATH =
+  '/workspaces/:workspaceId/schema/catalogs/:catalogName/:schemaName/:tableName'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
 const WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH =
   '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName'
@@ -45,6 +47,21 @@ export const routeDefinitions = {
     path: WORKSPACE_SCHEMA_PATH,
     toPath: (params: { workspaceId: string }) =>
       generatePath(WORKSPACE_SCHEMA_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSchemaCatalogTable: {
+    path: WORKSPACE_SCHEMA_CATALOG_TABLE_PATH,
+    toPath: (params: {
+      catalogName: string
+      schemaName: string
+      tableName: string
+      workspaceId: string
+    }) =>
+      generatePath(WORKSPACE_SCHEMA_CATALOG_TABLE_PATH, {
+        catalogName: params.catalogName,
+        schemaName: params.schemaName,
+        tableName: params.tableName,
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
@@ -8,9 +8,9 @@ import { routePath, routePattern } from '@/routing/routemap'
 import { SchemaTableFunctionView } from './schema-table-function'
 
 const SCHEMA = {
-  namespaces: [
+  catalogs: [],
+  schemas: [
     {
-      kind: 'schema',
       items: [
         {
           arguments: [

--- a/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
@@ -8,8 +8,9 @@ import { routePath, routePattern } from '@/routing/routemap'
 import { SchemaTableFunctionView } from './schema-table-function'
 
 const SCHEMA = {
-  connectors: [
+  namespaces: [
     {
+      kind: 'schema',
       items: [
         {
           arguments: [

--- a/apps/reef/app/views/schema-explorer/schema-table.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table.test.tsx
@@ -1,0 +1,95 @@
+import { createMemoryRouter, Outlet, RouterProvider } from 'react-router'
+import { expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { SchemaResponse } from '@/lib/schema-explorer'
+import { routePath, routePattern } from '@/routing/routemap'
+
+import { SchemaTableView } from './schema-table'
+
+const SCHEMA = {
+  namespaces: [
+    {
+      kind: 'schema',
+      name: 'github',
+      items: [
+        {
+          columns: [],
+          columnsLoaded: false,
+          kind: 'table',
+          name: 'issues',
+          requiredFilters: [],
+        },
+      ],
+    },
+    {
+      kind: 'catalog',
+      name: 'pickl_v4',
+      schemas: [
+        {
+          name: 'public',
+          items: [
+            {
+              columns: [],
+              columnsLoaded: false,
+              kind: 'table',
+              name: 'products',
+              requiredFilters: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} satisfies SchemaResponse
+
+function tableRouter(path: string) {
+  return createMemoryRouter(
+    [
+      {
+        children: [
+          {
+            element: <SchemaTableView columns={[]} />,
+            path: 'catalogs/:catalogName/:schemaName/:tableName',
+          },
+          {
+            element: <SchemaTableView columns={[]} />,
+            path: ':schemaName/:tableName',
+          },
+        ],
+        element: <Outlet context={SCHEMA} />,
+        path: routePattern('workspaceSchema'),
+      },
+    ],
+    { initialEntries: [path] },
+  )
+}
+
+it('shows the fully qualified database table name', async () => {
+  const router = tableRouter(
+    routePath('workspaceSchemaCatalogTable', {
+      catalogName: 'pickl_v4',
+      schemaName: 'public',
+      tableName: 'products',
+      workspaceId: 'analytics',
+    }),
+  )
+  const screen = await render(<RouterProvider router={router} />)
+
+  await expect
+    .element(screen.getByRole('heading', { name: 'pickl_v4.public.products' }))
+    .toBeVisible()
+})
+
+it('keeps the existing two-part table heading', async () => {
+  const router = tableRouter(
+    routePath('workspaceSchemaTable', {
+      schemaName: 'github',
+      tableName: 'issues',
+      workspaceId: 'analytics',
+    }),
+  )
+  const screen = await render(<RouterProvider router={router} />)
+
+  await expect.element(screen.getByRole('heading', { name: 'github.issues' })).toBeVisible()
+})

--- a/apps/reef/app/views/schema-explorer/schema-table.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table.test.tsx
@@ -8,23 +8,9 @@ import { routePath, routePattern } from '@/routing/routemap'
 import { SchemaTableView } from './schema-table'
 
 const SCHEMA = {
-  namespaces: [
+  catalogs: [
     {
-      kind: 'schema',
-      name: 'github',
-      items: [
-        {
-          columns: [],
-          columnsLoaded: false,
-          kind: 'table',
-          name: 'issues',
-          requiredFilters: [],
-        },
-      ],
-    },
-    {
-      kind: 'catalog',
-      name: 'pickl_v4',
+      name: 'commerce',
       schemas: [
         {
           name: 'public',
@@ -37,6 +23,20 @@ const SCHEMA = {
               requiredFilters: [],
             },
           ],
+        },
+      ],
+    },
+  ],
+  schemas: [
+    {
+      name: 'github',
+      items: [
+        {
+          columns: [],
+          columnsLoaded: false,
+          kind: 'table',
+          name: 'issues',
+          requiredFilters: [],
         },
       ],
     },
@@ -68,7 +68,7 @@ function tableRouter(path: string) {
 it('shows the fully qualified database table name', async () => {
   const router = tableRouter(
     routePath('workspaceSchemaCatalogTable', {
-      catalogName: 'pickl_v4',
+      catalogName: 'commerce',
       schemaName: 'public',
       tableName: 'products',
       workspaceId: 'analytics',
@@ -77,7 +77,7 @@ it('shows the fully qualified database table name', async () => {
   const screen = await render(<RouterProvider router={router} />)
 
   await expect
-    .element(screen.getByRole('heading', { name: 'pickl_v4.public.products' }))
+    .element(screen.getByRole('heading', { name: 'commerce.public.products' }))
     .toBeVisible()
 })
 

--- a/apps/reef/app/views/schema-explorer/schema-table.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table.tsx
@@ -22,25 +22,35 @@ interface DisplayColumn {
 
 // The parent schema layout resolves its schema before rendering this Outlet, so
 // table metadata (description, required filters) is available synchronously.
-function useSelectedTable(): { schemaName: string; tableName: string; table?: TableDef } {
+function useSelectedTable(): {
+  catalogName: string
+  schemaName: string
+  tableName: string
+  table?: TableDef
+} {
   const schema = useOutletContext<SchemaResponse>()
   const params = useParams()
+  const catalogName = params.catalogName ?? ''
   const schemaName = params.schemaName ?? ''
   const tableName = params.tableName ?? ''
-  return { schemaName, tableName, table: findSchemaTable(schema, schemaName, tableName) }
+  return {
+    catalogName,
+    schemaName,
+    tableName,
+    table: findSchemaTable(schema, catalogName, schemaName, tableName),
+  }
 }
 
 // Detail-panel scaffold for a selected table: title, description, required
 // filters, and a "Columns" section body.
 function TableDetailLayout({ children }: { children: React.ReactNode }) {
-  const { schemaName, tableName, table } = useSelectedTable()
+  const { catalogName, schemaName, tableName, table } = useSelectedTable()
+  const qualifiedName = [catalogName, schemaName, tableName].filter(Boolean).join('.')
   return (
     <div className={styles.detailContent}>
       <div className={styles.detailHeader}>
         <div>
-          <Typography.HeadingSmall as="h2">
-            {schemaName}.{tableName}
-          </Typography.HeadingSmall>
+          <Typography.HeadingSmall as="h2">{qualifiedName}</Typography.HeadingSmall>
           {table?.description ? (
             <Typography.BodySmall as="p" className={styles.description}>
               {table.description}

--- a/apps/reef/app/views/schema-explorer/schema.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.test.tsx
@@ -8,32 +8,9 @@ import { routePath, routePattern } from '@/routing/routemap'
 import { SchemaExplorer } from './schema'
 
 const SCHEMA = {
-  namespaces: [
+  catalogs: [
     {
-      kind: 'schema',
-      name: 'github?api',
-      items: [
-        {
-          columns: [],
-          columnsLoaded: false,
-          kind: 'table',
-          name: 'issues/closed',
-          requiredFilters: [],
-        },
-        {
-          arguments: [
-            { name: 'channel', required: true, values: [] },
-            { name: 'cursor', required: false, values: [] },
-          ],
-          kind: 'tableFunction',
-          name: 'messages',
-          resultColumns: [],
-        },
-      ],
-    },
-    {
-      kind: 'catalog',
-      name: 'pickl_v4',
+      name: 'commerce',
       schemas: [
         {
           name: 'public',
@@ -65,6 +42,29 @@ const SCHEMA = {
               requiredFilters: [],
             },
           ],
+        },
+      ],
+    },
+  ],
+  schemas: [
+    {
+      name: 'github?api',
+      items: [
+        {
+          columns: [],
+          columnsLoaded: false,
+          kind: 'table',
+          name: 'issues/closed',
+          requiredFilters: [],
+        },
+        {
+          arguments: [
+            { name: 'channel', required: true, values: [] },
+            { name: 'cursor', required: false, values: [] },
+          ],
+          kind: 'tableFunction',
+          name: 'messages',
+          resultColumns: [],
         },
       ],
     },
@@ -120,7 +120,7 @@ it('renders and links database catalogs through their provider schemas', async (
   )
   const screen = await render(<RouterProvider router={router} />)
 
-  await screen.getByRole('button', { name: /pickl_v4/ }).click()
+  await screen.getByRole('button', { name: /commerce/ }).click()
   await expect.element(screen.getByRole('button', { name: /public/ })).toBeVisible()
   await expect.element(screen.getByRole('button', { name: /analytics/ })).toBeVisible()
 
@@ -128,7 +128,7 @@ it('renders and links database catalogs through their provider schemas', async (
   await expect.element(screen.getByRole('link', { name: 'products' })).toHaveAttribute(
     'href',
     routePath('workspaceSchemaCatalogTable', {
-      catalogName: 'pickl_v4',
+      catalogName: 'commerce',
       schemaName: 'public',
       tableName: 'products',
       workspaceId,

--- a/apps/reef/app/views/schema-explorer/schema.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.test.tsx
@@ -8,8 +8,9 @@ import { routePath, routePattern } from '@/routing/routemap'
 import { SchemaExplorer } from './schema'
 
 const SCHEMA = {
-  connectors: [
+  namespaces: [
     {
+      kind: 'schema',
       name: 'github?api',
       items: [
         {
@@ -27,6 +28,43 @@ const SCHEMA = {
           kind: 'tableFunction',
           name: 'messages',
           resultColumns: [],
+        },
+      ],
+    },
+    {
+      kind: 'catalog',
+      name: 'pickl_v4',
+      schemas: [
+        {
+          name: 'public',
+          items: [
+            {
+              columns: [],
+              columnsLoaded: false,
+              kind: 'table',
+              name: 'products',
+              requiredFilters: [],
+            },
+            {
+              columns: [],
+              columnsLoaded: false,
+              kind: 'table',
+              name: 'sales',
+              requiredFilters: [],
+            },
+          ],
+        },
+        {
+          name: 'analytics',
+          items: [
+            {
+              columns: [],
+              columnsLoaded: false,
+              kind: 'table',
+              name: 'revenue_by_product',
+              requiredFilters: [],
+            },
+          ],
         },
       ],
     },
@@ -67,4 +105,33 @@ it('links tables within the active workspace schema route', async () => {
         workspaceId,
       }),
     )
+})
+
+it('renders and links database catalogs through their provider schemas', async () => {
+  const workspaceId = 'team alpha'
+  const router = createMemoryRouter(
+    [
+      {
+        element: <SchemaExplorer schema={SCHEMA} workspaceId={workspaceId} />,
+        path: routePattern('workspaceSchema'),
+      },
+    ],
+    { initialEntries: [routePath('workspaceSchema', { workspaceId })] },
+  )
+  const screen = await render(<RouterProvider router={router} />)
+
+  await screen.getByRole('button', { name: /pickl_v4/ }).click()
+  await expect.element(screen.getByRole('button', { name: /public/ })).toBeVisible()
+  await expect.element(screen.getByRole('button', { name: /analytics/ })).toBeVisible()
+
+  await screen.getByRole('button', { name: /public/ }).click()
+  await expect.element(screen.getByRole('link', { name: 'products' })).toHaveAttribute(
+    'href',
+    routePath('workspaceSchemaCatalogTable', {
+      catalogName: 'pickl_v4',
+      schemaName: 'public',
+      tableName: 'products',
+      workspaceId,
+    }),
+  )
 })

--- a/apps/reef/app/views/schema-explorer/schema.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet, useParams, useRouteError } from 'react-router'
 
 import { ErrorBanner } from '@/components/error-banner'
 import type {
-  CatalogNamespace,
+  CatalogGroup,
   SchemaGroup,
   SchemaItemDef,
   SchemaResponse,
@@ -29,17 +29,11 @@ export function findSchemaTable(
 ): TableDef | undefined {
   let schemaGroup: SchemaGroup | undefined
   if (catalogName) {
-    schemaGroup = schema.namespaces
-      .find(
-        (namespace): namespace is CatalogNamespace =>
-          namespace.kind === 'catalog' && namespace.name === catalogName,
-      )
+    schemaGroup = schema.catalogs
+      .find((catalog) => catalog.name === catalogName)
       ?.schemas.find((providerSchema) => providerSchema.name === schemaName)
   } else {
-    const namespace = schema.namespaces.find(
-      (candidate) => candidate.kind === 'schema' && candidate.name === schemaName,
-    )
-    if (namespace?.kind === 'schema') schemaGroup = namespace
+    schemaGroup = schema.schemas.find((candidate) => candidate.name === schemaName)
   }
   return schemaGroup?.items.find(
     (item): item is TableDef => item.kind === 'table' && item.name === tableName,
@@ -51,16 +45,14 @@ export function findSchemaTableFunction(
   schemaName: string,
   functionName: string,
 ): TableFunctionDef | undefined {
-  const schemaGroup = schema.namespaces.find(
-    (namespace) => namespace.kind === 'schema' && namespace.name === schemaName,
-  )
-  if (!schemaGroup || schemaGroup.kind !== 'schema') return undefined
+  const schemaGroup = schema.schemas.find((candidate) => candidate.name === schemaName)
+  if (!schemaGroup) return undefined
   return schemaGroup.items.find(
     (item): item is TableFunctionDef => item.kind === 'tableFunction' && item.name === functionName,
   )
 }
 
-function catalogMatchesSearch(catalog: CatalogNamespace, search: string) {
+function catalogMatchesSearch(catalog: CatalogGroup, search: string) {
   if (!search || catalog.name.toLowerCase().includes(search)) return true
   return catalog.schemas.some((schema) => schemaMatchesSearch(schema, search))
 }
@@ -95,7 +87,7 @@ function visibleItemsForSchema(schema: SchemaGroup, search: string) {
   return schema.items.filter((item) => catalogItemMatchesSearch(item, search))
 }
 
-function visibleSchemasForCatalog(catalog: CatalogNamespace, search: string) {
+function visibleSchemasForCatalog(catalog: CatalogGroup, search: string) {
   if (!search || catalog.name.toLowerCase().includes(search)) return catalog.schemas
   return catalog.schemas.filter((schema) => schemaMatchesSearch(schema, search))
 }
@@ -203,6 +195,152 @@ function SchemaItemLinks({
   )
 }
 
+function CatalogTreeGroup({
+  activeItem,
+  catalog,
+  expandedCatalogs,
+  expandedSchemas,
+  normalizedSearch,
+  setExpandedCatalogs,
+  setExpandedSchemas,
+  workspaceId,
+}: {
+  activeItem: Readonly<Record<string, string | undefined>>
+  catalog: CatalogGroup
+  expandedCatalogs: Set<string>
+  expandedSchemas: Set<string>
+  normalizedSearch: string
+  setExpandedCatalogs: React.Dispatch<React.SetStateAction<Set<string>>>
+  setExpandedSchemas: React.Dispatch<React.SetStateAction<Set<string>>>
+  workspaceId: string
+}) {
+  const catalogMatches = catalog.name.toLowerCase().includes(normalizedSearch)
+  const descendantSearch = catalogMatches ? '' : normalizedSearch
+  const visibleSchemas = visibleSchemasForCatalog(catalog, normalizedSearch)
+  const expanded = normalizedSearch !== '' || expandedCatalogs.has(catalog.name)
+  const catalogChildrenId = `catalog-${catalog.name}-schemas`
+  return (
+    <div>
+      <ButtonContainer
+        aria-controls={expanded ? catalogChildrenId : undefined}
+        aria-expanded={expanded}
+        className={styles.treeRow}
+        fullWidth
+        onClick={() => toggleExpanded(setExpandedCatalogs, catalog.name)}
+        size="22"
+        variant="bare"
+      >
+        <Icon color="secondary" name={expanded ? 'ChevronDown' : 'ChevronRight'} size="14" />
+        <Typography.BodyStrong className={styles.connectorName}>
+          {catalog.name}
+        </Typography.BodyStrong>
+        <Typography.BodySmall className={styles.connectorItemCount} variant="tertiary">
+          {visibleSchemas.length}
+        </Typography.BodySmall>
+      </ButtonContainer>
+
+      {expanded ? (
+        <div className={styles.connectorChildren} id={catalogChildrenId}>
+          {visibleSchemas.map((providerSchema) => {
+            const schemaKey = expansionKey(catalog.name, providerSchema.name)
+            const schemaExpanded = normalizedSearch !== '' || expandedSchemas.has(schemaKey)
+            const schemaChildrenId = `catalog-${catalog.name}-schema-${providerSchema.name}-items`
+            const visibleItems = visibleItemsForSchema(providerSchema, descendantSearch)
+            return (
+              <div key={schemaKey}>
+                <ButtonContainer
+                  aria-controls={schemaExpanded ? schemaChildrenId : undefined}
+                  aria-expanded={schemaExpanded}
+                  className={styles.treeRow}
+                  fullWidth
+                  onClick={() => toggleExpanded(setExpandedSchemas, schemaKey)}
+                  size="22"
+                  variant="bare"
+                >
+                  <Icon
+                    color="secondary"
+                    name={schemaExpanded ? 'ChevronDown' : 'ChevronRight'}
+                    size="14"
+                  />
+                  <Typography.BodyStrong className={styles.connectorName}>
+                    {providerSchema.name}
+                  </Typography.BodyStrong>
+                  <Typography.BodySmall className={styles.connectorItemCount} variant="tertiary">
+                    {visibleItems.length}
+                  </Typography.BodySmall>
+                </ButtonContainer>
+
+                {schemaExpanded ? (
+                  <SchemaItemLinks
+                    activeItem={activeItem}
+                    catalogName={catalog.name}
+                    childrenId={schemaChildrenId}
+                    items={visibleItems}
+                    schemaName={providerSchema.name}
+                    workspaceId={workspaceId}
+                  />
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function SchemaTreeGroup({
+  activeItem,
+  expandedSchemas,
+  normalizedSearch,
+  schema,
+  setExpandedSchemas,
+  workspaceId,
+}: {
+  activeItem: Readonly<Record<string, string | undefined>>
+  expandedSchemas: Set<string>
+  normalizedSearch: string
+  schema: SchemaGroup
+  setExpandedSchemas: React.Dispatch<React.SetStateAction<Set<string>>>
+  workspaceId: string
+}) {
+  const expanded = normalizedSearch !== '' || expandedSchemas.has(schema.name)
+  const schemaChildrenId = `schema-${schema.name}-items`
+  const visibleItems = visibleItemsForSchema(schema, normalizedSearch)
+  return (
+    <div>
+      <ButtonContainer
+        aria-controls={expanded ? schemaChildrenId : undefined}
+        aria-expanded={expanded}
+        className={styles.treeRow}
+        fullWidth
+        onClick={() => toggleExpanded(setExpandedSchemas, schema.name)}
+        size="22"
+        variant="bare"
+      >
+        <Icon color="secondary" name={expanded ? 'ChevronDown' : 'ChevronRight'} size="14" />
+        <Typography.BodyStrong className={styles.connectorName}>
+          {schema.name}
+        </Typography.BodyStrong>
+        <Typography.BodySmall className={styles.connectorItemCount} variant="tertiary">
+          {visibleItems.length}
+        </Typography.BodySmall>
+      </ButtonContainer>
+
+      {expanded ? (
+        <SchemaItemLinks
+          activeItem={activeItem}
+          catalogName=""
+          childrenId={schemaChildrenId}
+          items={visibleItems}
+          schemaName={schema.name}
+          workspaceId={workspaceId}
+        />
+      ) : null}
+    </div>
+  )
+}
+
 export function tableFunctionTreeArguments(tableFunction: TableFunctionDef) {
   const argumentsToShow = tableFunction.arguments
     .filter((argument) => argument.required)
@@ -259,21 +397,22 @@ export function SchemaExplorer({
 }) {
   const activeItem = useParams()
   const [search, setSearch] = useState('')
-  // Collapsed by default so the initial render is one row per root namespace.
+  // Collapsed by default so the initial render is one row per schema or catalog.
   // A search exposes matching descendants without mutating these expansion sets.
   const [expandedCatalogs, setExpandedCatalogs] = useState<Set<string>>(() => new Set())
   const [expandedSchemas, setExpandedSchemas] = useState<Set<string>>(() => new Set())
 
   const normalizedSearch = search.trim().toLowerCase()
-  const filteredNamespaces = useMemo(
+  const filteredSchemas = useMemo(
     () =>
-      schema.namespaces.filter((namespace) =>
-        namespace.kind === 'catalog'
-          ? catalogMatchesSearch(namespace, normalizedSearch)
-          : schemaMatchesSearch(namespace, normalizedSearch),
-      ),
-    [normalizedSearch, schema],
+      schema.schemas.filter((schemaGroup) => schemaMatchesSearch(schemaGroup, normalizedSearch)),
+    [normalizedSearch, schema.schemas],
   )
+  const filteredCatalogs = useMemo(
+    () => schema.catalogs.filter((catalog) => catalogMatchesSearch(catalog, normalizedSearch)),
+    [normalizedSearch, schema.catalogs],
+  )
+  const filteredCount = filteredSchemas.length + filteredCatalogs.length
 
   return (
     <section aria-label="Schema explorer" className={styles.root}>
@@ -293,13 +432,13 @@ export function SchemaExplorer({
         <div className={styles.treePanel}>
           <div className={styles.treeContent}>
             <ScrollArea constrainWidth>
-              {normalizedSearch && filteredNamespaces.length === 0 ? (
+              {normalizedSearch && filteredCount === 0 ? (
                 <div className={styles.treeEmpty}>
                   <Typography.BodySmall variant="tertiary">
                     No results for "{search}"
                   </Typography.BodySmall>
                 </div>
-              ) : filteredNamespaces.length === 0 ? (
+              ) : filteredCount === 0 ? (
                 <div className={styles.treeEmpty}>
                   <Typography.BodySmall variant="tertiary">
                     No queryable tables or table functions in this workspace.
@@ -307,141 +446,30 @@ export function SchemaExplorer({
                 </div>
               ) : (
                 <div className={styles.treeList}>
-                  {filteredNamespaces.map((namespace) => {
-                    if (namespace.kind === 'catalog') {
-                      const catalogMatches = namespace.name.toLowerCase().includes(normalizedSearch)
-                      const descendantSearch = catalogMatches ? '' : normalizedSearch
-                      const visibleSchemas = visibleSchemasForCatalog(namespace, normalizedSearch)
-                      const expanded =
-                        normalizedSearch !== '' || expandedCatalogs.has(namespace.name)
-                      const catalogChildrenId = `catalog-${namespace.name}-schemas`
-                      return (
-                        <div key={`catalog:${namespace.name}`}>
-                          <ButtonContainer
-                            aria-controls={expanded ? catalogChildrenId : undefined}
-                            aria-expanded={expanded}
-                            className={styles.treeRow}
-                            fullWidth
-                            onClick={() => toggleExpanded(setExpandedCatalogs, namespace.name)}
-                            size="22"
-                            variant="bare"
-                          >
-                            <Icon
-                              color="secondary"
-                              name={expanded ? 'ChevronDown' : 'ChevronRight'}
-                              size="14"
-                            />
-                            <Typography.BodyStrong className={styles.connectorName}>
-                              {namespace.name}
-                            </Typography.BodyStrong>
-                            <Typography.BodySmall
-                              className={styles.connectorItemCount}
-                              variant="tertiary"
-                            >
-                              {visibleSchemas.length}
-                            </Typography.BodySmall>
-                          </ButtonContainer>
-
-                          {expanded ? (
-                            <div className={styles.connectorChildren} id={catalogChildrenId}>
-                              {visibleSchemas.map((providerSchema) => {
-                                const schemaKey = expansionKey(namespace.name, providerSchema.name)
-                                const schemaExpanded =
-                                  normalizedSearch !== '' || expandedSchemas.has(schemaKey)
-                                const schemaChildrenId = `catalog-${namespace.name}-schema-${providerSchema.name}-items`
-                                const visibleItems = visibleItemsForSchema(
-                                  providerSchema,
-                                  descendantSearch,
-                                )
-                                return (
-                                  <div key={schemaKey}>
-                                    <ButtonContainer
-                                      aria-controls={schemaExpanded ? schemaChildrenId : undefined}
-                                      aria-expanded={schemaExpanded}
-                                      className={styles.treeRow}
-                                      fullWidth
-                                      onClick={() => toggleExpanded(setExpandedSchemas, schemaKey)}
-                                      size="22"
-                                      variant="bare"
-                                    >
-                                      <Icon
-                                        color="secondary"
-                                        name={schemaExpanded ? 'ChevronDown' : 'ChevronRight'}
-                                        size="14"
-                                      />
-                                      <Typography.BodyStrong className={styles.connectorName}>
-                                        {providerSchema.name}
-                                      </Typography.BodyStrong>
-                                      <Typography.BodySmall
-                                        className={styles.connectorItemCount}
-                                        variant="tertiary"
-                                      >
-                                        {visibleItems.length}
-                                      </Typography.BodySmall>
-                                    </ButtonContainer>
-
-                                    {schemaExpanded ? (
-                                      <SchemaItemLinks
-                                        activeItem={activeItem}
-                                        catalogName={namespace.name}
-                                        childrenId={schemaChildrenId}
-                                        items={visibleItems}
-                                        schemaName={providerSchema.name}
-                                        workspaceId={workspaceId}
-                                      />
-                                    ) : null}
-                                  </div>
-                                )
-                              })}
-                            </div>
-                          ) : null}
-                        </div>
-                      )
-                    }
-
-                    const expanded = normalizedSearch !== '' || expandedSchemas.has(namespace.name)
-                    const connectorChildrenId = `schema-${namespace.name}-items`
-                    const visibleItems = visibleItemsForSchema(namespace, normalizedSearch)
-                    return (
-                      <div key={`schema:${namespace.name}`}>
-                        <ButtonContainer
-                          aria-controls={expanded ? connectorChildrenId : undefined}
-                          aria-expanded={expanded}
-                          className={styles.treeRow}
-                          fullWidth
-                          onClick={() => toggleExpanded(setExpandedSchemas, namespace.name)}
-                          size="22"
-                          variant="bare"
-                        >
-                          <Icon
-                            color="secondary"
-                            name={expanded ? 'ChevronDown' : 'ChevronRight'}
-                            size="14"
-                          />
-                          <Typography.BodyStrong className={styles.connectorName}>
-                            {namespace.name}
-                          </Typography.BodyStrong>
-                          <Typography.BodySmall
-                            className={styles.connectorItemCount}
-                            variant="tertiary"
-                          >
-                            {visibleItems.length}
-                          </Typography.BodySmall>
-                        </ButtonContainer>
-
-                        {expanded ? (
-                          <SchemaItemLinks
-                            activeItem={activeItem}
-                            catalogName=""
-                            childrenId={connectorChildrenId}
-                            items={visibleItems}
-                            schemaName={namespace.name}
-                            workspaceId={workspaceId}
-                          />
-                        ) : null}
-                      </div>
-                    )
-                  })}
+                  {filteredSchemas.map((schemaGroup) => (
+                    <SchemaTreeGroup
+                      activeItem={activeItem}
+                      expandedSchemas={expandedSchemas}
+                      key={schemaGroup.name}
+                      normalizedSearch={normalizedSearch}
+                      schema={schemaGroup}
+                      setExpandedSchemas={setExpandedSchemas}
+                      workspaceId={workspaceId}
+                    />
+                  ))}
+                  {filteredCatalogs.map((catalog) => (
+                    <CatalogTreeGroup
+                      activeItem={activeItem}
+                      catalog={catalog}
+                      expandedCatalogs={expandedCatalogs}
+                      expandedSchemas={expandedSchemas}
+                      key={catalog.name}
+                      normalizedSearch={normalizedSearch}
+                      setExpandedCatalogs={setExpandedCatalogs}
+                      setExpandedSchemas={setExpandedSchemas}
+                      workspaceId={workspaceId}
+                    />
+                  ))}
                 </div>
               )}
             </ScrollArea>

--- a/apps/reef/app/views/schema-explorer/schema.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet, useParams, useRouteError } from 'react-router'
 
 import { ErrorBanner } from '@/components/error-banner'
 import type {
+  CatalogNamespace,
   SchemaGroup,
   SchemaItemDef,
   SchemaResponse,
@@ -22,12 +23,27 @@ import { formatError, useRouteRetry } from './shared'
 
 export function findSchemaTable(
   schema: SchemaResponse,
+  catalogName: string,
   schemaName: string,
   tableName: string,
 ): TableDef | undefined {
-  return schema.connectors
-    .find((connector) => connector.name === schemaName)
-    ?.items.find((item): item is TableDef => item.kind === 'table' && item.name === tableName)
+  let schemaGroup: SchemaGroup | undefined
+  if (catalogName) {
+    schemaGroup = schema.namespaces
+      .find(
+        (namespace): namespace is CatalogNamespace =>
+          namespace.kind === 'catalog' && namespace.name === catalogName,
+      )
+      ?.schemas.find((providerSchema) => providerSchema.name === schemaName)
+  } else {
+    const namespace = schema.namespaces.find(
+      (candidate) => candidate.kind === 'schema' && candidate.name === schemaName,
+    )
+    if (namespace?.kind === 'schema') schemaGroup = namespace
+  }
+  return schemaGroup?.items.find(
+    (item): item is TableDef => item.kind === 'table' && item.name === tableName,
+  )
 }
 
 export function findSchemaTableFunction(
@@ -35,12 +51,18 @@ export function findSchemaTableFunction(
   schemaName: string,
   functionName: string,
 ): TableFunctionDef | undefined {
-  return schema.connectors
-    .find((connector) => connector.name === schemaName)
-    ?.items.find(
-      (item): item is TableFunctionDef =>
-        item.kind === 'tableFunction' && item.name === functionName,
-    )
+  const schemaGroup = schema.namespaces.find(
+    (namespace) => namespace.kind === 'schema' && namespace.name === schemaName,
+  )
+  if (!schemaGroup || schemaGroup.kind !== 'schema') return undefined
+  return schemaGroup.items.find(
+    (item): item is TableFunctionDef => item.kind === 'tableFunction' && item.name === functionName,
+  )
+}
+
+function catalogMatchesSearch(catalog: CatalogNamespace, search: string) {
+  if (!search || catalog.name.toLowerCase().includes(search)) return true
+  return catalog.schemas.some((schema) => schemaMatchesSearch(schema, search))
 }
 
 function schemaMatchesSearch(schema: SchemaGroup, search: string) {
@@ -73,18 +95,112 @@ function visibleItemsForSchema(schema: SchemaGroup, search: string) {
   return schema.items.filter((item) => catalogItemMatchesSearch(item, search))
 }
 
-function tablePath(workspaceId: string, schemaName: string, tableName: string) {
-  return routePath('workspaceSchemaTable', { schemaName, tableName, workspaceId })
+function visibleSchemasForCatalog(catalog: CatalogNamespace, search: string) {
+  if (!search || catalog.name.toLowerCase().includes(search)) return catalog.schemas
+  return catalog.schemas.filter((schema) => schemaMatchesSearch(schema, search))
+}
+
+function tablePath(
+  workspaceId: string,
+  catalogName: string,
+  schemaName: string,
+  tableName: string,
+) {
+  return catalogName
+    ? routePath('workspaceSchemaCatalogTable', {
+        catalogName,
+        schemaName,
+        tableName,
+        workspaceId,
+      })
+    : routePath('workspaceSchemaTable', { schemaName, tableName, workspaceId })
 }
 
 function tableFunctionPath(workspaceId: string, schemaName: string, functionName: string) {
   return routePath('workspaceSchemaTableFunction', { functionName, schemaName, workspaceId })
 }
 
-function catalogItemPath(workspaceId: string, schemaName: string, item: SchemaItemDef) {
+function catalogItemPath(
+  workspaceId: string,
+  catalogName: string,
+  schemaName: string,
+  item: SchemaItemDef,
+) {
   return item.kind === 'table'
-    ? tablePath(workspaceId, schemaName, item.name)
+    ? tablePath(workspaceId, catalogName, schemaName, item.name)
     : tableFunctionPath(workspaceId, schemaName, item.name)
+}
+
+function expansionKey(catalogName: string, schemaName: string) {
+  return `${catalogName}\u0000${schemaName}`
+}
+
+function toggleExpanded(
+  setExpanded: React.Dispatch<React.SetStateAction<Set<string>>>,
+  key: string,
+) {
+  setExpanded((previous) => {
+    const next = new Set(previous)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
+}
+
+function SchemaItemLinks({
+  activeItem,
+  catalogName,
+  childrenId,
+  items,
+  schemaName,
+  workspaceId,
+}: {
+  activeItem: Readonly<Record<string, string | undefined>>
+  catalogName: string
+  childrenId: string
+  items: SchemaItemDef[]
+  schemaName: string
+  workspaceId: string
+}) {
+  return (
+    <div className={styles.connectorChildren} id={childrenId}>
+      {items.map((item) => {
+        const path = catalogItemPath(workspaceId, catalogName, schemaName, item)
+        const active =
+          activeItem.schemaName === schemaName &&
+          (catalogName ? activeItem.catalogName === catalogName : !activeItem.catalogName) &&
+          (item.kind === 'table'
+            ? activeItem.tableName === item.name
+            : activeItem.functionName === item.name)
+        return (
+          <ButtonContainer
+            as={NavLink}
+            className={styles.treeRow}
+            fullWidth
+            isActive={active}
+            key={path}
+            size="22"
+            to={path}
+            variant="bare"
+          >
+            <Icon
+              color="secondary"
+              name={item.kind === 'table' ? 'Table2' : 'SquareFunction'}
+              size="14"
+            />
+            {item.kind === 'table' ? (
+              <Typography.BodyStrong className={styles.itemName}>{item.name}</Typography.BodyStrong>
+            ) : (
+              <span className={styles.itemName}>
+                <Typography.BodyStrong>{item.name}</Typography.BodyStrong>
+                <Typography.Body>{tableFunctionTreeArguments(item)}</Typography.Body>
+              </span>
+            )}
+          </ButtonContainer>
+        )
+      })}
+    </div>
+  )
 }
 
 export function tableFunctionTreeArguments(tableFunction: TableFunctionDef) {
@@ -143,25 +259,21 @@ export function SchemaExplorer({
 }) {
   const activeItem = useParams()
   const [search, setSearch] = useState('')
-  // Collapsed by default so the initial render is one row per schema, not one per
-  // catalog item — expanding every schema up front renders hundreds of rows and makes the
-  // first paint sluggish. A search expands matching schemas (see `expanded` below).
+  // Collapsed by default so the initial render is one row per root namespace.
+  // A search exposes matching descendants without mutating these expansion sets.
+  const [expandedCatalogs, setExpandedCatalogs] = useState<Set<string>>(() => new Set())
   const [expandedSchemas, setExpandedSchemas] = useState<Set<string>>(() => new Set())
 
   const normalizedSearch = search.trim().toLowerCase()
-  const filteredSchemas = useMemo(
-    () => schema.connectors.filter((connector) => schemaMatchesSearch(connector, normalizedSearch)),
+  const filteredNamespaces = useMemo(
+    () =>
+      schema.namespaces.filter((namespace) =>
+        namespace.kind === 'catalog'
+          ? catalogMatchesSearch(namespace, normalizedSearch)
+          : schemaMatchesSearch(namespace, normalizedSearch),
+      ),
     [normalizedSearch, schema],
   )
-
-  const toggleSchema = (name: string) => {
-    setExpandedSchemas((previous) => {
-      const next = new Set(previous)
-      if (next.has(name)) next.delete(name)
-      else next.add(name)
-      return next
-    })
-  }
 
   return (
     <section aria-label="Schema explorer" className={styles.root}>
@@ -181,13 +293,13 @@ export function SchemaExplorer({
         <div className={styles.treePanel}>
           <div className={styles.treeContent}>
             <ScrollArea constrainWidth>
-              {normalizedSearch && filteredSchemas.length === 0 ? (
+              {normalizedSearch && filteredNamespaces.length === 0 ? (
                 <div className={styles.treeEmpty}>
                   <Typography.BodySmall variant="tertiary">
                     No results for "{search}"
                   </Typography.BodySmall>
                 </div>
-              ) : filteredSchemas.length === 0 ? (
+              ) : filteredNamespaces.length === 0 ? (
                 <div className={styles.treeEmpty}>
                   <Typography.BodySmall variant="tertiary">
                     No queryable tables or table functions in this workspace.
@@ -195,19 +307,109 @@ export function SchemaExplorer({
                 </div>
               ) : (
                 <div className={styles.treeList}>
-                  {filteredSchemas.map((connector) => {
-                    // A search forces matching schemas open so results are visible.
-                    const expanded = normalizedSearch !== '' || expandedSchemas.has(connector.name)
-                    const connectorChildrenId = `schema-${connector.name}-items`
-                    const visibleItems = visibleItemsForSchema(connector, normalizedSearch)
+                  {filteredNamespaces.map((namespace) => {
+                    if (namespace.kind === 'catalog') {
+                      const catalogMatches = namespace.name.toLowerCase().includes(normalizedSearch)
+                      const descendantSearch = catalogMatches ? '' : normalizedSearch
+                      const visibleSchemas = visibleSchemasForCatalog(namespace, normalizedSearch)
+                      const expanded =
+                        normalizedSearch !== '' || expandedCatalogs.has(namespace.name)
+                      const catalogChildrenId = `catalog-${namespace.name}-schemas`
+                      return (
+                        <div key={`catalog:${namespace.name}`}>
+                          <ButtonContainer
+                            aria-controls={expanded ? catalogChildrenId : undefined}
+                            aria-expanded={expanded}
+                            className={styles.treeRow}
+                            fullWidth
+                            onClick={() => toggleExpanded(setExpandedCatalogs, namespace.name)}
+                            size="22"
+                            variant="bare"
+                          >
+                            <Icon
+                              color="secondary"
+                              name={expanded ? 'ChevronDown' : 'ChevronRight'}
+                              size="14"
+                            />
+                            <Typography.BodyStrong className={styles.connectorName}>
+                              {namespace.name}
+                            </Typography.BodyStrong>
+                            <Typography.BodySmall
+                              className={styles.connectorItemCount}
+                              variant="tertiary"
+                            >
+                              {visibleSchemas.length}
+                            </Typography.BodySmall>
+                          </ButtonContainer>
+
+                          {expanded ? (
+                            <div className={styles.connectorChildren} id={catalogChildrenId}>
+                              {visibleSchemas.map((providerSchema) => {
+                                const schemaKey = expansionKey(namespace.name, providerSchema.name)
+                                const schemaExpanded =
+                                  normalizedSearch !== '' || expandedSchemas.has(schemaKey)
+                                const schemaChildrenId = `catalog-${namespace.name}-schema-${providerSchema.name}-items`
+                                const visibleItems = visibleItemsForSchema(
+                                  providerSchema,
+                                  descendantSearch,
+                                )
+                                return (
+                                  <div key={schemaKey}>
+                                    <ButtonContainer
+                                      aria-controls={schemaExpanded ? schemaChildrenId : undefined}
+                                      aria-expanded={schemaExpanded}
+                                      className={styles.treeRow}
+                                      fullWidth
+                                      onClick={() => toggleExpanded(setExpandedSchemas, schemaKey)}
+                                      size="22"
+                                      variant="bare"
+                                    >
+                                      <Icon
+                                        color="secondary"
+                                        name={schemaExpanded ? 'ChevronDown' : 'ChevronRight'}
+                                        size="14"
+                                      />
+                                      <Typography.BodyStrong className={styles.connectorName}>
+                                        {providerSchema.name}
+                                      </Typography.BodyStrong>
+                                      <Typography.BodySmall
+                                        className={styles.connectorItemCount}
+                                        variant="tertiary"
+                                      >
+                                        {visibleItems.length}
+                                      </Typography.BodySmall>
+                                    </ButtonContainer>
+
+                                    {schemaExpanded ? (
+                                      <SchemaItemLinks
+                                        activeItem={activeItem}
+                                        catalogName={namespace.name}
+                                        childrenId={schemaChildrenId}
+                                        items={visibleItems}
+                                        schemaName={providerSchema.name}
+                                        workspaceId={workspaceId}
+                                      />
+                                    ) : null}
+                                  </div>
+                                )
+                              })}
+                            </div>
+                          ) : null}
+                        </div>
+                      )
+                    }
+
+                    const expanded = normalizedSearch !== '' || expandedSchemas.has(namespace.name)
+                    const connectorChildrenId = `schema-${namespace.name}-items`
+                    const visibleItems = visibleItemsForSchema(namespace, normalizedSearch)
                     return (
-                      <div key={connector.name}>
+                      <div key={`schema:${namespace.name}`}>
                         <ButtonContainer
                           aria-controls={expanded ? connectorChildrenId : undefined}
                           aria-expanded={expanded}
                           className={styles.treeRow}
                           fullWidth
-                          onClick={() => toggleSchema(connector.name)}
+                          onClick={() => toggleExpanded(setExpandedSchemas, namespace.name)}
                           size="22"
                           variant="bare"
                         >
@@ -217,7 +419,7 @@ export function SchemaExplorer({
                             size="14"
                           />
                           <Typography.BodyStrong className={styles.connectorName}>
-                            {connector.name}
+                            {namespace.name}
                           </Typography.BodyStrong>
                           <Typography.BodySmall
                             className={styles.connectorItemCount}
@@ -228,46 +430,14 @@ export function SchemaExplorer({
                         </ButtonContainer>
 
                         {expanded ? (
-                          <div className={styles.connectorChildren} id={connectorChildrenId}>
-                            {visibleItems.map((item) => {
-                              const path = catalogItemPath(workspaceId, connector.name, item)
-                              const active =
-                                activeItem.schemaName === connector.name &&
-                                (item.kind === 'table'
-                                  ? activeItem.tableName === item.name
-                                  : activeItem.functionName === item.name)
-                              return (
-                                <ButtonContainer
-                                  as={NavLink}
-                                  className={styles.treeRow}
-                                  fullWidth
-                                  isActive={active}
-                                  key={path}
-                                  size="22"
-                                  to={path}
-                                  variant="bare"
-                                >
-                                  <Icon
-                                    color="secondary"
-                                    name={item.kind === 'table' ? 'Table2' : 'SquareFunction'}
-                                    size="14"
-                                  />
-                                  {item.kind === 'table' ? (
-                                    <Typography.BodyStrong className={styles.itemName}>
-                                      {item.name}
-                                    </Typography.BodyStrong>
-                                  ) : (
-                                    <span className={styles.itemName}>
-                                      <Typography.BodyStrong>{item.name}</Typography.BodyStrong>
-                                      <Typography.Body>
-                                        {tableFunctionTreeArguments(item)}
-                                      </Typography.Body>
-                                    </span>
-                                  )}
-                                </ButtonContainer>
-                              )
-                            })}
-                          </div>
+                          <SchemaItemLinks
+                            activeItem={activeItem}
+                            catalogName=""
+                            childrenId={connectorChildrenId}
+                            items={visibleItems}
+                            schemaName={namespace.name}
+                            workspaceId={workspaceId}
+                          />
                         ) : null}
                       </div>
                     )


### PR DESCRIPTION
## Summary

- preserve database catalog and provider-schema hierarchy in the Reef schema explorer
- route database table details with the full catalog, schema, and table identity
- include catalog_name in ListColumns requests while retaining existing two-part source and table-function routes
- cover catalog grouping, encoded routes, loader identity, tree navigation, and qualified table headings

## Root cause

Reef discarded catalog_name while grouping ListCatalog results and omitted it from ListColumns requests. Database tables therefore collapsed into ordinary schema groups and could not be addressed reliably when catalogs shared schema and table names.

## Validation

- npm run check --prefix apps/reef
- npm run typecheck --prefix apps/reef
- npm test --prefix apps/reef (108 files, 451 tests)
- npm run build --prefix apps/reef
- git diff --check