### PR TITLE
fix(engine): serialize database pool initialization

### DIFF
--- a/crates/coral-engine/src/backends/database/registry.rs
+++ b/crates/coral-engine/src/backends/database/registry.rs
@@ -2,18 +2,20 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use datafusion::error::Result as DataFusionResult;
 use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
+use tokio::sync::{Mutex as AsyncMutex, OwnedRwLockReadGuard, RwLock};
 
 /// Reusable remote database connection pools for one workspace.
 ///
 /// Coral's application layer creates one registry per workspace and passes it
 /// into every query runtime built for that workspace.
 pub struct DatabasePoolRegistry {
-    pools: Mutex<HashMap<String, DatabasePool>>,
+    catalogs: Mutex<HashMap<String, Arc<CatalogPoolState>>>,
 }
 
 impl DatabasePoolRegistry {
@@ -21,48 +23,142 @@ impl DatabasePoolRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            pools: Mutex::new(HashMap::new()),
+            catalogs: Mutex::new(HashMap::new()),
         }
     }
 
-    pub(super) async fn get_or_create(
+    fn catalog_state(&self, catalog_name: &str) -> Arc<CatalogPoolState> {
+        Arc::clone(
+            self.catalogs
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .entry(catalog_name.to_string())
+                .or_insert_with(|| Arc::new(CatalogPoolState::new())),
+        )
+    }
+
+    pub(super) async fn begin_registration(
         &self,
         catalog_name: &str,
-        create: impl Future<Output = DataFusionResult<DatabasePool>>,
-    ) -> DataFusionResult<DatabasePool> {
-        if let Some(pool) = self
-            .pools
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(catalog_name)
-            .cloned()
-        {
-            return Ok(pool);
+    ) -> DatabaseRegistrationAttempt {
+        let state = self.catalog_state(catalog_name);
+        let registration = Arc::clone(&state.registrations).read_owned().await;
+        let successful_registrations = state.successful_registrations.load(Ordering::Acquire);
+        DatabaseRegistrationAttempt {
+            state,
+            registration,
+            successful_registrations,
         }
-
-        let pool = create.await?;
-        let mut pools = self
-            .pools
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        Ok(pools
-            .entry(catalog_name.to_string())
-            .or_insert(pool)
-            .clone())
     }
 
     /// Removes one catalog's pool without disturbing other workspace sources.
     pub fn remove_catalog(&self, catalog_name: &str) {
-        self.pools
+        if let Some(state) = self
+            .catalogs
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(catalog_name);
+            .remove(catalog_name)
+        {
+            state
+                .pool
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+        }
     }
 }
 
 impl Default for DatabasePoolRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+struct CatalogPoolState {
+    pool: Mutex<Option<DatabasePool>>,
+    initialization: AsyncMutex<()>,
+    registrations: Arc<RwLock<()>>,
+    successful_registrations: AtomicU64,
+}
+
+impl CatalogPoolState {
+    fn new() -> Self {
+        Self {
+            pool: Mutex::new(None),
+            initialization: AsyncMutex::new(()),
+            registrations: Arc::new(RwLock::new(())),
+            successful_registrations: AtomicU64::new(0),
+        }
+    }
+
+    async fn get_or_create(
+        &self,
+        create: impl Future<Output = DataFusionResult<DatabasePool>>,
+    ) -> DataFusionResult<DatabasePool> {
+        if let Some(pool) = self
+            .pool
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        {
+            return Ok(pool);
+        }
+
+        let _initialization = self.initialization.lock().await;
+        if let Some(pool) = self
+            .pool
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        {
+            return Ok(pool);
+        }
+
+        let pool = create.await?;
+        self.pool
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .replace(pool.clone());
+        Ok(pool)
+    }
+}
+
+pub(super) struct DatabaseRegistrationAttempt {
+    state: Arc<CatalogPoolState>,
+    registration: OwnedRwLockReadGuard<()>,
+    successful_registrations: u64,
+}
+
+impl DatabaseRegistrationAttempt {
+    pub(super) async fn get_or_create(
+        &self,
+        create: impl Future<Output = DataFusionResult<DatabasePool>>,
+    ) -> DataFusionResult<DatabasePool> {
+        self.state.get_or_create(create).await
+    }
+
+    pub(super) fn succeeded(self) {
+        self.state
+            .successful_registrations
+            .fetch_add(1, Ordering::Release);
+    }
+
+    pub(super) async fn evict_after_timeout(self) {
+        let Self {
+            state,
+            registration,
+            successful_registrations,
+        } = self;
+        drop(registration);
+
+        let _exclusive_registration = Arc::clone(&state.registrations).write_owned().await;
+        if state.successful_registrations.load(Ordering::Acquire) == successful_registrations {
+            state
+                .pool
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+        }
     }
 }
 
@@ -76,27 +172,148 @@ pub(super) enum DatabasePool {
 
 #[cfg(test)]
 mod tests {
+    use std::future::poll_fn;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::Poll;
+
+    use datafusion::error::Result as DataFusionResult;
+    use futures::poll;
+
     use super::{DatabasePool, DatabasePoolRegistry};
 
-    #[test]
-    fn removing_one_catalog_pool_preserves_other_catalogs() {
+    #[tokio::test]
+    async fn concurrent_get_or_create_starts_only_one_constructor() {
         let registry = DatabasePoolRegistry::new();
-        {
-            let mut pools = registry
-                .pools
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            pools.insert("orders".to_string(), DatabasePool::Test);
-            pools.insert("inventory".to_string(), DatabasePool::Test);
-        }
+        let creations = Arc::new(AtomicUsize::new(0));
+        let create = || {
+            let creations = Arc::clone(&creations);
+            poll_fn(move |_context| {
+                creations.fetch_add(1, Ordering::SeqCst);
+                Poll::<DataFusionResult<DatabasePool>>::Pending
+            })
+        };
+
+        let first_registration = registry.begin_registration("orders").await;
+        let mut first = std::pin::pin!(first_registration.get_or_create(create()));
+        assert!(poll!(&mut first).is_pending());
+
+        let second_registration = registry.begin_registration("orders").await;
+        let mut second = std::pin::pin!(second_registration.get_or_create(create()));
+        assert!(poll!(&mut second).is_pending());
+
+        assert_eq!(creations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn different_catalogs_initialize_concurrently() {
+        let registry = DatabasePoolRegistry::new();
+        let creations = Arc::new(AtomicUsize::new(0));
+        let create = || {
+            let creations = Arc::clone(&creations);
+            poll_fn(move |_context| {
+                creations.fetch_add(1, Ordering::SeqCst);
+                Poll::<DataFusionResult<DatabasePool>>::Pending
+            })
+        };
+
+        let orders_registration = registry.begin_registration("orders").await;
+        let mut orders = std::pin::pin!(orders_registration.get_or_create(create()));
+        assert!(poll!(&mut orders).is_pending());
+
+        let inventory_registration = registry.begin_registration("inventory").await;
+        let mut inventory = std::pin::pin!(inventory_registration.get_or_create(create()));
+        assert!(poll!(&mut inventory).is_pending());
+
+        assert_eq!(creations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn canceled_initializer_allows_a_waiter_to_retry() {
+        let registry = DatabasePoolRegistry::new();
+        let creations = Arc::new(AtomicUsize::new(0));
+        let first_registration = registry.begin_registration("orders").await;
+        let first_creations = Arc::clone(&creations);
+        let mut first = Box::pin(first_registration.get_or_create(poll_fn(move |_context| {
+            first_creations.fetch_add(1, Ordering::SeqCst);
+            Poll::<DataFusionResult<DatabasePool>>::Pending
+        })));
+        assert!(poll!(&mut first).is_pending());
+        drop(first);
+
+        let second_registration = registry.begin_registration("orders").await;
+        let second_creations = Arc::clone(&creations);
+        second_registration
+            .get_or_create(async move {
+                second_creations.fetch_add(1, Ordering::SeqCst);
+                Ok(DatabasePool::Test)
+            })
+            .await
+            .expect("waiter should become the initializer");
+
+        assert_eq!(creations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn timeout_without_a_successful_peer_evicts_the_pool() {
+        let registry = DatabasePoolRegistry::new();
+        let creations = Arc::new(AtomicUsize::new(0));
+
+        let first_registration = registry.begin_registration("orders").await;
+        let first_creations = Arc::clone(&creations);
+        first_registration
+            .get_or_create(async move {
+                first_creations.fetch_add(1, Ordering::SeqCst);
+                Ok(DatabasePool::Test)
+            })
+            .await
+            .expect("first pool");
+        first_registration.evict_after_timeout().await;
+
+        let retry_registration = registry.begin_registration("orders").await;
+        let retry_creations = Arc::clone(&creations);
+        retry_registration
+            .get_or_create(async move {
+                retry_creations.fetch_add(1, Ordering::SeqCst);
+                Ok(DatabasePool::Test)
+            })
+            .await
+            .expect("fresh retry pool");
+
+        assert_eq!(creations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn removing_one_catalog_pool_preserves_other_catalogs() {
+        let registry = DatabasePoolRegistry::new();
+        let orders_registration = registry.begin_registration("orders").await;
+        orders_registration
+            .get_or_create(async { Ok(DatabasePool::Test) })
+            .await
+            .expect("orders pool");
+        orders_registration.succeeded();
+        let inventory_registration = registry.begin_registration("inventory").await;
+        inventory_registration
+            .get_or_create(async { Ok(DatabasePool::Test) })
+            .await
+            .expect("inventory pool");
+        inventory_registration.succeeded();
 
         registry.remove_catalog("orders");
 
-        let pools = registry
-            .pools
+        let catalogs = registry
+            .catalogs
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        assert!(!pools.contains_key("orders"));
-        assert!(pools.contains_key("inventory"));
+        assert!(!catalogs.contains_key("orders"));
+        assert!(
+            catalogs
+                .get("inventory")
+                .expect("inventory state")
+                .pool
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_some()
+        );
     }
 }

--- a/crates/coral-engine/src/backends/database/source.rs
+++ b/crates/coral-engine/src/backends/database/source.rs
@@ -510,7 +510,11 @@ mod tests {
 
         async fn wait_for_calls(&self, expected: usize) {
             while self.calls.load(Ordering::SeqCst) < expected {
-                self.progressed.notified().await;
+                let notified = self.progressed.notified();
+                if self.calls.load(Ordering::SeqCst) >= expected {
+                    break;
+                }
+                notified.await;
             }
         }
     }

--- a/crates/coral-engine/src/backends/database/source.rs
+++ b/crates/coral-engine/src/backends/database/source.rs
@@ -21,7 +21,7 @@ use datafusion_table_providers::util::secrets::to_secret_map;
 
 use super::catalog::{DatabaseCatalog, DatabaseRelation, build_database_catalog, provider_error};
 use super::columns::{MYSQL_COLUMNS_SQL, POSTGRES_COLUMNS_SQL, SQLITE_COLUMNS_SQL};
-use super::registry::{DatabasePool, DatabasePoolRegistry};
+use super::registry::{DatabasePool, DatabasePoolRegistry, DatabaseRegistrationAttempt};
 use crate::backends::shared::template::{RenderContext, render_template};
 use crate::backends::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
@@ -65,7 +65,7 @@ trait DatabaseCatalogStrategy: Send + Sync {
         &self,
         catalog_name: &str,
         context: &RenderContext<'_>,
-        pool_registry: &DatabasePoolRegistry,
+        registration: &DatabaseRegistrationAttempt,
     ) -> DataFusionResult<DatabaseCatalog>;
 }
 
@@ -84,15 +84,32 @@ async fn register_database_catalog(
     pool_registry: &DatabasePoolRegistry,
 ) -> DataFusionResult<DatabaseCatalog> {
     let Some(timeout) = strategy.registration_timeout() else {
-        return strategy
-            .build_catalog(catalog_name, context, pool_registry)
-            .await;
+        let registration = pool_registry.begin_registration(catalog_name).await;
+        return match strategy
+            .build_catalog(catalog_name, context, &registration)
+            .await
+        {
+            Ok(catalog) => {
+                registration.succeeded();
+                Ok(catalog)
+            }
+            Err(error) => Err(error),
+        };
     };
-    let registration = || strategy.build_catalog(catalog_name, context, pool_registry);
     for _attempt in 0..MAX_REMOTE_DATABASE_REGISTRATION_ATTEMPTS {
-        match tokio::time::timeout(timeout, registration()).await {
-            Ok(result) => return result,
-            Err(_elapsed) => pool_registry.remove_catalog(catalog_name),
+        let registration = pool_registry.begin_registration(catalog_name).await;
+        match tokio::time::timeout(
+            timeout,
+            strategy.build_catalog(catalog_name, context, &registration),
+        )
+        .await
+        {
+            Ok(Ok(catalog)) => {
+                registration.succeeded();
+                return Ok(catalog);
+            }
+            Ok(Err(error)) => return Err(error),
+            Err(_elapsed) => registration.evict_after_timeout().await,
         }
     }
     Err(DataFusionError::Execution(format!(
@@ -162,7 +179,7 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
         &self,
         catalog_name: &str,
         context: &RenderContext<'_>,
-        pool_registry: &DatabasePoolRegistry,
+        registration: &DatabaseRegistrationAttempt,
     ) -> DataFusionResult<DatabaseCatalog> {
         let mut params = render_connection_params(
             [
@@ -177,8 +194,8 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
         if let Some(sslmode) = self.sslmode.as_ref() {
             params.insert("sslmode".to_string(), render_template(sslmode, context)?);
         }
-        let pool = pool_registry
-            .get_or_create(catalog_name, async move {
+        let pool = registration
+            .get_or_create(async move {
                 Ok(DatabasePool::Postgres(Arc::new(
                     PostgresConnectionPool::new(to_secret_map(params))
                         .await
@@ -214,7 +231,7 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
         &self,
         catalog_name: &str,
         context: &RenderContext<'_>,
-        pool_registry: &DatabasePoolRegistry,
+        registration: &DatabaseRegistrationAttempt,
     ) -> DataFusionResult<DatabaseCatalog> {
         let mut params = render_connection_params(
             [
@@ -236,8 +253,8 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
             }
         };
         params.insert("tcp_port".to_string(), tcp_port.to_string());
-        let pool = pool_registry
-            .get_or_create(catalog_name, async move {
+        let pool = registration
+            .get_or_create(async move {
                 Ok(DatabasePool::MySql(Arc::new(
                     MySQLConnectionPool::new(to_secret_map(params))
                         .await
@@ -287,7 +304,7 @@ impl DatabaseCatalogStrategy for SqliteConnectionSpec {
         &self,
         catalog_name: &str,
         context: &RenderContext<'_>,
-        _pool_registry: &DatabasePoolRegistry,
+        _registration: &DatabaseRegistrationAttempt,
     ) -> DataFusionResult<DatabaseCatalog> {
         let path = render_template(&self.path, context)?;
         let pool = SqliteConnectionPoolFactory::new(&path, Mode::File, SQLITE_BUSY_TIMEOUT)
@@ -436,23 +453,104 @@ fn database_relation_inventory(relations: &[DatabaseRelation]) -> Vec<Registered
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::future::pending;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
+    use async_trait::async_trait;
     use coral_spec::{
         DatabaseConnectionSpec, DatabaseSourceManifest, MySqlConnectionSpec, ParsedTemplate,
         SourceManifestCommon, SqliteConnectionSpec,
     };
+    use datafusion::catalog::MemoryCatalogProvider;
+    use tokio::sync::Notify;
 
     use super::{
-        DatabaseCatalogStrategy, MYSQL_INVENTORY_RECOGNIZED_DATA_TYPES,
-        MYSQL_INVENTORY_SESSION_SQL, mysql_relations_sql,
+        DatabaseCatalog, DatabaseCatalogStrategy, DatabasePool,
+        MYSQL_INVENTORY_RECOGNIZED_DATA_TYPES, MYSQL_INVENTORY_SESSION_SQL, mysql_relations_sql,
+        register_database_catalog,
     };
     use crate::backends::shared::template::RenderContext;
+    use crate::backends::{ColumnInventoryFilter, DatabaseColumnFetcher, DatabaseColumnRow};
     use crate::{
         CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
         SourceDecorator, SourceDecoratorError, SourceFailurePolicy, SourceTables,
     };
 
     struct AbortOnSourceFailureDecorator;
+
+    #[derive(Debug)]
+    struct EmptyColumnFetcher;
+
+    #[async_trait]
+    impl DatabaseColumnFetcher for EmptyColumnFetcher {
+        async fn fetch_columns(
+            &self,
+            _filter: &ColumnInventoryFilter,
+        ) -> datafusion::error::Result<Vec<DatabaseColumnRow>> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct TimeoutRaceStrategy {
+        calls: AtomicUsize,
+        creations: AtomicUsize,
+        progressed: Notify,
+    }
+
+    impl TimeoutRaceStrategy {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                creations: AtomicUsize::new(0),
+                progressed: Notify::new(),
+            }
+        }
+
+        async fn wait_for_calls(&self, expected: usize) {
+            while self.calls.load(Ordering::SeqCst) < expected {
+                self.progressed.notified().await;
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DatabaseCatalogStrategy for TimeoutRaceStrategy {
+        fn provider_name(&self) -> &'static str {
+            "test"
+        }
+
+        fn registration_timeout(&self) -> Option<Duration> {
+            Some(Duration::from_millis(25))
+        }
+
+        async fn build_catalog(
+            &self,
+            _catalog_name: &str,
+            _context: &RenderContext<'_>,
+            registration: &super::DatabaseRegistrationAttempt,
+        ) -> datafusion::error::Result<DatabaseCatalog> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            registration
+                .get_or_create(async {
+                    self.creations.fetch_add(1, Ordering::SeqCst);
+                    Ok(DatabasePool::Test)
+                })
+                .await?;
+            self.progressed.notify_waiters();
+
+            if call == 1 || call == 3 {
+                return pending().await;
+            }
+
+            Ok(DatabaseCatalog {
+                provider: Arc::new(MemoryCatalogProvider::new()),
+                relations: Vec::new(),
+                column_fetcher: Arc::new(EmptyColumnFetcher),
+            })
+        }
+    }
 
     impl SourceDecorator for AbortOnSourceFailureDecorator {
         fn name(&self) -> &'static str {
@@ -488,6 +586,46 @@ mod tests {
             user: template("root"),
             password: template("password"),
         }
+    }
+
+    #[tokio::test]
+    async fn timed_out_registration_does_not_evict_pool_used_by_successful_peer() {
+        let strategy = Arc::new(TimeoutRaceStrategy::new());
+        let registry = Arc::new(super::DatabasePoolRegistry::new());
+
+        let first = tokio::spawn({
+            let strategy = Arc::clone(&strategy);
+            let registry = Arc::clone(&registry);
+            async move {
+                let inputs = BTreeMap::new();
+                let context = RenderContext::source_scoped(&inputs);
+                register_database_catalog(strategy.as_ref(), "orders", &context, &registry).await
+            }
+        });
+        strategy.wait_for_calls(1).await;
+
+        let second = tokio::spawn({
+            let strategy = Arc::clone(&strategy);
+            let registry = Arc::clone(&registry);
+            async move {
+                let inputs = BTreeMap::new();
+                let context = RenderContext::source_scoped(&inputs);
+                register_database_catalog(strategy.as_ref(), "orders", &context, &registry).await
+            }
+        });
+        second
+            .await
+            .expect("successful registration task")
+            .expect("concurrent registration should succeed");
+
+        strategy.wait_for_calls(3).await;
+        assert_eq!(strategy.creations.load(Ordering::SeqCst), 1);
+
+        first.abort();
+        let Err(error) = first.await else {
+            panic!("aborted registration should not complete");
+        };
+        assert!(error.is_cancelled());
     }
 
     #[test]
@@ -564,8 +702,9 @@ mod tests {
             let connection = mysql_connection(port);
             let context = RenderContext::source_scoped(&resolved_inputs);
             let registry = super::DatabasePoolRegistry::new();
+            let registration = registry.begin_registration("coral_db").await;
             let Err(error) = connection
-                .build_catalog("coral_db", &context, &registry)
+                .build_catalog("coral_db", &context, &registration)
                 .await
             else {
                 panic!("invalid MySQL port should fail before provider fallback");


### PR DESCRIPTION
Coordinate pool creation per catalog and protect pools used by successful concurrent registrations from stale timeout eviction. Preserve fresh-pool retries when no registration succeeds, with deterministic concurrency coverage.