### PR TITLE
fix(search): fail sources whose runtime component identity diverges

### DIFF
--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -101,10 +101,11 @@ impl ObservedValuesLiveScopeLoader {
             loaded_runtime.runtime_contract_fingerprint.as_str(),
             source.credential_revision,
         );
-        Ok(source_surface_scopes(&loaded_runtime.query_source, seed)
-            .into_iter()
-            .map(|scope| scope.live_scope())
-            .collect())
+        // A component whose name diverges from its package fails this source
+        // closed through the existing partial-result channel.
+        let scopes = source_surface_scopes(&loaded_runtime.query_source, seed)
+            .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+        Ok(scopes.into_iter().map(|scope| scope.live_scope()).collect())
     }
 }
 
@@ -262,6 +263,7 @@ mod tests {
                 credential_revision,
             ),
         )
+        .expect("coherent source identity")
         .into_iter()
         .next()
         .expect("publisher scope")

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -98,7 +98,22 @@ impl SearchObservationHandle {
                 source.runtime_contract_fingerprint,
                 source.credential_revision,
             );
-            for scope in source_surface_scopes(source.query_source, seed) {
+            // Fail this source closed without touching the others: the arm
+            // above aborts capture for every selected source, which a single
+            // source's incoherent identity must not do.
+            let source_scopes = match source_surface_scopes(source.query_source, seed) {
+                Ok(source_scopes) => source_scopes,
+                Err(error) => {
+                    tracing::warn!(
+                        workspace = %workspace_name.as_str(),
+                        source = %source.query_source.source_name(),
+                        error = %error,
+                        "skipping observed-values capture for a source whose runtime component identity diverges"
+                    );
+                    continue;
+                }
+            };
+            for scope in source_scopes {
                 scopes.insert(scope.key(), RegisteredSurface { scope, epoch });
             }
         }
@@ -302,9 +317,11 @@ mod tests {
         let source = http_query_source("/issues");
 
         let first_scope = source_surface_scopes(&source, SourceScopeSeed::PRE_ACTIVATION)
+            .expect("coherent source identity")
             .pop()
             .expect("first scope");
         let second_scope = source_surface_scopes(&source, SourceScopeSeed::PRE_ACTIVATION)
+            .expect("coherent source identity")
             .pop()
             .expect("second scope");
 
@@ -318,18 +335,21 @@ mod tests {
             &source,
             SourceScopeSeed::new("runtime-contract-a", Uuid::from_u128(1)),
         )
+        .expect("coherent source identity")
         .pop()
         .expect("first scope");
         let contract_changed = source_surface_scopes(
             &source,
             SourceScopeSeed::new("runtime-contract-b", Uuid::from_u128(1)),
         )
+        .expect("coherent source identity")
         .pop()
         .expect("contract scope");
         let credential_changed = source_surface_scopes(
             &source,
             SourceScopeSeed::new("runtime-contract-a", Uuid::from_u128(2)),
         )
+        .expect("coherent source identity")
         .pop()
         .expect("credential scope");
 
@@ -435,30 +455,28 @@ mod tests {
     }
 
     #[test]
-    fn publisher_preserves_owner_and_query_schema_for_multi_surface_v4_package() {
+    fn divergent_component_identity_is_skipped_without_affecting_other_sources() {
         let temp = tempdir().expect("tempdir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
-        let source = multi_surface_v4_query_source();
-        let extensions =
-            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
+        let divergent = divergent_component_query_source();
+        let coherent = single_component_query_source("github_mcp_v4");
+        let extensions = handle.extensions_for(
+            &workspace,
+            &[
+                SearchObservationSource::for_test(&divergent),
+                SearchObservationSource::for_test(&coherent),
+            ],
+        );
         let publisher = extensions
             .source_observation_publishers
             .first()
             .expect("publisher");
-        let batch = RecordBatch::try_new(
-            Arc::new(Schema::new(vec![Field::new(
-                "title",
-                DataType::Utf8,
-                false,
-            )])),
-            vec![Arc::new(StringArray::from(vec!["Fix the bug"]))],
-        )
-        .expect("batch");
+        let batch = title_batch();
 
-        for source_name in ["github_v4_rest", "github_v4_mcp"] {
+        for source_name in ["github_v4_rest", "github_v4_mcp", "github_mcp_v4"] {
             publisher.publish_source_scan(SourceScanObservation {
                 source_name,
                 surface_kind: SourceObservationSurfaceKind::Table,
@@ -467,33 +485,31 @@ mod tests {
             });
         }
 
-        let identities = wait_for_source_identities(&layout, &workspace, 2);
+        // Only the coherent source registered a surface, so only its
+        // observation is captured; the divergent package writes nothing, and
+        // failing it does not abort capture for its neighbour.
+        let identities = wait_for_source_identities(&layout, &workspace, 1);
         assert_eq!(
             identities,
-            [
-                (
-                    "github_v4".to_string(),
-                    "github_v4_rest".to_string(),
-                    "list_issues".to_string(),
-                ),
-                (
-                    "github_v4".to_string(),
-                    "github_v4_mcp".to_string(),
-                    "list_issues".to_string(),
-                ),
-            ]
+            [(
+                "github_mcp_v4".to_string(),
+                "github_mcp_v4".to_string(),
+                "list_issues".to_string(),
+            )]
         );
+    }
 
-        let store = SqliteObservedValuesStore::new(layout);
-        store
-            .clear_source_and_advance_epoch(&workspace, "github_v4")
-            .expect("clear logical source owner");
-        assert_eq!(
-            store
-                .pending_queue_job_count(&workspace)
-                .expect("queue count"),
-            0
-        );
+    #[test]
+    fn divergent_component_identity_fails_scope_derivation() {
+        let source = divergent_component_query_source();
+
+        let error = source_surface_scopes(&source, SourceScopeSeed::PRE_ACTIVATION)
+            .expect_err("divergent component identity must not derive scopes");
+
+        // This is what makes retrieval fail closed: the live-scope loader turns
+        // this error into a per-source load failure.
+        assert!(error.to_string().contains("github_v4"));
+        assert!(error.to_string().contains("github_v4_rest"));
     }
 
     #[test]
@@ -628,9 +644,10 @@ tables:
         )
     }
 
-    fn multi_surface_v4_query_source() -> QuerySource {
-        // Multi-surface v4 sources reach the engine through this backend-ready
-        // package shape: one installed owner with one schema per component.
+    /// Package in the pre-#1791 shape: components named differently from the
+    /// package that carries them. Unreachable through the sources domain, which
+    /// is exactly what the tripwire defends against.
+    fn divergent_component_query_source() -> QuerySource {
         QuerySource::from_runtime_components(
             RuntimeSourcePackage {
                 source_name: "github_v4".to_string(),
@@ -647,7 +664,36 @@ tables:
             BTreeMap::new(),
             BTreeMap::new(),
         )
-        .expect("multi-surface query source")
+        .expect("divergent component query source")
+    }
+
+    fn single_component_query_source(source_name: &str) -> QuerySource {
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: source_name.to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                identity_requirements: None,
+                components: vec![http_component(source_name)],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("single component query source")
+    }
+
+    fn title_batch() -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "title",
+                DataType::Utf8,
+                false,
+            )])),
+            vec![Arc::new(StringArray::from(vec!["Fix the bug"]))],
+        )
+        .expect("batch")
     }
 
     fn http_component(source_name: &str) -> RuntimeSourceComponent {

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -48,6 +48,23 @@ impl<'a> SourceScopeSeed<'a> {
     }
 }
 
+/// A runtime component whose name diverges from its package's source name.
+///
+/// Since #1791 one source publishes exactly one surface and one SQL namespace,
+/// and the sources domain copies both names from the same `manifest.common.name`
+/// field, so this is unreachable on every production path. Search still refuses
+/// the source rather than writing rows under an identity that would select
+/// nothing back -- a tripwire at the single seam that derives identity from a
+/// runtime package, not an enforcement boundary.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "source '{source_name}' exposes runtime component '{component_source_name}'; one installed source must publish exactly one runtime schema"
+)]
+pub(crate) struct ObservedSourceIdentityMismatch {
+    source_name: String,
+    component_source_name: String,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ObservedSourceSurfaceScope {
     /// Canonical installed source that owns lifecycle clears and invalidation epochs.
@@ -77,9 +94,26 @@ impl ObservedSourceSurfaceScope {
 pub(super) fn source_surface_scopes(
     source: &QuerySource,
     seed: SourceScopeSeed<'_>,
-) -> Vec<ObservedSourceSurfaceScope> {
+) -> Result<Vec<ObservedSourceSurfaceScope>, ObservedSourceIdentityMismatch> {
+    let source_name = source.source_name();
     let mut scopes = Vec::new();
     for component in source.components() {
+        let component_source_name = match component {
+            // Database components declare no HTTP/MCP observation surfaces, so
+            // they never contribute a stored identity for the tripwire to
+            // protect; the arm below enumerates nothing for them.
+            RuntimeSourceComponent::Database(_) => source_name,
+            RuntimeSourceComponent::Http(manifest) => manifest.common.name.as_str(),
+            RuntimeSourceComponent::File(manifest) => manifest.common.name.as_str(),
+            RuntimeSourceComponent::Mcp(manifest) => manifest.common.name.as_str(),
+        };
+        if component_source_name != source_name {
+            return Err(ObservedSourceIdentityMismatch {
+                source_name: source_name.to_string(),
+                component_source_name: component_source_name.to_string(),
+            });
+        }
+
         match component {
             RuntimeSourceComponent::Database(_) => {
                 // Database tables do not declare HTTP/MCP observation surfaces.
@@ -137,7 +171,7 @@ pub(super) fn source_surface_scopes(
             }
         }
     }
-    scopes
+    Ok(scopes)
 }
 
 fn surface_scope(
@@ -176,4 +210,48 @@ struct ScopeFingerprint<'a> {
     component_source_name: &'a str,
     surface_kind: &'static str,
     surface_name: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::{SOURCE_SCOPE_FORMAT_VERSION, ScopeFingerprint};
+    use crate::hash::sha256_hex;
+
+    /// Pins the exact bytes hashed into `source_scope_id`.
+    ///
+    /// Every stored observed row is keyed by that id and retrieval is
+    /// fail-closed, so a change to this serialization silently hides the entire
+    /// observed corpus rather than failing anything. The struct is private and
+    /// its field names are part of the on-disk format, not an implementation
+    /// detail -- if a refactor needs to rename one, it owes a `#[serde(rename)]`
+    /// and this test must keep passing untouched.
+    #[test]
+    fn scope_fingerprint_hash_is_stable() {
+        let scope_bytes = serde_json::to_vec(&ScopeFingerprint {
+            format_version: SOURCE_SCOPE_FORMAT_VERSION,
+            runtime_contract_fingerprint: "v1:test-runtime-contract",
+            credential_revision: Uuid::nil(),
+            component_source_name: "github_v4",
+            surface_kind: "table",
+            surface_name: "issues",
+        })
+        .expect("scope fingerprint serializes");
+
+        assert_eq!(
+            String::from_utf8(scope_bytes.clone()).expect("scope fingerprint is utf-8"),
+            concat!(
+                r#"{"format_version":1,"#,
+                r#""runtime_contract_fingerprint":"v1:test-runtime-contract","#,
+                r#""credential_revision":"00000000-0000-0000-0000-000000000000","#,
+                r#""component_source_name":"github_v4","#,
+                r#""surface_kind":"table","surface_name":"issues"}"#,
+            )
+        );
+        assert_eq!(
+            sha256_hex(&scope_bytes),
+            "82fca0aa8c55fc4b8a22cf7a8f57a63d5acab8d7d2d84853d3f12b3b7a24886b"
+        );
+    }
 }


### PR DESCRIPTION
## What

Establishes the two identity invariants the rest of the stack relies on, while
the owner/component pair still exists:

1. **Tripwire** — a runtime component whose name differs from its package's
   `source_name()` fails that source closed, source-locally.
2. **Scope-id pin** — the exact bytes hashed into `source_scope_id`, and their
   sha256.

#2038 downstack collapses the two stored identities into one and renames the
hashed field. Landing these first means that change rests on verified
invariants rather than assumed ones.

## The tripwire

Universal Search stores two identities per observed row: the installed source
that owns lifecycle clears and epochs, and the runtime component name used as
the SQL schema. #1791 made those the same thing — one source, one surface, one
SQL namespace — but nothing in search checked it.

It fails through channels that already exist; no new machinery:

- **capture**: the per-source loop skips the offending source and logs.
  Deliberately *not* the store-error arm above it, which aborts capture for
  every selected source — one source's incoherent identity must not silence its
  neighbours.
- **retrieval**: `load_source_scopes` propagates, and the existing
  `ObservedValuesLiveScopeLoadFailure` channel fails that source closed and
  surfaces a partial-result note.

### This is a tripwire, not an enforcement boundary

Producing singular identity is the sources domain's job. On current paths
divergence is not merely unlikely but impossible: the package `source_name` and
every component name are copied from the same `manifest.common.name` field in
the same function, and installed name == manifest name is enforced at load
(`sources/catalog.rs` `resolve_installed_manifest`).

Search defends at its own seam anyway, because its storage can still
*represent* divergence — nothing in SQLite prevents it, and a synthetic engine
package can construct it. Deliberately no validator in `runtime_package.rs`, no
change to `sources/manager.rs`.

Database components are exempt: they declare no HTTP/MCP observation surfaces,
so they contribute no stored identity for the tripwire to protect.

## The scope-id pin

`source_scope_id` is `sha256(serde_json::to_vec(ScopeFingerprint { .. }))`, and
every stored observed row is keyed by it. Retrieval is **fail-closed**: a row
whose scope id no longer matches a live scope is invisible. So a change to this
serialization does not fail a test, return an error, or log anything — it
silently hides the observed corpus.

`ScopeFingerprint` is a private struct with ordinary-looking Rust field names,
and nothing marked them as an on-disk format. The test asserts both the exact
serialized JSON and its digest.

It passes against today's code unchanged — no behaviour change here. #2038 then
renames that field with `#[serde(rename)]`, and this pre-existing assertion
staying green is what proves the rename moved no bytes.

## Notes for review

`publisher_preserves_owner_and_query_schema_for_multi_surface_v4_package`
asserted the exact topology the tripwire rejects — one package, two
differently-named components. It is replaced by tests that a divergent package
derives no scopes at all, and that skipping it leaves a healthy source
alongside it fully captured.
