### PR TITLE
feat(engine): model canonical runtime catalogs

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -57,7 +57,7 @@ pub enum AppError {
     },
     /// A DSL v4 source has missing or stale generated runtime artifacts.
     #[error(
-        "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source or reconcile the selected artifact files."
+        "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source or explicitly regenerate its artifacts."
     )]
     MissingOrIncompatibleV4Materialization {
         /// Source name whose installed artifacts failed validation.

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashSet};
 
-use coral_engine::{QuerySource, RuntimeSourceComponent, UdfRuntimeDefinition};
+use coral_engine::{QuerySource, UdfRuntimeDefinition};
 
 use crate::bootstrap::AppError;
 
@@ -33,9 +33,13 @@ pub(crate) fn source_sql_publish_targets_for_schemas(
 ) -> SqlPublishTargets {
     let mut targets = HashSet::new();
     for source in selected_sources {
-        for component in source.components() {
-            if schemas.contains(component.source_name()) {
-                record_source_component_sql_targets(component, &mut targets);
+        for relation in source.declared_relations() {
+            let sql_name = relation.sql_name();
+            if schemas.contains(sql_name.schema_name()) {
+                targets.insert(SqlPublishTarget::new(
+                    sql_name.schema_name(),
+                    sql_name.name(),
+                ));
             }
         }
     }
@@ -57,49 +61,15 @@ pub(crate) fn unchecked_source_publish_schemas(
 fn source_sql_publish_targets(selected_sources: &[QuerySource]) -> SqlPublishTargets {
     let mut targets = HashSet::new();
     for source in selected_sources {
-        for component in source.components() {
-            record_source_component_sql_targets(component, &mut targets);
+        for relation in source.declared_relations() {
+            let sql_name = relation.sql_name();
+            targets.insert(SqlPublishTarget::new(
+                sql_name.schema_name(),
+                sql_name.name(),
+            ));
         }
     }
     targets
-}
-
-fn record_source_component_sql_targets(
-    component: &RuntimeSourceComponent,
-    targets: &mut SqlPublishTargets,
-) {
-    match component {
-        RuntimeSourceComponent::Database(_) => {
-            // Database tables are discovered at registration and have no static publish targets.
-        }
-        RuntimeSourceComponent::Http(manifest) => {
-            for table in &manifest.tables {
-                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
-            }
-            for function in &manifest.functions {
-                targets.insert(SqlPublishTarget::new(&manifest.common.name, &function.name));
-            }
-        }
-        RuntimeSourceComponent::File(manifest) => {
-            for table in &manifest.tables {
-                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
-            }
-        }
-        RuntimeSourceComponent::Mcp(manifest) => {
-            for table in &manifest.tables {
-                targets.insert(SqlPublishTarget::new(
-                    &manifest.common.name,
-                    &table.common.name,
-                ));
-            }
-            for function in &manifest.functions {
-                targets.insert(SqlPublishTarget::new(
-                    &manifest.common.name,
-                    &function.common.name,
-                ));
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -172,10 +142,10 @@ tables:
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
-                components: primary
-                    .components()
+                catalogs: primary
+                    .catalogs()
                     .iter()
-                    .chain(secondary.components())
+                    .chain(secondary.catalogs())
                     .cloned()
                     .collect(),
             },

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -149,7 +149,7 @@ impl SourceDecorator for CatalogFailureRecorder {
         "catalog_failure_recorder"
     }
 
-    fn supports_catalog_sources(&self) -> bool {
+    fn supports_provider_discovered_catalogs(&self) -> bool {
         true
     }
 
@@ -1506,9 +1506,10 @@ mod tests {
         let guides = required_query_guides(&catalog, &resources);
 
         assert_eq!(guides.len(), 1);
-        assert_eq!(guides[0].guide, "Use GitHub guidance.");
+        let guide = guides.first().expect("required guide");
+        assert_eq!(guide.guide, "Use GitHub guidance.");
         assert_eq!(
-            guides[0].guide_id,
+            guide.guide_id,
             required_guide_id(Some("github_v4"), "issues", "list", "Use GitHub guidance.")
         );
     }
@@ -2448,7 +2449,7 @@ surface:
         let issues = projections
             .projections
             .iter_mut()
-            .find(|projection| projection.sql_name.name() == "issues")
+            .find(|projection| projection.operation_id == "issues_list")
             .expect("issues projection");
         issues.guide = "Use issue_search for lookups.".to_string();
         issues.require_guide_read = true;
@@ -2465,7 +2466,7 @@ surface:
         )
         .expect("write projection override");
 
-        let sql = "SELECT id, title FROM github_v4_query.issues";
+        let sql = "SELECT id, title FROM github_v4_query.list";
         let required = fixture
             .manager
             .execute_sql(
@@ -2480,7 +2481,7 @@ surface:
             panic!("overridden projection guide should be required");
         };
         let required = required.first().expect("required projection guide");
-        assert_eq!(required.resource_name, "issues");
+        assert_eq!(required.resource_name, "list");
         assert_eq!(required.guide, "Use issue_search for lookups.");
         assert!(
             server
@@ -2647,7 +2648,7 @@ surface:
             .manager
             .execute_sql(
                 &workspace_name,
-                "SELECT id FROM github_v4_pagination_override.widgets LIMIT 3",
+                "SELECT id FROM github_v4_pagination_override.list LIMIT 3",
                 None,
                 &QueryAttribution::default(),
             )

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -2448,7 +2448,7 @@ surface:
         let issues = projections
             .projections
             .iter_mut()
-            .find(|projection| projection.name == "issues")
+            .find(|projection| projection.sql_name.name() == "issues")
             .expect("issues projection");
         issues.guide = "Use issue_search for lookups.".to_string();
         issues.require_guide_read = true;

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -294,7 +294,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use coral_engine::{
-        QuerySource, RuntimeSourceComponent, RuntimeSourcePackage, SourceObservationSurfaceKind,
+        QuerySource, RuntimeCatalog, RuntimeSourcePackage, SourceObservationSurfaceKind,
         SourceScanObservation,
     };
     use coral_spec::{DO_NOT_INDEX_COLUMN_METADATA_KEY, parse_source_manifest_yaml};
@@ -656,7 +656,7 @@ tables:
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
-                components: vec![
+                catalogs: vec![
                     http_component("github_v4_rest"),
                     http_component("github_v4_mcp"),
                 ],
@@ -676,7 +676,7 @@ tables:
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
-                components: vec![http_component(source_name)],
+                catalogs: vec![http_component(source_name)],
             },
             BTreeMap::new(),
             BTreeMap::new(),
@@ -696,7 +696,7 @@ tables:
         .expect("batch")
     }
 
-    fn http_component(source_name: &str) -> RuntimeSourceComponent {
+    fn http_component(source_name: &str) -> RuntimeCatalog {
         let yaml = format!(
             r"
 dsl_version: 3
@@ -715,7 +715,10 @@ tables:
 "
         );
         let manifest = parse_source_manifest_yaml(&yaml).expect("component manifest");
-        RuntimeSourceComponent::Http(manifest.as_http().expect("HTTP component").clone())
+        RuntimeCatalog::try_from_default_catalog_http_manifest(
+            manifest.as_http().expect("HTTP component").clone(),
+        )
+        .expect("HTTP catalog")
     }
 
     fn wait_for_payloads(layout: &AppStateLayout, workspace: &WorkspaceName) -> Vec<String> {

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -1,6 +1,6 @@
 //! Source-surface routing and opaque scope derivation for observed values.
 
-use coral_engine::{QuerySource, RuntimeSourceComponent};
+use coral_engine::{QuerySource, RuntimeRelationKind};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -48,17 +48,16 @@ impl<'a> SourceScopeSeed<'a> {
     }
 }
 
-/// A runtime component whose name diverges from its package's source name.
+/// A runtime SQL namespace whose name diverges from its package's source name.
 ///
 /// Since #1791 one source publishes exactly one surface and one SQL namespace,
-/// and the sources domain copies both names from the same `manifest.common.name`
-/// field, so this is unreachable on every production path. Search still refuses
-/// the source rather than writing rows under an identity that would select
-/// nothing back -- a tripwire at the single seam that derives identity from a
-/// runtime package, not an enforcement boundary.
+/// Default-catalog relations use their schema as the namespace. Catalog-backed
+/// relations use their catalog, leaving provider or projection schemas free to
+/// differ. Search refuses a source whose top-level namespace does not match its
+/// installed owner rather than writing rows under an incoherent identity.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error(
-    "source '{source_name}' exposes runtime component '{component_source_name}'; one installed source must publish exactly one runtime schema"
+    "source '{source_name}' exposes runtime namespace '{component_source_name}'; one installed source must publish exactly one top-level SQL namespace"
 )]
 pub(crate) struct ObservedSourceIdentityMismatch {
     source_name: String,
@@ -97,15 +96,12 @@ pub(super) fn source_surface_scopes(
 ) -> Result<Vec<ObservedSourceSurfaceScope>, ObservedSourceIdentityMismatch> {
     let source_name = source.source_name();
     let mut scopes = Vec::new();
-    for component in source.components() {
-        let component_source_name = match component {
-            // Database components declare no HTTP/MCP observation surfaces, so
-            // they never contribute a stored identity for the tripwire to
-            // protect; the arm below enumerates nothing for them.
-            RuntimeSourceComponent::Database(_) => source_name,
-            RuntimeSourceComponent::Http(manifest) => manifest.common.name.as_str(),
-            RuntimeSourceComponent::File(manifest) => manifest.common.name.as_str(),
-            RuntimeSourceComponent::Mcp(manifest) => manifest.common.name.as_str(),
+    for relation in source.declared_relations() {
+        let sql_name = relation.sql_name();
+        let component_source_name = if sql_name.catalog_name() == "datafusion" {
+            sql_name.schema_name()
+        } else {
+            sql_name.catalog_name()
         };
         if component_source_name != source_name {
             return Err(ObservedSourceIdentityMismatch {
@@ -113,63 +109,17 @@ pub(super) fn source_surface_scopes(
                 component_source_name: component_source_name.to_string(),
             });
         }
-
-        match component {
-            RuntimeSourceComponent::Database(_) => {
-                // Database tables do not declare HTTP/MCP observation surfaces.
-            }
-            RuntimeSourceComponent::Http(manifest) => {
-                scopes.extend(manifest.tables.iter().map(|table| {
-                    surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
-                        ObservedValuesSurfaceKind::Table,
-                        table.name(),
-                        seed,
-                    )
-                }));
-                scopes.extend(manifest.functions.iter().map(|function| {
-                    surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
-                        ObservedValuesSurfaceKind::Function,
-                        function.name.as_str(),
-                        seed,
-                    )
-                }));
-            }
-            RuntimeSourceComponent::File(manifest) => {
-                scopes.extend(manifest.tables.iter().map(|table| {
-                    surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
-                        ObservedValuesSurfaceKind::Table,
-                        table.name(),
-                        seed,
-                    )
-                }));
-            }
-            RuntimeSourceComponent::Mcp(manifest) => {
-                scopes.extend(manifest.tables.iter().map(|table| {
-                    surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
-                        ObservedValuesSurfaceKind::Table,
-                        table.name(),
-                        seed,
-                    )
-                }));
-                scopes.extend(manifest.functions.iter().map(|function| {
-                    surface_scope(
-                        source,
-                        manifest.common.name.as_str(),
-                        ObservedValuesSurfaceKind::Function,
-                        function.name(),
-                        seed,
-                    )
-                }));
-            }
-        }
+        let surface_kind = match relation.kind() {
+            RuntimeRelationKind::Table => ObservedValuesSurfaceKind::Table,
+            RuntimeRelationKind::TableFunction => ObservedValuesSurfaceKind::Function,
+        };
+        scopes.push(surface_scope(
+            source,
+            component_source_name,
+            surface_kind,
+            sql_name.name(),
+            seed,
+        ));
     }
     Ok(scopes)
 }

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -2409,7 +2409,7 @@ surface:
                 "projection_override={projection_override}, metadata_override={metadata_override}: {message}"
             );
             assert!(
-                message.contains("Re-add the source or reconcile the selected artifact files"),
+                message.contains("Re-add the source or explicitly regenerate its artifacts"),
                 "projection_override={projection_override}, metadata_override={metadata_override}: {message}"
             );
             assert!(
@@ -2654,6 +2654,49 @@ surface:
             &manifest,
         )
         .expect("full valid override should rescue old materialization");
+    }
+
+    #[test]
+    fn pre_catalog_contract_projection_requires_explicit_regeneration() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let projections_path = layout
+            .v4_materialized_dir(&workspace_name(), &source_name())
+            .join(PROJECTIONS_FILENAME);
+        let mut catalog: serde_yaml::Value =
+            read_yaml(&projections_path).expect("read generated projection catalog");
+        let projections = catalog
+            .get_mut("projections")
+            .and_then(serde_yaml::Value::as_sequence_mut)
+            .expect("projection sequence");
+        for projection in projections {
+            let projection = projection.as_mapping_mut().expect("projection mapping");
+            let sql_name = projection
+                .remove(serde_yaml::Value::String("sql_name".to_string()))
+                .expect("generated SQL name");
+            let legacy_name = sql_name.get("name").cloned().expect("generated leaf name");
+            projection.insert(serde_yaml::Value::String("name".to_string()), legacy_name);
+        }
+        write_yaml(&projections_path, &catalog).expect("write pre-contract projection catalog");
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("projection artifacts without sql_name must be regenerated");
+
+        assert!(matches!(
+            error,
+            AppError::MissingOrIncompatibleV4Materialization { .. }
+        ));
+        assert!(error.to_string().contains("missing field `sql_name`"));
+        assert!(
+            error
+                .to_string()
+                .contains("Re-add the source or explicitly regenerate its artifacts")
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -261,7 +261,7 @@ fn http_manifest_for_surface(
             .ok_or_else(|| {
                 AppError::FailedPrecondition(format!(
                     "DSL v4 projection '{}' references missing operation '{}'",
-                    projection.name, projection.operation_id
+                    projection.sql_name, projection.operation_id
                 ))
             })?;
         let rest = rest_execution_for_operation(operation)?;
@@ -277,7 +277,7 @@ fn http_manifest_for_surface(
             ProjectionKind::Table => {
                 tables.push(HttpTableSpec {
                     common: TableCommon {
-                        name: projection.name.clone(),
+                        name: projection.sql_name.name().to_string(),
                         description: projection.description.clone(),
                         guide: projection.guide.clone(),
                         require_guide_read: projection.require_guide_read,
@@ -295,7 +295,7 @@ fn http_manifest_for_surface(
             }
             ProjectionKind::TableFunction { function_kind } => {
                 functions.push(SourceTableFunctionSpec {
-                    name: projection.name.clone(),
+                    name: projection.sql_name.name().to_string(),
                     kind: *function_kind,
                     description: projection.description.clone(),
                     guide: projection.guide.clone(),
@@ -371,13 +371,13 @@ fn mcp_manifest_for_surface(
             .ok_or_else(|| {
                 AppError::FailedPrecondition(format!(
                     "DSL v4 projection '{}' references missing operation '{}'",
-                    projection.name, projection.operation_id
+                    projection.sql_name, projection.operation_id
                 ))
             })?;
         let IrExecutionAttachment::Mcp(mcp) = &operation.execution else {
             return Err(AppError::FailedPrecondition(format!(
                 "DSL v4 projection '{}' is not backed by an MCP operation",
-                projection.name
+                projection.sql_name
             )));
         };
         let (cursor_pagination, offset_pagination) =
@@ -429,7 +429,7 @@ fn mcp_table_spec(
 ) -> McpTableSpec {
     McpTableSpec {
         common: TableCommon {
-            name: projection.name.clone(),
+            name: projection.sql_name.name().to_string(),
             description: projection.description.clone(),
             guide: projection.guide.clone(),
             require_guide_read: projection.require_guide_read,
@@ -462,7 +462,7 @@ fn mcp_table_function_spec(
         pagination,
         offset_pagination,
         common: SourceTableFunctionSpec {
-            name: projection.name.clone(),
+            name: projection.sql_name.name().to_string(),
             kind: function_kind,
             description: projection.description.clone(),
             guide: projection.guide.clone(),
@@ -1017,7 +1017,8 @@ mod tests {
 
     fn published_projection(operation_id: &str) -> Projection {
         Projection {
-            name: "list_issues".to_string(),
+            sql_name: coral_spec::SqlObjectName::try_new("github_v4", "public", "list_issues")
+                .expect("SQL name"),
             kind: ProjectionKind::Table,
             description: String::new(),
             guide: String::new(),
@@ -1034,7 +1035,8 @@ mod tests {
 
     fn published_function_projection(operation_id: &str) -> Projection {
         Projection {
-            name: "search_issues".to_string(),
+            sql_name: coral_spec::SqlObjectName::try_new("github_v4", "public", "search_issues")
+                .expect("SQL name"),
             kind: ProjectionKind::TableFunction {
                 function_kind: SourceTableFunctionKind::Search,
             },
@@ -1413,13 +1415,16 @@ surface:
             surface: openapi_surface(),
         };
         let mut table = published_projection("items_list");
-        table.name = "items".to_string();
+        table.sql_name =
+            coral_spec::SqlObjectName::try_new("github_v4", "public", "items").expect("SQL name");
         table.inputs = vec![
             persisted_projection_input("q", SqlInputExposure::Filter, true),
             persisted_projection_input("state", SqlInputExposure::Internal, false),
         ];
         let mut function = published_projection("items_list");
-        function.name = "search_items".to_string();
+        function.sql_name =
+            coral_spec::SqlObjectName::try_new("github_v4", "public", "search_items")
+                .expect("SQL name");
         function.kind = ProjectionKind::TableFunction {
             function_kind: SourceTableFunctionKind::Search,
         };

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use coral_engine::{QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use coral_engine::{DatabaseRuntimeBackend, QuerySource, RuntimeCatalog, RuntimeSourcePackage};
 use coral_spec::backends::database::DatabaseSourceManifest;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::backends::mcp::{
@@ -77,25 +77,41 @@ enum V4RuntimeContract<'a> {
     Mcp(&'a coral_spec::backends::mcp::McpSourceManifest),
 }
 
+#[derive(Debug, Clone)]
+enum V4RuntimeComponent {
+    Database(DatabaseSourceManifest),
+    Http(HttpSourceManifest),
+    Mcp(McpSourceManifest),
+}
+
+impl V4RuntimeComponent {
+    fn into_runtime_catalog(self) -> Result<RuntimeCatalog, AppError> {
+        let result = match self {
+            Self::Database(manifest) => RuntimeCatalog::try_database_provider_discovered(
+                manifest.common.name,
+                DatabaseRuntimeBackend::new(manifest.common.dsl_version, manifest.connection),
+            ),
+            Self::Http(manifest) => {
+                RuntimeCatalog::try_from_default_catalog_http_manifest(manifest)
+            }
+            Self::Mcp(manifest) => RuntimeCatalog::try_from_default_catalog_mcp_manifest(manifest),
+        };
+        result.map_err(|error| AppError::FailedPrecondition(error.to_string()))
+    }
+}
+
 /// Fingerprints authored manifest content, deterministic non-secret variable
 /// bindings, and the materialised v4 runtime contract. Filesystem paths and
 /// resolved credential material are deliberately excluded.
-pub(crate) fn runtime_contract_fingerprint(
+fn runtime_contract_fingerprint(
     manifest_yaml: &str,
     variables: &BTreeMap<String, String>,
-    v4_component: Option<&RuntimeSourceComponent>,
+    v4_component: Option<&V4RuntimeComponent>,
 ) -> Result<RuntimeContractFingerprint, AppError> {
     let v4_runtime_contract = match v4_component {
-        Some(RuntimeSourceComponent::Database(database)) => {
-            Some(V4RuntimeContract::Database(database))
-        }
-        Some(RuntimeSourceComponent::Http(http)) => Some(V4RuntimeContract::Http(http)),
-        Some(RuntimeSourceComponent::Mcp(mcp)) => Some(V4RuntimeContract::Mcp(mcp)),
-        Some(RuntimeSourceComponent::File(_)) => {
-            return Err(AppError::Internal(
-                "DSL v4 runtime fingerprint received a file component".to_string(),
-            ));
-        }
+        Some(V4RuntimeComponent::Database(database)) => Some(V4RuntimeContract::Database(database)),
+        Some(V4RuntimeComponent::Http(http)) => Some(V4RuntimeContract::Http(http)),
+        Some(V4RuntimeComponent::Mcp(mcp)) => Some(V4RuntimeContract::Mcp(mcp)),
         None => None,
     };
     let input = RuntimeContractFingerprintInput {
@@ -161,7 +177,10 @@ pub(crate) fn query_source_from_installed_manifest(
                 declared_inputs: source_spec.declared_inputs().to_vec(),
                 test_queries: source_spec.test_queries().to_vec(),
                 identity_requirements: None,
-                components: component.into_iter().collect(),
+                catalogs: component
+                    .into_iter()
+                    .map(V4RuntimeComponent::into_runtime_catalog)
+                    .collect::<Result<Vec<_>, _>>()?,
             },
             source.variables.clone(),
             resolved_secrets,
@@ -181,10 +200,10 @@ pub(crate) fn query_source_from_installed_manifest(
     })
 }
 
-pub(crate) fn runtime_component_for_v4_source(
+fn runtime_component_for_v4_source(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
-) -> Result<Option<RuntimeSourceComponent>, AppError> {
+) -> Result<Option<V4RuntimeComponent>, AppError> {
     if manifest.identity_requirements.is_some() {
         return Err(AppError::UnsupportedV4IdentityRequirements {
             source_name: manifest.common.name.clone(),
@@ -194,10 +213,11 @@ pub(crate) fn runtime_component_for_v4_source(
         return Ok(None);
     }
     match manifest.surface.surface_type {
-        SurfaceType::OpenApi => Ok(Some(RuntimeSourceComponent::Http(
-            http_manifest_for_surface(manifest, materialized)?,
-        ))),
-        SurfaceType::Mcp => Ok(Some(RuntimeSourceComponent::Mcp(mcp_manifest_for_surface(
+        SurfaceType::OpenApi => Ok(Some(V4RuntimeComponent::Http(http_manifest_for_surface(
+            manifest,
+            materialized,
+        )?))),
+        SurfaceType::Mcp => Ok(Some(V4RuntimeComponent::Mcp(mcp_manifest_for_surface(
             manifest,
             materialized,
         )?))),
@@ -205,13 +225,13 @@ pub(crate) fn runtime_component_for_v4_source(
     }
 }
 
-pub(crate) fn runtime_component_for_v4_database_source(
+fn runtime_component_for_v4_database_source(
     manifest: &V4SourceManifest,
-) -> Result<RuntimeSourceComponent, AppError> {
+) -> Result<V4RuntimeComponent, AppError> {
     let database_runtime = manifest.surface.database_runtime().ok_or_else(|| {
         AppError::FailedPrecondition("DSL v4 surface is not a database surface".to_string())
     })?;
-    Ok(RuntimeSourceComponent::Database(DatabaseSourceManifest {
+    Ok(V4RuntimeComponent::Database(DatabaseSourceManifest {
         common: SourceManifestCommon {
             dsl_version: manifest.common.dsl_version,
             name: manifest.common.name.clone(),
@@ -558,7 +578,6 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    use coral_engine::RuntimeSourceComponent;
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
@@ -582,8 +601,8 @@ mod tests {
     use crate::bootstrap::AppError;
 
     use super::{
-        runtime_component_for_v4_database_source, runtime_component_for_v4_source,
-        runtime_contract_fingerprint, surface_base_url,
+        V4RuntimeComponent, runtime_component_for_v4_database_source,
+        runtime_component_for_v4_source, runtime_contract_fingerprint, surface_base_url,
     };
 
     fn surface_without_authored_base_url() -> V4Surface {
@@ -1121,7 +1140,7 @@ surface:
 
         let component =
             runtime_component_for_v4_database_source(v4).expect("database runtime component");
-        let RuntimeSourceComponent::Database(database) = component else {
+        let V4RuntimeComponent::Database(database) = component else {
             panic!("database component");
         };
 
@@ -1334,7 +1353,7 @@ surface:
         let component = runtime_component_for_v4_source(&manifest, &materialized)
             .expect("runtime component")
             .expect("published component");
-        let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+        let V4RuntimeComponent::Http(http) = component else {
             panic!("expected HTTP component");
         };
         assert_eq!(http.common.name, "github_v4");
@@ -1385,7 +1404,7 @@ surface:
         let component = runtime_component_for_v4_source(&manifest, &materialized)
             .expect("runtime component")
             .expect("published component");
-        let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+        let V4RuntimeComponent::Http(http) = component else {
             panic!("expected HTTP component");
         };
 
@@ -1456,7 +1475,7 @@ surface:
         let component = runtime_component_for_v4_source(&manifest, &materialized)
             .expect("runtime component")
             .expect("published component");
-        let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+        let V4RuntimeComponent::Http(http) = component else {
             panic!("expected HTTP component");
         };
         let filters = &http.tables.first().expect("table").common.filters;
@@ -1505,7 +1524,7 @@ surface:
             let component = runtime_component_for_v4_source(&manifest, &materialized)
                 .expect("runtime component")
                 .expect("published component");
-            let coral_engine::RuntimeSourceComponent::Http(http) = component else {
+            let V4RuntimeComponent::Http(http) = component else {
                 panic!("expected HTTP component");
             };
             http
@@ -1553,7 +1572,7 @@ surface:
             let component = runtime_component_for_v4_source(&manifest, &materialized)
                 .expect("runtime component")
                 .expect("published component");
-            let coral_engine::RuntimeSourceComponent::Mcp(mcp) = component else {
+            let V4RuntimeComponent::Mcp(mcp) = component else {
                 panic!("expected MCP component");
             };
             mcp
@@ -1621,7 +1640,7 @@ surface:
         let component = runtime_component_for_v4_source(&manifest, &materialized)
             .expect("runtime component")
             .expect("published component");
-        let coral_engine::RuntimeSourceComponent::Mcp(mcp) = component else {
+        let V4RuntimeComponent::Mcp(mcp) = component else {
             panic!("expected MCP component");
         };
 
@@ -1660,7 +1679,7 @@ surface:
         let component = runtime_component_for_v4_source(&manifest, &materialized)
             .expect("runtime component")
             .expect("published component");
-        let coral_engine::RuntimeSourceComponent::Mcp(mcp) = component else {
+        let V4RuntimeComponent::Mcp(mcp) = component else {
             panic!("expected MCP component");
         };
 
@@ -1719,7 +1738,7 @@ surface:
         let component = runtime_component_for_v4_source(&manifest, &materialized)
             .expect("runtime component")
             .expect("published component");
-        let coral_engine::RuntimeSourceComponent::Mcp(mcp) = component else {
+        let V4RuntimeComponent::Mcp(mcp) = component else {
             panic!("expected MCP component");
         };
 

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -52,7 +52,7 @@ impl SourceDecorator for PausingCatalogDecorator {
         "pausing_catalog_resolution"
     }
 
-    fn supports_catalog_sources(&self) -> bool {
+    fn supports_provider_discovered_catalogs(&self) -> bool {
         true
     }
 

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -10,12 +10,10 @@ use std::fs;
 
 use coral_client::local::ServerBuilder;
 use coral_engine::{
-    CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
+    CoralQuery, DatabaseRuntimeBackend, QueryRuntimeConfig, QuerySource, RuntimeCatalog,
+    RuntimeSourcePackage,
 };
-use coral_spec::{
-    DatabaseConnectionSpec, DatabaseSourceManifest, ParsedTemplate, PostgresConnectionSpec,
-    SourceManifestCommon,
-};
+use coral_spec::{DatabaseConnectionSpec, ParsedTemplate, PostgresConnectionSpec};
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
 
@@ -120,15 +118,9 @@ fn postgres_source(database_url: &str) -> QuerySource {
             }
         });
     let template = |value: &str| ParsedTemplate::parse(value).expect("literal template");
-    let manifest = DatabaseSourceManifest {
-        common: SourceManifestCommon {
-            dsl_version: 4,
-            name: "postgres_inventory".to_string(),
-            version: String::new(),
-            description: "Postgres inventory integration fixture".to_string(),
-            test_queries: Vec::new(),
-        },
-        connection: DatabaseConnectionSpec::Postgres(PostgresConnectionSpec {
+    let backend = DatabaseRuntimeBackend::new(
+        4,
+        DatabaseConnectionSpec::Postgres(PostgresConnectionSpec {
             host: template(host),
             port: template(&port.to_string()),
             database: template(database),
@@ -136,8 +128,7 @@ fn postgres_source(database_url: &str) -> QuerySource {
             password: template(url.password().unwrap_or_default()),
             sslmode: Some(template(&sslmode)),
         }),
-        declared_inputs: Vec::new(),
-    };
+    );
     QuerySource::from_runtime_components(
         RuntimeSourcePackage {
             source_name: "postgres_inventory".to_string(),
@@ -146,7 +137,10 @@ fn postgres_source(database_url: &str) -> QuerySource {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![RuntimeSourceComponent::Database(manifest)],
+            catalogs: vec![
+                RuntimeCatalog::try_database_provider_discovered("postgres_inventory", backend)
+                    .expect("database catalog"),
+            ],
         },
         BTreeMap::new(),
         BTreeMap::new(),

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -366,6 +366,7 @@ fn mock_validate_response() -> ValidateSourceResponse {
         ],
         table_functions: vec![TableFunction {
             workspace: Some(workspace()),
+            catalog_name: String::new(),
             schema_name: "github".to_string(),
             name: "search_issues".to_string(),
             description: "Search issues".to_string(),

--- a/crates/coral-engine/src/backends/database/source.rs
+++ b/crates/coral-engine/src/backends/database/source.rs
@@ -663,7 +663,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn database_catalog_registration_rejects_source_decorators() {
+    async fn provider_discovered_catalog_rejects_unsupported_source_decorators() {
         let temp = tempfile::tempdir().expect("temp dir");
         let db_path = temp.path().join("coral.sqlite");
         drop(rusqlite::Connection::open(&db_path).expect("sqlite db"));
@@ -682,10 +682,10 @@ mod tests {
             Some("users"),
         )
         .await
-        .expect_err("catalog registrations must reject source decorators");
+        .expect_err("provider-discovered catalogs must reject unsupported decorators");
         assert!(
             error.to_string().contains(
-                "registers database catalogs, which source decorator \
+                "registers provider-discovered catalogs, which source decorator \
                      'abort-on-source-failure' does not support"
             ),
             "unexpected error: {error}"

--- a/crates/coral-engine/src/backends/database/source.rs
+++ b/crates/coral-engine/src/backends/database/source.rs
@@ -438,8 +438,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use coral_spec::{
-        DatabaseConnectionSpec, DatabaseSourceManifest, MySqlConnectionSpec, ParsedTemplate,
-        SourceManifestCommon, SqliteConnectionSpec,
+        DatabaseConnectionSpec, MySqlConnectionSpec, ParsedTemplate, SqliteConnectionSpec,
     };
 
     use super::{
@@ -448,8 +447,9 @@ mod tests {
     };
     use crate::backends::shared::template::RenderContext;
     use crate::{
-        CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
-        SourceDecorator, SourceDecoratorError, SourceFailurePolicy, SourceTables,
+        CoralQuery, DatabaseRuntimeBackend, QueryRuntimeConfig, QuerySource, RuntimeCatalog,
+        RuntimeSourcePackage, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
+        SourceTables,
     };
 
     struct AbortOnSourceFailureDecorator;
@@ -519,19 +519,12 @@ mod tests {
     }
 
     fn sqlite_source(path: String) -> QuerySource {
-        let database = DatabaseSourceManifest {
-            common: SourceManifestCommon {
-                dsl_version: 4,
-                name: "coral_db".to_string(),
-                version: String::new(),
-                description: "Coral test database".to_string(),
-                test_queries: Vec::new(),
-            },
-            connection: DatabaseConnectionSpec::Sqlite(SqliteConnectionSpec {
+        let backend = DatabaseRuntimeBackend::new(
+            4,
+            DatabaseConnectionSpec::Sqlite(SqliteConnectionSpec {
                 path: ParsedTemplate::parse(path).expect("sqlite path template"),
             }),
-            declared_inputs: Vec::new(),
-        };
+        );
         QuerySource::from_runtime_components(
             RuntimeSourcePackage {
                 source_name: "coral_db".to_string(),
@@ -540,7 +533,10 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
-                components: vec![RuntimeSourceComponent::Database(database)],
+                catalogs: vec![
+                    RuntimeCatalog::try_database_provider_discovered("coral_db", backend)
+                        .expect("database catalog"),
+                ],
             },
             BTreeMap::new(),
             BTreeMap::new(),

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -70,9 +70,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::contracts::RuntimeBackendManifest;
 use crate::{
     BoundRequestIdentityHttpAuthenticator, CoreError, QuerySource, RequestAuthenticator,
-    RuntimeSourceComponent, SourceInputResolver, SourceObservationPublisher,
+    SourceInputResolver, SourceObservationPublisher,
 };
 #[cfg(test)]
 use coral_spec::ValidatedSourceManifest;
@@ -105,9 +106,9 @@ pub(crate) fn compile_query_source(
     source_observation_publishers: &[Arc<dyn SourceObservationPublisher>],
     request_identity_http_authenticators: &HashMap<String, BoundRequestIdentityHttpAuthenticator>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
-    if source.components().is_empty() {
+    if source.catalogs().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
-            "source '{}' has no runtime components",
+            "source '{}' has no runtime catalogs",
             source.source_name()
         )));
     }
@@ -122,10 +123,23 @@ pub(crate) fn compile_query_source(
         source_observation_publishers,
         request_identity_http_authenticators,
     };
-    let compiled_components = source
-        .components()
+    let manifests = source
+        .catalogs()
         .iter()
-        .map(|component| compile_component(component, &request))
+        .map(|catalog| catalog.backend_manifests(source))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    if manifests.is_empty() {
+        return Err(CoreError::FailedPrecondition(format!(
+            "source '{}' has no runtime relations",
+            source.source_name()
+        )));
+    }
+    let compiled_components = manifests
+        .iter()
+        .map(|manifest| compile_component(manifest, &request))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(composite::compile_source(
         source.source_name().to_string(),
@@ -134,14 +148,14 @@ pub(crate) fn compile_query_source(
 }
 
 fn compile_component(
-    component: &RuntimeSourceComponent,
+    component: &RuntimeBackendManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     match component {
-        RuntimeSourceComponent::Database(manifest) => {
+        RuntimeBackendManifest::Database(manifest) => {
             Ok(database::compile_manifest(manifest, request))
         }
-        RuntimeSourceComponent::Http(manifest) => {
+        RuntimeBackendManifest::Http(manifest) => {
             let request_identity_http_authenticator = request
                 .source
                 .identity_requirements()
@@ -164,8 +178,8 @@ fn compile_component(
                 request_identity_http_authenticator,
             ))
         }
-        RuntimeSourceComponent::File(manifest) => Ok(file::compile_manifest(manifest, request)),
-        RuntimeSourceComponent::Mcp(manifest) => Ok(mcp::compile_manifest(manifest, request)),
+        RuntimeBackendManifest::File(manifest) => Ok(file::compile_manifest(manifest, request)),
+        RuntimeBackendManifest::Mcp(manifest) => Ok(mcp::compile_manifest(manifest, request)),
     }
 }
 

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -95,7 +95,10 @@ pub(crate) mod database;
 pub(crate) mod file;
 pub(crate) mod http;
 pub(crate) mod mcp;
+mod preparation;
 pub(crate) mod shared;
+
+pub(crate) use preparation::{CatalogPreparation, CatalogPublication, CatalogRegistration};
 
 pub(crate) fn compile_query_source(
     source: &QuerySource,

--- a/crates/coral-engine/src/backends/preparation.rs
+++ b/crates/coral-engine/src/backends/preparation.rs
@@ -1,0 +1,410 @@
+//! Source-scoped catalog staging and decoration.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
+
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
+use datafusion::datasource::TableProvider;
+
+use super::{
+    BackendCatalogRegistration, BackendRegistration, BackendSchemaRegistration,
+    DatabaseColumnFetcher, RegisteredSource, SourceQualifiedName,
+};
+use crate::runtime::schema_provider::StaticSchemaProvider;
+use crate::{CoreError, QuerySource, SourceDecorator, SourceTables};
+use coral_spec::SqlObjectName;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogPublication {
+    ExtendExisting,
+    InstallNew,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTarget {
+    pub(crate) catalog_name: String,
+    pub(crate) publication: CatalogPublication,
+}
+
+pub(crate) struct DeclaredCatalogDraft {
+    target: CatalogTarget,
+    tables: BTreeMap<SqlObjectName, Arc<dyn TableProvider>>,
+    source: RegisteredSource,
+}
+
+pub(crate) struct ProviderDiscoveredCatalogDraft {
+    target: CatalogTarget,
+    provider: Arc<dyn CatalogProvider>,
+    source: RegisteredSource,
+    column_fetcher: Option<Arc<dyn DatabaseColumnFetcher>>,
+}
+
+pub(crate) struct CatalogRegistration {
+    pub(crate) target: CatalogTarget,
+    pub(crate) provider: Arc<dyn CatalogProvider>,
+    pub(crate) source: RegisteredSource,
+    pub(crate) column_fetcher: Option<Arc<dyn DatabaseColumnFetcher>>,
+}
+
+pub(crate) struct CatalogPreparation<'a> {
+    source: &'a QuerySource,
+    decorators: &'a mut [Box<dyn SourceDecorator>],
+    declared: Vec<DeclaredCatalogDraft>,
+    provider_discovered: Vec<ProviderDiscoveredCatalogDraft>,
+}
+
+impl<'a> CatalogPreparation<'a> {
+    pub(crate) fn new(
+        source: &'a QuerySource,
+        decorators: &'a mut [Box<dyn SourceDecorator>],
+    ) -> Self {
+        Self {
+            source,
+            decorators,
+            declared: Vec::new(),
+            provider_discovered: Vec::new(),
+        }
+    }
+
+    pub(crate) fn stage_backend_registration(
+        &mut self,
+        registration: BackendRegistration,
+    ) -> Result<(), CoreError> {
+        for schema in registration.schemas {
+            self.stage_declared(Self::declared_draft(schema)?)?;
+        }
+        for catalog in registration.catalogs {
+            self.stage_provider_discovered(Self::provider_discovered_draft(catalog)?)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn stage_declared(&mut self, draft: DeclaredCatalogDraft) -> Result<(), CoreError> {
+        if draft.target.publication != CatalogPublication::ExtendExisting {
+            return Err(CoreError::InvalidInput(
+                "declared v3 catalog drafts must extend the default catalog".to_string(),
+            ));
+        }
+        self.declared.push(draft);
+        Ok(())
+    }
+
+    pub(crate) fn stage_provider_discovered(
+        &mut self,
+        draft: ProviderDiscoveredCatalogDraft,
+    ) -> Result<(), CoreError> {
+        if draft.target.publication != CatalogPublication::InstallNew {
+            return Err(CoreError::InvalidInput(
+                "provider-discovered catalog drafts must install a new catalog".to_string(),
+            ));
+        }
+        self.provider_discovered.push(draft);
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> Result<Vec<CatalogRegistration>, CoreError> {
+        self.ensure_provider_discovered_support()?;
+
+        let mut providers = BTreeMap::new();
+        for draft in &self.declared {
+            for (sql_name, provider) in &draft.tables {
+                if providers
+                    .insert(sql_name.clone(), Arc::clone(provider))
+                    .is_some()
+                {
+                    return Err(CoreError::InvalidInput(format!(
+                        "source '{}' staged duplicate table identity '{sql_name}'",
+                        self.source.source_name()
+                    )));
+                }
+            }
+        }
+
+        let expected_identities = providers.keys().cloned().collect::<BTreeSet<_>>();
+        let mut tables = SourceTables::new(providers);
+        if !self.declared.is_empty() {
+            for decorator in self.decorators {
+                tables = decorator
+                    .decorate_source(self.source, tables)
+                    .map_err(|error| decorator_error(decorator.name(), &error))?;
+            }
+        }
+        let actual_identities = tables.iter().map(|(name, _)| name.clone()).collect();
+        if expected_identities != actual_identities {
+            return Err(CoreError::FailedPrecondition(format!(
+                "source '{}' decoration changed its canonical table identity set",
+                self.source.source_name()
+            )));
+        }
+
+        let mut decorated = tables.into_inner();
+        let mut registrations =
+            Vec::with_capacity(self.declared.len() + self.provider_discovered.len());
+        for draft in self.declared {
+            let mut schema_tables = HashMap::with_capacity(draft.tables.len());
+            for sql_name in draft.tables.keys() {
+                let provider = decorated.remove(sql_name).ok_or_else(|| {
+                    CoreError::FailedPrecondition(format!(
+                        "source '{}' decoration omitted table identity '{sql_name}'",
+                        self.source.source_name()
+                    ))
+                })?;
+                schema_tables.insert(sql_name.name().to_string(), provider);
+            }
+            let schema_name = draft.source.qualified_name.name().to_string();
+            let provider = Arc::new(MemoryCatalogProvider::new());
+            provider
+                .register_schema(
+                    &schema_name,
+                    Arc::new(StaticSchemaProvider::new(schema_tables)),
+                )
+                .map_err(|error| CoreError::FailedPrecondition(error.to_string()))?;
+            registrations.push(CatalogRegistration {
+                target: draft.target,
+                provider,
+                source: draft.source,
+                column_fetcher: None,
+            });
+        }
+        debug_assert!(decorated.is_empty());
+
+        registrations.extend(self.provider_discovered.into_iter().map(|draft| {
+            CatalogRegistration {
+                target: draft.target,
+                provider: draft.provider,
+                source: draft.source,
+                column_fetcher: draft.column_fetcher,
+            }
+        }));
+        Ok(registrations)
+    }
+
+    fn ensure_provider_discovered_support(&self) -> Result<(), CoreError> {
+        if self.provider_discovered.is_empty() {
+            return Ok(());
+        }
+        if let Some(decorator) = self
+            .decorators
+            .iter()
+            .find(|decorator| !decorator.supports_provider_discovered_catalogs())
+        {
+            return Err(CoreError::FailedPrecondition(format!(
+                "source '{}' registers provider-discovered catalogs, which source decorator '{}' does not support",
+                self.source.source_name(),
+                decorator.name()
+            )));
+        }
+        Ok(())
+    }
+
+    fn declared_draft(
+        registration: BackendSchemaRegistration,
+    ) -> Result<DeclaredCatalogDraft, CoreError> {
+        let BackendSchemaRegistration { tables, source } = registration;
+        let SourceQualifiedName::Schema(schema_name) = &source.qualified_name else {
+            return Err(CoreError::InvalidInput(
+                "declared backend registration must publish a schema".to_string(),
+            ));
+        };
+        let tables = tables
+            .into_iter()
+            .map(|(table_name, provider)| {
+                let sql_name = SqlObjectName::try_new("datafusion", schema_name, table_name)
+                    .map_err(|error| CoreError::InvalidInput(error.to_string()))?;
+                Ok((sql_name, provider))
+            })
+            .collect::<Result<_, CoreError>>()?;
+        Ok(DeclaredCatalogDraft {
+            target: CatalogTarget {
+                catalog_name: "datafusion".to_string(),
+                publication: CatalogPublication::ExtendExisting,
+            },
+            tables,
+            source,
+        })
+    }
+
+    fn provider_discovered_draft(
+        registration: BackendCatalogRegistration,
+    ) -> Result<ProviderDiscoveredCatalogDraft, CoreError> {
+        let BackendCatalogRegistration {
+            catalog,
+            source,
+            column_fetcher,
+        } = registration;
+        let SourceQualifiedName::Catalog(catalog_name) = &source.qualified_name else {
+            return Err(CoreError::InvalidInput(
+                "provider-discovered backend registration must publish a catalog".to_string(),
+            ));
+        };
+        Ok(ProviderDiscoveredCatalogDraft {
+            target: CatalogTarget {
+                catalog_name: catalog_name.clone(),
+                publication: CatalogPublication::InstallNew,
+            },
+            provider: catalog,
+            source,
+            column_fetcher: Some(column_fetcher),
+        })
+    }
+}
+
+fn decorator_error(name: &str, error: &crate::SourceDecoratorError) -> CoreError {
+    match error {
+        crate::SourceDecoratorError::InvalidInput(detail) => {
+            CoreError::InvalidInput(format!("source decorator '{name}': {detail}"))
+        }
+        crate::SourceDecoratorError::FailedPrecondition(detail) => {
+            CoreError::FailedPrecondition(format!("source decorator '{name}': {detail}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::catalog::MemoryCatalogProvider;
+    use datafusion::catalog::empty::EmptyTable;
+    use datafusion::datasource::TableProvider;
+
+    use super::{
+        CatalogPreparation, CatalogPublication, CatalogTarget, DeclaredCatalogDraft,
+        ProviderDiscoveredCatalogDraft,
+    };
+    use crate::backends::{RegisteredSource, SourceQualifiedName};
+    use crate::{
+        QuerySource, RuntimeSourcePackage, SourceDecorator, SourceDecoratorError, SourceTables,
+    };
+    use coral_spec::SqlObjectName;
+
+    struct CountingDecorator {
+        calls: Arc<AtomicUsize>,
+        fail: bool,
+        supports_provider_discovered: bool,
+    }
+
+    impl SourceDecorator for CountingDecorator {
+        fn name(&self) -> &'static str {
+            "counting"
+        }
+
+        fn supports_provider_discovered_catalogs(&self) -> bool {
+            self.supports_provider_discovered
+        }
+
+        fn decorate_source(
+            &mut self,
+            _source: &QuerySource,
+            tables: SourceTables,
+        ) -> Result<SourceTables, SourceDecoratorError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err(SourceDecoratorError::failed_precondition(
+                    "decoration failed",
+                ));
+            }
+            Ok(tables)
+        }
+    }
+
+    #[test]
+    fn provider_discovered_support_fails_before_decoration() {
+        let source = query_source();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut decorators: Vec<Box<dyn SourceDecorator>> = vec![Box::new(CountingDecorator {
+            calls: Arc::clone(&calls),
+            fail: false,
+            supports_provider_discovered: false,
+        })];
+        let mut preparation = CatalogPreparation::new(&source, &mut decorators);
+        preparation
+            .stage_provider_discovered(provider_discovered_draft())
+            .expect("stage provider-discovered catalog");
+
+        let Err(error) = preparation.finish() else {
+            panic!("unsupported provider discovery must fail closed");
+        };
+
+        assert!(error.to_string().contains("does not support"), "{error}");
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn decoration_failure_returns_no_catalog_registrations() {
+        let source = query_source();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut decorators: Vec<Box<dyn SourceDecorator>> = vec![Box::new(CountingDecorator {
+            calls: Arc::clone(&calls),
+            fail: true,
+            supports_provider_discovered: false,
+        })];
+        let mut preparation = CatalogPreparation::new(&source, &mut decorators);
+        preparation
+            .stage_declared(declared_draft("github", "issues"))
+            .expect("stage declared catalog");
+
+        let Err(error) = preparation.finish() else {
+            panic!("decoration failure must not produce registrations");
+        };
+
+        assert!(error.to_string().contains("decoration failed"), "{error}");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    fn query_source() -> QuerySource {
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "github".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                identity_requirements: None,
+                catalogs: Vec::new(),
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("query source")
+    }
+
+    fn declared_draft(schema_name: &str, table_name: &str) -> DeclaredCatalogDraft {
+        let sql_name = SqlObjectName::try_new("datafusion", schema_name, table_name)
+            .expect("canonical SQL name");
+        let provider: Arc<dyn TableProvider> = Arc::new(EmptyTable::new(Arc::new(Schema::empty())));
+        DeclaredCatalogDraft {
+            target: CatalogTarget {
+                catalog_name: "datafusion".to_string(),
+                publication: CatalogPublication::ExtendExisting,
+            },
+            tables: BTreeMap::from([(sql_name, provider)]),
+            source: RegisteredSource {
+                qualified_name: SourceQualifiedName::Schema(schema_name.to_string()),
+                tables: Vec::new(),
+                table_functions: Vec::new(),
+                inputs: Vec::new(),
+            },
+        }
+    }
+
+    fn provider_discovered_draft() -> ProviderDiscoveredCatalogDraft {
+        ProviderDiscoveredCatalogDraft {
+            target: CatalogTarget {
+                catalog_name: "github".to_string(),
+                publication: CatalogPublication::InstallNew,
+            },
+            provider: Arc::new(MemoryCatalogProvider::new()),
+            source: RegisteredSource {
+                qualified_name: SourceQualifiedName::Catalog("github".to_string()),
+                tables: Vec::new(),
+                table_functions: Vec::new(),
+                inputs: Vec::new(),
+            },
+            column_fetcher: None,
+        }
+    }
+}

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -14,10 +14,56 @@ use serde_json::Value;
 use crate::CoreError;
 use crate::contracts::{QueryExecutionProvenance, QuerySource};
 use coral_spec::v4::IdentityRequirements;
-use coral_spec::{ManifestInputKind, ManifestInputSpec};
+use coral_spec::{ManifestInputKind, ManifestInputSpec, SqlObjectName};
 
-/// One source's table providers keyed by manifest table name.
-pub type SourceTables = HashMap<String, Arc<dyn TableProvider>>;
+/// One source's table providers keyed by complete canonical SQL identity.
+pub struct SourceTables {
+    tables: BTreeMap<SqlObjectName, Arc<dyn TableProvider>>,
+}
+
+impl SourceTables {
+    pub(crate) fn new(tables: BTreeMap<SqlObjectName, Arc<dyn TableProvider>>) -> Self {
+        Self { tables }
+    }
+
+    /// Iterates over providers in canonical SQL-name order.
+    pub fn iter(&self) -> impl Iterator<Item = (&SqlObjectName, &Arc<dyn TableProvider>)> {
+        self.tables.iter()
+    }
+
+    /// Returns the provider for one complete canonical SQL identity.
+    #[must_use]
+    pub fn get(&self, sql_name: &SqlObjectName) -> Option<&Arc<dyn TableProvider>> {
+        self.tables.get(sql_name)
+    }
+
+    /// Replaces providers while preserving the exact canonical identity set.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by `map`.
+    pub fn try_map_providers<F>(self, mut map: F) -> Result<Self, SourceDecoratorError>
+    where
+        F: FnMut(
+            &SqlObjectName,
+            Arc<dyn TableProvider>,
+        ) -> Result<Arc<dyn TableProvider>, SourceDecoratorError>,
+    {
+        let tables = self
+            .tables
+            .into_iter()
+            .map(|(sql_name, provider)| {
+                let provider = map(&sql_name, provider)?;
+                Ok((sql_name, provider))
+            })
+            .collect::<Result<_, SourceDecoratorError>>()?;
+        Ok(Self { tables })
+    }
+
+    pub(crate) fn into_inner(self) -> BTreeMap<SqlObjectName, Arc<dyn TableProvider>> {
+        self.tables
+    }
+}
 
 /// Neutral bundle of optional engine extensions for one runtime build.
 #[derive(Default)]
@@ -541,14 +587,14 @@ pub trait SourceDecorator: Send + Sync {
     /// Stable decorator name used in diagnostics.
     fn name(&self) -> &'static str;
 
-    /// Whether this decorator supports sources registered as `SQL` catalogs.
+    /// Whether this decorator supports provider-discovered `SQL` catalogs.
     ///
-    /// Catalog-backed sources expose table providers lazily, so
+    /// Provider-discovered catalogs expose table providers lazily, so
     /// [`SourceDecorator::decorate_source`] is not called for them. Decorators
     /// should return `true` only when their guarantees remain intact without
     /// decorating those table providers, such as when they only observe
     /// registration lifecycle events.
-    fn supports_catalog_sources(&self) -> bool {
+    fn supports_provider_discovered_catalogs(&self) -> bool {
         false
     }
 
@@ -602,12 +648,42 @@ pub trait SourceDecorator: Send + Sync {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
+    use arrow::datatypes::Schema;
+    use coral_spec::SqlObjectName;
     use coral_spec::parse_source_manifest_value;
     use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
+    use datafusion::catalog::empty::EmptyTable;
+    use datafusion::datasource::TableProvider;
     use serde_json::{Value, json};
 
-    use crate::{QuerySource, RequestIdentitySelectionContext, SourceInputResolutionContext};
+    use crate::{
+        QuerySource, RequestIdentitySelectionContext, SourceInputResolutionContext, SourceTables,
+    };
+
+    #[test]
+    fn source_tables_provider_mapping_preserves_canonical_identities() {
+        let first = SqlObjectName::try_new("datafusion", "github", "issues").expect("SQL name");
+        let second = SqlObjectName::try_new("datafusion", "github", "pulls").expect("SQL name");
+        let provider =
+            || -> Arc<dyn TableProvider> { Arc::new(EmptyTable::new(Arc::new(Schema::empty()))) };
+        let tables = SourceTables::new(BTreeMap::from([
+            (first.clone(), provider()),
+            (second.clone(), provider()),
+        ]));
+
+        let mapped = tables
+            .try_map_providers(|_sql_name, provider| Ok(provider))
+            .expect("map providers");
+
+        assert!(mapped.get(&first).is_some());
+        assert!(mapped.get(&second).is_some());
+        assert_eq!(
+            mapped.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            vec![&first, &second]
+        );
+    }
 
     fn identity_context(
         identity_specs: &[&str],

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -17,16 +17,18 @@ pub use query::{
     QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue,
     QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    ResolvedQueryResources, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
+    ResolvedQueryResources, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
+pub(crate) use runtime_catalog::RuntimeBackendManifest;
 pub use runtime_catalog::{
     DatabaseProviderDiscoveredRuntimeCatalog, DatabaseRuntimeBackend, DeclaredRuntimeCatalog,
     FileDeclaredRuntimeCatalog, FileRuntimeBackend, FileRuntimeRelation, FileRuntimeTableRelation,
     HttpDeclaredRuntimeCatalog, HttpRuntimeBackend, HttpRuntimeRelation,
     HttpRuntimeTableFunctionRelation, HttpRuntimeTableRelation, McpDeclaredRuntimeCatalog,
     McpRuntimeBackend, McpRuntimeRelation, McpRuntimeTableFunctionRelation,
-    McpRuntimeTableRelation, ProviderDiscoveredRuntimeCatalog, RuntimeCatalog,
+    McpRuntimeTableRelation, ProviderDiscoveredRuntimeCatalog, RuntimeCatalog, RuntimeRelationKind,
+    RuntimeRelationRef,
 };
 pub use udfs::{
     UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod error;
 mod query;
 mod query_error;
+mod runtime_catalog;
 mod udfs;
 
 pub use catalog::{
@@ -19,6 +20,14 @@ pub use query::{
     ResolvedQueryResources, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
+pub use runtime_catalog::{
+    DatabaseProviderDiscoveredRuntimeCatalog, DatabaseRuntimeBackend, DeclaredRuntimeCatalog,
+    FileDeclaredRuntimeCatalog, FileRuntimeBackend, FileRuntimeRelation, FileRuntimeTableRelation,
+    HttpDeclaredRuntimeCatalog, HttpRuntimeBackend, HttpRuntimeRelation,
+    HttpRuntimeTableFunctionRelation, HttpRuntimeTableRelation, McpDeclaredRuntimeCatalog,
+    McpRuntimeBackend, McpRuntimeRelation, McpRuntimeTableFunctionRelation,
+    McpRuntimeTableRelation, ProviderDiscoveredRuntimeCatalog, RuntimeCatalog,
+};
 pub use udfs::{
     UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
     UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -8,15 +8,11 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
-use coral_spec::backends::database::{DatabaseConnectionSpec, DatabaseSourceManifest};
-use coral_spec::backends::file::FileSourceManifest;
-use coral_spec::backends::http::HttpSourceManifest;
-use coral_spec::backends::mcp::McpSourceManifest;
 use coral_spec::v4::IdentityRequirements;
 use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 use opentelemetry::Context as OtelContext;
 
-use super::ColumnInfo;
+use super::{ColumnInfo, RuntimeCatalog, RuntimeRelationRef};
 use crate::{
     EngineExtensions, RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
     RequestIdentitySelector,
@@ -31,7 +27,7 @@ pub struct QuerySource {
     declared_inputs: Vec<ManifestInputSpec>,
     test_queries: Vec<String>,
     identity_requirements: Option<IdentityRequirements>,
-    components: Vec<RuntimeSourceComponent>,
+    catalogs: Vec<RuntimeCatalog>,
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
 }
@@ -51,21 +47,8 @@ pub struct RuntimeSourcePackage {
     pub test_queries: Vec<String>,
     /// Source-level request identity requirements, when declared.
     pub identity_requirements: Option<IdentityRequirements>,
-    /// Backend-ready runtime components that make up the logical source.
-    pub components: Vec<RuntimeSourceComponent>,
-}
-
-/// One backend-ready component inside an app-assembled query source package.
-#[derive(Clone)]
-pub enum RuntimeSourceComponent {
-    /// Relational database-backed runtime component.
-    Database(DatabaseSourceManifest),
-    /// HTTP-backed runtime component.
-    Http(HttpSourceManifest),
-    /// File-backed runtime component.
-    File(FileSourceManifest),
-    /// MCP-backed runtime component.
-    Mcp(McpSourceManifest),
+    /// Backend-ready runtime catalogs that make up the logical source.
+    pub catalogs: Vec<RuntimeCatalog>,
 }
 
 impl fmt::Debug for QuerySource {
@@ -77,41 +60,10 @@ impl fmt::Debug for QuerySource {
             .field("description", &self.description)
             .field("declared_inputs", &self.declared_inputs)
             .field("test_queries", &self.test_queries)
-            .field("components", &self.components)
+            .field("catalogs", &self.catalogs)
             .field("variables", &self.variables)
             .field("secret_count", &self.secrets.len())
             .finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for RuntimeSourceComponent {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Database(manifest) => {
-                let provider = match &manifest.connection {
-                    DatabaseConnectionSpec::Postgres(_) => "postgres",
-                    DatabaseConnectionSpec::MySql(_) => "mysql",
-                    DatabaseConnectionSpec::Sqlite(_) => "sqlite",
-                };
-                formatter
-                    .debug_struct("Database")
-                    .field("source_name", &manifest.common.name)
-                    .field("provider", &provider)
-                    .finish_non_exhaustive()
-            }
-            Self::Http(manifest) => formatter
-                .debug_struct("Http")
-                .field("source_name", &manifest.common.name)
-                .finish_non_exhaustive(),
-            Self::File(manifest) => formatter
-                .debug_struct("File")
-                .field("source_name", &manifest.common.name)
-                .finish_non_exhaustive(),
-            Self::Mcp(manifest) => formatter
-                .debug_struct("Mcp")
-                .field("source_name", &manifest.common.name)
-                .finish_non_exhaustive(),
-        }
     }
 }
 
@@ -138,7 +90,7 @@ impl QuerySource {
         variables: BTreeMap<String, String>,
         secrets: BTreeMap<String, String>,
     ) -> Self {
-        let components = components_from_manifest(source_spec);
+        let catalogs = catalogs_from_manifest(source_spec);
         Self {
             source_name: source_spec.schema_name().to_string(),
             authored_version: source_spec.source_version().map(ToString::to_string),
@@ -146,13 +98,13 @@ impl QuerySource {
             declared_inputs: source_spec.declared_inputs().to_vec(),
             test_queries: source_spec.test_queries().to_vec(),
             identity_requirements: None,
-            components,
+            catalogs,
             variables,
             secrets,
         }
     }
 
-    /// Builds one source selection from app-assembled runtime components.
+    /// Builds one source selection from app-assembled runtime catalogs.
     ///
     /// # Errors
     ///
@@ -167,15 +119,6 @@ impl QuerySource {
                 "runtime source package source_name must not be empty".to_string(),
             ));
         }
-        for component in &package.components {
-            let schema_name = component.source_name();
-            if schema_name.trim().is_empty() {
-                return Err(crate::CoreError::InvalidInput(format!(
-                    "runtime source package '{}' has a component with an empty schema name",
-                    package.source_name
-                )));
-            }
-        }
         validate_runtime_source_identity_requirements(&package)?;
         Ok(Self {
             source_name: package.source_name,
@@ -184,7 +127,7 @@ impl QuerySource {
             declared_inputs: package.declared_inputs,
             test_queries: package.test_queries,
             identity_requirements: package.identity_requirements,
-            components: package.components,
+            catalogs: package.catalogs,
             variables,
             secrets,
         })
@@ -235,45 +178,54 @@ impl QuerySource {
     }
 
     #[must_use]
-    /// Returns backend-ready runtime components supplied by the app.
-    pub fn components(&self) -> &[RuntimeSourceComponent] {
-        &self.components
+    /// Returns backend-ready runtime catalogs supplied by the app.
+    pub fn catalogs(&self) -> &[RuntimeCatalog] {
+        &self.catalogs
+    }
+
+    /// Returns read-only views of every app-declared table and table function.
+    #[must_use]
+    pub fn declared_relations(&self) -> Vec<RuntimeRelationRef<'_>> {
+        self.catalogs
+            .iter()
+            .flat_map(RuntimeCatalog::relations)
+            .collect()
     }
 
     #[must_use]
-    /// Returns the SQL schema names published by this source's two-part
-    /// components. Database components publish catalogs instead; see
-    /// [`Self::catalog_names`]. A source with no components claims its source
+    /// Returns the SQL schema names published by this source's declared
+    /// catalogs. Provider-discovered database catalogs publish catalogs instead;
+    /// see [`Self::catalog_names`]. A source with no catalogs claims its source
     /// name as a schema. Schema and catalog names of all selected sources
     /// share one flat namespace.
     pub fn schema_names(&self) -> Vec<&str> {
         let mut names = Vec::new();
-        for component in &self.components {
-            if matches!(component, RuntimeSourceComponent::Database(_)) {
-                continue;
-            }
-            let name = component.source_name();
-            if !names.contains(&name) {
-                names.push(name);
+        for catalog in &self.catalogs {
+            for sql_name in catalog.sql_names() {
+                if sql_name.catalog_name() == "datafusion"
+                    && !names.contains(&sql_name.schema_name())
+                {
+                    names.push(sql_name.schema_name());
+                }
             }
         }
-        if self.components.is_empty() {
+        if self.catalogs.is_empty() {
             names.push(self.source_name());
         }
         names
     }
 
     #[must_use]
-    /// Returns the SQL catalog names published by this source's database
-    /// components. Tables of these components resolve as
+    /// Returns the SQL catalog names published by this source's
+    /// provider-discovered database catalogs. Their tables resolve as
     /// `catalog.schema.table`, with schemas discovered at registration time.
     pub fn catalog_names(&self) -> Vec<&str> {
         let mut names = Vec::new();
-        for component in &self.components {
-            let RuntimeSourceComponent::Database(manifest) = component else {
+        for catalog in &self.catalogs {
+            let name = catalog.catalog_name();
+            if name == "datafusion" {
                 continue;
-            };
-            let name = manifest.common.name.as_str();
+            }
             if !names.contains(&name) {
                 names.push(name);
             }
@@ -294,20 +246,6 @@ impl QuerySource {
     }
 }
 
-impl RuntimeSourceComponent {
-    #[must_use]
-    /// Returns the name this component publishes at runtime: a schema name,
-    /// or a catalog name for database components.
-    pub fn source_name(&self) -> &str {
-        match self {
-            Self::Database(manifest) => &manifest.common.name,
-            Self::Http(manifest) => &manifest.common.name,
-            Self::File(manifest) => &manifest.common.name,
-            Self::Mcp(manifest) => &manifest.common.name,
-        }
-    }
-}
-
 fn validate_runtime_source_identity_requirements(
     package: &RuntimeSourcePackage,
 ) -> Result<(), crate::CoreError> {
@@ -315,32 +253,41 @@ fn validate_runtime_source_identity_requirements(
         return Ok(());
     }
 
-    for component in &package.components {
-        let RuntimeSourceComponent::Http(manifest) = component else {
+    for catalog in &package.catalogs {
+        let Some((catalog_name, dsl_version)) = catalog.declared_http_metadata() else {
             return Err(crate::CoreError::InvalidInput(format!(
-                "runtime source package '{}' declares identity_requirements, but identity_requirements require every runtime component to be a DSL v4 HTTP component",
+                "runtime source package '{}' declares identity_requirements, but identity_requirements require every runtime catalog to be a DSL v4 HTTP catalog",
                 package.source_name
             )));
         };
-        if manifest.common.dsl_version != 4 {
+        if dsl_version != 4 {
             return Err(crate::CoreError::InvalidInput(format!(
-                "runtime source package '{}' declares identity_requirements, but component '{}' uses DSL v{} HTTP instead of DSL v4 HTTP",
-                package.source_name, manifest.common.name, manifest.common.dsl_version
+                "runtime source package '{}' declares identity_requirements, but catalog '{}' uses DSL v{} HTTP instead of DSL v4 HTTP",
+                package.source_name, catalog_name, dsl_version
             )));
         }
     }
     Ok(())
 }
 
-fn components_from_manifest(source_spec: &ValidatedSourceManifest) -> Vec<RuntimeSourceComponent> {
+fn catalogs_from_manifest(source_spec: &ValidatedSourceManifest) -> Vec<RuntimeCatalog> {
     if let Some(http) = source_spec.as_http() {
-        return vec![RuntimeSourceComponent::Http(http.clone())];
+        return vec![
+            RuntimeCatalog::try_from_default_catalog_http_manifest(http.clone())
+                .expect("validated v3 HTTP manifest must produce a runtime catalog"),
+        ];
     }
     if let Some(file) = source_spec.as_file() {
-        return vec![RuntimeSourceComponent::File(file.clone())];
+        return vec![
+            RuntimeCatalog::try_from_default_catalog_file_manifest(file.clone())
+                .expect("validated v3 file manifest must produce a runtime catalog"),
+        ];
     }
     if let Some(mcp) = source_spec.as_mcp() {
-        return vec![RuntimeSourceComponent::Mcp(mcp.clone())];
+        return vec![
+            RuntimeCatalog::try_from_default_catalog_mcp_manifest(mcp.clone())
+                .expect("validated v3 MCP manifest must produce a runtime catalog"),
+        ];
     }
     Vec::new()
 }
@@ -1271,7 +1218,7 @@ mod tests {
     use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
     use serde_json::json;
 
-    use super::{MemorySize, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+    use super::{MemorySize, QuerySource, RuntimeCatalog, RuntimeSourcePackage};
 
     #[test]
     fn memory_size_parses_binary_units() {
@@ -1310,7 +1257,10 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: Some(identity_requirements()),
-                components: vec![RuntimeSourceComponent::Http(http_manifest())],
+                catalogs: vec![
+                    RuntimeCatalog::try_from_default_catalog_http_manifest(http_manifest())
+                        .expect("HTTP catalog"),
+                ],
             },
             BTreeMap::new(),
             BTreeMap::new(),
@@ -1339,7 +1289,10 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: Some(requirements.clone()),
-                components: vec![RuntimeSourceComponent::Http(manifest)],
+                catalogs: vec![
+                    RuntimeCatalog::try_from_default_catalog_http_manifest(manifest)
+                        .expect("HTTP catalog"),
+                ],
             },
             BTreeMap::new(),
             BTreeMap::new(),
@@ -1362,8 +1315,8 @@ mod tests {
         assert!(source.identity_requirements().is_none());
         assert!(source.identity_selection_context().is_none());
         assert!(matches!(
-            source.components(),
-            [RuntimeSourceComponent::Http(http)] if http.common.dsl_version == 3
+            source.catalogs(),
+            [catalog] if catalog.declared_http_metadata() == Some(("datafusion", 3))
         ));
     }
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -1248,7 +1248,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_source_package_rejects_identity_requirements_on_non_v4_http_component() {
+    fn runtime_source_package_rejects_identity_requirements_on_non_v4_http_catalog() {
         let error = QuerySource::from_runtime_components(
             RuntimeSourcePackage {
                 source_name: "github".to_string(),
@@ -1265,11 +1265,11 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
         )
-        .expect_err("v3 HTTP component should not accept identity requirements");
+        .expect_err("v3 HTTP catalog should not accept identity requirements");
 
         assert!(
             error.to_string().contains(
-                "declares identity_requirements, but component 'github' uses DSL v3 HTTP instead of DSL v4 HTTP"
+                "declares identity_requirements, but catalog 'datafusion' uses DSL v3 HTTP instead of DSL v4 HTTP"
             ),
             "unexpected error: {error}"
         );

--- a/crates/coral-engine/src/contracts/runtime_catalog.rs
+++ b/crates/coral-engine/src/contracts/runtime_catalog.rs
@@ -71,9 +71,9 @@ pub struct HttpRuntimeTableFunctionRelation {
 #[derive(Debug, Clone)]
 pub enum McpRuntimeRelation {
     /// MCP-backed table.
-    Table(McpRuntimeTableRelation),
+    Table(Box<McpRuntimeTableRelation>),
     /// MCP-backed table function.
-    TableFunction(McpRuntimeTableFunctionRelation),
+    TableFunction(Box<McpRuntimeTableFunctionRelation>),
 }
 
 /// Validated MCP table payload paired with its SQL identity.
@@ -213,6 +213,10 @@ impl DatabaseRuntimeBackend {
 
 impl HttpRuntimeRelation {
     /// Builds an HTTP table relation after checking its leaf identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the definition leaf disagrees with the SQL identity.
     pub fn try_table(
         sql_name: SqlObjectName,
         definition: HttpTableSpec,
@@ -225,6 +229,10 @@ impl HttpRuntimeRelation {
     }
 
     /// Builds an HTTP table-function relation after checking its leaf identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the definition leaf disagrees with the SQL identity.
     pub fn try_table_function(
         sql_name: SqlObjectName,
         definition: SourceTableFunctionSpec,
@@ -246,27 +254,37 @@ impl HttpRuntimeRelation {
 
 impl McpRuntimeRelation {
     /// Builds an MCP table relation after checking its leaf identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the definition leaf disagrees with the SQL identity.
     pub fn try_table(
         sql_name: SqlObjectName,
         definition: McpTableSpec,
     ) -> Result<Self, crate::CoreError> {
         validate_definition_name(&sql_name, definition.name(), "MCP table")?;
-        Ok(Self::Table(McpRuntimeTableRelation {
+        Ok(Self::Table(Box::new(McpRuntimeTableRelation {
             sql_name,
             definition,
-        }))
+        })))
     }
 
     /// Builds an MCP table-function relation after checking its leaf identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the definition leaf disagrees with the SQL identity.
     pub fn try_table_function(
         sql_name: SqlObjectName,
         definition: McpTableFunctionSpec,
     ) -> Result<Self, crate::CoreError> {
         validate_definition_name(&sql_name, &definition.common.name, "MCP table function")?;
-        Ok(Self::TableFunction(McpRuntimeTableFunctionRelation {
-            sql_name,
-            definition,
-        }))
+        Ok(Self::TableFunction(Box::new(
+            McpRuntimeTableFunctionRelation {
+                sql_name,
+                definition,
+            },
+        )))
     }
 
     fn sql_name(&self) -> &SqlObjectName {
@@ -279,6 +297,10 @@ impl McpRuntimeRelation {
 
 impl FileRuntimeRelation {
     /// Builds a file table relation after checking its leaf identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the definition leaf disagrees with the SQL identity.
     pub fn try_table(
         sql_name: SqlObjectName,
         definition: FileTableSpec,
@@ -299,6 +321,10 @@ impl FileRuntimeRelation {
 
 impl RuntimeCatalog {
     /// Builds a declared HTTP catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the catalog name or relation identities are invalid.
     pub fn try_http_declared(
         catalog_name: impl Into<String>,
         backend: HttpRuntimeBackend,
@@ -319,6 +345,10 @@ impl RuntimeCatalog {
     }
 
     /// Builds a declared MCP catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the catalog name or relation identities are invalid.
     pub fn try_mcp_declared(
         catalog_name: impl Into<String>,
         backend: McpRuntimeBackend,
@@ -339,6 +369,10 @@ impl RuntimeCatalog {
     }
 
     /// Builds a declared file catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the catalog name or relation identities are invalid.
     pub fn try_file_declared(
         catalog_name: impl Into<String>,
         backend: FileRuntimeBackend,
@@ -359,6 +393,10 @@ impl RuntimeCatalog {
     }
 
     /// Builds a provider-discovered database catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the catalog name is invalid.
     pub fn try_database_provider_discovered(
         catalog_name: impl Into<String>,
         backend: DatabaseRuntimeBackend,
@@ -374,6 +412,10 @@ impl RuntimeCatalog {
     }
 
     /// Adapts one validated v3 HTTP manifest to the canonical default catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the manifest cannot form valid canonical identities.
     pub fn try_from_default_catalog_http_manifest(
         manifest: HttpSourceManifest,
     ) -> Result<Self, crate::CoreError> {
@@ -398,6 +440,10 @@ impl RuntimeCatalog {
     }
 
     /// Adapts one validated v3 MCP manifest to the canonical default catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the manifest cannot form valid canonical identities.
     pub fn try_from_default_catalog_mcp_manifest(
         manifest: McpSourceManifest,
     ) -> Result<Self, crate::CoreError> {
@@ -416,6 +462,10 @@ impl RuntimeCatalog {
     }
 
     /// Adapts one validated v3 file manifest to the canonical default catalog.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::CoreError`] when the manifest cannot form valid canonical identities.
     pub fn try_from_default_catalog_file_manifest(
         manifest: FileSourceManifest,
     ) -> Result<Self, crate::CoreError> {
@@ -599,6 +649,10 @@ impl RuntimeCatalog {
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The temporary v3 compatibility adapter exhaustively branches over the closed backend algebra."
+    )]
     pub(crate) fn backend_manifests(
         &self,
         source: &QuerySource,

--- a/crates/coral-engine/src/contracts/runtime_catalog.rs
+++ b/crates/coral-engine/src/contracts/runtime_catalog.rs
@@ -1,0 +1,483 @@
+//! Closed backend-specific runtime catalog contracts.
+
+#![allow(
+    dead_code,
+    reason = "The catalog contract lands before RuntimeSourcePackage switches to consuming it."
+)]
+
+use coral_spec::backends::database::DatabaseConnectionSpec;
+use coral_spec::backends::file::{FileSourceManifest, FileTableSpec};
+use coral_spec::backends::http::{AuthSpec, HttpSourceManifest, HttpTableSpec, RateLimitSpec};
+use coral_spec::backends::mcp::{
+    McpServerSpec, McpSourceManifest, McpTableFunctionSpec, McpTableSpec,
+};
+use coral_spec::{HeaderSpec, ParsedTemplate, SourceTableFunctionSpec, SqlObjectName};
+
+/// Source-wide HTTP execution configuration without a relation inventory.
+#[derive(Debug, Clone)]
+pub struct HttpRuntimeBackend {
+    dsl_version: u32,
+    base_url: ParsedTemplate,
+    auth: AuthSpec,
+    request_headers: Vec<HeaderSpec>,
+    rate_limit: RateLimitSpec,
+}
+
+/// Source-wide MCP execution configuration without a relation inventory.
+#[derive(Debug, Clone)]
+pub struct McpRuntimeBackend {
+    dsl_version: u32,
+    server: McpServerSpec,
+}
+
+/// Source-wide file execution configuration without a relation inventory.
+#[derive(Debug, Clone, Copy)]
+pub struct FileRuntimeBackend {
+    dsl_version: u32,
+}
+
+/// Source-wide database execution configuration.
+#[derive(Debug, Clone)]
+pub struct DatabaseRuntimeBackend {
+    dsl_version: u32,
+    connection: DatabaseConnectionSpec,
+}
+
+/// One declared HTTP relation with a complete SQL identity.
+#[derive(Debug, Clone)]
+pub enum HttpRuntimeRelation {
+    /// HTTP-backed table.
+    Table(HttpRuntimeTableRelation),
+    /// HTTP-backed table function.
+    TableFunction(HttpRuntimeTableFunctionRelation),
+}
+
+/// Validated HTTP table payload paired with its SQL identity.
+#[derive(Debug, Clone)]
+pub struct HttpRuntimeTableRelation {
+    sql_name: SqlObjectName,
+    definition: HttpTableSpec,
+}
+
+/// Validated HTTP table-function payload paired with its SQL identity.
+#[derive(Debug, Clone)]
+pub struct HttpRuntimeTableFunctionRelation {
+    sql_name: SqlObjectName,
+    definition: SourceTableFunctionSpec,
+}
+
+/// One declared MCP relation with a complete SQL identity.
+#[derive(Debug, Clone)]
+pub enum McpRuntimeRelation {
+    /// MCP-backed table.
+    Table(McpRuntimeTableRelation),
+    /// MCP-backed table function.
+    TableFunction(McpRuntimeTableFunctionRelation),
+}
+
+/// Validated MCP table payload paired with its SQL identity.
+#[derive(Debug, Clone)]
+pub struct McpRuntimeTableRelation {
+    sql_name: SqlObjectName,
+    definition: McpTableSpec,
+}
+
+/// Validated MCP table-function payload paired with its SQL identity.
+#[derive(Debug, Clone)]
+pub struct McpRuntimeTableFunctionRelation {
+    sql_name: SqlObjectName,
+    definition: McpTableFunctionSpec,
+}
+
+/// One declared file relation with a complete SQL identity.
+#[derive(Debug, Clone)]
+pub enum FileRuntimeRelation {
+    /// File-backed table.
+    Table(FileRuntimeTableRelation),
+}
+
+/// Validated file table payload paired with its SQL identity.
+#[derive(Debug, Clone)]
+pub struct FileRuntimeTableRelation {
+    sql_name: SqlObjectName,
+    definition: FileTableSpec,
+}
+
+/// A declared runtime catalog whose complete relation inventory is known.
+#[derive(Debug, Clone)]
+pub enum DeclaredRuntimeCatalog {
+    /// HTTP-backed declared catalog.
+    Http(HttpDeclaredRuntimeCatalog),
+    /// MCP-backed declared catalog.
+    Mcp(McpDeclaredRuntimeCatalog),
+    /// File-backed declared catalog.
+    File(FileDeclaredRuntimeCatalog),
+}
+
+/// HTTP declared-catalog payload with private validated fields.
+#[derive(Debug, Clone)]
+pub struct HttpDeclaredRuntimeCatalog {
+    catalog_name: String,
+    backend: HttpRuntimeBackend,
+    relations: Vec<HttpRuntimeRelation>,
+}
+
+/// MCP declared-catalog payload with private validated fields.
+#[derive(Debug, Clone)]
+pub struct McpDeclaredRuntimeCatalog {
+    catalog_name: String,
+    backend: McpRuntimeBackend,
+    relations: Vec<McpRuntimeRelation>,
+}
+
+/// File declared-catalog payload with private validated fields.
+#[derive(Debug, Clone)]
+pub struct FileDeclaredRuntimeCatalog {
+    catalog_name: String,
+    backend: FileRuntimeBackend,
+    relations: Vec<FileRuntimeRelation>,
+}
+
+/// A runtime catalog whose provider discovers its schemas and relations.
+#[derive(Debug, Clone)]
+pub enum ProviderDiscoveredRuntimeCatalog {
+    /// Database-backed provider-discovered catalog.
+    Database(DatabaseProviderDiscoveredRuntimeCatalog),
+}
+
+/// Database provider-discovered payload with private validated fields.
+#[derive(Debug, Clone)]
+pub struct DatabaseProviderDiscoveredRuntimeCatalog {
+    catalog_name: String,
+    backend: DatabaseRuntimeBackend,
+}
+
+/// Closed runtime catalog algebra accepted at the app-to-engine boundary.
+#[derive(Debug, Clone)]
+pub enum RuntimeCatalog {
+    /// Complete, app-declared relation inventory.
+    Declared(DeclaredRuntimeCatalog),
+    /// Relation inventory discovered from the runtime provider.
+    ProviderDiscovered(ProviderDiscoveredRuntimeCatalog),
+}
+impl HttpRuntimeBackend {
+    /// Builds source-wide HTTP runtime configuration.
+    #[must_use]
+    pub fn new(
+        dsl_version: u32,
+        base_url: ParsedTemplate,
+        auth: AuthSpec,
+        request_headers: Vec<HeaderSpec>,
+        rate_limit: RateLimitSpec,
+    ) -> Self {
+        Self {
+            dsl_version,
+            base_url,
+            auth,
+            request_headers,
+            rate_limit,
+        }
+    }
+}
+
+impl McpRuntimeBackend {
+    /// Builds source-wide MCP runtime configuration.
+    #[must_use]
+    pub fn new(dsl_version: u32, server: McpServerSpec) -> Self {
+        Self {
+            dsl_version,
+            server,
+        }
+    }
+}
+
+impl FileRuntimeBackend {
+    /// Builds source-wide file runtime configuration.
+    #[must_use]
+    pub fn new(dsl_version: u32) -> Self {
+        Self { dsl_version }
+    }
+}
+
+impl DatabaseRuntimeBackend {
+    /// Builds source-wide database runtime configuration.
+    #[must_use]
+    pub fn new(dsl_version: u32, connection: DatabaseConnectionSpec) -> Self {
+        Self {
+            dsl_version,
+            connection,
+        }
+    }
+}
+
+impl HttpRuntimeRelation {
+    /// Builds an HTTP table relation after checking its leaf identity.
+    pub fn try_table(
+        sql_name: SqlObjectName,
+        definition: HttpTableSpec,
+    ) -> Result<Self, crate::CoreError> {
+        validate_definition_name(&sql_name, definition.name(), "HTTP table")?;
+        Ok(Self::Table(HttpRuntimeTableRelation {
+            sql_name,
+            definition,
+        }))
+    }
+
+    /// Builds an HTTP table-function relation after checking its leaf identity.
+    pub fn try_table_function(
+        sql_name: SqlObjectName,
+        definition: SourceTableFunctionSpec,
+    ) -> Result<Self, crate::CoreError> {
+        validate_definition_name(&sql_name, &definition.name, "HTTP table function")?;
+        Ok(Self::TableFunction(HttpRuntimeTableFunctionRelation {
+            sql_name,
+            definition,
+        }))
+    }
+
+    fn sql_name(&self) -> &SqlObjectName {
+        match self {
+            Self::Table(relation) => &relation.sql_name,
+            Self::TableFunction(relation) => &relation.sql_name,
+        }
+    }
+}
+
+impl McpRuntimeRelation {
+    /// Builds an MCP table relation after checking its leaf identity.
+    pub fn try_table(
+        sql_name: SqlObjectName,
+        definition: McpTableSpec,
+    ) -> Result<Self, crate::CoreError> {
+        validate_definition_name(&sql_name, definition.name(), "MCP table")?;
+        Ok(Self::Table(McpRuntimeTableRelation {
+            sql_name,
+            definition,
+        }))
+    }
+
+    /// Builds an MCP table-function relation after checking its leaf identity.
+    pub fn try_table_function(
+        sql_name: SqlObjectName,
+        definition: McpTableFunctionSpec,
+    ) -> Result<Self, crate::CoreError> {
+        validate_definition_name(&sql_name, &definition.common.name, "MCP table function")?;
+        Ok(Self::TableFunction(McpRuntimeTableFunctionRelation {
+            sql_name,
+            definition,
+        }))
+    }
+
+    fn sql_name(&self) -> &SqlObjectName {
+        match self {
+            Self::Table(relation) => &relation.sql_name,
+            Self::TableFunction(relation) => &relation.sql_name,
+        }
+    }
+}
+
+impl FileRuntimeRelation {
+    /// Builds a file table relation after checking its leaf identity.
+    pub fn try_table(
+        sql_name: SqlObjectName,
+        definition: FileTableSpec,
+    ) -> Result<Self, crate::CoreError> {
+        validate_definition_name(&sql_name, definition.name(), "file table")?;
+        Ok(Self::Table(FileRuntimeTableRelation {
+            sql_name,
+            definition,
+        }))
+    }
+
+    fn sql_name(&self) -> &SqlObjectName {
+        match self {
+            Self::Table(relation) => &relation.sql_name,
+        }
+    }
+}
+
+impl RuntimeCatalog {
+    /// Builds a declared HTTP catalog.
+    pub fn try_http_declared(
+        catalog_name: impl Into<String>,
+        backend: HttpRuntimeBackend,
+        relations: Vec<HttpRuntimeRelation>,
+    ) -> Result<Self, crate::CoreError> {
+        let catalog_name = catalog_name.into();
+        validate_declared_catalog(
+            &catalog_name,
+            relations.iter().map(HttpRuntimeRelation::sql_name),
+        )?;
+        Ok(Self::Declared(DeclaredRuntimeCatalog::Http(
+            HttpDeclaredRuntimeCatalog {
+                catalog_name,
+                backend,
+                relations,
+            },
+        )))
+    }
+
+    /// Builds a declared MCP catalog.
+    pub fn try_mcp_declared(
+        catalog_name: impl Into<String>,
+        backend: McpRuntimeBackend,
+        relations: Vec<McpRuntimeRelation>,
+    ) -> Result<Self, crate::CoreError> {
+        let catalog_name = catalog_name.into();
+        validate_declared_catalog(
+            &catalog_name,
+            relations.iter().map(McpRuntimeRelation::sql_name),
+        )?;
+        Ok(Self::Declared(DeclaredRuntimeCatalog::Mcp(
+            McpDeclaredRuntimeCatalog {
+                catalog_name,
+                backend,
+                relations,
+            },
+        )))
+    }
+
+    /// Builds a declared file catalog.
+    pub fn try_file_declared(
+        catalog_name: impl Into<String>,
+        backend: FileRuntimeBackend,
+        relations: Vec<FileRuntimeRelation>,
+    ) -> Result<Self, crate::CoreError> {
+        let catalog_name = catalog_name.into();
+        validate_declared_catalog(
+            &catalog_name,
+            relations.iter().map(FileRuntimeRelation::sql_name),
+        )?;
+        Ok(Self::Declared(DeclaredRuntimeCatalog::File(
+            FileDeclaredRuntimeCatalog {
+                catalog_name,
+                backend,
+                relations,
+            },
+        )))
+    }
+
+    /// Builds a provider-discovered database catalog.
+    pub fn try_database_provider_discovered(
+        catalog_name: impl Into<String>,
+        backend: DatabaseRuntimeBackend,
+    ) -> Result<Self, crate::CoreError> {
+        let catalog_name = catalog_name.into();
+        validate_catalog_name(&catalog_name)?;
+        Ok(Self::ProviderDiscovered(
+            ProviderDiscoveredRuntimeCatalog::Database(DatabaseProviderDiscoveredRuntimeCatalog {
+                catalog_name,
+                backend,
+            }),
+        ))
+    }
+
+    /// Adapts one validated v3 HTTP manifest to the canonical default catalog.
+    pub fn try_from_default_catalog_http_manifest(
+        manifest: HttpSourceManifest,
+    ) -> Result<Self, crate::CoreError> {
+        let schema_name = manifest.common.name.clone();
+        let backend = HttpRuntimeBackend::new(
+            manifest.common.dsl_version,
+            manifest.base_url,
+            manifest.auth,
+            manifest.request_headers,
+            manifest.rate_limit,
+        );
+        let mut relations = Vec::with_capacity(manifest.tables.len() + manifest.functions.len());
+        for table in manifest.tables {
+            let sql_name = default_catalog_sql_name(&schema_name, table.name())?;
+            relations.push(HttpRuntimeRelation::try_table(sql_name, table)?);
+        }
+        for function in manifest.functions {
+            let sql_name = default_catalog_sql_name(&schema_name, &function.name)?;
+            relations.push(HttpRuntimeRelation::try_table_function(sql_name, function)?);
+        }
+        Self::try_http_declared("datafusion", backend, relations)
+    }
+
+    /// Adapts one validated v3 MCP manifest to the canonical default catalog.
+    pub fn try_from_default_catalog_mcp_manifest(
+        manifest: McpSourceManifest,
+    ) -> Result<Self, crate::CoreError> {
+        let schema_name = manifest.common.name.clone();
+        let backend = McpRuntimeBackend::new(manifest.common.dsl_version, manifest.server);
+        let mut relations = Vec::with_capacity(manifest.tables.len() + manifest.functions.len());
+        for table in manifest.tables {
+            let sql_name = default_catalog_sql_name(&schema_name, table.name())?;
+            relations.push(McpRuntimeRelation::try_table(sql_name, table)?);
+        }
+        for function in manifest.functions {
+            let sql_name = default_catalog_sql_name(&schema_name, &function.common.name)?;
+            relations.push(McpRuntimeRelation::try_table_function(sql_name, function)?);
+        }
+        Self::try_mcp_declared("datafusion", backend, relations)
+    }
+
+    /// Adapts one validated v3 file manifest to the canonical default catalog.
+    pub fn try_from_default_catalog_file_manifest(
+        manifest: FileSourceManifest,
+    ) -> Result<Self, crate::CoreError> {
+        let schema_name = manifest.common.name.clone();
+        let backend = FileRuntimeBackend::new(manifest.common.dsl_version);
+        let relations = manifest
+            .tables
+            .into_iter()
+            .map(|table| {
+                let sql_name = default_catalog_sql_name(&schema_name, table.name())?;
+                FileRuntimeRelation::try_table(sql_name, table)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::try_file_declared("datafusion", backend, relations)
+    }
+}
+
+fn default_catalog_sql_name(
+    schema_name: &str,
+    name: &str,
+) -> Result<SqlObjectName, crate::CoreError> {
+    SqlObjectName::try_new("datafusion", schema_name, name)
+        .map_err(|error| crate::CoreError::InvalidInput(error.to_string()))
+}
+
+fn validate_definition_name(
+    sql_name: &SqlObjectName,
+    definition_name: &str,
+    label: &str,
+) -> Result<(), crate::CoreError> {
+    if sql_name.name() == definition_name {
+        return Ok(());
+    }
+    Err(crate::CoreError::InvalidInput(format!(
+        "{label} definition name '{definition_name}' does not match SQL name '{}'",
+        sql_name.name()
+    )))
+}
+
+fn validate_catalog_name(catalog_name: &str) -> Result<(), crate::CoreError> {
+    SqlObjectName::try_new(catalog_name, "public", "relation")
+        .map(|_| ())
+        .map_err(|error| crate::CoreError::InvalidInput(error.to_string()))
+}
+
+fn validate_declared_catalog<'a>(
+    catalog_name: &str,
+    sql_names: impl Iterator<Item = &'a SqlObjectName>,
+) -> Result<(), crate::CoreError> {
+    validate_catalog_name(catalog_name)?;
+    let mut seen = std::collections::BTreeSet::new();
+    for sql_name in sql_names {
+        if sql_name.catalog_name() != catalog_name {
+            return Err(crate::CoreError::InvalidInput(format!(
+                "declared runtime catalog '{catalog_name}' contains relation '{sql_name}' from catalog '{}'",
+                sql_name.catalog_name()
+            )));
+        }
+        if !seen.insert(sql_name) {
+            return Err(crate::CoreError::InvalidInput(format!(
+                "declared runtime catalog '{catalog_name}' contains duplicate relation '{sql_name}'"
+            )));
+        }
+    }
+    Ok(())
+}

--- a/crates/coral-engine/src/contracts/runtime_catalog.rs
+++ b/crates/coral-engine/src/contracts/runtime_catalog.rs
@@ -1,17 +1,18 @@
 //! Closed backend-specific runtime catalog contracts.
 
-#![allow(
-    dead_code,
-    reason = "The catalog contract lands before RuntimeSourcePackage switches to consuming it."
-)]
+use std::collections::BTreeMap;
 
-use coral_spec::backends::database::DatabaseConnectionSpec;
+use coral_spec::backends::database::{DatabaseConnectionSpec, DatabaseSourceManifest};
 use coral_spec::backends::file::{FileSourceManifest, FileTableSpec};
 use coral_spec::backends::http::{AuthSpec, HttpSourceManifest, HttpTableSpec, RateLimitSpec};
 use coral_spec::backends::mcp::{
     McpServerSpec, McpSourceManifest, McpTableFunctionSpec, McpTableSpec,
 };
-use coral_spec::{HeaderSpec, ParsedTemplate, SourceTableFunctionSpec, SqlObjectName};
+use coral_spec::{
+    HeaderSpec, ParsedTemplate, SourceManifestCommon, SourceTableFunctionSpec, SqlObjectName,
+};
+
+use super::QuerySource;
 
 /// Source-wide HTTP execution configuration without a relation inventory.
 #[derive(Debug, Clone)]
@@ -480,4 +481,265 @@ fn validate_declared_catalog<'a>(
         }
     }
     Ok(())
+}
+
+/// SQL-visible kind of one declared runtime relation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeRelationKind {
+    /// SQL table.
+    Table,
+    /// SQL table-valued function.
+    TableFunction,
+}
+
+/// Read-only view of one declared relation in a runtime package.
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeRelationRef<'a> {
+    sql_name: &'a SqlObjectName,
+    kind: RuntimeRelationKind,
+}
+
+impl RuntimeRelationRef<'_> {
+    /// Returns the relation's complete canonical SQL identity.
+    #[must_use]
+    pub fn sql_name(&self) -> &SqlObjectName {
+        self.sql_name
+    }
+
+    /// Returns whether this relation is a table or table function.
+    #[must_use]
+    pub fn kind(&self) -> RuntimeRelationKind {
+        self.kind
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RuntimeBackendManifest {
+    Database(DatabaseSourceManifest),
+    Http(HttpSourceManifest),
+    File(FileSourceManifest),
+    Mcp(McpSourceManifest),
+}
+
+impl RuntimeCatalog {
+    pub(crate) fn catalog_name(&self) -> &str {
+        match self {
+            Self::Declared(DeclaredRuntimeCatalog::Http(catalog)) => &catalog.catalog_name,
+            Self::Declared(DeclaredRuntimeCatalog::Mcp(catalog)) => &catalog.catalog_name,
+            Self::Declared(DeclaredRuntimeCatalog::File(catalog)) => &catalog.catalog_name,
+            Self::ProviderDiscovered(ProviderDiscoveredRuntimeCatalog::Database(catalog)) => {
+                &catalog.catalog_name
+            }
+        }
+    }
+
+    pub(crate) fn sql_names(&self) -> Vec<&SqlObjectName> {
+        match self {
+            Self::Declared(DeclaredRuntimeCatalog::Http(catalog)) => catalog
+                .relations
+                .iter()
+                .map(HttpRuntimeRelation::sql_name)
+                .collect(),
+            Self::Declared(DeclaredRuntimeCatalog::Mcp(catalog)) => catalog
+                .relations
+                .iter()
+                .map(McpRuntimeRelation::sql_name)
+                .collect(),
+            Self::Declared(DeclaredRuntimeCatalog::File(catalog)) => catalog
+                .relations
+                .iter()
+                .map(FileRuntimeRelation::sql_name)
+                .collect(),
+            Self::ProviderDiscovered(_) => Vec::new(),
+        }
+    }
+
+    pub(crate) fn relations(&self) -> Vec<RuntimeRelationRef<'_>> {
+        match self {
+            Self::Declared(DeclaredRuntimeCatalog::Http(catalog)) => catalog
+                .relations
+                .iter()
+                .map(|relation| RuntimeRelationRef {
+                    sql_name: relation.sql_name(),
+                    kind: match relation {
+                        HttpRuntimeRelation::Table(_) => RuntimeRelationKind::Table,
+                        HttpRuntimeRelation::TableFunction(_) => RuntimeRelationKind::TableFunction,
+                    },
+                })
+                .collect(),
+            Self::Declared(DeclaredRuntimeCatalog::Mcp(catalog)) => catalog
+                .relations
+                .iter()
+                .map(|relation| RuntimeRelationRef {
+                    sql_name: relation.sql_name(),
+                    kind: match relation {
+                        McpRuntimeRelation::Table(_) => RuntimeRelationKind::Table,
+                        McpRuntimeRelation::TableFunction(_) => RuntimeRelationKind::TableFunction,
+                    },
+                })
+                .collect(),
+            Self::Declared(DeclaredRuntimeCatalog::File(catalog)) => catalog
+                .relations
+                .iter()
+                .map(|relation| RuntimeRelationRef {
+                    sql_name: relation.sql_name(),
+                    kind: RuntimeRelationKind::Table,
+                })
+                .collect(),
+            Self::ProviderDiscovered(_) => Vec::new(),
+        }
+    }
+
+    pub(crate) fn declared_http_metadata(&self) -> Option<(&str, u32)> {
+        match self {
+            Self::Declared(DeclaredRuntimeCatalog::Http(catalog)) => {
+                Some((&catalog.catalog_name, catalog.backend.dsl_version))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn backend_manifests(
+        &self,
+        source: &QuerySource,
+    ) -> Result<Vec<RuntimeBackendManifest>, crate::CoreError> {
+        match self {
+            Self::Declared(DeclaredRuntimeCatalog::Http(catalog)) => {
+                require_default_catalog(&catalog.catalog_name)?;
+                let mut by_schema: BTreeMap<
+                    String,
+                    (Vec<HttpTableSpec>, Vec<SourceTableFunctionSpec>),
+                > = BTreeMap::new();
+                for relation in &catalog.relations {
+                    match relation {
+                        HttpRuntimeRelation::Table(relation) => by_schema
+                            .entry(relation.sql_name.schema_name().to_string())
+                            .or_default()
+                            .0
+                            .push(relation.definition.clone()),
+                        HttpRuntimeRelation::TableFunction(relation) => by_schema
+                            .entry(relation.sql_name.schema_name().to_string())
+                            .or_default()
+                            .1
+                            .push(relation.definition.clone()),
+                    }
+                }
+                Ok(by_schema
+                    .into_iter()
+                    .map(|(schema_name, (tables, functions))| {
+                        RuntimeBackendManifest::Http(HttpSourceManifest {
+                            common: runtime_manifest_common(
+                                source,
+                                catalog.backend.dsl_version,
+                                schema_name,
+                            ),
+                            base_url: catalog.backend.base_url.clone(),
+                            auth: catalog.backend.auth.clone(),
+                            request_headers: catalog.backend.request_headers.clone(),
+                            rate_limit: catalog.backend.rate_limit.clone(),
+                            tables,
+                            functions,
+                            declared_inputs: source.declared_inputs().to_vec(),
+                        })
+                    })
+                    .collect())
+            }
+            Self::Declared(DeclaredRuntimeCatalog::Mcp(catalog)) => {
+                require_default_catalog(&catalog.catalog_name)?;
+                let mut by_schema: BTreeMap<
+                    String,
+                    (Vec<McpTableSpec>, Vec<McpTableFunctionSpec>),
+                > = BTreeMap::new();
+                for relation in &catalog.relations {
+                    match relation {
+                        McpRuntimeRelation::Table(relation) => by_schema
+                            .entry(relation.sql_name.schema_name().to_string())
+                            .or_default()
+                            .0
+                            .push(relation.definition.clone()),
+                        McpRuntimeRelation::TableFunction(relation) => by_schema
+                            .entry(relation.sql_name.schema_name().to_string())
+                            .or_default()
+                            .1
+                            .push(relation.definition.clone()),
+                    }
+                }
+                Ok(by_schema
+                    .into_iter()
+                    .map(|(schema_name, (tables, functions))| {
+                        RuntimeBackendManifest::Mcp(McpSourceManifest {
+                            common: runtime_manifest_common(
+                                source,
+                                catalog.backend.dsl_version,
+                                schema_name,
+                            ),
+                            server: catalog.backend.server.clone(),
+                            functions,
+                            tables,
+                            declared_inputs: source.declared_inputs().to_vec(),
+                        })
+                    })
+                    .collect())
+            }
+            Self::Declared(DeclaredRuntimeCatalog::File(catalog)) => {
+                require_default_catalog(&catalog.catalog_name)?;
+                let mut by_schema: BTreeMap<String, Vec<FileTableSpec>> = BTreeMap::new();
+                for relation in &catalog.relations {
+                    let FileRuntimeRelation::Table(relation) = relation;
+                    by_schema
+                        .entry(relation.sql_name.schema_name().to_string())
+                        .or_default()
+                        .push(relation.definition.clone());
+                }
+                Ok(by_schema
+                    .into_iter()
+                    .map(|(schema_name, tables)| {
+                        RuntimeBackendManifest::File(FileSourceManifest {
+                            common: runtime_manifest_common(
+                                source,
+                                catalog.backend.dsl_version,
+                                schema_name,
+                            ),
+                            tables,
+                            declared_inputs: source.declared_inputs().to_vec(),
+                        })
+                    })
+                    .collect())
+            }
+            Self::ProviderDiscovered(ProviderDiscoveredRuntimeCatalog::Database(catalog)) => Ok(
+                vec![RuntimeBackendManifest::Database(DatabaseSourceManifest {
+                    common: runtime_manifest_common(
+                        source,
+                        catalog.backend.dsl_version,
+                        catalog.catalog_name.clone(),
+                    ),
+                    connection: catalog.backend.connection.clone(),
+                    declared_inputs: source.declared_inputs().to_vec(),
+                })],
+            ),
+        }
+    }
+}
+
+fn require_default_catalog(catalog_name: &str) -> Result<(), crate::CoreError> {
+    if catalog_name == "datafusion" {
+        return Ok(());
+    }
+    Err(crate::CoreError::FailedPrecondition(format!(
+        "declared runtime catalog '{catalog_name}' cannot be compiled before catalog registration is enabled"
+    )))
+}
+
+fn runtime_manifest_common(
+    source: &QuerySource,
+    dsl_version: u32,
+    name: String,
+) -> SourceManifestCommon {
+    SourceManifestCommon {
+        dsl_version,
+        name,
+        version: source.version().unwrap_or_default().to_string(),
+        description: source.description().to_string(),
+        test_queries: source.test_queries().to_vec(),
+    }
 }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -90,12 +90,12 @@ pub use contracts::{
     ProviderDiscoveredRuntimeCatalog, QueryExecution, QueryExecutionProvenance, QueryMemoryConfig,
     QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult,
-    QueryTestSuccess, ResolvedQueryResources, RuntimeCatalog, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
-    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
-    UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
-    UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
-    UdfRuntimeTableFunctionPublish,
+    QueryTestSuccess, ResolvedQueryResources, RuntimeCatalog, RuntimeRelationKind,
+    RuntimeRelationRef, RuntimeSourcePackage, SourceValidationReport, StatusCode,
+    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo, UdfRuntimeArgument, UdfRuntimeDefinition,
+    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
+    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
 };
 pub use runtime::normalize_catalog_name;
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -80,16 +80,22 @@ pub use composition::{
     SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation, SourceTables,
 };
 pub use contracts::{
-    CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
-    DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
-    QueryTestFailure, QueryTestResult, QueryTestSuccess, ResolvedQueryResources,
-    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
-    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo, UdfRuntimeArgument, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    CatalogInfo, ColumnInfo, CoreError, DatabaseProviderDiscoveredRuntimeCatalog,
+    DatabaseRuntimeBackend, DeclaredRuntimeCatalog, DependentJoinConfig, DependentJoinSourceConfig,
+    DescribeTableInfo, EffectiveDependentJoinConfig, FileDeclaredRuntimeCatalog,
+    FileRuntimeBackend, FileRuntimeRelation, FileRuntimeTableRelation, HttpDeclaredRuntimeCatalog,
+    HttpRuntimeBackend, HttpRuntimeRelation, HttpRuntimeTableFunctionRelation,
+    HttpRuntimeTableRelation, McpDeclaredRuntimeCatalog, McpRuntimeBackend, McpRuntimeRelation,
+    McpRuntimeTableFunctionRelation, McpRuntimeTableRelation, MemorySize,
+    ProviderDiscoveredRuntimeCatalog, QueryExecution, QueryExecutionProvenance, QueryMemoryConfig,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult,
+    QueryTestSuccess, ResolvedQueryResources, RuntimeCatalog, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
+    UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+    UdfRuntimeTableFunctionPublish,
 };
 pub use runtime::normalize_catalog_name;
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -1812,8 +1812,9 @@ mod tests {
             .await
             .expect("legacy function");
         assert_eq!(legacy.table_functions.len(), 1);
-        assert!(legacy.table_functions[0].catalog_name.is_none());
-        assert_eq!(legacy.table_functions[0].function_name, "search_issues");
+        let function = legacy.table_functions.first().expect("table function");
+        assert!(function.catalog_name.is_none());
+        assert_eq!(function.function_name, "search_issues");
     }
 
     #[tokio::test]

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -8,11 +8,10 @@ use datafusion::prelude::SessionContext;
 use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
-    BackendCatalogRegistration, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CatalogColumnFetcher, CompiledBackendSource, RegisteredSource,
+    BackendRegistrationContext, CatalogColumnFetcher, CatalogPreparation, CatalogPublication,
+    CatalogRegistration, CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
-use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
 /// Source SQL names the runtime owns. Mirrored by `RESERVED_SOURCE_SCHEMA_NAMES`
@@ -137,38 +136,40 @@ async fn register_sources_inner(
                 match register_source(
                     ctx,
                     &registration_context,
-                    &mut seen_schemas,
-                    &mut seen_catalogs,
                     compiled_source.as_ref(),
+                    query_source,
+                    source_decorators,
                 )
                 .await
                 {
-                    Ok(registration) => {
-                        register_backend_registration(
+                    Ok(registrations) => {
+                        claim_catalog_registrations(
+                            &registrations,
+                            &mut seen_schemas,
+                            &mut seen_catalogs,
+                        )?;
+                        publish_catalog_registrations(
                             ctx,
                             catalog.as_ref(),
-                            source_decorators,
-                            query_source,
                             &source_name,
-                            registration,
+                            registrations,
                             &mut result,
                         )?;
                     }
                     Err(error) => {
-                        let core_error = datafusion_to_core(&error, &[]);
                         if handle_source_registration_failure(
                             source_decorators,
                             query_source,
-                            &core_error,
+                            &error,
                         )? {
-                            return Err(core_error);
+                            return Err(error);
                         }
                         let qualified_name = compiled_source.qualified_name();
                         push_source_failure(
                             &mut result,
                             &source_name,
                             qualified_name.name(),
-                            core_error.to_string(),
+                            error.to_string(),
                         );
                     }
                 }
@@ -241,157 +242,120 @@ pub(crate) fn register_sources_blocking(
 async fn register_source(
     ctx: &SessionContext,
     registration_context: &BackendRegistrationContext,
-    seen_schemas: &mut std::collections::HashSet<String>,
-    seen_catalogs: &mut std::collections::HashSet<String>,
     source: &dyn CompiledBackendSource,
-) -> DataFusionResult<BackendRegistration> {
-    source.validate_runtime_capabilities()?;
-
-    let registration = source.register(ctx, registration_context).await?;
-    claim_registration_schemas(&registration, seen_schemas)?;
-    claim_registration_catalogs(&registration, seen_catalogs)?;
-
-    Ok(registration)
+    query_source: &QuerySource,
+    source_decorators: &mut [Box<dyn SourceDecorator>],
+) -> std::result::Result<Vec<CatalogRegistration>, CoreError> {
+    source
+        .validate_runtime_capabilities()
+        .map_err(|error| datafusion_to_core(&error, &[]))?;
+    let registration = source
+        .register(ctx, registration_context)
+        .await
+        .map_err(|error| datafusion_to_core(&error, &[]))?;
+    let mut preparation = CatalogPreparation::new(query_source, source_decorators);
+    preparation.stage_backend_registration(registration)?;
+    preparation.finish()
 }
 
-fn claim_registration_schemas(
-    registration: &BackendRegistration,
+fn claim_catalog_registrations(
+    registrations: &[CatalogRegistration],
     seen_schemas: &mut std::collections::HashSet<String>,
-) -> DataFusionResult<()> {
+    seen_catalogs: &mut std::collections::HashSet<String>,
+) -> std::result::Result<(), CoreError> {
     let mut registration_schemas = std::collections::HashSet::new();
-    for schema in &registration.schemas {
-        let schema_name = schema.source.qualified_name.name();
-        check_reserved_schema(schema_name)?;
-
-        if !registration_schemas.insert(schema_name.to_string())
-            || seen_schemas.contains(schema_name)
-        {
-            return Err(DataFusionError::Execution(format!(
-                "duplicate source schema '{schema_name}'"
-            )));
+    let mut registration_catalogs = std::collections::HashSet::new();
+    for registration in registrations {
+        match registration.target.publication {
+            CatalogPublication::ExtendExisting => {
+                for schema_name in registration.provider.schema_names() {
+                    check_reserved_schema(&schema_name)
+                        .map_err(|error| datafusion_to_core(&error, &[]))?;
+                    if !registration_schemas.insert(schema_name.clone())
+                        || seen_schemas.contains(&schema_name)
+                    {
+                        return Err(CoreError::InvalidInput(format!(
+                            "duplicate source schema '{schema_name}'"
+                        )));
+                    }
+                }
+            }
+            CatalogPublication::InstallNew => {
+                let catalog_name = &registration.target.catalog_name;
+                check_reserved_schema(catalog_name)
+                    .map_err(|error| datafusion_to_core(&error, &[]))?;
+                if !registration_catalogs.insert(catalog_name.clone())
+                    || seen_catalogs.contains(catalog_name)
+                {
+                    return Err(CoreError::InvalidInput(format!(
+                        "duplicate source catalog '{catalog_name}'"
+                    )));
+                }
+            }
         }
     }
     seen_schemas.extend(registration_schemas);
-    Ok(())
-}
-
-fn claim_registration_catalogs(
-    registration: &BackendRegistration,
-    seen_catalogs: &mut std::collections::HashSet<String>,
-) -> DataFusionResult<()> {
-    let mut registration_catalogs = std::collections::HashSet::new();
-    for catalog in &registration.catalogs {
-        let catalog_name = catalog.source.qualified_name.name();
-        check_reserved_schema(catalog_name)?;
-
-        if !registration_catalogs.insert(catalog_name.to_string())
-            || seen_catalogs.contains(catalog_name)
-        {
-            return Err(DataFusionError::Execution(format!(
-                "duplicate source catalog '{catalog_name}'"
-            )));
-        }
-    }
     seen_catalogs.extend(registration_catalogs);
     Ok(())
 }
 
-fn register_backend_registration(
+fn publish_catalog_registrations(
     ctx: &SessionContext,
-    catalog: &dyn datafusion::catalog::CatalogProvider,
-    source_decorators: &mut [Box<dyn SourceDecorator>],
-    query_source: &QuerySource,
+    default_catalog: &dyn datafusion::catalog::CatalogProvider,
     source_name: &str,
-    registration: BackendRegistration,
+    registrations: Vec<CatalogRegistration>,
     result: &mut SourceRegistrationResult,
 ) -> std::result::Result<(), CoreError> {
-    // Source decorators wrap table providers at registration time, but catalog
-    // registrations expose providers lazily through the catalog itself.
-    // Decorators must explicitly allow that their table-decoration hook is
-    // skipped so policy decorators fail closed while lifecycle observers can
-    // still participate.
-    if let Some(decorator) = source_decorators.iter().find(|decorator| {
-        !registration.catalogs.is_empty() && !decorator.supports_catalog_sources()
-    }) {
-        let core_error = CoreError::FailedPrecondition(format!(
-            "source '{source_name}' registers database catalogs, which source decorator '{}' does not support",
-            decorator.name()
-        ));
-        if handle_source_registration_failure(source_decorators, query_source, &core_error)? {
-            return Err(core_error);
+    let mut registered_schema_names = Vec::new();
+    for registration in &registrations {
+        if registration.target.publication != CatalogPublication::ExtendExisting {
+            continue;
         }
-        push_source_failure(result, source_name, source_name, core_error.to_string());
-        return Ok(());
-    }
-
-    let mut staged = Vec::with_capacity(registration.schemas.len());
-    let mut catalog_staged = Vec::with_capacity(registration.catalogs.len());
-    for catalog_registration in registration.catalogs {
-        let BackendCatalogRegistration {
-            catalog,
-            source,
-            column_fetcher,
-        } = catalog_registration;
-        let catalog_name = source.qualified_name.name().to_string();
-        catalog_staged.push((catalog_name, catalog, source, column_fetcher));
-    }
-
-    for schema_registration in registration.schemas {
-        let BackendSchemaRegistration {
-            tables,
-            source: registered_source,
-        } = schema_registration;
-        let schema_name = registered_source.qualified_name.name().to_string();
-        let decorated_tables = decorate_source_tables(source_decorators, query_source, tables)?;
-        staged.push((schema_name, decorated_tables, registered_source));
-    }
-
-    let mut registered_schema_names = Vec::with_capacity(staged.len());
-    for (schema_name, decorated_tables, _registered_source) in &mut staged {
-        match catalog.register_schema(
-            schema_name,
-            Arc::new(StaticSchemaProvider::new(std::mem::take(decorated_tables))),
-        ) {
-            Ok(_) => {
-                registered_schema_names.push(schema_name.clone());
+        for schema_name in registration.provider.schema_names() {
+            let schema = registration.provider.schema(&schema_name).ok_or_else(|| {
+                CoreError::FailedPrecondition(format!(
+                    "prepared catalog '{}' omitted schema '{schema_name}'",
+                    registration.target.catalog_name
+                ))
+            })?;
+            if let Err(error) = default_catalog.register_schema(&schema_name, schema) {
+                rollback_registered_schemas(default_catalog, &registered_schema_names);
+                return Err(datafusion_to_core(&error, &[]));
             }
-            Err(error) => {
-                rollback_registered_schemas(catalog, &registered_schema_names);
-                let core_error = datafusion_to_core(&error, &[]);
-                if handle_source_registration_failure(source_decorators, query_source, &core_error)?
-                {
-                    return Err(core_error);
-                }
-                push_source_failure(result, source_name, schema_name, core_error.to_string());
-                return Ok(());
-            }
+            registered_schema_names.push(schema_name);
         }
     }
 
-    for (catalog_name, registered_catalog, _registered_source, _column_fetcher) in &catalog_staged {
-        ctx.register_catalog(catalog_name, Arc::clone(registered_catalog));
+    for registration in &registrations {
+        if registration.target.publication == CatalogPublication::InstallNew {
+            ctx.register_catalog(
+                &registration.target.catalog_name,
+                Arc::clone(&registration.provider),
+            );
+        }
     }
 
-    for (_schema_name, _decorated_tables, registered_source) in staged {
-        result.active_sources.push(registered_source);
+    for registration in registrations {
+        if let Some(column_fetcher) = registration.column_fetcher {
+            result.column_fetchers.push(CatalogColumnFetcher {
+                catalog_name: registration.target.catalog_name,
+                relation_names: registration
+                    .source
+                    .tables
+                    .iter()
+                    .filter_map(|table| {
+                        table
+                            .schema_name
+                            .as_ref()
+                            .map(|schema_name| (schema_name.clone(), table.table_name.clone()))
+                    })
+                    .collect(),
+                fetcher: column_fetcher,
+            });
+        }
+        result.active_sources.push(registration.source);
     }
-    for (catalog_name, _registered_catalog, registered_source, column_fetcher) in catalog_staged {
-        result.column_fetchers.push(CatalogColumnFetcher {
-            catalog_name,
-            relation_names: registered_source
-                .tables
-                .iter()
-                .filter_map(|table| {
-                    table
-                        .schema_name
-                        .as_ref()
-                        .map(|schema_name| (schema_name.clone(), table.table_name.clone()))
-                })
-                .collect(),
-            fetcher: column_fetcher,
-        });
-        result.active_sources.push(registered_source);
-    }
+    tracing::debug!(source = source_name, "published prepared source catalogs");
     Ok(())
 }
 
@@ -439,19 +403,6 @@ fn prepare_source_decorators(
             .map_err(|error| source_decorator_error(decorator.name(), &error))?;
     }
     Ok(())
-}
-
-fn decorate_source_tables(
-    source_decorators: &mut [Box<dyn SourceDecorator>],
-    source: &QuerySource,
-    mut tables: crate::SourceTables,
-) -> std::result::Result<crate::SourceTables, CoreError> {
-    for decorator in source_decorators {
-        tables = decorator
-            .decorate_source(source, tables)
-            .map_err(|error| source_decorator_error(decorator.name(), &error))?;
-    }
-    Ok(tables)
 }
 
 fn handle_source_registration_failure(

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -566,7 +566,7 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
-                components: Vec::new(),
+                catalogs: Vec::new(),
             },
             BTreeMap::new(),
             BTreeMap::new(),

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use coral_engine::{
-    BoundRequestIdentityHttpAuthenticator, CoralQuery, HttpRuntimeBackend, HttpRuntimeRelation,
-    QueryRuntimeConfig, QuerySource, RequestIdentityHttpAuthenticatorError,
-    RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
-    RequestIdentitySelectionError, RequestIdentitySelector, RuntimeCatalog, RuntimeSourcePackage,
-    SelectedRequestIdentity,
+    BoundRequestIdentityHttpAuthenticator, CoralQuery, EngineExtensions, HttpRuntimeBackend,
+    HttpRuntimeRelation, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
+    RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
+    RuntimeCatalog, RuntimeSourcePackage, SelectedRequestIdentity, SourceDecorator,
+    SourceDecoratorError, SourceTables,
 };
 use coral_spec::SqlObjectName;
 use coral_spec::parse_source_manifest_yaml;
@@ -33,7 +34,7 @@ fn declared_http_catalog_rejects_relation_catalog_disagreement() {
     );
     let relation = HttpRuntimeRelation::try_table(
         SqlObjectName::try_new("other", "github", "issues").expect("SQL name"),
-        manifest.tables[0].clone(),
+        manifest.tables.first().expect("HTTP table").clone(),
     )
     .expect("relation");
 
@@ -60,7 +61,7 @@ fn declared_http_catalog_rejects_duplicate_sql_identity() {
     );
     let relation = HttpRuntimeRelation::try_table(
         SqlObjectName::try_new("datafusion", "github", "issues").expect("SQL name"),
-        manifest.tables[0].clone(),
+        manifest.tables.first().expect("HTTP table").clone(),
     )
     .expect("relation");
 
@@ -82,7 +83,7 @@ fn http_relation_rejects_definition_leaf_disagreement() {
 
     let error = HttpRuntimeRelation::try_table(
         SqlObjectName::try_new("datafusion", "github", "pulls").expect("SQL name"),
-        manifest.tables[0].clone(),
+        manifest.tables.first().expect("HTTP table").clone(),
     )
     .expect_err("definition disagreement must fail");
 
@@ -242,6 +243,94 @@ async fn multi_component_source_can_register_multiple_schemas() {
         vec![
             json!({"kind": "issue", "id": 1, "title": "Issue"}),
             json!({"kind": "pull", "id": 2, "title": "Pull"}),
+        ]
+    );
+}
+
+struct RecordingSourceDecorator {
+    calls: Arc<AtomicUsize>,
+    sql_names: Arc<Mutex<Vec<String>>>,
+}
+
+impl SourceDecorator for RecordingSourceDecorator {
+    fn name(&self) -> &'static str {
+        "recording-source-decorator"
+    }
+
+    fn decorate_source(
+        &mut self,
+        _source: &QuerySource,
+        tables: SourceTables,
+    ) -> Result<SourceTables, SourceDecoratorError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.sql_names
+            .lock()
+            .map_err(|_poison| {
+                SourceDecoratorError::failed_precondition("SQL name recorder poisoned")
+            })?
+            .extend(
+                tables
+                    .iter()
+                    .map(|(sql_name, _provider)| sql_name.to_string()),
+            );
+        tables.try_map_providers(|_sql_name, provider| Ok(provider))
+    }
+}
+
+#[tokio::test]
+async fn composite_declared_catalogs_decorate_one_complete_source_inventory() {
+    let source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "github".to_string(),
+            authored_version: None,
+            description: "Composite GitHub runtime package".to_string(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: None,
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_http_manifest(http_component(
+                    "https://api.example.com",
+                    "github_rest",
+                    "issues",
+                    "/issues",
+                ))
+                .expect("issues catalog"),
+                RuntimeCatalog::try_from_default_catalog_http_manifest(http_component(
+                    "https://api.example.com",
+                    "github_mcp",
+                    "pulls",
+                    "/pulls",
+                ))
+                .expect("pulls catalog"),
+            ],
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("runtime package");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let sql_names = Arc::new(Mutex::new(Vec::new()));
+    let mut extensions = EngineExtensions::default();
+    extensions
+        .source_decorators
+        .push(Box::new(RecordingSourceDecorator {
+            calls: Arc::clone(&calls),
+            sql_names: Arc::clone(&sql_names),
+        }));
+
+    CoralQuery::prepare(
+        &[source],
+        QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
+    )
+    .await
+    .expect("prepare composite source");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *sql_names.lock().expect("SQL name recorder"),
+        vec![
+            "datafusion.github_mcp.pulls".to_string(),
+            "datafusion.github_rest.issues".to_string(),
         ]
     );
 }

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -7,8 +7,8 @@ use coral_engine::{
     BoundRequestIdentityHttpAuthenticator, CoralQuery, HttpRuntimeBackend, HttpRuntimeRelation,
     QueryRuntimeConfig, QuerySource, RequestIdentityHttpAuthenticatorError,
     RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
-    RequestIdentitySelectionError, RequestIdentitySelector, RuntimeCatalog, RuntimeSourceComponent,
-    RuntimeSourcePackage, SelectedRequestIdentity,
+    RequestIdentitySelectionError, RequestIdentitySelector, RuntimeCatalog, RuntimeSourcePackage,
+    SelectedRequestIdentity,
 };
 use coral_spec::SqlObjectName;
 use coral_spec::parse_source_manifest_yaml;
@@ -122,9 +122,11 @@ async fn multi_component_source_executes_across_component_tables() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_http_manifest(issues)
+                    .expect("issues catalog"),
+                RuntimeCatalog::try_from_default_catalog_http_manifest(pulls)
+                    .expect("pulls catalog"),
             ],
         },
         BTreeMap::new(),
@@ -152,7 +154,7 @@ async fn multi_component_source_executes_across_component_tables() {
 }
 
 #[tokio::test]
-async fn composite_source_rejects_unsupported_lookup_key_component_backend() {
+async fn composite_source_rejects_unsupported_lookup_key_catalog_backend() {
     let source = QuerySource::from_runtime_components(
         RuntimeSourcePackage {
             source_name: "demo".to_string(),
@@ -161,9 +163,12 @@ async fn composite_source_rejects_unsupported_lookup_key_component_backend() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![RuntimeSourceComponent::File(
-                file_component_with_lookup_key_filter(),
-            )],
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_file_manifest(
+                    file_component_with_lookup_key_filter(),
+                )
+                .expect("file catalog"),
+            ],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -172,7 +177,7 @@ async fn composite_source_rejects_unsupported_lookup_key_component_backend() {
 
     let error = CoralQuery::validate_source(&source, test_runtime(), &[])
         .await
-        .expect_err("composite validation should reject unsupported lookup_key component backend");
+        .expect_err("composite validation should reject unsupported lookup_key catalog backend");
 
     assert!(
         error.to_string().contains(
@@ -210,9 +215,11 @@ async fn multi_component_source_can_register_multiple_schemas() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_http_manifest(issues)
+                    .expect("issues catalog"),
+                RuntimeCatalog::try_from_default_catalog_http_manifest(pulls)
+                    .expect("pulls catalog"),
             ],
         },
         BTreeMap::new(),
@@ -250,12 +257,15 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![RuntimeSourceComponent::Http(http_component(
-                &server.uri(),
-                "github_v4_rest",
-                "issues",
-                "/issues",
-            ))],
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_http_manifest(http_component(
+                    &server.uri(),
+                    "github_v4_rest",
+                    "issues",
+                    "/issues",
+                ))
+                .expect("first catalog"),
+            ],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -269,12 +279,15 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![RuntimeSourceComponent::Http(http_component(
-                &server.uri(),
-                "github_v4_rest",
-                "pulls",
-                "/pulls",
-            ))],
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_http_manifest(http_component(
+                    &server.uri(),
+                    "github_v4_rest",
+                    "pulls",
+                    "/pulls",
+                ))
+                .expect("second catalog"),
+            ],
         },
         BTreeMap::new(),
         BTreeMap::new(),
@@ -306,9 +319,11 @@ async fn validate_source_reports_only_component_schemas_for_multi_schema_source(
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: vec![
-                RuntimeSourceComponent::Http(issues),
-                RuntimeSourceComponent::Http(pulls),
+            catalogs: vec![
+                RuntimeCatalog::try_from_default_catalog_http_manifest(issues)
+                    .expect("issues catalog"),
+                RuntimeCatalog::try_from_default_catalog_http_manifest(pulls)
+                    .expect("pulls catalog"),
             ],
         },
         BTreeMap::new(),
@@ -547,9 +562,12 @@ fn identity_runtime_source_with_components(
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: Some(identity_requirements()),
-            components: components
+            catalogs: components
                 .into_iter()
-                .map(RuntimeSourceComponent::Http)
+                .map(|manifest| {
+                    RuntimeCatalog::try_from_default_catalog_http_manifest(manifest)
+                        .expect("HTTP catalog")
+                })
                 .collect(),
         },
         BTreeMap::new(),

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -4,11 +4,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use coral_engine::{
-    BoundRequestIdentityHttpAuthenticator, CoralQuery, QueryRuntimeConfig, QuerySource,
-    RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
-    RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
-    RuntimeSourceComponent, RuntimeSourcePackage, SelectedRequestIdentity,
+    BoundRequestIdentityHttpAuthenticator, CoralQuery, HttpRuntimeBackend, HttpRuntimeRelation,
+    QueryRuntimeConfig, QuerySource, RequestIdentityHttpAuthenticatorError,
+    RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
+    RequestIdentitySelectionError, RequestIdentitySelector, RuntimeCatalog, RuntimeSourceComponent,
+    RuntimeSourcePackage, SelectedRequestIdentity,
 };
+use coral_spec::SqlObjectName;
 use coral_spec::parse_source_manifest_yaml;
 use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
 use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
@@ -18,6 +20,79 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{execution_to_rows, test_runtime};
+
+#[test]
+fn declared_http_catalog_rejects_relation_catalog_disagreement() {
+    let manifest = http_component("https://api.example.com", "github", "issues", "/issues");
+    let backend = HttpRuntimeBackend::new(
+        manifest.common.dsl_version,
+        manifest.base_url.clone(),
+        manifest.auth.clone(),
+        manifest.request_headers.clone(),
+        manifest.rate_limit.clone(),
+    );
+    let relation = HttpRuntimeRelation::try_table(
+        SqlObjectName::try_new("other", "github", "issues").expect("SQL name"),
+        manifest.tables[0].clone(),
+    )
+    .expect("relation");
+
+    let error = RuntimeCatalog::try_http_declared("datafusion", backend, vec![relation])
+        .expect_err("catalog disagreement must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("contains relation 'other.github.issues' from catalog 'other'"),
+        "{error}"
+    );
+}
+
+#[test]
+fn declared_http_catalog_rejects_duplicate_sql_identity() {
+    let manifest = http_component("https://api.example.com", "github", "issues", "/issues");
+    let backend = HttpRuntimeBackend::new(
+        manifest.common.dsl_version,
+        manifest.base_url.clone(),
+        manifest.auth.clone(),
+        manifest.request_headers.clone(),
+        manifest.rate_limit.clone(),
+    );
+    let relation = HttpRuntimeRelation::try_table(
+        SqlObjectName::try_new("datafusion", "github", "issues").expect("SQL name"),
+        manifest.tables[0].clone(),
+    )
+    .expect("relation");
+
+    let error =
+        RuntimeCatalog::try_http_declared("datafusion", backend, vec![relation.clone(), relation])
+            .expect_err("duplicate relation must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("contains duplicate relation 'datafusion.github.issues'"),
+        "{error}"
+    );
+}
+
+#[test]
+fn http_relation_rejects_definition_leaf_disagreement() {
+    let manifest = http_component("https://api.example.com", "github", "issues", "/issues");
+
+    let error = HttpRuntimeRelation::try_table(
+        SqlObjectName::try_new("datafusion", "github", "pulls").expect("SQL name"),
+        manifest.tables[0].clone(),
+    )
+    .expect_err("definition disagreement must fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("HTTP table definition name 'issues' does not match SQL name 'pulls'"),
+        "{error}"
+    );
+}
 
 #[tokio::test]
 async fn multi_component_source_executes_across_component_tables() {

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -543,7 +543,7 @@ async fn infer_udf_signature_maps_component_schema_to_canonical_source_name() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
-            components: component_source.components().to_vec(),
+            catalogs: component_source.catalogs().to_vec(),
         },
         BTreeMap::new(),
         BTreeMap::new(),

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -779,7 +779,11 @@ mod tests {
         };
 
         let value = list_catalog_value(&response);
-        let item = &value["items"][0];
+        let item = value
+            .get("items")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|items| items.first())
+            .expect("first catalog item");
         assert_eq!(item["catalog_name"], "github_v4");
         assert_eq!(item["name"], "github_v4.issues.list_for_repo");
         assert_eq!(item["sql_reference"], "github_v4.issues.list_for_repo");

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -88,6 +88,7 @@ mod inputs;
 mod loader;
 mod parser;
 mod schema;
+mod sql_name;
 mod template;
 mod udf;
 pub mod v4;
@@ -134,6 +135,7 @@ pub use loader::load_manifest_path;
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };
+pub use sql_name::{SqlObjectName, SqlObjectNameError};
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub use udf::{
     FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec,

--- a/crates/coral-spec/src/sql_name.rs
+++ b/crates/coral-spec/src/sql_name.rs
@@ -1,0 +1,183 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+
+/// Complete, validated SQL identity for a table or table function.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct SqlObjectName {
+    catalog_name: String,
+    schema_name: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct SerializedSqlObjectName {
+    catalog_name: String,
+    schema_name: String,
+    name: String,
+}
+
+impl<'de> Deserialize<'de> for SqlObjectName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let serialized = SerializedSqlObjectName::deserialize(deserializer)?;
+        Self::try_new(
+            serialized.catalog_name,
+            serialized.schema_name,
+            serialized.name,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+impl SqlObjectName {
+    /// Constructs a complete SQL name after validating every identifier.
+    pub fn try_new(
+        catalog_name: impl Into<String>,
+        schema_name: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Result<Self, SqlObjectNameError> {
+        let catalog_name = catalog_name.into();
+        let schema_name = schema_name.into();
+        let name = name.into();
+        validate_coordinate(SqlObjectNameCoordinate::Catalog, &catalog_name)?;
+        validate_coordinate(SqlObjectNameCoordinate::Schema, &schema_name)?;
+        validate_coordinate(SqlObjectNameCoordinate::Name, &name)?;
+        Ok(Self {
+            catalog_name,
+            schema_name,
+            name,
+        })
+    }
+
+    #[must_use]
+    /// Returns the catalog coordinate.
+    pub fn catalog_name(&self) -> &str {
+        &self.catalog_name
+    }
+
+    #[must_use]
+    /// Returns the schema coordinate.
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    #[must_use]
+    /// Returns the bare relation or function coordinate.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Display for SqlObjectName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}.{}.{}",
+            self.catalog_name, self.schema_name, self.name
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SqlObjectNameCoordinate {
+    Catalog,
+    Schema,
+    Name,
+}
+
+impl fmt::Display for SqlObjectNameCoordinate {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Catalog => "catalog_name",
+            Self::Schema => "schema_name",
+            Self::Name => "name",
+        })
+    }
+}
+
+/// Validation failure for one coordinate of a [`SqlObjectName`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("SQL object {coordinate} {reason}: '{value}'")]
+pub struct SqlObjectNameError {
+    coordinate: SqlObjectNameCoordinate,
+    value: String,
+    reason: &'static str,
+}
+
+fn validate_coordinate(
+    coordinate: SqlObjectNameCoordinate,
+    value: &str,
+) -> Result<(), SqlObjectNameError> {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err(SqlObjectNameError {
+            coordinate,
+            value: value.to_string(),
+            reason: "must not be empty",
+        });
+    };
+    if first != '_' && !first.is_ascii_alphabetic() {
+        return Err(SqlObjectNameError {
+            coordinate,
+            value: value.to_string(),
+            reason: "must start with an ASCII letter or underscore",
+        });
+    }
+    if chars.any(|character| character != '_' && !character.is_ascii_alphanumeric()) {
+        return Err(SqlObjectNameError {
+            coordinate,
+            value: value.to_string(),
+            reason: "may contain only ASCII letters, numbers, and underscores",
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SqlObjectName;
+
+    #[test]
+    fn complete_sql_name_round_trips_with_named_coordinates() {
+        let name =
+            SqlObjectName::try_new("github_v4", "issues", "list_for_repo").expect("valid SQL name");
+        let yaml = serde_yaml::to_string(&name).expect("serialize SQL name");
+
+        assert!(yaml.contains("catalog_name: github_v4"));
+        assert!(yaml.contains("schema_name: issues"));
+        assert!(yaml.contains("name: list_for_repo"));
+        assert_eq!(
+            serde_yaml::from_str::<SqlObjectName>(&yaml).expect("deserialize SQL name"),
+            name
+        );
+    }
+
+    #[test]
+    fn complete_sql_name_rejects_empty_or_non_identifier_coordinates() {
+        for (catalog, schema, name, coordinate) in [
+            ("", "issues", "list", "catalog_name"),
+            ("github_v4", "9issues", "list", "schema_name"),
+            ("github_v4", "issues", "list-for-repo", "name"),
+        ] {
+            let error = SqlObjectName::try_new(catalog, schema, name).expect_err("invalid name");
+            assert!(error.to_string().contains(coordinate), "{error}");
+        }
+    }
+
+    #[test]
+    fn deserialization_cannot_bypass_coordinate_validation() {
+        let error = serde_yaml::from_str::<SqlObjectName>(
+            "catalog_name: github_v4\nschema_name: issues\nname: list-for-repo\n",
+        )
+        .expect_err("invalid serialized SQL name");
+
+        assert!(
+            error.to_string().contains("name may contain only"),
+            "{error}"
+        );
+    }
+}

--- a/crates/coral-spec/src/sql_name.rs
+++ b/crates/coral-spec/src/sql_name.rs
@@ -74,11 +74,11 @@ impl SqlObjectName {
 
 impl fmt::Display for SqlObjectName {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            formatter,
-            "{}.{}.{}",
-            self.catalog_name, self.schema_name, self.name
-        )
+        fmt_coordinate(formatter, &self.catalog_name)?;
+        formatter.write_str(".")?;
+        fmt_coordinate(formatter, &self.schema_name)?;
+        formatter.write_str(".")?;
+        fmt_coordinate(formatter, &self.name)
     }
 }
 
@@ -112,29 +112,34 @@ fn validate_coordinate(
     coordinate: SqlObjectNameCoordinate,
     value: &str,
 ) -> Result<(), SqlObjectNameError> {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
+    if value.trim().is_empty() {
         return Err(SqlObjectNameError {
             coordinate,
             value: value.to_string(),
             reason: "must not be empty",
         });
-    };
-    if first != '_' && !first.is_ascii_alphabetic() {
-        return Err(SqlObjectNameError {
-            coordinate,
-            value: value.to_string(),
-            reason: "must start with an ASCII letter or underscore",
-        });
     }
-    if chars.any(|character| character != '_' && !character.is_ascii_alphanumeric()) {
+    if value.chars().any(char::is_control) {
         return Err(SqlObjectNameError {
             coordinate,
             value: value.to_string(),
-            reason: "may contain only ASCII letters, numbers, and underscores",
+            reason: "must not contain control characters",
         });
     }
     Ok(())
+}
+
+fn fmt_coordinate(formatter: &mut fmt::Formatter<'_>, value: &str) -> fmt::Result {
+    let mut chars = value.chars();
+    let can_render_bare = chars
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric());
+    if can_render_bare {
+        formatter.write_str(value)
+    } else {
+        write!(formatter, "\"{}\"", value.replace('"', "\"\""))
+    }
 }
 
 #[cfg(test)]
@@ -157,11 +162,11 @@ mod tests {
     }
 
     #[test]
-    fn complete_sql_name_rejects_empty_or_non_identifier_coordinates() {
+    fn complete_sql_name_rejects_empty_or_control_character_coordinates() {
         for (catalog, schema, name, coordinate) in [
             ("", "issues", "list", "catalog_name"),
-            ("github_v4", "9issues", "list", "schema_name"),
-            ("github_v4", "issues", "list-for-repo", "name"),
+            ("github_v4", "\n", "list", "schema_name"),
+            ("github_v4", "issues", "list\0for_repo", "name"),
         ] {
             let error = SqlObjectName::try_new(catalog, schema, name).expect_err("invalid name");
             assert!(error.to_string().contains(coordinate), "{error}");
@@ -171,13 +176,21 @@ mod tests {
     #[test]
     fn deserialization_cannot_bypass_coordinate_validation() {
         let error = serde_yaml::from_str::<SqlObjectName>(
-            "catalog_name: github_v4\nschema_name: issues\nname: list-for-repo\n",
+            "catalog_name: github_v4\nschema_name: issues\nname: \"\\0\"\n",
         )
         .expect_err("invalid serialized SQL name");
 
         assert!(
-            error.to_string().contains("name may contain only"),
+            error.to_string().contains("name must not contain control"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn complete_sql_name_quotes_non_bare_coordinates_for_display() {
+        let name = SqlObjectName::try_new("source-name", "public", "player.stats")
+            .expect("quoted SQL name");
+
+        assert_eq!(name.to_string(), "\"source-name\".public.\"player.stats\"");
     }
 }

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -96,14 +96,22 @@ pub fn validate_materialized_source_structure(
     }
     let mut projection_names = BTreeSet::new();
     for projection in &materialized.projections.projections {
-        if !projection_names.insert(projection.name.as_str()) {
+        if projection.sql_name.catalog_name() != materialized.projections.source_name {
+            return Err(ManifestError::validation(format!(
+                "DSL v4 projection '{}' belongs to catalog '{}', not projection catalog owner '{}'",
+                projection.sql_name,
+                projection.sql_name.catalog_name(),
+                materialized.projections.source_name
+            )));
+        }
+        if !projection_names.insert(&projection.sql_name) {
             return Err(ManifestError::validation(format!(
                 "DSL v4 projection '{}' is repeated",
-                projection.name
+                projection.sql_name
             )));
         }
         crate::validate_required_guide(
-            &format!("DSL v4 projection '{}'", projection.name),
+            &format!("DSL v4 projection '{}'", projection.sql_name),
             &projection.guide,
             projection.require_guide_read,
         )?;
@@ -115,7 +123,6 @@ pub fn validate_materialized_source_structure(
 mod tests {
     use std::path::PathBuf;
 
-    use crate::parse_source_manifest_yaml;
     use crate::v4::ir::SemanticIr;
     use crate::v4::projections::{
         Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility,
@@ -125,6 +132,7 @@ mod tests {
         OperationMetadataCatalog, PROJECTION_GENERATOR_VERSION, SURFACE_IMPORTER_VERSION,
         SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4SourceManifest, ValidatedSurfacePlan,
     };
+    use crate::{SqlObjectName, parse_source_manifest_yaml};
 
     use super::{
         Fingerprint, FingerprintSurface, MaterializedSurface, V4MaterializedSource,
@@ -212,7 +220,7 @@ surface:
 
     fn projection(name: &str) -> Projection {
         Projection {
-            name: name.to_string(),
+            sql_name: SqlObjectName::try_new("demo", "public", name).expect("SQL name"),
             kind: ProjectionKind::Table,
             description: String::new(),
             guide: String::new(),
@@ -322,7 +330,23 @@ surface:
         let error = validate_materialized_source_structure(&manifest(), &materialized)
             .expect_err("duplicate projection names should fail validation");
 
-        assert_eq!(error.to_string(), "DSL v4 projection 'items' is repeated");
+        assert_eq!(
+            error.to_string(),
+            "DSL v4 projection 'demo.public.items' is repeated"
+        );
+    }
+
+    #[test]
+    fn structural_validation_rejects_projection_owned_by_another_catalog() {
+        let mut materialized = materialized_source();
+        let mut foreign = projection("items");
+        foreign.sql_name = SqlObjectName::try_new("other", "public", "items").expect("SQL name");
+        materialized.projections.projections.push(foreign);
+
+        let error = validate_materialized_source_structure(&manifest(), &materialized)
+            .expect_err("projection catalog must own every SQL name");
+
+        assert!(error.to_string().contains("belongs to catalog 'other'"));
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -3,12 +3,12 @@
     reason = "DSL v4 contracts are field-heavy artifact models documented in the PRD."
 )]
 
-pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
+pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 6;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v8";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
 pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v14";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -257,7 +257,8 @@ components:
         .iter()
         .find(|projection| projection.operation_id == "get_quotes")
         .expect("quotes projection");
-    assert_eq!(quotes_projection.name, "forex_get_quotes");
+    assert_eq!(quotes_projection.sql_name.schema_name(), "forex");
+    assert_eq!(quotes_projection.sql_name.name(), "get_quotes");
     assert!(matches!(quotes_projection.kind, ProjectionKind::Table));
 }
 
@@ -890,7 +891,7 @@ components:
         .iter()
         .find(|projection| projection.operation_id == "issues_list_for_repo")
         .expect("projection");
-    assert_eq!(projection.name, "issue");
+    assert_eq!(projection.sql_name.name(), "list_for_repo");
     assert_eq!(projection.visibility, ProjectionVisibility::Published);
     assert!(matches!(
         projection.kind,

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -5,7 +5,8 @@ use super::test_support::github_openapi;
 use super::*;
 use crate::backends::mcp::McpPaginationSpec;
 use crate::{
-    ManifestDataType, PaginationMode, SourceTableFunctionKind, parse_source_manifest_yaml,
+    ManifestDataType, PaginationMode, SourceTableFunctionKind, SqlObjectName,
+    parse_source_manifest_yaml,
 };
 
 #[test]
@@ -34,11 +35,71 @@ surface:
         .projections
         .iter()
         .filter(|projection| projection.visibility == ProjectionVisibility::Published)
-        .map(|projection| projection.name.as_str())
+        .map(|projection| projection.sql_name.name())
         .collect::<Vec<_>>();
-    assert!(published.contains(&"issue"), "{published:?}");
-    assert!(published.contains(&"search_issues"), "{published:?}");
-    assert!(published.contains(&"get_issues"), "{published:?}");
+    assert!(published.contains(&"list_for_repo"), "{published:?}");
+    assert!(
+        published.contains(&"issues_and_pull_requests"),
+        "{published:?}"
+    );
+    assert!(published.contains(&"get"), "{published:?}");
+}
+
+#[test]
+fn projections_publish_complete_schema_local_sql_names() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: github_v4
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.github.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let ir = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.0.3
+paths:
+  /issues:
+    get:
+      tags: ['', 'Issue Tracking', ignored]
+      operationId: issues/list
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}}
+  /pulls:
+    get:
+      tags: ['Pull Requests']
+      operationId: pulls/list
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}}
+  /health:
+    get:
+      operationId: health/get
+      responses: {'200': {content: {application/json: {schema: {type: object}}}}}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog =
+        generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
+    let names = catalog
+        .projections
+        .iter()
+        .map(|projection| {
+            (
+                projection.sql_name.catalog_name(),
+                projection.sql_name.schema_name(),
+                projection.sql_name.name(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert!(names.contains(&("github_v4", "issue_tracking", "list")));
+    assert!(names.contains(&("github_v4", "pull_requests", "list")));
+    assert!(names.contains(&("github_v4", "public", "get")));
 }
 
 fn items_api_catalog(lookup_keys: Option<(bool, &[&str])>) -> ProjectionCatalog {
@@ -396,23 +457,28 @@ components:
     let names = catalog
         .projections
         .iter()
-        .map(|projection| projection.name.as_str())
+        .map(|projection| {
+            (
+                projection.sql_name.schema_name(),
+                projection.sql_name.name(),
+            )
+        })
         .collect::<BTreeSet<_>>();
     let expected = [
-        "billing_get_github_billing_ai_credit_usage_report_org",
-        "billing_get_github_billing_ai_credit_usage_report_user",
-        "repos_list_for_user",
-        "activity_list_repos_watched_by_user",
-        "projects_list_items_for_org",
-        "projects_list_items_for_user",
-        "projects_list_view_items_for_org",
-        "projects_list_view_items_for_user",
+        ("billing", "get_github_billing_ai_credit_usage_report_org"),
+        ("billing", "get_github_billing_ai_credit_usage_report_user"),
+        ("repos", "list_for_user"),
+        ("activity", "list_repos_watched_by_user"),
+        ("projects", "list_items_for_org"),
+        ("projects", "list_items_for_user"),
+        ("projects", "list_view_items_for_org"),
+        ("projects", "list_view_items_for_user"),
     ];
     for name in expected {
-        assert!(names.contains(name), "missing {name}: {names:?}");
+        assert!(names.contains(&name), "missing {name:?}: {names:?}");
     }
     assert!(
-        names.iter().all(|name| !name.contains("__")),
+        names.iter().all(|(_, name)| !name.contains("__")),
         "tag-grouped names should not need hash suffixes: {names:?}"
     );
     assert!(
@@ -1147,7 +1213,7 @@ components:
         .map(|projection| {
             (
                 projection.operation_id.as_str(),
-                (projection.name.as_str(), &projection.kind),
+                (projection.sql_name.name(), &projection.kind),
             )
         })
         .collect::<HashMap<_, _>>();
@@ -1155,19 +1221,19 @@ components:
     let issues_list = names_by_operation
         .get("issues_list")
         .expect("issues_list projection");
-    assert_eq!(issues_list.0, "issue");
+    assert_eq!(issues_list.0, "list");
     let org_issues = names_by_operation
         .get("issues_list_for_org")
         .expect("issues_list_for_org projection");
-    assert_eq!(org_issues.0, "orgs_issue");
+    assert_eq!(org_issues.0, "list_for_org");
     let repo_issues = names_by_operation
         .get("issues_list_for_repo")
         .expect("issues_list_for_repo projection");
-    assert_eq!(repo_issues.0, "repos_issue");
+    assert_eq!(repo_issues.0, "list_for_repo");
     let pulls = names_by_operation
         .get("pulls_list")
         .expect("pulls_list projection");
-    assert_eq!(pulls.0, "pull_request");
+    assert_eq!(pulls.0, "repos_list");
     assert!(matches!(
         pulls.1,
         ProjectionKind::TableFunction {
@@ -1177,11 +1243,11 @@ components:
     let commits = names_by_operation
         .get("repos_list_commits")
         .expect("repos_list_commits projection");
-    assert_eq!(commits.0, "commit");
+    assert_eq!(commits.0, "list_commits");
     let pull_commits = names_by_operation
         .get("pulls_list_commits")
         .expect("pulls_list_commits projection");
-    assert_eq!(pull_commits.0, "repos_pulls_commit");
+    assert_eq!(pull_commits.0, "repos_pulls_list_commits");
     let pull_commits_projection = catalog
         .projections
         .iter()
@@ -1198,7 +1264,7 @@ components:
         .iter()
         .filter(|diagnostic| diagnostic.message.contains("projection name collision"))
         .collect::<Vec<_>>();
-    assert_eq!(catalog_collision_diagnostics.len(), 3);
+    assert_eq!(catalog_collision_diagnostics.len(), 2);
     let projection_collision_diagnostics = catalog
         .projections
         .iter()
@@ -1328,6 +1394,10 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
         .iter()
         .find(|projection| projection.operation_id == "search_issues")
         .expect("mcp search projection");
+
+    assert_eq!(projection.sql_name.catalog_name(), "github_mcp");
+    assert_eq!(projection.sql_name.schema_name(), "public");
+    assert_eq!(projection.sql_name.name(), "search_issues");
 
     let columns = projection
         .columns
@@ -2119,7 +2189,7 @@ fn projection_compatibility_rejects_missing_operation() {
     let mut catalog = generate_projection_catalog(&manifest, &plan).expect("projections");
     let projection = catalog.projections.first_mut().expect("projection");
     projection.operation_id = "items/missing".to_string();
-    let projection_name = projection.name.clone();
+    let projection_name = projection.sql_name.clone();
 
     let error = validate_projection_compatibility(&plan, &catalog)
         .expect_err("missing operation must fail");
@@ -2281,7 +2351,12 @@ fn projection_compatibility_accepts_conservative_choices_without_mutation() {
     let plan = imported.validated_plan().expect("plan");
     let mut catalog = generate_projection_catalog(&manifest, &plan).expect("projections");
     let projection = catalog.projections.first_mut().expect("projection");
-    projection.name = "authored_items".to_string();
+    projection.sql_name = SqlObjectName::try_new(
+        projection.sql_name.catalog_name(),
+        projection.sql_name.schema_name(),
+        "authored_items",
+    )
+    .expect("SQL name");
     projection.guide = "Keep this guide".to_string();
     let input = projection
         .inputs

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -5,10 +5,13 @@ use crate::v4::ir::{
     HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput, IrType,
     IrTypeShape, OutputCardinality, RestExecutionAttachment, SemanticIr,
 };
-use crate::v4::manifest::V4SourceManifest;
+use crate::v4::manifest::{SurfaceType, V4SourceManifest};
 use crate::v4::naming::{normalize_identifier, normalize_sql_identifier, stable_suffix};
 use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION, ValidatedSurfacePlan};
-use crate::{ManifestDataType, ManifestError, Result, SearchLimitsSpec, SourceTableFunctionKind};
+use crate::{
+    ManifestDataType, ManifestError, Result, SearchLimitsSpec, SourceTableFunctionKind,
+    SqlObjectName,
+};
 
 use super::model::{
     Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,
@@ -35,7 +38,8 @@ pub fn generate_projection_catalog(
     }
     let type_by_id = type_index(surface);
     for operation in &surface.operations {
-        let projection = generate_projection(plan, &type_by_id, operation, &mut diagnostics);
+        let projection =
+            generate_projection(manifest, plan, &type_by_id, operation, &mut diagnostics)?;
         projections.push(projection);
     }
     diagnostics.extend(surface.diagnostics.clone());
@@ -43,7 +47,7 @@ pub fn generate_projection_catalog(
         manifest,
         surface,
         &mut projections,
-    ));
+    )?);
     Ok(ProjectionCatalog {
         artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
         source_name: manifest.common.name.clone(),
@@ -54,11 +58,12 @@ pub fn generate_projection_catalog(
 }
 
 fn generate_projection(
+    manifest: &V4SourceManifest,
     plan: &ValidatedSurfacePlan,
     type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
     diagnostics: &mut Vec<Diagnostic>,
-) -> Projection {
+) -> Result<Projection> {
     let is_search = is_search_operation(operation);
     let rest = rest_execution(operation);
     let mut visibility = initial_projection_visibility(operation, rest);
@@ -131,9 +136,12 @@ fn generate_projection(
         .collect::<Vec<_>>();
     let columns = projection_columns(plan, type_by_id, operation);
     let name = generated_projection_name(operation, is_search);
+    let schema_name = projection_schema_name(plan.semantic_ir().surface_type, operation)?;
+    let sql_name = SqlObjectName::try_new(&manifest.common.name, schema_name, name)
+        .map_err(|error| ManifestError::validation(error.to_string()))?;
     let guide = projection_guide(&kind, &inputs, is_search);
     let projection = Projection {
-        name,
+        sql_name,
         kind,
         description: operation.description.clone(),
         guide,
@@ -151,7 +159,22 @@ fn generate_projection(
         diagnostics: projection_diagnostics.clone(),
     };
     diagnostics.extend(projection_diagnostics);
-    projection
+    Ok(projection)
+}
+
+fn projection_schema_name(surface_type: SurfaceType, operation: &IrOperation) -> Result<String> {
+    match surface_type {
+        SurfaceType::OpenApi => Ok(operation
+            .naming
+            .as_ref()
+            .and_then(|naming| naming.group.clone())
+            .filter(|group| !group.is_empty())
+            .unwrap_or_else(|| "public".to_string())),
+        SurfaceType::Mcp => Ok("public".to_string()),
+        SurfaceType::Database => Err(ManifestError::validation(
+            "database surfaces do not generate projection catalogs",
+        )),
+    }
 }
 
 fn rest_execution(operation: &IrOperation) -> Option<&RestExecutionAttachment> {

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -159,7 +159,11 @@ mod tests {
         );
         assert!(!yaml.contains("surface_id:"), "surface ID leaked: {yaml}");
         let value: serde_yaml::Value = serde_yaml::from_str(&yaml).expect("projection YAML");
-        let projection = &value["projections"][0];
+        let projection = value
+            .get("projections")
+            .and_then(serde_yaml::Value::as_sequence)
+            .and_then(|projections| projections.first())
+            .expect("first projection");
         assert!(
             projection.get("sql_name").is_some(),
             "missing sql_name: {yaml}"

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::IrInputLocation;
-use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
+use crate::{
+    DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind, SqlObjectName,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectionCatalog {
@@ -16,7 +18,7 @@ pub struct ProjectionCatalog {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Projection {
-    pub name: String,
+    pub sql_name: SqlObjectName,
     pub kind: ProjectionKind,
     pub description: String,
     pub guide: String,
@@ -91,7 +93,7 @@ mod tests {
         SqlInputExposure,
     };
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
-    use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
+    use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind, SqlObjectName};
 
     #[test]
     fn projection_catalog_yaml_uses_editor_friendly_enum_shapes() {
@@ -100,7 +102,8 @@ mod tests {
             source_name: "demo".to_string(),
             generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
             projections: vec![Projection {
-                name: "search_issues".to_string(),
+                sql_name: SqlObjectName::try_new("demo", "issues", "search_issues")
+                    .expect("SQL name"),
                 kind: ProjectionKind::TableFunction {
                     function_kind: SourceTableFunctionKind::Search,
                 },
@@ -155,6 +158,16 @@ mod tests {
             "required guide-read policy should serialize: {yaml}"
         );
         assert!(!yaml.contains("surface_id:"), "surface ID leaked: {yaml}");
+        let value: serde_yaml::Value = serde_yaml::from_str(&yaml).expect("projection YAML");
+        let projection = &value["projections"][0];
+        assert!(
+            projection.get("sql_name").is_some(),
+            "missing sql_name: {yaml}"
+        );
+        assert!(
+            projection.get("name").is_none(),
+            "legacy flattened projection name leaked: {yaml}"
+        );
 
         let decoded = serde_yaml::from_str::<ProjectionCatalog>(&yaml)
             .expect("projection catalog should round-trip");
@@ -202,7 +215,10 @@ diagnostics: []
 artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}
 source_name: demo
 projections:
-  - name: items
+  - sql_name:
+      catalog_name: demo
+      schema_name: public
+      name: items
     kind:
       type: table
     description: ""
@@ -224,7 +240,12 @@ diagnostics: []
             serde_yaml::from_str(&raw).expect("unknown future fields should be advisory");
 
         assert_eq!(
-            catalog.projections.first().expect("projection").name,
+            catalog
+                .projections
+                .first()
+                .expect("projection")
+                .sql_name
+                .name(),
             "items"
         );
     }

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -4,6 +4,7 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrExecutionAttachment, IrOperation, OutputCardinality, SemanticIr};
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, stable_suffix};
+use crate::{ManifestError, Result, SqlObjectName};
 
 use super::model::{
     Projection, ProjectionInput, ProjectionKind, ProjectionVisibility, SqlInputExposure,
@@ -13,16 +14,19 @@ pub(super) fn resolve_projection_name_collisions(
     manifest: &V4SourceManifest,
     surface: &SemanticIr,
     projections: &mut [Projection],
-) -> Vec<Diagnostic> {
+) -> Result<Vec<Diagnostic>> {
     let operations = surface
         .operations
         .iter()
         .map(|operation| (operation.id.as_str(), operation))
         .collect::<HashMap<_, _>>();
-    let mut groups: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    let mut groups: BTreeMap<(String, String), Vec<usize>> = BTreeMap::new();
     for (index, projection) in projections.iter().enumerate() {
         groups
-            .entry(projection.name.clone())
+            .entry((
+                projection.sql_name.schema_name().to_string(),
+                projection.sql_name.name().to_string(),
+            ))
             .or_default()
             .push(index);
     }
@@ -46,7 +50,10 @@ pub(super) fn resolve_projection_name_collisions(
     let mut used_names = HashSet::new();
     for index in keep_base_name.iter().copied() {
         if let Some(projection) = projections.get(index) {
-            used_names.insert(projection.name.clone());
+            used_names.insert((
+                projection.sql_name.schema_name().to_string(),
+                projection.sql_name.name().to_string(),
+            ));
         }
     }
 
@@ -62,11 +69,16 @@ pub(super) fn resolve_projection_name_collisions(
             let operation = operations.get(projection.operation_id.as_str()).copied();
             let name =
                 collision_resolved_projection_name(manifest, projection, operation, &used_names);
-            used_names.insert(name.clone());
+            used_names.insert((projection.sql_name.schema_name().to_string(), name.clone()));
             let projection = projections
                 .get_mut(*index)
                 .expect("projection index came from projections");
-            projection.name.clone_from(&name);
+            projection.sql_name = SqlObjectName::try_new(
+                projection.sql_name.catalog_name(),
+                projection.sql_name.schema_name(),
+                &name,
+            )
+            .map_err(|error| ManifestError::validation(error.to_string()))?;
             let diagnostic = Diagnostic::new(
                 format!("projection name collision resolved as '{name}'"),
                 Some(projection.operation_id.clone()),
@@ -75,7 +87,7 @@ pub(super) fn resolve_projection_name_collisions(
             diagnostics.push(diagnostic);
         }
     }
-    diagnostics
+    Ok(diagnostics)
 }
 
 fn projection_name_priority(
@@ -96,14 +108,19 @@ fn collision_resolved_projection_name(
     manifest: &V4SourceManifest,
     projection: &Projection,
     operation: Option<&IrOperation>,
-    used_names: &HashSet<String>,
+    used_names: &HashSet<(String, String)>,
 ) -> String {
-    let base_name = projection.name.as_str();
+    let base_name = projection.sql_name.name();
     let contextual_name = operation.map_or_else(
         || normalize_identifier(&projection.operation_id, "projection"),
         |operation| contextual_projection_name(base_name, operation),
     );
-    if contextual_name != base_name && !used_names.contains(&contextual_name) {
+    if contextual_name != base_name
+        && !used_names.contains(&(
+            projection.sql_name.schema_name().to_string(),
+            contextual_name.clone(),
+        ))
+    {
         return contextual_name;
     }
 
@@ -240,9 +257,8 @@ pub(super) fn projection_name(operation: &IrOperation, is_search: bool) -> Strin
 
 pub(super) fn projection_name_from_operation_naming(operation: &IrOperation) -> Option<String> {
     let naming = operation.naming.as_ref()?;
-    let group = non_empty_naming_part(naming.group.as_deref())?;
     let operation = non_empty_naming_part(naming.operation.as_deref())?;
-    Some(format!("{group}_{operation}"))
+    Some(operation.to_string())
 }
 
 fn non_empty_naming_part(part: Option<&str>) -> Option<&str> {

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -108,7 +108,7 @@ pub fn request_spec_for_projection(
     let IrExecutionAttachment::Rest(rest) = &operation.execution else {
         return Err(crate::ManifestError::validation(format!(
             "projection '{}' is not backed by a REST operation",
-            projection.name
+            projection.sql_name
         )));
     };
     let mut path = rest.path_template.clone();

--- a/crates/coral-spec/src/v4/projections/validation.rs
+++ b/crates/coral-spec/src/v4/projections/validation.rs
@@ -30,7 +30,7 @@ pub fn validate_projection_compatibility(
         let Some(operation) = operations.get(projection.operation_id.as_str()) else {
             return Err(ManifestError::validation(format!(
                 "projection '{}' references missing operation '{}'",
-                projection.name, projection.operation_id
+                projection.sql_name, projection.operation_id
             )));
         };
         if matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
@@ -56,7 +56,11 @@ fn validate_projection_inputs(
         }) else {
             return Err(ManifestError::validation(format!(
                 "projection '{}' input '{}' does not match a {:?} input named '{}' on operation '{}'",
-                projection.name, input.name, input.source_location, input.wire_name, operation.id
+                projection.sql_name,
+                input.name,
+                input.source_location,
+                input.wire_name,
+                operation.id
             )));
         };
 
@@ -65,7 +69,7 @@ fn validate_projection_inputs(
         if pagination_owned && input.sql_exposure != SqlInputExposure::Internal {
             return Err(ManifestError::validation(format!(
                 "projection '{}' input '{}' on operation '{}' is owned by pagination but has sql_exposure '{}'; pagination-owned inputs must be internal",
-                projection.name,
+                projection.sql_name,
                 input.name,
                 operation.id,
                 sql_exposure_name(input.sql_exposure)
@@ -76,7 +80,7 @@ fn validate_projection_inputs(
             if !matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
                 return Err(ManifestError::validation(format!(
                     "projection '{}' input '{}' on operation '{}' has lookup_key=true, but lookup keys are only valid for REST inputs",
-                    projection.name, input.name, operation.id
+                    projection.sql_name, input.name, operation.id
                 )));
             }
             // The metadata allowlist is keyed by wire name alone, and only
@@ -86,13 +90,13 @@ fn validate_projection_inputs(
             if input.source_location != IrInputLocation::Query {
                 return Err(ManifestError::validation(format!(
                     "projection '{}' input '{}' on operation '{}' has lookup_key=true with source location {:?}; lookup keys are only valid for query inputs",
-                    projection.name, input.name, operation.id, input.source_location
+                    projection.sql_name, input.name, operation.id, input.source_location
                 )));
             }
             if input.sql_exposure != SqlInputExposure::Filter {
                 return Err(ManifestError::validation(format!(
                     "projection '{}' input '{}' on operation '{}' has lookup_key=true with sql_exposure '{}'; lookup keys must be exposed as filters",
-                    projection.name,
+                    projection.sql_name,
                     input.name,
                     operation.id,
                     sql_exposure_name(input.sql_exposure)
@@ -101,7 +105,7 @@ fn validate_projection_inputs(
             if !plan.input_is_lookup_key(&operation.id, &input.wire_name) {
                 return Err(ManifestError::validation(format!(
                     "projection '{}' input '{}' on operation '{}' has lookup_key=true, but wire input '{}' is not authorised by the operation metadata lookup-key allowlist",
-                    projection.name, input.name, operation.id, input.wire_name
+                    projection.sql_name, input.name, operation.id, input.wire_name
                 )));
             }
         }
@@ -113,7 +117,7 @@ fn validate_projection_inputs(
         {
             return Err(ManifestError::validation(format!(
                 "projection '{}' input '{}' on operation '{}' has sql_exposure '{}'; {} projections expose non-internal inputs as {}",
-                projection.name,
+                projection.sql_name,
                 input.name,
                 operation.id,
                 sql_exposure_name(input.sql_exposure),
@@ -132,7 +136,7 @@ fn validate_projection_inputs(
         {
             return Err(ManifestError::validation(format!(
                 "projection '{}' input '{}' on operation '{}' is required by the operation but has sql_exposure 'internal'; published projections cannot internalize required inputs",
-                projection.name, input.name, operation.id
+                projection.sql_name, input.name, operation.id
             )));
         }
     }
@@ -176,13 +180,13 @@ fn validate_projection_columns(
         let Some(fields) = row_fields else {
             return Err(ManifestError::validation(format!(
                 "projection '{}' column '{}' reads field '{field_name}', but the rows operation '{operation_id}' yields have type '{row_type_ref}', which is not an object and names no fields",
-                projection.name, column.name
+                projection.sql_name, column.name
             )));
         };
         let Some(field) = fields.iter().find(|field| field.name == *field_name) else {
             return Err(ManifestError::validation(format!(
                 "projection '{}' column '{}' reads field '{field_name}', but the rows operation '{operation_id}' yields have type '{row_type_ref}', which has no such field",
-                projection.name, column.name
+                projection.sql_name, column.name
             )));
         };
         // The generator only ever emits one segment, but an authored override
@@ -191,7 +195,7 @@ fn validate_projection_columns(
         if let Err(reason) = walk_source_path(&field.type_ref, nested, types) {
             return Err(ManifestError::validation(format!(
                 "projection '{}' column '{}' reads source path '{}', but {reason}",
-                projection.name,
+                projection.sql_name,
                 column.name,
                 column.source_path.join(".")
             )));


### PR DESCRIPTION
## Stack

Depends on #2081. This is PR 2 of the unified catalog-schema stack.

## Current delivery

- persist validated three-part SQL identities on DSL v4 projections
- derive OpenAPI tag schemas with public fallback and MCP public schemas
- resolve projection collisions within each schema
- advance artifact and projection-generator versions
- reject pre-contract projection artifacts with explicit reinstall or regeneration guidance

## Planned in this PR

- encode the supported runtime catalog/backend matrix
- add source-scoped catalog preparation while preserving v3 placement and decorator semantics

## Validation

- cargo test -p coral-spec projection
- cargo test -p coral-app materialization
- cargo test -p coral-spec
- cargo test -p coral-app sources::runtime_package

## Review state

Slice 4 is complete and reviewed at its required checkpoint. Slices 5–6 remain pending, so this PR stays draft until the batch is complete.