### PR TITLE
feat: add catalog-aware relation contracts

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -366,6 +366,10 @@ describe('Architectural Tests', () => {
       // Schema is a layout with nested table-detail routes.
       expect(routeConfig).toContain("route(routePattern('workspaceSchema'), 'routes/schema.tsx', [")
       expect(routeConfig).toContain("index('routes/schema-empty.tsx')")
+      expect(routeConfig).toContain("'catalogs/:catalogName/:schemaName/:tableName'")
+      expect(routeConfig).toContain("'routes/schema-catalog-table.tsx'")
+      expect(routeConfig).toContain("'catalogs/:catalogName/:schemaName/functions/:functionName'")
+      expect(routeConfig).toContain("'routes/schema-catalog-table-function.tsx'")
       expect(routeConfig).toContain("route(':schemaName/:tableName', 'routes/schema-table.tsx')")
       expect(routeConfig).toContain(
         "route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx')",

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -56,6 +56,7 @@ export interface TableFunctionDef {
 export type SchemaItemDef = TableDef | TableFunctionDef
 
 export interface SchemaGroup {
+  catalogName?: string
   items: SchemaItemDef[]
   name: string
 }

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -20,6 +20,11 @@ export default [
     route(routePattern('workspaceFunctions'), 'routes/functions.tsx'),
     route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
       index('routes/schema-empty.tsx'),
+      route('catalogs/:catalogName/:schemaName/:tableName', 'routes/schema-catalog-table.tsx'),
+      route(
+        'catalogs/:catalogName/:schemaName/functions/:functionName',
+        'routes/schema-catalog-table-function.tsx',
+      ),
       route(':schemaName/:tableName', 'routes/schema-table.tsx'),
       route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx'),
     ]),

--- a/apps/reef/app/routes/schema-catalog-table-function.tsx
+++ b/apps/reef/app/routes/schema-catalog-table-function.tsx
@@ -1,0 +1,1 @@
+export { default } from './schema-table-function'

--- a/apps/reef/app/routes/schema-catalog-table.tsx
+++ b/apps/reef/app/routes/schema-catalog-table.tsx
@@ -1,0 +1,1 @@
+export { ErrorBoundary, default, loader } from './schema-table'

--- a/apps/reef/app/routes/schema-loaders.server.test.ts
+++ b/apps/reef/app/routes/schema-loaders.server.test.ts
@@ -24,7 +24,15 @@ describe('schema loaders', () => {
 
   it('lists catalog tables for the workspace route parameter', async () => {
     const request = new Request('http://reef.test/workspaces/analytics/schema')
-    const schema = { connectors: [] }
+    const schema = {
+      connectors: [
+        {
+          catalogName: 'github_v4',
+          items: [{ kind: 'tableFunction', name: 'list_for_repo' }],
+          name: 'issues',
+        },
+      ],
+    }
     fetchSchemaFromCoral.mockResolvedValue(schema)
 
     await expect(

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -10,6 +10,10 @@ const CANONICAL_PATTERNS = {
   workspaces: '/workspaces',
   workspaceFunctions: '/workspaces/:workspaceId/functions',
   workspaceSchema: '/workspaces/:workspaceId/schema',
+  workspaceSchemaCatalogTable:
+    '/workspaces/:workspaceId/schema/catalogs/:catalogName/:schemaName/:tableName',
+  workspaceSchemaCatalogTableFunction:
+    '/workspaces/:workspaceId/schema/catalogs/:catalogName/:schemaName/functions/:functionName',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
   workspaceSchemaTableFunction:
     '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName',
@@ -43,6 +47,18 @@ describe('route map', () => {
       workspaces: routePath('workspaces'),
       workspaceFunctions: routePath('workspaceFunctions', { workspaceId: 'analytics' }),
       workspaceSchema: routePath('workspaceSchema', { workspaceId: 'analytics' }),
+      workspaceSchemaCatalogTable: routePath('workspaceSchemaCatalogTable', {
+        catalogName: 'github_v4',
+        schemaName: 'issues',
+        tableName: 'list_for_repo',
+        workspaceId: 'analytics',
+      }),
+      workspaceSchemaCatalogTableFunction: routePath('workspaceSchemaCatalogTableFunction', {
+        catalogName: 'github_v4',
+        functionName: 'list_for_repo',
+        schemaName: 'issues',
+        workspaceId: 'analytics',
+      }),
       workspaceSchemaTable: routePath('workspaceSchemaTable', {
         schemaName: 'github',
         tableName: 'issues',
@@ -76,6 +92,10 @@ describe('route map', () => {
       workspaces: '/workspaces',
       workspaceFunctions: '/workspaces/analytics/functions',
       workspaceSchema: '/workspaces/analytics/schema',
+      workspaceSchemaCatalogTable:
+        '/workspaces/analytics/schema/catalogs/github_v4/issues/list_for_repo',
+      workspaceSchemaCatalogTableFunction:
+        '/workspaces/analytics/schema/catalogs/github_v4/issues/functions/list_for_repo',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSchemaTableFunction: '/workspaces/analytics/schema/github/functions/search_issues',
       workspaceSource: '/workspaces/analytics/sources/github',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -6,6 +6,10 @@ const ONBOARDING_PATH = '/onboarding'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_FUNCTIONS_PATH = '/workspaces/:workspaceId/functions'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
+const WORKSPACE_SCHEMA_CATALOG_TABLE_PATH =
+  '/workspaces/:workspaceId/schema/catalogs/:catalogName/:schemaName/:tableName'
+const WORKSPACE_SCHEMA_CATALOG_TABLE_FUNCTION_PATH =
+  '/workspaces/:workspaceId/schema/catalogs/:catalogName/:schemaName/functions/:functionName'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
 const WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH =
   '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName'
@@ -45,6 +49,36 @@ export const routeDefinitions = {
     path: WORKSPACE_SCHEMA_PATH,
     toPath: (params: { workspaceId: string }) =>
       generatePath(WORKSPACE_SCHEMA_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSchemaCatalogTable: {
+    path: WORKSPACE_SCHEMA_CATALOG_TABLE_PATH,
+    toPath: (params: {
+      catalogName: string
+      schemaName: string
+      tableName: string
+      workspaceId: string
+    }) =>
+      generatePath(WORKSPACE_SCHEMA_CATALOG_TABLE_PATH, {
+        catalogName: params.catalogName,
+        schemaName: params.schemaName,
+        tableName: params.tableName,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSchemaCatalogTableFunction: {
+    path: WORKSPACE_SCHEMA_CATALOG_TABLE_FUNCTION_PATH,
+    toPath: (params: {
+      catalogName: string
+      functionName: string
+      schemaName: string
+      workspaceId: string
+    }) =>
+      generatePath(WORKSPACE_SCHEMA_CATALOG_TABLE_FUNCTION_PATH, {
+        catalogName: params.catalogName,
+        functionName: params.functionName,
+        schemaName: params.schemaName,
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
@@ -68,3 +68,51 @@ it('shows table-function arguments and result columns from the parent schema res
   await expect.element(screen.getByRole('cell', { name: 'general, random' })).toBeVisible()
   await expect.element(screen.getByRole('cell', { name: 'Message text.' })).toBeVisible()
 })
+
+it('shows a catalog-qualified table function at its disambiguated route', async () => {
+  const schema = {
+    connectors: [
+      {
+        catalogName: 'github_v4',
+        items: [
+          {
+            arguments: [],
+            kind: 'tableFunction',
+            name: 'list_for_repo',
+            resultColumns: [],
+          },
+        ],
+        name: 'issues',
+      },
+    ],
+  } satisfies SchemaResponse
+  const router = createMemoryRouter(
+    [
+      {
+        children: [
+          {
+            element: <SchemaTableFunctionView />,
+            path: 'catalogs/:catalogName/:schemaName/functions/:functionName',
+          },
+        ],
+        element: <Outlet context={schema} />,
+        path: routePattern('workspaceSchema'),
+      },
+    ],
+    {
+      initialEntries: [
+        routePath('workspaceSchemaCatalogTableFunction', {
+          catalogName: 'github_v4',
+          functionName: 'list_for_repo',
+          schemaName: 'issues',
+          workspaceId: 'analytics',
+        }),
+      ],
+    },
+  )
+  const screen = await render(<RouterProvider router={router} />)
+
+  await expect
+    .element(screen.getByRole('heading', { name: 'github_v4.issues.list_for_repo()' }))
+    .toBeVisible()
+})

--- a/apps/reef/app/views/schema-explorer/schema-table-function.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.tsx
@@ -12,9 +12,10 @@ import { SchemaColumnsTable } from './schema-table'
 export function SchemaTableFunctionView() {
   const schema = useOutletContext<SchemaResponse>()
   const params = useParams()
+  const catalogName = params.catalogName
   const schemaName = params.schemaName ?? ''
   const functionName = params.functionName ?? ''
-  const tableFunction = findSchemaTableFunction(schema, schemaName, functionName)
+  const tableFunction = findSchemaTableFunction(schema, catalogName, schemaName, functionName)
 
   if (!tableFunction) {
     return (
@@ -29,6 +30,7 @@ export function SchemaTableFunctionView() {
       <div className={styles.detailHeader}>
         <div>
           <Typography.HeadingSmall as="h2">
+            {catalogName ? `${catalogName}.` : ''}
             {schemaName}.{tableFunction.name}
             <Typography.Body>{tableFunctionTreeArguments(tableFunction)}</Typography.Body>
           </Typography.HeadingSmall>

--- a/apps/reef/app/views/schema-explorer/schema-table.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table.tsx
@@ -22,23 +22,35 @@ interface DisplayColumn {
 
 // The parent schema layout resolves its schema before rendering this Outlet, so
 // table metadata (description, required filters) is available synchronously.
-function useSelectedTable(): { schemaName: string; tableName: string; table?: TableDef } {
+function useSelectedTable(): {
+  catalogName?: string
+  schemaName: string
+  tableName: string
+  table?: TableDef
+} {
   const schema = useOutletContext<SchemaResponse>()
   const params = useParams()
+  const catalogName = params.catalogName
   const schemaName = params.schemaName ?? ''
   const tableName = params.tableName ?? ''
-  return { schemaName, tableName, table: findSchemaTable(schema, schemaName, tableName) }
+  return {
+    catalogName,
+    schemaName,
+    tableName,
+    table: findSchemaTable(schema, catalogName, schemaName, tableName),
+  }
 }
 
 // Detail-panel scaffold for a selected table: title, description, required
 // filters, and a "Columns" section body.
 function TableDetailLayout({ children }: { children: React.ReactNode }) {
-  const { schemaName, tableName, table } = useSelectedTable()
+  const { catalogName, schemaName, tableName, table } = useSelectedTable()
   return (
     <div className={styles.detailContent}>
       <div className={styles.detailHeader}>
         <div>
           <Typography.HeadingSmall as="h2">
+            {catalogName ? `${catalogName}.` : ''}
             {schemaName}.{tableName}
           </Typography.HeadingSmall>
           {table?.description ? (

--- a/apps/reef/app/views/schema-explorer/schema.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.test.tsx
@@ -30,6 +30,25 @@ const SCHEMA = {
         },
       ],
     },
+    {
+      catalogName: 'github_v4',
+      name: 'issues',
+      items: [
+        {
+          columns: [],
+          columnsLoaded: false,
+          kind: 'table',
+          name: 'list_for_repo',
+          requiredFilters: [],
+        },
+        {
+          arguments: [],
+          kind: 'tableFunction',
+          name: 'search',
+          resultColumns: [],
+        },
+      ],
+    },
   ],
 } satisfies SchemaResponse
 
@@ -67,4 +86,24 @@ it('links tables within the active workspace schema route', async () => {
         workspaceId,
       }),
     )
+
+  await screen.getByRole('button', { name: /github_v4\.issues/ }).click()
+  await expect.element(screen.getByRole('link', { name: 'list_for_repo' })).toHaveAttribute(
+    'href',
+    routePath('workspaceSchemaCatalogTable', {
+      catalogName: 'github_v4',
+      schemaName: 'issues',
+      tableName: 'list_for_repo',
+      workspaceId,
+    }),
+  )
+  await expect.element(screen.getByRole('link', { name: 'search()' })).toHaveAttribute(
+    'href',
+    routePath('workspaceSchemaCatalogTableFunction', {
+      catalogName: 'github_v4',
+      functionName: 'search',
+      schemaName: 'issues',
+      workspaceId,
+    }),
+  )
 })

--- a/apps/reef/app/views/schema-explorer/schema.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.tsx
@@ -22,21 +22,23 @@ import { formatError, useRouteRetry } from './shared'
 
 export function findSchemaTable(
   schema: SchemaResponse,
+  catalogName: string | undefined,
   schemaName: string,
   tableName: string,
 ): TableDef | undefined {
   return schema.connectors
-    .find((connector) => connector.name === schemaName)
+    .find((connector) => connector.catalogName === catalogName && connector.name === schemaName)
     ?.items.find((item): item is TableDef => item.kind === 'table' && item.name === tableName)
 }
 
 export function findSchemaTableFunction(
   schema: SchemaResponse,
+  catalogName: string | undefined,
   schemaName: string,
   functionName: string,
 ): TableFunctionDef | undefined {
   return schema.connectors
-    .find((connector) => connector.name === schemaName)
+    .find((connector) => connector.catalogName === catalogName && connector.name === schemaName)
     ?.items.find(
       (item): item is TableFunctionDef =>
         item.kind === 'tableFunction' && item.name === functionName,
@@ -52,7 +54,7 @@ function schemaMatchesSearch(schema: SchemaGroup, search: string) {
 }
 
 function schemaNameMatchesSearch(schema: SchemaGroup, search: string) {
-  return schema.name.toLowerCase().includes(search)
+  return schemaDisplayName(schema).toLowerCase().includes(search)
 }
 
 function catalogItemMatchesSearch(item: SchemaItemDef, search: string) {
@@ -73,18 +75,41 @@ function visibleItemsForSchema(schema: SchemaGroup, search: string) {
   return schema.items.filter((item) => catalogItemMatchesSearch(item, search))
 }
 
-function tablePath(workspaceId: string, schemaName: string, tableName: string) {
-  return routePath('workspaceSchemaTable', { schemaName, tableName, workspaceId })
+function schemaKey(schema: SchemaGroup) {
+  return JSON.stringify([schema.catalogName ?? null, schema.name])
 }
 
-function tableFunctionPath(workspaceId: string, schemaName: string, functionName: string) {
-  return routePath('workspaceSchemaTableFunction', { functionName, schemaName, workspaceId })
+function schemaDisplayName(schema: SchemaGroup) {
+  return schema.catalogName ? `${schema.catalogName}.${schema.name}` : schema.name
 }
 
-function catalogItemPath(workspaceId: string, schemaName: string, item: SchemaItemDef) {
+function catalogItemPath(workspaceId: string, schema: SchemaGroup, item: SchemaItemDef) {
+  if (schema.catalogName) {
+    return item.kind === 'table'
+      ? routePath('workspaceSchemaCatalogTable', {
+          catalogName: schema.catalogName,
+          schemaName: schema.name,
+          tableName: item.name,
+          workspaceId,
+        })
+      : routePath('workspaceSchemaCatalogTableFunction', {
+          catalogName: schema.catalogName,
+          functionName: item.name,
+          schemaName: schema.name,
+          workspaceId,
+        })
+  }
   return item.kind === 'table'
-    ? tablePath(workspaceId, schemaName, item.name)
-    : tableFunctionPath(workspaceId, schemaName, item.name)
+    ? routePath('workspaceSchemaTable', {
+        schemaName: schema.name,
+        tableName: item.name,
+        workspaceId,
+      })
+    : routePath('workspaceSchemaTableFunction', {
+        functionName: item.name,
+        schemaName: schema.name,
+        workspaceId,
+      })
 }
 
 export function tableFunctionTreeArguments(tableFunction: TableFunctionDef) {
@@ -154,11 +179,11 @@ export function SchemaExplorer({
     [normalizedSearch, schema],
   )
 
-  const toggleSchema = (name: string) => {
+  const toggleSchema = (key: string) => {
     setExpandedSchemas((previous) => {
       const next = new Set(previous)
-      if (next.has(name)) next.delete(name)
-      else next.add(name)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
       return next
     })
   }
@@ -196,18 +221,19 @@ export function SchemaExplorer({
               ) : (
                 <div className={styles.treeList}>
                   {filteredSchemas.map((connector) => {
+                    const connectorKey = schemaKey(connector)
                     // A search forces matching schemas open so results are visible.
-                    const expanded = normalizedSearch !== '' || expandedSchemas.has(connector.name)
-                    const connectorChildrenId = `schema-${connector.name}-items`
+                    const expanded = normalizedSearch !== '' || expandedSchemas.has(connectorKey)
+                    const connectorChildrenId = `schema-${encodeURIComponent(connectorKey)}-items`
                     const visibleItems = visibleItemsForSchema(connector, normalizedSearch)
                     return (
-                      <div key={connector.name}>
+                      <div key={connectorKey}>
                         <ButtonContainer
                           aria-controls={expanded ? connectorChildrenId : undefined}
                           aria-expanded={expanded}
                           className={styles.treeRow}
                           fullWidth
-                          onClick={() => toggleSchema(connector.name)}
+                          onClick={() => toggleSchema(connectorKey)}
                           size="22"
                           variant="bare"
                         >
@@ -217,7 +243,7 @@ export function SchemaExplorer({
                             size="14"
                           />
                           <Typography.BodyStrong className={styles.connectorName}>
-                            {connector.name}
+                            {schemaDisplayName(connector)}
                           </Typography.BodyStrong>
                           <Typography.BodySmall
                             className={styles.connectorItemCount}
@@ -230,8 +256,9 @@ export function SchemaExplorer({
                         {expanded ? (
                           <div className={styles.connectorChildren} id={connectorChildrenId}>
                             {visibleItems.map((item) => {
-                              const path = catalogItemPath(workspaceId, connector.name, item)
+                              const path = catalogItemPath(workspaceId, connector, item)
                               const active =
+                                activeItem.catalogName === connector.catalogName &&
                                 activeItem.schemaName === connector.name &&
                                 (item.kind === 'table'
                                   ? activeItem.tableName === item.name

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -151,6 +151,9 @@ message TableFunction {
   SearchLimits search_limits = 8;
   // User-facing query guidance.
   string guide = 9;
+  // SQL catalog containing the schema. Empty for two-part functions; otherwise
+  // the function is addressed as catalog_name.schema_name.name.
+  string catalog_name = 10;
 }
 
 // Catalog item kind filter for unified discovery.

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -420,7 +420,7 @@ fn catalog_item_sort_key(item: &CatalogItem) -> (&str, &str, &str, &'static str)
             "table",
         ),
         CatalogItem::TableFunction(function) => (
-            "",
+            function.catalog_name.as_deref().unwrap_or_default(),
             &function.schema_name,
             &function.function_name,
             "table_function",
@@ -534,27 +534,42 @@ fn table_function_matched_fields(
     function: &TableFunctionInfo,
     regex: &Regex,
 ) -> Vec<CatalogMetadataField> {
-    let name = format!("{}.{}", function.schema_name, function.function_name);
-    let candidates = [
-        (
-            CatalogMetadataField::SchemaName,
-            function.schema_name.as_str(),
-        ),
-        (
-            CatalogMetadataField::FunctionName,
-            function.function_name.as_str(),
-        ),
-        (CatalogMetadataField::Name, name.as_str()),
-        (
-            CatalogMetadataField::Description,
-            function.description.as_str(),
-        ),
-        (CatalogMetadataField::Guide, function.guide.as_str()),
-    ];
-    let mut matches = candidates
-        .into_iter()
-        .filter_map(|(field, value)| regex.is_match(value).then_some(field))
-        .collect::<Vec<_>>();
+    let addressable_schema = function.catalog_name.as_deref().map_or_else(
+        || function.schema_name.clone(),
+        |catalog_name| format!("{catalog_name}.{}", function.schema_name),
+    );
+    let name = format!("{addressable_schema}.{}", function.function_name);
+    let mut matches = Vec::new();
+    let catalog_matched = function
+        .catalog_name
+        .as_deref()
+        .is_some_and(|catalog_name| regex.is_match(catalog_name));
+    let schema_matched = regex.is_match(&function.schema_name);
+    if catalog_matched {
+        matches.push(CatalogMetadataField::CatalogName);
+    }
+    if schema_matched {
+        matches.push(CatalogMetadataField::SchemaName);
+    }
+    if !catalog_matched
+        && !schema_matched
+        && addressable_schema != function.schema_name
+        && regex.is_match(&addressable_schema)
+    {
+        matches.push(CatalogMetadataField::QualifiedSchema);
+    }
+    if regex.is_match(&function.function_name) {
+        matches.push(CatalogMetadataField::FunctionName);
+    }
+    if regex.is_match(&name) {
+        matches.push(CatalogMetadataField::Name);
+    }
+    if regex.is_match(&function.description) {
+        matches.push(CatalogMetadataField::Description);
+    }
+    if regex.is_match(&function.guide) {
+        matches.push(CatalogMetadataField::Guide);
+    }
     if function.arguments.iter().any(|argument| {
         regex.is_match(&argument.name) || argument.values.iter().any(|value| regex.is_match(value))
     }) {
@@ -723,10 +738,10 @@ pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
 mod tests {
     use super::{
         CatalogMetadataField, CatalogTableRef, available_table_schemas, compile_metadata_regex,
-        missing_table_suggestions, same_schema_tables, table_matched_fields, table_matches_ref,
-        table_metadata_contains_literal,
+        missing_table_suggestions, same_schema_tables, table_function_matched_fields,
+        table_matched_fields, table_matches_ref, table_metadata_contains_literal,
     };
-    use coral_engine::TableInfo;
+    use coral_engine::{TableFunctionInfo, TableInfo};
 
     fn table(required_filters: Vec<String>) -> TableInfo {
         TableInfo {
@@ -859,5 +874,36 @@ mod tests {
             same_schema_table,
             "coral_db.main.users"
         ));
+    }
+
+    #[test]
+    fn catalog_qualified_function_matches_complete_identity() {
+        let function = TableFunctionInfo {
+            catalog_name: Some("github_v4".to_string()),
+            schema_name: "issues".to_string(),
+            function_name: "list_for_repo".to_string(),
+            description: String::new(),
+            guide: String::new(),
+            require_guide_read: false,
+            arguments: Vec::new(),
+            result_columns: Vec::new(),
+            kind: coral_spec::SourceTableFunctionKind::Table,
+            search_limits: None,
+        };
+
+        assert_eq!(
+            table_function_matched_fields(
+                &function,
+                &regex::Regex::new("^github_v4\\.issues\\.list_for_repo$").expect("regex")
+            ),
+            vec![CatalogMetadataField::Name]
+        );
+        assert_eq!(
+            table_function_matched_fields(
+                &function,
+                &regex::Regex::new("^github_v4$").expect("regex")
+            ),
+            vec![CatalogMetadataField::CatalogName]
+        );
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1065,21 +1065,32 @@ fn required_query_guides(
     let mut guides = Vec::new();
     for usage in resources.tables() {
         if let Some(table) = catalog.tables.iter().find(|table| {
-            table.schema_name == usage.schema_name() && table.table_name == usage.table_name()
+            table.catalog_name.as_deref() == usage.catalog_name()
+                && table.schema_name == usage.schema_name()
+                && table.table_name == usage.table_name()
         }) && table.require_guide_read
         {
             let guide = table.guide.clone();
             guides.push(RequiredQueryGuide {
                 schema_name: table.schema_name.clone(),
                 resource_name: table.table_name.clone(),
-                guide_id: required_guide_id(&table.schema_name, &table.table_name, &guide),
+                guide_id: required_guide_id(
+                    table.catalog_name.as_deref(),
+                    &table.schema_name,
+                    &table.table_name,
+                    &guide,
+                ),
                 guide,
             });
         }
     }
     for usage in resources.table_functions() {
         if let Some(function) = catalog.table_functions.iter().find(|function| {
-            function.schema_name == usage.schema_name()
+            function
+                .catalog_name
+                .as_deref()
+                .is_none_or(|catalog_name| catalog_name == usage.source_name())
+                && function.schema_name == usage.schema_name()
                 && function.function_name == usage.function_name()
         }) && function.require_guide_read
         {
@@ -1087,7 +1098,12 @@ fn required_query_guides(
             guides.push(RequiredQueryGuide {
                 schema_name: function.schema_name.clone(),
                 resource_name: function.function_name.clone(),
-                guide_id: required_guide_id(&function.schema_name, &function.function_name, &guide),
+                guide_id: required_guide_id(
+                    function.catalog_name.as_deref(),
+                    &function.schema_name,
+                    &function.function_name,
+                    &guide,
+                ),
                 guide,
             });
         }
@@ -1095,8 +1111,17 @@ fn required_query_guides(
     guides
 }
 
-fn required_guide_id(schema_name: &str, resource_name: &str, guide: &str) -> String {
-    sha256_hex(format!("{schema_name}\0{resource_name}\0{guide}").as_bytes())
+fn required_guide_id(
+    catalog_name: Option<&str>,
+    schema_name: &str,
+    resource_name: &str,
+    guide: &str,
+) -> String {
+    let identity = catalog_name.map_or_else(
+        || format!("{schema_name}\0{resource_name}\0{guide}"),
+        |catalog_name| format!("{catalog_name}\0{schema_name}\0{resource_name}\0{guide}"),
+    );
+    sha256_hex(identity.as_bytes())
 }
 
 fn query_sources_from_loaded(loaded_sources: &[LoadedQuerySource]) -> Vec<QuerySource> {
@@ -1383,6 +1408,7 @@ mod tests {
         EngineExtensions, QueryExecutionProvenance, QueryTableFunctionUsage, QueryTableUsage,
         ResolvedQueryResources, SourceDecorator, SourceDecoratorError,
         SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
+        TableFunctionInfo,
     };
     use coral_spec::parse_source_manifest_yaml;
     use coral_spec::v4::ProjectionCatalog;
@@ -1438,6 +1464,53 @@ mod tests {
             manager,
             db,
         }
+    }
+
+    #[test]
+    fn required_guide_identity_includes_catalog_coordinate() {
+        let legacy = required_guide_id(None, "issues", "list", "Read this guide.");
+        let github = required_guide_id(Some("github_v4"), "issues", "list", "Read this guide.");
+        let gitlab = required_guide_id(Some("gitlab_v4"), "issues", "list", "Read this guide.");
+
+        assert_ne!(legacy, github);
+        assert_ne!(github, gitlab);
+    }
+
+    #[test]
+    fn required_function_guide_matches_catalog_owner() {
+        let function = |catalog_name: &str, guide: &str| TableFunctionInfo {
+            catalog_name: Some(catalog_name.to_string()),
+            schema_name: "issues".to_string(),
+            function_name: "list".to_string(),
+            description: String::new(),
+            guide: guide.to_string(),
+            require_guide_read: true,
+            arguments: Vec::new(),
+            result_columns: Vec::new(),
+            kind: coral_spec::SourceTableFunctionKind::Table,
+            search_limits: None,
+        };
+        let catalog = CatalogInfo {
+            tables: Vec::new(),
+            table_functions: vec![
+                function("gitlab_v4", "Use GitLab guidance."),
+                function("github_v4", "Use GitHub guidance."),
+            ],
+        };
+        let resources = ResolvedQueryResources::new(
+            vec!["github_v4".to_string()],
+            Vec::new(),
+            vec![QueryTableFunctionUsage::new("github_v4", "issues", "list")],
+        );
+
+        let guides = required_query_guides(&catalog, &resources);
+
+        assert_eq!(guides.len(), 1);
+        assert_eq!(guides[0].guide, "Use GitHub guidance.");
+        assert_eq!(
+            guides[0].guide_id,
+            required_guide_id(Some("github_v4"), "issues", "list", "Use GitHub guidance.")
+        );
     }
 
     async fn query_manager_with_unavailable_keychain() -> QueryManagerFixture {

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -822,6 +822,7 @@ mod tests {
     #[test]
     fn required_function_argument_does_not_count_as_omitted_evidence() {
         let mut function = TableFunctionInfo {
+            catalog_name: None,
             schema_name: "fixture".to_string(),
             function_name: "search".to_string(),
             description: String::new(),

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -442,10 +442,12 @@ pub(crate) fn table_function_to_proto(
     workspace_name: &WorkspaceName,
     function: coral_engine::TableFunctionInfo,
 ) -> TableFunction {
+    let catalog_name = function.catalog_name.unwrap_or_default();
     let schema_name = function.schema_name;
     let function_name = function.function_name;
     TableFunction {
         workspace: Some(workspace_to_proto(workspace_name)),
+        catalog_name,
         schema_name,
         name: function_name,
         description: function.description,
@@ -977,11 +979,12 @@ mod tests {
     }
 
     #[test]
-    fn table_function_to_proto_preserves_argument_metadata() {
+    fn table_function_to_proto_preserves_catalog_and_argument_metadata() {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let function = TableFunctionInfo {
-            schema_name: "demo".to_string(),
-            function_name: "search".to_string(),
+            catalog_name: Some("github_v4".to_string()),
+            schema_name: "issues".to_string(),
+            function_name: "list_for_repo".to_string(),
             description: "Search demo records".to_string(),
             guide: "Prefer search for record lookup.".to_string(),
             require_guide_read: true,
@@ -999,8 +1002,9 @@ mod tests {
         let proto = table_function_to_proto(&workspace_name, function);
 
         assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
-        assert_eq!(proto.schema_name, "demo");
-        assert_eq!(proto.name, "search");
+        assert_eq!(proto.catalog_name, "github_v4");
+        assert_eq!(proto.schema_name, "issues");
+        assert_eq!(proto.name, "list_for_repo");
         assert_eq!(proto.description, "Search demo records");
         assert_eq!(proto.guide, "Prefer search for record lookup.");
         assert_eq!(proto.arguments.len(), 1);

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -117,6 +117,7 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
         catalog_item::Item::TableFunction(function) => function,
         catalog_item::Item::Table(_) => panic!("expected table function"),
     };
+    assert_eq!(function.catalog_name, "");
     assert_eq!(function.schema_name, "searchy");
     assert_eq!(function.name, "lookup_issue");
     assert_eq!(function.guide, "Use this function for exact issue lookup.");
@@ -160,6 +161,14 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
             catalog_item::Item::TableFunction(_)
         )
     }));
+
+    let sql_rows = harness
+        .execute_sql_rows(
+            "SELECT catalog_name FROM coral.table_functions \
+             WHERE schema_name = 'searchy' AND function_name = 'lookup_issue'",
+        )
+        .await;
+    assert_eq!(sql_rows, [serde_json::json!({ "catalog_name": "" })]);
 }
 
 #[tokio::test]

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -424,7 +424,11 @@ fn provider_status_text(status: &coral_api::v1::SearchProviderStatus) -> String 
 /// Formats the shortest SQL call example for a table function.
 #[must_use]
 pub fn minimal_table_function_call_example(function: &TableFunction) -> String {
-    let reference = format_schema_table_equivalent(None, &function.schema_name, &function.name);
+    let reference = format_schema_table_equivalent(
+        optional_catalog_name(&function.catalog_name),
+        &function.schema_name,
+        &function.name,
+    );
     let required_arguments = function
         .arguments
         .iter()
@@ -449,8 +453,7 @@ pub fn format_table_name(
 }
 
 /// Formats a SQL table or table-function reference, qualified by schema and, when
-/// `catalog_name` is `Some`, by catalog. Pass `None` for a two-part reference —
-/// table functions and the surfaces whose protos carry no catalog field.
+/// `catalog_name` is `Some`, by catalog. Pass `None` for a two-part reference.
 #[must_use]
 pub fn format_schema_table_equivalent(
     catalog_name: Option<&str>,
@@ -772,6 +775,53 @@ mod tests {
                 .get("sql_reference")
                 .and_then(Value::as_str),
             Some("warehouse.analytics.events")
+        );
+    }
+
+    #[test]
+    fn catalog_qualified_function_search_result_preserves_all_three_parts() {
+        let mut result = function_result();
+        result.surface = Some(SearchSurfaceRef {
+            catalog_name: "github_v4".to_string(),
+            schema_name: "issues".to_string(),
+            name: "list_for_repo".to_string(),
+        });
+
+        let response = response(vec![result]);
+        let value = search_response_json_value(&response);
+        assert_eq!(
+            first_result(&value)
+                .get("sql_reference")
+                .and_then(Value::as_str),
+            Some("github_v4.issues.list_for_repo")
+        );
+        assert!(
+            format_search_response_text(&response)
+                .contains("[function] github_v4.issues.list_for_repo")
+        );
+    }
+
+    #[test]
+    fn table_function_call_examples_render_two_or_three_part_identity() {
+        let legacy = TableFunction {
+            schema_name: "github".to_string(),
+            name: "search_issues".to_string(),
+            ..Default::default()
+        };
+        let catalog_qualified = TableFunction {
+            catalog_name: "github_v4".to_string(),
+            schema_name: "issues".to_string(),
+            name: "list_for_repo".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            minimal_table_function_call_example(&legacy),
+            "github.search_issues()"
+        );
+        assert_eq!(
+            minimal_table_function_call_example(&catalog_qualified),
+            "github_v4.issues.list_for_repo()"
         );
     }
 }

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -90,6 +90,8 @@ pub struct TableFunctionResultColumnInfo {
 /// Describes one table function.
 #[derive(Debug, Clone)]
 pub struct TableFunctionInfo {
+    /// `SQL` catalog name. Absent for two-part table-function references.
+    pub catalog_name: Option<String>,
     /// `SQL` schema name.
     pub schema_name: String,
     /// Function name within the schema.

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -842,6 +842,7 @@ mod tests {
 
     fn table_function(schema: &str, name: &str) -> TableFunctionInfo {
         TableFunctionInfo {
+            catalog_name: None,
             schema_name: schema.to_string(),
             function_name: name.to_string(),
             description: String::new(),

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -244,9 +244,18 @@ impl StructuredQueryError {
         metadata.insert("object_kind".to_string(), "table_function".to_string());
         metadata.insert("schema".to_string(), function.schema_name.clone());
         metadata.insert("function".to_string(), function.function_name.clone());
+        if let Some(catalog_name) = function.catalog_name.as_ref() {
+            metadata.insert("catalog".to_string(), catalog_name.clone());
+        }
 
         let schema_sql = sql_string_literal(&function.schema_name);
         let function_sql = sql_string_literal(&function.function_name);
+        let catalog_filter = function
+            .catalog_name
+            .as_deref()
+            .map_or_else(String::new, |name| {
+                format!("catalog_name = {} AND ", sql_string_literal(name))
+            });
 
         Self::new(
             TABLE_FUNCTION_NOT_TABLE_REASON,
@@ -255,7 +264,7 @@ impl StructuredQueryError {
                 "`{display_ref}` is registered as a table function. Query it as `FROM {display_ref}(...)`; inspect arguments and result columns in `coral.table_functions`, or run `DESCRIBE SELECT * FROM {display_ref}(...)` after filling any required arguments."
             ),
             Some(format!(
-                "Inspect table functions with `SELECT schema_name, function_name, arguments_json, result_columns_json FROM coral.table_functions WHERE schema_name = {schema_sql} AND function_name = {function_sql}`."
+                "Inspect table functions with `SELECT catalog_name, schema_name, function_name, arguments_json, result_columns_json FROM coral.table_functions WHERE {catalog_filter}schema_name = {schema_sql} AND function_name = {function_sql}`."
             )),
             false,
             StatusCode::InvalidArgument,
@@ -583,10 +592,22 @@ fn format_schema_table_fully_quoted(info: &TableInfo) -> String {
 }
 
 fn format_schema_function(info: &TableFunctionInfo) -> String {
-    format!(
-        "{}.{}",
-        quote_dotted_identifier(&info.schema_name),
-        quote_identifier(&info.function_name)
+    info.catalog_name.as_deref().map_or_else(
+        || {
+            format!(
+                "{}.{}",
+                quote_dotted_identifier(&info.schema_name),
+                quote_identifier(&info.function_name)
+            )
+        },
+        |catalog_name| {
+            format!(
+                "{}.{}.{}",
+                quote_identifier(catalog_name),
+                quote_identifier(&info.schema_name),
+                quote_identifier(&info.function_name)
+            )
+        },
     )
 }
 
@@ -855,6 +876,13 @@ mod tests {
         }
     }
 
+    fn catalog_table_function(catalog: &str, schema: &str, name: &str) -> TableFunctionInfo {
+        TableFunctionInfo {
+            catalog_name: Some(catalog.to_string()),
+            ..table_function(schema, name)
+        }
+    }
+
     fn cp(relation: &[&str], name: &str) -> ColumnParts {
         ColumnParts {
             relation: relation.iter().map(ToString::to_string).collect(),
@@ -999,6 +1027,35 @@ mod tests {
                 .contains("DESCRIBE SELECT * FROM datadog.metrics(...)"),
             "got: {}",
             err.detail()
+        );
+    }
+
+    #[test]
+    fn catalog_table_function_error_uses_complete_identity_and_hint_filter() {
+        let err = StructuredQueryError::table_function_not_table(&catalog_table_function(
+            "github_v4",
+            "issues",
+            "list_for_repo",
+        ));
+
+        assert_eq!(
+            err.summary(),
+            "`github_v4.issues.list_for_repo` is a table function, not a table"
+        );
+        assert!(
+            err.detail()
+                .contains("FROM github_v4.issues.list_for_repo(...)")
+        );
+        let hint = err.hint().expect("catalog-qualified hint");
+        assert!(hint.contains("catalog_name = 'github_v4'"), "got: {hint}");
+        assert!(hint.contains("schema_name = 'issues'"), "got: {hint}");
+        assert!(
+            hint.contains("function_name = 'list_for_repo'"),
+            "got: {hint}"
+        );
+        assert_eq!(
+            err.metadata().get("catalog").map(String::as_str),
+            Some("github_v4")
         );
     }
 

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -75,6 +75,7 @@ impl CatalogColumnFetchFailures {
 /// Catalog-only metadata for one SQL table-function surface.
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogTableFunction {
+    pub(crate) catalog_name: Option<String>,
     pub(crate) schema_name: String,
     pub(crate) function_name: String,
     pub(crate) description: String,
@@ -162,6 +163,7 @@ fn build_table_functions_table(
         Field::new("kind", DataType::Utf8, false),
         Field::new("search_limits_json", DataType::Utf8, true),
         Field::new("guide", DataType::Utf8, false),
+        Field::new("catalog_name", DataType::Utf8, false),
     ]));
 
     let rows = catalog_table_functions(active_sources, catalog_only_table_functions);
@@ -190,6 +192,10 @@ fn build_table_functions_table(
             utf8_column(rows.iter().map(|row| Some(row.kind.as_str()))),
             utf8_column(search_limits_json.iter().map(|value| value.as_deref())),
             utf8_column(rows.iter().map(|row| Some(row.guide.as_str()))),
+            utf8_column(
+                rows.iter()
+                    .map(|row| Some(row.catalog_name.as_deref().unwrap_or_default())),
+            ),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -900,6 +906,7 @@ pub(crate) fn collect_table_functions(
     catalog_table_functions(active_sources, catalog_only_table_functions)
         .into_iter()
         .map(|function| TableFunctionInfo {
+            catalog_name: function.catalog_name,
             schema_name: function.schema_name,
             function_name: function.function_name,
             description: function.description,
@@ -938,10 +945,12 @@ fn catalog_table_functions(
     let mut functions = active_sources
         .iter()
         .flat_map(|source| {
+            let catalog_name = source.qualified_name.catalog_name().map(str::to_string);
             source
                 .table_functions
                 .iter()
-                .map(|function| CatalogTableFunction {
+                .map(move |function| CatalogTableFunction {
+                    catalog_name: catalog_name.clone(),
                     schema_name: function.schema_name.clone(),
                     function_name: function.function_name.clone(),
                     description: function.description.clone(),
@@ -974,7 +983,11 @@ fn catalog_table_functions(
         .chain(catalog_only_table_functions.iter().cloned())
         .collect::<Vec<_>>();
     functions.sort_by(|left, right| {
-        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+        (&left.catalog_name, &left.schema_name, &left.function_name).cmp(&(
+            &right.catalog_name,
+            &right.schema_name,
+            &right.function_name,
+        ))
     });
     functions
 }
@@ -1738,9 +1751,9 @@ mod tests {
 
     use super::{
         CatalogColumnFetchFailures, ColumnPins, PinColumn, build_columns_table,
-        build_columns_table_with_failures, catalog_filter_rows, catalog_input_rows,
-        collect_static_tables, collect_table_functions, column_pin, source_catalog_column_rows,
-        string_array,
+        build_columns_table_with_failures, build_table_functions_table, catalog_filter_rows,
+        catalog_input_rows, collect_static_tables, collect_table_functions, column_pin,
+        source_catalog_column_rows, string_array,
     };
 
     #[derive(Clone, Debug)]
@@ -2141,5 +2154,52 @@ mod tests {
             functions.first().map(|function| function.kind.as_str()),
             Some("search")
         );
+    }
+
+    #[tokio::test]
+    async fn table_function_metadata_preserves_catalog_backed_identity() {
+        let sources = [RegisteredSource {
+            qualified_name: SourceQualifiedName::Catalog("github_v4".to_string()),
+            tables: Vec::new(),
+            table_functions: vec![RegisteredTableFunction {
+                schema_name: "issues".to_string(),
+                function_name: "list_for_repo".to_string(),
+                factory: Arc::new(StubSourceFunctionFactory::default()),
+                kind: coral_spec::SourceTableFunctionKind::Table,
+                description: String::new(),
+                guide: String::new(),
+                require_guide_read: false,
+                arguments: Vec::new(),
+                result_columns: Vec::new(),
+                search_limits: None,
+            }],
+            inputs: Vec::new(),
+        }];
+        let functions = collect_table_functions(&sources, &[]);
+
+        assert_eq!(functions.len(), 1);
+        let function = functions.first().expect("catalog-backed function");
+        assert_eq!(function.catalog_name.as_deref(), Some("github_v4"));
+        assert_eq!(function.schema_name, "issues");
+        assert_eq!(function.function_name, "list_for_repo");
+
+        let table = build_table_functions_table(&sources, &[]).expect("table functions table");
+        let context = SessionContext::new();
+        context
+            .register_table("table_functions", Arc::new(table))
+            .expect("register table functions table");
+        let batches = context
+            .sql(
+                "SELECT catalog_name FROM table_functions \
+                 WHERE schema_name = 'issues' AND function_name = 'list_for_repo'",
+            )
+            .await
+            .expect("plan table functions query")
+            .collect()
+            .await
+            .expect("collect table functions query");
+        let batch = batches.first().expect("table functions batch");
+        let catalog_names = string_array(batch, "catalog_name").expect("catalog names");
+        assert_eq!(catalog_names.value(0), "github_v4");
     }
 }

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -382,6 +382,7 @@ mod tests {
 
     fn table_function(schema: &str, name: &str) -> TableFunctionInfo {
         TableFunctionInfo {
+            catalog_name: None,
             schema_name: schema.to_string(),
             function_name: name.to_string(),
             description: String::new(),

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -325,10 +325,23 @@ fn resolve_table_function<'a>(
         return None;
     }
 
+    if let [catalog_name, schema_name, function_name] = parts
+        && let Some(function) = table_functions.iter().find(|function| {
+            function
+                .catalog_name
+                .as_deref()
+                .is_some_and(|catalog| catalog.eq_ignore_ascii_case(catalog_name))
+                && function.schema_name.eq_ignore_ascii_case(schema_name)
+                && function.function_name.eq_ignore_ascii_case(function_name)
+        })
+    {
+        return Some(function);
+    }
+
     for candidate in SchemaQualifiedName::candidates(parts) {
         if let Some(function) = table_functions
             .iter()
-            .find(|function| candidate.matches(function))
+            .find(|function| function.catalog_name.is_none() && candidate.matches(function))
         {
             return Some(function);
         }
@@ -395,6 +408,13 @@ mod tests {
         }
     }
 
+    fn catalog_table_function(catalog: &str, schema: &str, name: &str) -> TableFunctionInfo {
+        TableFunctionInfo {
+            catalog_name: Some(catalog.to_string()),
+            ..table_function(schema, name)
+        }
+    }
+
     fn table_ref(parts: &[&str]) -> TableRefParts {
         TableRefParts::new(parts.iter().map(ToString::to_string).collect())
     }
@@ -456,6 +476,19 @@ mod tests {
 
         assert_eq!(function.schema_name, "datadog");
         assert_eq!(function.function_name, "metrics");
+    }
+
+    #[test]
+    fn table_function_ref_matches_all_three_coordinates() {
+        let functions = vec![
+            catalog_table_function("gitlab_v4", "issues", "list"),
+            catalog_table_function("github_v4", "issues", "list"),
+        ];
+        let function =
+            table_function_for_ref(&table_ref(&["github_v4", "issues", "list"]), &functions)
+                .expect("catalog-qualified table function should match");
+
+        assert_eq!(function.catalog_name.as_deref(), Some("github_v4"));
     }
 
     #[test]

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -604,12 +604,18 @@ impl QueryRuntimeAdapter {
 
     fn list_table_functions(
         &self,
-        source_filter: Option<&str>,
+        catalog_filter: Option<&str>,
+        schema_filter: Option<&str>,
         function_filter: Option<&str>,
     ) -> Vec<TableFunctionInfo> {
+        let normalized_catalog_filter = normalize_catalog_name(catalog_filter);
         self.table_functions
             .iter()
-            .filter(|function| source_filter.is_none_or(|value| function.schema_name == value))
+            .filter(|function| {
+                catalog_filter.is_none()
+                    || function.catalog_name.as_deref() == normalized_catalog_filter
+            })
+            .filter(|function| schema_filter.is_none_or(|value| function.schema_name == value))
             .filter(|function| function_filter.is_none_or(|value| function.function_name == value))
             .cloned()
             .collect()
@@ -620,8 +626,6 @@ impl QueryRuntimeAdapter {
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
-        let includes_schema_sources =
-            catalog_filter.is_none_or(|value| normalize_catalog_name(Some(value)).is_none());
         // Catalog summaries never surface columns, so skip the coral.columns
         // expansion (and the remote database inventory fetches behind it).
         let tables =
@@ -630,11 +634,7 @@ impl QueryRuntimeAdapter {
                 .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         Ok(CatalogInfo {
             tables,
-            table_functions: if includes_schema_sources {
-                self.list_table_functions(schema_filter, None)
-            } else {
-                Vec::new()
-            },
+            table_functions: self.list_table_functions(catalog_filter, schema_filter, None),
         })
     }
 
@@ -670,7 +670,10 @@ impl QueryRuntimeAdapter {
             table_functions: self
                 .table_functions
                 .iter()
-                .filter(|function| schema_names.contains(&function.schema_name.as_str()))
+                .filter(|function| match function.catalog_name.as_deref() {
+                    Some(catalog_name) => catalog_names.contains(&catalog_name),
+                    None => schema_names.contains(&function.schema_name.as_str()),
+                })
                 .cloned()
                 .collect(),
         })
@@ -1759,6 +1762,58 @@ mod tests {
             .expect("catalog info");
         assert_eq!(catalog.tables.len(), 1);
         assert_eq!(catalog.table_functions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn catalog_qualified_table_function_respects_catalog_and_schema_filters() {
+        let mut adapter = adapter_with_sources(Vec::new());
+        adapter.table_functions.extend([
+            TableFunctionInfo {
+                catalog_name: Some("github_v4".to_string()),
+                schema_name: "issues".to_string(),
+                function_name: "list_for_repo".to_string(),
+                description: String::new(),
+                guide: String::new(),
+                require_guide_read: false,
+                arguments: Vec::new(),
+                result_columns: Vec::new(),
+                kind: coral_spec::SourceTableFunctionKind::Table,
+                search_limits: None,
+            },
+            TableFunctionInfo {
+                catalog_name: None,
+                schema_name: "github".to_string(),
+                function_name: "search_issues".to_string(),
+                description: String::new(),
+                guide: String::new(),
+                require_guide_read: false,
+                arguments: Vec::new(),
+                result_columns: Vec::new(),
+                kind: coral_spec::SourceTableFunctionKind::Search,
+                search_limits: None,
+            },
+        ]);
+
+        let catalog = adapter
+            .catalog_info(Some("github_v4"), Some("issues"))
+            .await
+            .expect("catalog-qualified function");
+        assert_eq!(catalog.table_functions.len(), 1);
+        let function = catalog.table_functions.first().expect("table function");
+        assert_eq!(function.catalog_name.as_deref(), Some("github_v4"));
+        assert_eq!(function.schema_name, "issues");
+        assert_eq!(function.function_name, "list_for_repo");
+
+        let legacy = adapter
+            .catalog_info(
+                Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
+                Some("github"),
+            )
+            .await
+            .expect("legacy function");
+        assert_eq!(legacy.table_functions.len(), 1);
+        assert!(legacy.table_functions[0].catalog_name.is_none());
+        assert_eq!(legacy.table_functions[0].function_name, "search_issues");
     }
 
     #[tokio::test]

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -1728,6 +1728,7 @@ mod tests {
     async fn explicit_datafusion_catalog_filters_schema_metadata() {
         let mut adapter = adapter_with_sources(vec![demo_source()]);
         adapter.table_functions.push(TableFunctionInfo {
+            catalog_name: None,
             schema_name: "demo".to_string(),
             function_name: "search_events".to_string(),
             description: "Search events.".to_string(),

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -159,6 +159,7 @@ fn catalog_table_function(
 ) -> CatalogTableFunction {
     let publish = &udf.publish.table_function;
     CatalogTableFunction {
+        catalog_name: None,
         schema_name: key.schema.clone(),
         function_name: key.function.clone(),
         kind: coral_spec::SourceTableFunctionKind::Table,

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -483,7 +483,7 @@ async fn coral_table_functions_lists_source_functions() {
         &CoralQuery::execute_sql(
             &sources,
             test_runtime(),
-            "SELECT schema_name, function_name, kind, description, arguments_json, result_columns_json, search_limits_json, guide \
+            "SELECT schema_name, function_name, kind, description, arguments_json, result_columns_json, search_limits_json, guide, catalog_name \
              FROM coral.table_functions WHERE schema_name = 'searchy'",
         )
         .await
@@ -494,6 +494,7 @@ async fn coral_table_functions_lists_source_functions() {
     let row = &rows[0];
     assert_eq!(row["schema_name"], "searchy");
     assert_eq!(row["function_name"], "search_issues");
+    assert_eq!(row["catalog_name"], "");
     assert_eq!(row["kind"], "search");
     assert_eq!(row["description"], "Search issues");
     assert_eq!(row["guide"], "Prefer this function for issue lookup.");
@@ -639,6 +640,7 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
             "kind",
             "search_limits_json",
             "guide",
+            "catalog_name",
         ]
     );
 

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -416,7 +416,7 @@ impl CoralMcpServer {
 
     async fn load_guide_catalog(
         &self,
-    ) -> Result<(Vec<ProtoTableSummary>, Vec<String>), tonic::Status> {
+    ) -> Result<(Vec<ProtoTableSummary>, Vec<(String, String)>), tonic::Status> {
         self.load_catalog(
             None,
             None,
@@ -480,7 +480,7 @@ impl CoralMcpServer {
 
     async fn load_sources_and_guide_catalog(
         &self,
-    ) -> Result<(Vec<Source>, Vec<ProtoTableSummary>, Vec<String>), tonic::Status> {
+    ) -> Result<(Vec<Source>, Vec<ProtoTableSummary>, Vec<(String, String)>), tonic::Status> {
         let (sources, (tables, table_function_schema_names)) =
             tokio::try_join!(self.load_sources(), self.load_guide_catalog())?;
         Ok((sources, tables, table_function_schema_names))
@@ -1150,14 +1150,14 @@ fn catalog_item_kind_from_tool(kind: Option<CatalogToolKind>) -> ProtoCatalogIte
 
 fn guide_catalog_from_response(
     response: ListCatalogResponse,
-) -> (Vec<ProtoTableSummary>, Vec<String>) {
+) -> (Vec<ProtoTableSummary>, Vec<(String, String)>) {
     let mut tables = Vec::new();
     let mut table_function_schema_names = Vec::new();
     for item in response.items {
         match item.item {
             Some(catalog_item::Item::Table(table)) => tables.push(table),
             Some(catalog_item::Item::TableFunction(function)) => {
-                table_function_schema_names.push(function.schema_name);
+                table_function_schema_names.push((function.catalog_name, function.schema_name));
             }
             None => {}
         }

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -621,6 +621,7 @@ struct CatalogTableValue<'a> {
 #[schemars(deny_unknown_fields)]
 struct CatalogTableFunctionItemValue<'a> {
     kind: CatalogTableFunctionKind,
+    catalog_name: &'a str,
     schema_name: &'a str,
     name: String,
     sql_reference: String,
@@ -633,10 +634,15 @@ impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionItemValue<'a> {
     fn from(function: &'a ProtoTableFunction) -> Self {
         Self {
             kind: CatalogTableFunctionKind::TableFunction,
+            catalog_name: &function.catalog_name,
             schema_name: &function.schema_name,
-            name: format!("{}.{}", function.schema_name, function.name),
+            name: format_table_name(
+                optional_catalog_name(&function.catalog_name),
+                &function.schema_name,
+                &function.name,
+            ),
             sql_reference: format_schema_table_equivalent(
-                None,
+                optional_catalog_name(&function.catalog_name),
                 &function.schema_name,
                 &function.name,
             ),
@@ -729,12 +735,15 @@ struct ColumnSearchRowValue<'a>(
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::{Column, ColumnSearchResult, ListColumnsResponse, PaginationResponse};
+    use coral_api::v1::{
+        CatalogItem, Column, ColumnSearchResult, ListCatalogResponse, ListColumnsResponse,
+        PaginationResponse, TableFunction, catalog_item,
+    };
     use serde_json::{Map, Value, json};
 
     use super::{
-        DEFAULT_IGNORE_CASE, DEFAULT_REQUIRED_ONLY, list_catalog_arguments, list_columns_arguments,
-        list_columns_value,
+        DEFAULT_IGNORE_CASE, DEFAULT_REQUIRED_ONLY, list_catalog_arguments, list_catalog_value,
+        list_columns_arguments, list_columns_value,
     };
     use crate::surface::discovery::{DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_OFFSET};
 
@@ -746,6 +755,35 @@ mod tests {
         let list = list_catalog_arguments(Some(&arguments)).expect("list arguments");
 
         assert_eq!(list.kind, None);
+    }
+
+    #[test]
+    fn catalog_qualified_table_function_uses_complete_identity() {
+        let response = ListCatalogResponse {
+            items: vec![CatalogItem {
+                item: Some(catalog_item::Item::TableFunction(TableFunction {
+                    catalog_name: "github_v4".to_string(),
+                    schema_name: "issues".to_string(),
+                    name: "list_for_repo".to_string(),
+                    ..Default::default()
+                })),
+            }],
+            pagination: Some(PaginationResponse {
+                total_count: 1,
+                limit: 50,
+                offset: 0,
+                has_more: false,
+                next_offset: 0,
+            }),
+            ..Default::default()
+        };
+
+        let value = list_catalog_value(&response);
+        let item = &value["items"][0];
+        assert_eq!(item["catalog_name"], "github_v4");
+        assert_eq!(item["name"], "github_v4.issues.list_for_repo");
+        assert_eq!(item["sql_reference"], "github_v4.issues.list_for_repo");
+        assert_eq!(item["sql_call_example"], "github_v4.issues.list_for_repo()");
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -71,7 +71,7 @@ pub(crate) fn tables_resource(visible_table_count: usize) -> Resource {
 pub(crate) fn guide_resource_content(
     sources: &[Source],
     tables: &[TableSummary],
-    table_function_schema_names: &[String],
+    table_function_schemas: &[(String, String)],
     observed_values_search_enabled: bool,
 ) -> String {
     let mut sources_section = String::from("## Available Schemas\n\n");
@@ -87,10 +87,12 @@ pub(crate) fn guide_resource_content(
     // as path segments, so a schema publishing table functions could otherwise
     // carry a newline and break out of its `Visible schemas:` bullet.
     schemas.extend(
-        table_function_schema_names
+        table_function_schemas
             .iter()
-            .filter(|schema| *schema != "coral")
-            .map(|schema| prompt_safe_text(schema)),
+            .filter(|(_, schema_name)| schema_name != "coral")
+            .map(|(catalog_name, schema_name)| {
+                visible_schema_coordinates(catalog_name, schema_name)
+            }),
     );
     if schemas.is_empty() {
         if sources.is_empty() {
@@ -213,13 +215,17 @@ fn is_coral_system_schema(table: &TableSummary) -> bool {
 /// is `warehouse`. Keeping them apart is also what the `coral.*` metadata
 /// tables expect, since they filter on `catalog_name` and `schema_name`.
 fn visible_schema_entry(table: &TableSummary) -> String {
-    let schema_name = prompt_safe_text(&table.schema_name);
-    if table.catalog_name.is_empty() {
+    visible_schema_coordinates(&table.catalog_name, &table.schema_name)
+}
+
+fn visible_schema_coordinates(catalog_name: &str, schema_name: &str) -> String {
+    let schema_name = prompt_safe_text(schema_name);
+    if catalog_name.is_empty() {
         schema_name
     } else {
         format!(
             "{schema_name} (catalog: {})",
-            prompt_safe_text(&table.catalog_name)
+            prompt_safe_text(catalog_name)
         )
     }
 }
@@ -591,13 +597,22 @@ WHERE title LIKE '%bug%'",
 
     #[test]
     fn guide_content_includes_function_only_schemas() {
-        let function_schemas = vec!["searchy".to_string()];
+        let function_schemas = vec![(String::new(), "searchy".to_string())];
 
         let content = guide_resource_content(&[source("searchy")], &[], &function_schemas, false);
 
         assert!(content.contains("Visible schemas:"));
         assert!(content.contains("- searchy"));
         assert!(!content.contains("No user-visible schemas are currently available."));
+    }
+
+    #[test]
+    fn guide_content_qualifies_catalog_backed_function_schema() {
+        let function_schemas = vec![("github_v4".to_string(), "issues".to_string())];
+
+        let content = guide_resource_content(&[source("github_v4")], &[], &function_schemas, false);
+
+        assert!(content.contains("Visible schemas:\n- issues (catalog: github_v4)"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add catalog identity to table-function metadata across the protobuf, engine catalog, app transport, and coral.table_functions
- render canonical two-part v3 and three-part v4 identities in client, MCP, search, guide, and error surfaces
- add stable catalog-qualified Reef table and function routes backed by mock catalog metadata while preserving existing v3 URLs

## Validation

- cargo test -p coral-app --test grpc catalog_discovery
- cargo test -p coral-client
- cargo test -p coral-mcp
- npm run check --prefix apps/reef
- npm run typecheck --prefix apps/reef
- npm test --prefix apps/reef

## Follow-up boundary

This PR establishes public and consumer contracts against mocked v4 metadata. Runtime materialization and placement begin in the next stacked PR; Reef loaders consume the real three-coordinate contract in the final stack.