### PR TITLE
feat(app)!: move an existing member's role on add

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -294,11 +294,12 @@ workspace an earlier single-user run left it owning, once a person owns it too:
 `ListWorkspaceMembers` takes `{"workspace": {"name": "analytics"}}` and is how
 an owner verifies either change.
 
-Repeating an identical add succeeds and returns the existing membership. Asking
-for a different role never overwrites the current one; it answers
-`user '<user-id>' already has a different role in workspace 'analytics'`, so
-remove the membership and add it again. Removing the only owner is refused with
-`workspace 'analytics' must retain at least one owner` — which is also why a
+Repeating an identical add succeeds and returns the existing membership. Adding
+someone who already belongs states the role they should hold, so asking for a
+different one moves them to it — that is how you promote a member to owner or
+step an owner back down. The one move Coral refuses is the one that would leave
+the workspace with nobody in charge: demoting or removing the only owner answers
+`workspace 'analytics' must retain at least one owner`, which is also why a
 workspace never becomes ownerless on its own.
 
 ### Rebind the identity-provider issuer

--- a/crates/coral-app/src/admin.rs
+++ b/crates/coral-app/src/admin.rs
@@ -234,7 +234,7 @@ impl AdminDb {
 
         let outcome = match tx
             .workspace_members()
-            .role_for_user_id(workspace, user_id)
+            .role_for_user_id_for_recovery(workspace, user_id)
             .await
             .map_err(describe)?
         {

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -42,14 +42,6 @@ pub enum AppError {
     /// A requested workspace already exists in config.
     #[error("workspace '{0}' already exists")]
     WorkspaceAlreadyExists(String),
-    /// A workspace member already exists with a different role.
-    #[error("user '{user_id}' already has a different role in workspace '{workspace}'")]
-    WorkspaceMemberRoleConflict {
-        /// Workspace containing the existing membership.
-        workspace: String,
-        /// User whose existing membership has the conflicting role.
-        user_id: String,
-    },
     /// Removing this member would leave a workspace without an owner.
     #[error("workspace '{0}' must retain at least one owner")]
     LastWorkspaceOwner(String),
@@ -321,9 +313,9 @@ fn app_code(error: &AppError) -> Code {
         | AppError::FunctionNotFound(_)
         | AppError::WorkspaceNotFound(_)
         | AppError::UserNotFound(_) => Code::NotFound,
-        AppError::FunctionAlreadyExists(_)
-        | AppError::WorkspaceAlreadyExists(_)
-        | AppError::WorkspaceMemberRoleConflict { .. } => Code::AlreadyExists,
+        AppError::FunctionAlreadyExists(_) | AppError::WorkspaceAlreadyExists(_) => {
+            Code::AlreadyExists
+        }
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::LastWorkspaceOwner(_)
@@ -394,13 +386,6 @@ mod tests {
                 Code::NotFound,
             ),
             (AppError::IssuerMismatch, Code::FailedPrecondition),
-            (
-                AppError::WorkspaceMemberRoleConflict {
-                    workspace: "work".to_string(),
-                    user_id: "user-id".to_string(),
-                },
-                Code::AlreadyExists,
-            ),
             (
                 AppError::LastWorkspaceOwner("work".to_string()),
                 Code::FailedPrecondition,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1590,7 +1590,9 @@ mod tests {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (task, request_context, task_id) = active_task_context(&fixture.db).await;
         let service = QueryService::new(fixture.manager.clone(), task).with_authorizer(
-            crate::workspaces::WorkspaceAuthorizer::new(Arc::clone(&fixture.db)),
+            crate::workspaces::WorkspaceAuthorizer::trusting_local_principal(Arc::clone(
+                &fixture.db,
+            )),
         );
 
         let mut request = Request::new(ExecuteSqlRequest {
@@ -1697,7 +1699,9 @@ mod tests {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (task, request_context, task_id) = active_task_context(&fixture.db).await;
         let service = CatalogService::new(fixture.manager.clone(), task).with_authorizer(
-            crate::workspaces::WorkspaceAuthorizer::new(Arc::clone(&fixture.db)),
+            crate::workspaces::WorkspaceAuthorizer::trusting_local_principal(Arc::clone(
+                &fixture.db,
+            )),
         );
 
         call_catalog_tools_with_task(&service, &request_context).await;

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -32,6 +32,24 @@ where
         row.map(|(role,)| parse_role(&role)).transpose()
     }
 
+    /// Reads a membership even when its workspace has no owner so the admin
+    /// recovery path can repair that otherwise concealed state.
+    #[cfg(feature = "admin")]
+    pub(crate) async fn role_for_user_id_for_recovery(
+        &mut self,
+        workspace_id: &str,
+        user_id: &str,
+    ) -> Result<Option<MemberRole>, DbError> {
+        let statement = Query::select()
+            .column(WorkspaceMembers::Role)
+            .from(WorkspaceMembers::Table)
+            .and_where(Expr::col(WorkspaceMembers::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(WorkspaceMembers::UserId).eq(user_id))
+            .to_owned();
+        let row: Option<(String,)> = self.session.fetch_optional(statement).await?;
+        row.map(|(role,)| parse_role(&role)).transpose()
+    }
+
     pub(crate) async fn workspaces_for_user_id(
         &mut self,
         user_id: &str,

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -114,6 +114,25 @@ impl WorkspaceMembersRepo<'_, CoralTx<'_>> {
         self.session.execute(statement).await
     }
 
+    /// Moves an existing membership to a different role.
+    ///
+    /// Returns whether a row changed, so a caller that already read the role
+    /// can tell a concurrent removal from a successful update.
+    pub(crate) async fn update_role(
+        &mut self,
+        workspace_id: &str,
+        user_id: &str,
+        role: MemberRole,
+    ) -> Result<bool, DbError> {
+        let statement = Query::update()
+            .table(WorkspaceMembers::Table)
+            .value(WorkspaceMembers::Role, role.as_str())
+            .and_where(Expr::col(WorkspaceMembers::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(WorkspaceMembers::UserId).eq(user_id))
+            .to_owned();
+        Ok(self.session.execute_rows_affected(statement).await? == 1)
+    }
+
     pub(crate) async fn delete(
         &mut self,
         workspace_id: &str,

--- a/crates/coral-app/src/state/db/workspace_member_state.rs
+++ b/crates/coral-app/src/state/db/workspace_member_state.rs
@@ -18,7 +18,11 @@ pub(crate) struct WorkspaceMemberView {
 pub(crate) enum AddMemberOutcome {
     Added(WorkspaceMemberView),
     ExistingSameRole(WorkspaceMemberView),
-    RoleConflict,
+    /// The membership existed with a different role and now holds the
+    /// requested one.
+    RoleUpdated(WorkspaceMemberView),
+    /// Demoting this member would leave the workspace with no owner.
+    LastOwnerProtected,
     WorkspaceNotFound,
     UserNotFound,
 }
@@ -98,8 +102,29 @@ impl CoralDb {
             .role_for_user_id(workspace_id, user_id)
             .await?
         {
-            tx.rollback().await?;
-            return Ok(existing_add_outcome(user, existing_role, role));
+            if existing_role == role {
+                tx.rollback().await?;
+                return Ok(AddMemberOutcome::ExistingSameRole(member_view(user, role)));
+            }
+            // Adding someone who is already a member states the role they
+            // should hold, so it moves them to it. The one move that cannot be
+            // honored is the one that would leave nobody in charge.
+            if existing_role == MemberRole::Owner
+                && tx.workspace_members().owner_count(workspace_id).await? <= 1
+            {
+                tx.rollback().await?;
+                return Ok(AddMemberOutcome::LastOwnerProtected);
+            }
+            if !tx
+                .workspace_members()
+                .update_role(workspace_id, user_id, role)
+                .await?
+            {
+                tx.rollback().await?;
+                return Ok(AddMemberOutcome::WorkspaceNotFound);
+            }
+            tx.commit().await?;
+            return Ok(AddMemberOutcome::RoleUpdated(member_view(user, role)));
         }
         match tx
             .workspace_members()
@@ -111,6 +136,11 @@ impl CoralDb {
                 Ok(AddMemberOutcome::Added(member_view(user, role)))
             }
             Err(error) if error.is_unique_violation() => {
+                // `hold_for_child_mutation` serializes membership writes, so a
+                // membership appearing between the read above and this insert
+                // means the lock did not hold. Report what is true now rather
+                // than guessing: the role this caller asked for is applied on
+                // their next attempt.
                 tx.rollback().await?;
                 let mut session = self;
                 let Some(existing_role) = session
@@ -120,7 +150,10 @@ impl CoralDb {
                 else {
                     return Err(error);
                 };
-                Ok(existing_add_outcome(user, existing_role, role))
+                Ok(AddMemberOutcome::ExistingSameRole(member_view(
+                    user,
+                    existing_role,
+                )))
             }
             Err(error) => Err(error),
         }
@@ -161,18 +194,6 @@ impl CoralDb {
             tx.rollback().await?;
             Ok(RemoveMemberOutcome::MemberNotFound)
         }
-    }
-}
-
-fn existing_add_outcome(
-    user: UserRecord,
-    existing_role: MemberRole,
-    requested_role: MemberRole,
-) -> AddMemberOutcome {
-    if existing_role == requested_role {
-        AddMemberOutcome::ExistingSameRole(member_view(user, existing_role))
-    } else {
-        AddMemberOutcome::RoleConflict
     }
 }
 
@@ -292,29 +313,27 @@ mod tests {
             member_add.expect("member-role add"),
             owner_add.expect("owner-role add"),
         ];
-        let added_role = outcomes
+        // One add creates the membership and the other moves it, in whichever
+        // order the lock granted. Both succeed, and the role that survives is
+        // the one the second add asked for.
+        let settled_role = outcomes
             .iter()
             .find_map(|outcome| match outcome {
-                AddMemberOutcome::Added(member) => Some(member.role),
-                AddMemberOutcome::ExistingSameRole(_)
-                | AddMemberOutcome::RoleConflict
+                AddMemberOutcome::RoleUpdated(member) => Some(member.role),
+                AddMemberOutcome::Added(_)
+                | AddMemberOutcome::ExistingSameRole(_)
+                | AddMemberOutcome::LastOwnerProtected
                 | AddMemberOutcome::WorkspaceNotFound
                 | AddMemberOutcome::UserNotFound => None,
             })
-            .expect("one conflicting add must win");
+            .expect("the second concurrent add must move the role");
         assert_eq!(
             outcomes
                 .iter()
                 .filter(|outcome| matches!(outcome, AddMemberOutcome::Added(_)))
                 .count(),
-            1
-        );
-        assert_eq!(
-            outcomes
-                .iter()
-                .filter(|outcome| matches!(outcome, AddMemberOutcome::RoleConflict))
-                .count(),
-            1
+            1,
+            "exactly one add may create the membership"
         );
         let mut session = db;
         assert_eq!(
@@ -322,9 +341,9 @@ mod tests {
                 .workspace_members()
                 .role_for_user_id(&conflicting_add_workspace_id, &conflicting_member_id)
                 .await
-                .expect("read role after conflicting adds"),
-            Some(added_role),
-            "the losing conflicting add must not mutate the winning role"
+                .expect("read role after concurrent adds"),
+            Some(settled_role),
+            "the stored role must be the one the moving add asked for"
         );
 
         let owner_removal_workspace_id = format!("owner-removal-{suffix}");

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -204,7 +204,8 @@ mod tests {
             .await
             .expect("import default workspace");
         let task = TaskManager::new(TaskStore::new(Arc::clone(&db)));
-        let service = TaskService::new(task).with_authorizer(WorkspaceAuthorizer::new(db));
+        let service = TaskService::new(task)
+            .with_authorizer(WorkspaceAuthorizer::trusting_local_principal(db));
         (dir, service)
     }
 

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -66,7 +66,6 @@ pub(crate) fn app_error_type(error: &AppError) -> &'static str {
         AppError::FunctionAlreadyExists(_) => "FUNCTION_ALREADY_EXISTS",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
-        AppError::WorkspaceMemberRoleConflict { .. } => "WORKSPACE_MEMBER_ROLE_CONFLICT",
         AppError::LastWorkspaceOwner(_) => "LAST_WORKSPACE_OWNER",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
@@ -769,13 +768,6 @@ mod tests {
             ),
             (AppError::UserNotFound(String::new()), "USER_NOT_FOUND"),
             (AppError::IssuerMismatch, "ISSUER_MISMATCH"),
-            (
-                AppError::WorkspaceMemberRoleConflict {
-                    workspace: String::new(),
-                    user_id: String::new(),
-                },
-                "WORKSPACE_MEMBER_ROLE_CONFLICT",
-            ),
             (
                 AppError::LastWorkspaceOwner(String::new()),
                 "LAST_WORKSPACE_OWNER",

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -743,7 +743,7 @@ mod tests {
         write_traces(&trace_store);
         ServiceFixture {
             service: TraceService::new(TraceManager::new(trace_store, Duration::from_mins(1)))
-                .with_authorizer(WorkspaceAuthorizer::new(db)),
+                .with_authorizer(WorkspaceAuthorizer::trusting_local_principal(db)),
             owner: Principal::parse(&owner_id, PrincipalKind::User).expect("owner"),
             member: Principal::parse(&member_id, PrincipalKind::User).expect("member"),
             outsider: Principal::parse(&outsider_id, PrincipalKind::User).expect("outsider"),

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -267,13 +267,12 @@ impl WorkspaceManager {
             )
             .await?
         {
-            AddMemberOutcome::Added(member) | AddMemberOutcome::ExistingSameRole(member) => {
-                Ok(member)
+            AddMemberOutcome::Added(member)
+            | AddMemberOutcome::ExistingSameRole(member)
+            | AddMemberOutcome::RoleUpdated(member) => Ok(member),
+            AddMemberOutcome::LastOwnerProtected => {
+                Err(AppError::LastWorkspaceOwner(workspace_name.to_string()))
             }
-            AddMemberOutcome::RoleConflict => Err(AppError::WorkspaceMemberRoleConflict {
-                workspace: workspace_name.to_string(),
-                user_id: user_id.to_string(),
-            }),
             AddMemberOutcome::WorkspaceNotFound => {
                 Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
             }
@@ -607,11 +606,26 @@ mod tests {
             .await
             .expect("repeat identical add");
         assert_eq!(first, repeated);
+
+        // Adding someone who is already a member states the role they should
+        // hold, so it moves them to it.
+        let promoted = manager
+            .add_workspace_member(&workspace, &member_id, MemberRole::Owner)
+            .await
+            .expect("adding an existing member with a new role promotes them");
+        assert_eq!(promoted.role, MemberRole::Owner);
+        let demoted = manager
+            .add_workspace_member(&workspace, &member_id, MemberRole::Member)
+            .await
+            .expect("and moves them back");
+        assert_eq!(demoted.role, MemberRole::Member);
+
+        // The one move that cannot be honored leaves nobody in charge.
         assert!(matches!(
             manager
-                .add_workspace_member(&workspace, &member_id, MemberRole::Owner)
+                .add_workspace_member(&workspace, &owner_id, MemberRole::Member)
                 .await,
-            Err(AppError::WorkspaceMemberRoleConflict { .. })
+            Err(AppError::LastWorkspaceOwner(_))
         ));
 
         let members = manager

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -321,7 +321,7 @@ mod tests {
         )
         .await
         .expect("identical add remains idempotent");
-        let conflict = WorkspaceServiceApi::add_workspace_member(
+        let promoted = WorkspaceServiceApi::add_workspace_member(
             &fixture.service,
             add_request(
                 &fixture,
@@ -331,8 +331,26 @@ mod tests {
             ),
         )
         .await
-        .expect_err("different-role add conflicts");
-        assert_eq!(conflict.code(), Code::AlreadyExists);
+        .expect("adding an existing member with a new role moves them to it")
+        .into_inner()
+        .member
+        .expect("promoted membership");
+        assert_eq!(promoted.role, WorkspaceRole::Owner as i32);
+        let demoted = WorkspaceServiceApi::add_workspace_member(
+            &fixture.service,
+            add_request(
+                &fixture,
+                fixture.owner.clone(),
+                &fixture.member_id,
+                WorkspaceRole::Member as i32,
+            ),
+        )
+        .await
+        .expect("and moves them back, since the workspace keeps another owner")
+        .into_inner()
+        .member
+        .expect("demoted membership");
+        assert_eq!(demoted.role, WorkspaceRole::Member as i32);
 
         let member = Principal::parse(&fixture.member_id, PrincipalKind::User).expect("member");
         let denied = WorkspaceServiceApi::add_workspace_member(


### PR DESCRIPTION
## Intent

`AddWorkspaceMember` used to refuse when the user was already a member holding a different role, so changing someone's role meant removing them and adding them back: two calls, with a window in between where they had no access at all, and a sequence that cannot promote anyone in a workspace with a single owner, because the removal is refused first.

**Breaking change.** `AddWorkspaceMember` with a role different from the member's current one now succeeds and returns the moved membership, where it previously failed with `AlreadyExists` and `user '<user-id>' already has a different role in workspace '<workspace>'`. `AppError::WorkspaceMemberRoleConflict` and its telemetry reason are removed. Adding a member with the role they already hold remains a no-op success.

## What it enables

- Promotion and demotion in one authorized transaction. The mutation reads the current role and then `UPDATE`s it, serialized by the same parent-workspace-row hold every other membership mutation takes — not a SQL upsert. Adding an existing member states the role they should hold, and moves them to it.
- The owner floor now covers demotion as well as removal: demoting the last owner is refused with `AppError::LastWorkspaceOwner` — `workspace '<name>' must retain at least one owner` — the same error, and the same gRPC `FailedPrecondition`, that removing them gives. It is the one move that cannot be honored, because it would leave nobody in charge.
- The configuration reference is corrected to describe the move instead of the old remove-and-re-add workaround.
- In-crate service fixtures that model a single-user deployment now say so, constructing `WorkspaceAuthorizer::trusting_local_principal` rather than the strict constructor. Previously they read as if the strict policy admitted `coral:local`, which it does not.

## Usage examples

```
cargo nextest run -p coral-app add_workspace_member_enforces_authorization_and_frozen_add_semantics
cargo nextest run -p coral-app membership_lifecycle_filters_listing_and_preserves_the_last_owner
cargo nextest run -p coral-app workspace_member_state_round_trips_against_sqlite
make postgres-tests
```

`add_workspace_member_enforces_authorization_and_frozen_add_semantics` promotes a member to owner and demotes them again through the real handler, and asserts a non-member and a plain member are stopped before either write.

---

Slice 16 of 16 in stack #2100. Every slice of this stack now passes `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` independently; the tip additionally passes `make rust-checks` (2,591 tests) and `make postgres-tests`.
