### PR TITLE
feat(sources/community/zerops): add Zerops community source

### DIFF
--- a/sources/community/zerops/README.md
+++ b/sources/community/zerops/README.md
@@ -1,0 +1,483 @@
+# Zerops community source
+
+Query Zerops regions, supported service stack types, and personal access tokens through Coral SQL.
+This source adds the Zerops public REST API to the community catalog so users
+and agents can inspect available regions, browse the runtimes and managed
+services Zerops supports, and audit their own access tokens through SQL.
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `https://api.app-prg1.zerops.io/api/rest/public`
+
+## Why this source
+
+Zerops is a developer-first PaaS that runs on bare metal with fine-grained
+horizontal and vertical autoscaling and a configurable build and deploy
+pipeline. Coral did not have a Zerops source yet, so this community spec gives
+the reef a focused read/query surface for:
+
+- Discovering which Zerops regions a CLI, SDK, or agent can target.
+- Looking up the runtimes, databases, and storage types Zerops supports, and
+  whether each one is managed, backed up, or user-configurable.
+- Listing the personal access tokens associated with the current Zerops user
+  for audit and rotation workflows.
+- Looking up one personal access token by ID for detailed review.
+
+The v1 surface is intentionally narrow and read-oriented. It proves Coral can
+authenticate against Zerops with a personal access token, hit the
+authentication-free `/region` and `/settings` endpoints, and map the
+`/user-token` endpoints into verifiable tables. Project and service-level
+endpoints require a client ID and are out of scope for this first version.
+
+## Installation
+
+Community sources are not bundled with the Coral binary. Clone the Coral
+repository and add the manifest from this directory:
+
+```bash
+coral source add --file sources/community/zerops/manifest.yaml
+```
+
+You can also copy `manifest.yaml` into another workspace and pass that path to
+`coral source add --file`.
+
+## Authentication
+
+Create a personal access token from the Zerops GUI:
+
+1. Log in to the Zerops dashboard.
+2. Open the user menu and go to **Access Token management**.
+3. Create a new personal access token and copy it.
+
+See https://docs.zerops.io/references/api for the full REST API reference and
+the list of regions.
+
+Set the token as `ZEROPS_API_KEY` before adding or testing the source. Coral
+sends it as a Bearer token to the Zerops REST API.
+
+```bash
+export ZEROPS_API_KEY="your_zerops_personal_access_token"
+coral source add --file sources/community/zerops/manifest.yaml
+```
+
+Interactive install also works:
+
+```bash
+coral source add --interactive --file sources/community/zerops/manifest.yaml
+```
+
+The default API base URL is `https://api.app-prg1.zerops.io/api/rest/public`.
+Set `ZEROPS_BASE_URL` to point Coral at a different region when needed.
+
+## Provider docs
+
+- Zerops REST API reference: https://docs.zerops.io/references/api
+- Zerops introduction: https://docs.zerops.io
+- Zerops CLI (`zCLI`): https://docs.zerops.io/references/cli
+- Zerops YAML spec: https://docs.zerops.io/zerops-yaml/specification
+
+## Tables
+
+| Table | Description | Required filters |
+| --- | --- | --- |
+| `zerops.regions` | Zerops datacenters/regions exposed by the region API. | None |
+| `zerops.service_stack_types` | Supported Zerops service stack types (runtimes, databases, storage). | None |
+| `zerops.user_tokens` | Personal access tokens issued for the current Zerops user. | None |
+| `zerops.user_token` | A single Zerops personal access token by ID. | `id` |
+
+### `zerops.regions`
+
+Lists the regions Zerops exposes through `GET /region`. Use `address` as the
+base URL for a non-default region.
+
+```sql
+SELECT name, address, is_default FROM zerops.regions;
+```
+
+### `zerops.service_stack_types`
+
+Lists the supported service stack types from `GET /settings`. Each row includes
+runtime/managed/backup capability flags and a nested `service_stack_type_version_list`
+JSON column with the available versions for that stack type.
+
+```sql
+SELECT id, name, category, is_runtime, is_managed, has_backup
+FROM zerops.service_stack_types
+WHERE is_runtime = true
+LIMIT 10;
+```
+
+Filter by managed-service capability:
+
+```sql
+SELECT id, name, is_managed, has_backup
+FROM zerops.service_stack_types
+WHERE is_managed = true AND has_backup = true
+ORDER BY name;
+```
+
+### `zerops.user_tokens`
+
+Lists the personal access tokens for the current Zerops user via
+`GET /user-token/list`. Use the `id` to look up one token.
+
+```sql
+SELECT id, name, created FROM zerops.user_tokens;
+```
+
+### `zerops.user_token`
+
+Looks up one personal access token by ID via `GET /user-token/{id}`.
+
+```sql
+SELECT id, name, created FROM zerops.user_token
+WHERE id = 'MayA8Q6URQSwAoWAqqARmA';
+```
+
+## Validation
+
+Run the source-level checks with a valid `ZEROPS_API_KEY` before opening or
+updating a PR. The API key is required for `source add`, `source test`, and
+live SQL queries, but it should never be printed or committed.
+
+```bash
+coral source lint sources/community/zerops/manifest.yaml
+
+export ZEROPS_API_KEY="your_zerops_personal_access_token"
+coral source add --file sources/community/zerops/manifest.yaml
+coral source test zerops
+```
+
+The declared test queries cover region discovery, runtime stack filtering, a
+user-token list, and a single-user-token lookup:
+
+```sql
+SELECT name, address, is_default FROM zerops.regions;
+
+SELECT id, name, category, is_runtime, is_managed
+FROM zerops.service_stack_types
+WHERE is_runtime = true
+LIMIT 10;
+
+SELECT id, name, created FROM zerops.user_tokens LIMIT 10;
+
+SELECT id, name, created FROM zerops.user_token
+WHERE id = 'MayA8Q6URQSwAoWAqqARmA'
+LIMIT 1;
+```
+
+### Live validation output
+
+The following output was captured from a live validation run using a real
+Zerops personal access token.
+
+#### Manifest lint
+
+Command:
+
+```bash
+coral source lint sources/community/zerops/manifest.yaml
+```
+
+Output:
+
+```text
+Manifest is valid
+```
+
+#### Add source and run declared tests
+
+Command:
+
+```bash
+coral source add --file sources/community/zerops/manifest.yaml
+```
+
+Output:
+
+```text
+Added source zerops (secrets: keychain)
+Validating source...
+
+  ✓ zerops connected successfully
+  Secrets: keychain
+
+    zerops (4 tables)
+    ├─ regions
+    ├─ service_stack_types
+    ├─ user_token
+    └─ user_tokens
+    Query tests
+    4 declared · 4 passed · 0 failed
+
+    ✓ SELECT name, address, is_default FROM zerops.regions
+      1 row
+
+    ✓ SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10
+      10 rows
+
+    ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 10
+      1 row
+
+    ✓ SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1
+      1 row
+```
+
+#### Re-run source tests
+
+Command:
+
+```bash
+coral source test zerops
+```
+
+Output:
+
+```text
+  ✓ zerops connected successfully
+  Secrets: keychain
+
+    zerops (4 tables)
+    ├─ regions
+    ├─ service_stack_types
+    ├─ user_token
+    └─ user_tokens
+    Query tests
+    4 declared · 4 passed · 0 failed
+
+    ✓ SELECT name, address, is_default FROM zerops.regions
+      1 row
+
+    ✓ SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10
+      10 rows
+
+    ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 10
+      1 row
+
+    ✓ SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1
+      1 row
+```
+
+#### Confirm table discovery
+
+Command:
+
+```bash
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'zerops' ORDER BY table_name"
+```
+
+Output:
+
+```text
++---------------------+
+| table_name          |
++---------------------+
+| regions             |
+| service_stack_types |
+| user_token          |
+| user_tokens         |
++---------------------+
+```
+
+#### Confirm column discovery
+
+Command:
+
+```bash
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'zerops' ORDER BY table_name, ordinal_position"
+```
+
+Output:
+
+```text
++---------------------+---------------------------------+-----------+
+| table_name          | column_name                     | data_type |
++---------------------+---------------------------------+-----------+
+| regions             | name                            | Utf8      |
+| regions             | address                         | Utf8      |
+| regions             | is_default                      | Boolean   |
+| service_stack_types | id                              | Utf8      |
+| service_stack_types | name                            | Utf8      |
+| service_stack_types | description                     | Utf8      |
+| service_stack_types | category                        | Utf8      |
+| service_stack_types | subcategory                     | Utf8      |
+| service_stack_types | docs_url                        | Utf8      |
+| service_stack_types | is_build                        | Boolean   |
+| service_stack_types | is_runtime                      | Boolean   |
+| service_stack_types | is_managed                      | Boolean   |
+| service_stack_types | has_backup                      | Boolean   |
+| service_stack_types | has_access_details              | Boolean   |
+| service_stack_types | has_configuration               | Boolean   |
+| service_stack_types | os_list                         | Json      |
+| service_stack_types | mode_list                       | Json      |
+| service_stack_types | service_stack_type_version_list | Json      |
+| service_stack_types | created                         | Timestamp |
+| service_stack_types | last_update                     | Timestamp |
+| user_token          | id                              | Utf8      |
+| user_token          | name                            | Utf8      |
+| user_token          | created                         | Timestamp |
+| user_tokens         | id                              | Utf8      |
+| user_tokens         | name                            | Utf8      |
+| user_tokens         | created                         | Timestamp |
++---------------------+---------------------------------+-----------+
+```
+
+#### Confirm input discovery
+
+Command:
+
+```bash
+coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'zerops' ORDER BY key"
+```
+
+Output:
+
+```text
++-----------------+----------+----------+
+| key             | kind     | required |
++-----------------+----------+----------+
+| ZEROPS_API_KEY  | secret   | true     |
+| ZEROPS_BASE_URL | variable | false    |
++-----------------+----------+----------+
+```
+
+#### Run a live regions query
+
+Command:
+
+```bash
+coral sql "SELECT name, address, is_default FROM zerops.regions"
+```
+
+Output:
+
+```text
++------+------------------------+------------+
+| name | address                | is_default |
++------+------------------------+------------+
+| prg1 | api.app-prg1.zerops.io | true       |
++------+------------------------+------------+
+```
+
+#### Run a live runtime stack types query
+
+Command:
+
+```bash
+coral sql "SELECT id, name, category, is_runtime, is_managed, has_backup FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 5"
+```
+
+Output:
+
+```text
++--------+--------+----------+------------+------------+------------+
+| id     | name   | category | is_runtime | is_managed | has_backup |
++--------+--------+----------+------------+------------+------------+
+| alpine | Alpine | USER     | true       | false      | false      |
+| bun    | Bun    | USER     | false      | false      | false      |
+| deno   | Deno   | USER     | true       | false      | false      |
+| docker | Docker | USER     | true       | false      | false      |
+| dotnet | .NET   | USER     | true       | false      | false      |
++--------+--------+----------+------------+------------+------------+
+```
+
+#### Run a live managed services query
+
+Command:
+
+```bash
+coral sql "SELECT id, name, is_managed, has_backup FROM zerops.service_stack_types WHERE is_managed = true AND has_backup = true ORDER BY name"
+```
+
+Output:
+
+```text
++----------------+----------------+------------+------------+
+| id             | name           | is_managed | has_backup |
++----------------+----------------+------------+------------+
+| clickhouse     | ClickHouse     | true       | true       |
+| elasticsearch  | Elasticsearch  | true       | true       |
+| mariadb        | MariaDB        | true       | true       |
+| meilisearch    | Meilisearch    | true       | true       |
+| nats           | NATS           | true       | true       |
+| postgresql     | PostgreSQL     | true       | true       |
+| qdrant         | Qdrant         | true       | true       |
+| shared_storage | Shared Storage | true       | true       |
+| valkey         | Valkey         | true       | true       |
++----------------+----------------+------------+------------+
+```
+
+#### Run a live user tokens query
+
+Command:
+
+```bash
+coral sql "SELECT id, name, created FROM zerops.user_tokens"
+```
+
+Output:
+
+```text
++------------------------+-------+----------------------+
+| id                     | name  | created              |
++------------------------+-------+----------------------+
+| MayA8Q6URQSwAoWAqqARmA | login | 2026-08-09T00:46:53Z |
++------------------------+-------+----------------------+
+```
+
+#### Run a live single user token query
+
+Command:
+
+```bash
+coral sql "SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA'"
+```
+
+Output:
+
+```text
++------------------------+-------+----------------------+
+| id                     | name  | created              |
++------------------------+-------+----------------------+
+| MayA8Q6URQSwAoWAqqARmA | login | 2026-08-09T00:46:53Z |
++------------------------+-------+----------------------+
+```
+
+## Implementation notes
+
+- Uses Coral source-spec DSL v3 with the HTTP backend.
+- Uses `HeaderAuth` with `Authorization: Bearer {{input.ZEROPS_API_KEY}}`.
+- `base_url` defaults to `https://api.app-prg1.zerops.io/api/rest/public` and is
+  overridable via the `ZEROPS_BASE_URL` variable input for non-default regions.
+- Maps `GET /region` response rows from the `items` array into `zerops.regions`.
+- Maps `GET /settings` response rows from the `serviceStackList` array into
+  `zerops.service_stack_types`, including the nested
+  `serviceStackTypeVersionList` as a JSON column for downstream expansion.
+- Maps coralCase JSON keys (`isRuntime`, `hasBackup`, `docsUrl`, `lastUpdate`,
+  ...) onto snake_case columns through explicit `expr: path` entries.
+- Maps ISO 8601 `created` and `lastUpdate` timestamps into Arrow `Timestamp`
+  columns through `format_timestamp: input: iso8601` wrappers.
+- Maps `GET /user-token/list` response rows from the `list` array into
+  `zerops.user_tokens`, and `GET /user-token/{id}` directly into
+  `zerops.user_token`.
+- Does not require runtime, CLI, MCP, or UI changes.
+
+## Limitations
+
+- This source is read/query oriented and does not manage Zerops projects or
+  services.
+- Project and service-stack endpoints require a client ID, which is not
+  exposed by the current endpoints accessible to a personal access token.
+  Those endpoints are intentionally out of scope for this first version.
+- The `service_stack_type_versions` are exposed as a nested JSON column on
+  `service_stack_types`; a dedicated flattened versions table can be added in
+  a follow-up version once the consumption pattern stabilizes.
+- Available regions, service stack types, token metadata, and error responses
+  depend on the Zerops account, the personal access token permissions, and the
+  current provider API.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md), keep the manifest focused,
+and include the validation commands plus proof output in the PR description.

--- a/sources/community/zerops/README.md
+++ b/sources/community/zerops/README.md
@@ -46,15 +46,11 @@ You can also copy `manifest.yaml` into another workspace and pass that path to
 
 Create a personal access token from the Zerops GUI:
 
-1. Log in to the Zerops dashboard. The default prg1 region is at
-   <https://app-prg1.zerops.io/>; the other supported regions are
-   <https://app-ny1.zerops.io/> (US East, ny1) and
-   <https://app-sea1.zerops.io/> (US West, sea1).
+1. Log in to the Zerops dashboard at <https://app-prg1.zerops.io/>.
 2. Open the user menu and go to **Access Token management**.
 3. Create a new personal access token and copy it.
 
-See https://docs.zerops.io/references/api for the full REST API reference and
-the list of regions.
+See https://docs.zerops.io/references/api for the full REST API reference.
 
 Set the token as `ZEROPS_API_KEY` before adding or testing the source. Coral
 sends it as a Bearer token to the Zerops REST API.
@@ -71,12 +67,15 @@ coral source add --interactive --file sources/community/zerops/manifest.yaml
 ```
 
 The default HTTP host is `api.app-prg1.zerops.io`. The full base URL is
-constructed by the manifest as `https://{ZEROPS_HOST}/api/rest/public`, so
-for a non-default region set `ZEROPS_HOST` to one of:
+constructed by the manifest as `https://{ZEROPS_HOST}/api/rest/public`. The
+public region API currently reports a single region (prg1), so that host is
+the only one verified to work:
 
 - `api.app-prg1.zerops.io` (default)
-- `api.app-ny1.zerops.io`
-- `api.app-sea1.zerops.io`
+
+Do not assume other API hosts exist; the Zerops docs base URL references only
+`api.app-prg1.zerops.io`. Query `zerops.regions` to discover the hosts the
+region API actually exposes instead.
 
 Do not include the scheme or the `/api/rest/public` path; the manifest
 prepends `https://` and appends the path automatically.
@@ -492,6 +491,14 @@ Output:
 - The Zerops `service_stack_types.description` field is sometimes a literal
   `"todo"` placeholder from the provider. This is a provider data quality
   issue, not a source bug.
+- Several `service_stack_types` fields carry provider-side quirks that are
+  surfaced verbatim and cannot be normalized by this source: KeyDB, MongoDB,
+  and RabbitMQ report `is_managed = false` under the `STANDARD` category, six
+  stack types (KeyDB, MongoDB, RabbitMQ, and the three build/prepare runtimes)
+  report an empty `subcategory`, and `nodejs` reports an empty `mode_list`.
+- The public region API currently reports only the `prg1` region, so
+  `zerops.regions` returns a single row. Additional regions may exist upstream
+  but are not discoverable through the current API surface.
 - Available regions, service stack types, token metadata, and error responses
   depend on the Zerops account, the personal access token permissions, and the
   current provider API.

--- a/sources/community/zerops/README.md
+++ b/sources/community/zerops/README.md
@@ -46,7 +46,8 @@ You can also copy `manifest.yaml` into another workspace and pass that path to
 
 Create a personal access token from the Zerops GUI:
 
-1. Log in to the Zerops dashboard.
+1. Log in to the Zerops dashboard at <https://app-prg1.zerops.io/> (the
+   default prg1 region; other regions use the same path on their own host).
 2. Open the user menu and go to **Access Token management**.
 3. Create a new personal access token and copy it.
 
@@ -88,8 +89,9 @@ Set `ZEROPS_BASE_URL` to point Coral at a different region when needed.
 
 ### `zerops.regions`
 
-Lists the regions Zerops exposes through `GET /region`. Use `address` as the
-base URL for a non-default region.
+Lists the regions Zerops exposes through `GET /region`. The `address` column
+is the API host for that region — pass it as `ZEROPS_BASE_URL` when targeting
+a non-default region.
 
 ```sql
 SELECT name, address, is_default FROM zerops.regions;
@@ -149,8 +151,9 @@ coral source add --file sources/community/zerops/manifest.yaml
 coral source test zerops
 ```
 
-The declared test queries cover region discovery, runtime stack filtering, a
-user-token list, and a single-user-token lookup:
+The declared test queries cover region discovery, runtime stack filtering,
+a single service stack type lookup, a user-token list, and a
+single-user-token lookup:
 
 ```sql
 SELECT name, address, is_default FROM zerops.regions;
@@ -159,6 +162,10 @@ SELECT id, name, category, is_runtime, is_managed
 FROM zerops.service_stack_types
 WHERE is_runtime = true
 LIMIT 10;
+
+SELECT id, name FROM zerops.service_stack_types
+WHERE id = 'alpine'
+LIMIT 1;
 
 SELECT id, name, created FROM zerops.user_tokens LIMIT 10;
 
@@ -209,13 +216,16 @@ Validating source...
     ├─ user_token
     └─ user_tokens
     Query tests
-    4 declared · 4 passed · 0 failed
+    5 declared · 5 passed · 0 failed
 
     ✓ SELECT name, address, is_default FROM zerops.regions
       1 row
 
     ✓ SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10
       10 rows
+
+    ✓ SELECT id, name FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1
+      1 row
 
     ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 10
       1 row
@@ -244,13 +254,16 @@ Output:
     ├─ user_token
     └─ user_tokens
     Query tests
-    4 declared · 4 passed · 0 failed
+    5 declared · 5 passed · 0 failed
 
     ✓ SELECT name, address, is_default FROM zerops.regions
       1 row
 
     ✓ SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10
       10 rows
+
+    ✓ SELECT id, name FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1
+      1 row
 
     ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 10
       1 row
@@ -285,42 +298,42 @@ Output:
 Command:
 
 ```bash
-coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'zerops' ORDER BY table_name, ordinal_position"
+coral sql "SELECT table_name, column_name, data_type, is_nullable FROM coral.columns WHERE schema_name = 'zerops' ORDER BY table_name, ordinal_position"
 ```
 
 Output:
 
 ```text
-+---------------------+---------------------------------+-----------+
-| table_name          | column_name                     | data_type |
-+---------------------+---------------------------------+-----------+
-| regions             | name                            | Utf8      |
-| regions             | address                         | Utf8      |
-| regions             | is_default                      | Boolean   |
-| service_stack_types | id                              | Utf8      |
-| service_stack_types | name                            | Utf8      |
-| service_stack_types | description                     | Utf8      |
-| service_stack_types | category                        | Utf8      |
-| service_stack_types | subcategory                     | Utf8      |
-| service_stack_types | docs_url                        | Utf8      |
-| service_stack_types | is_build                        | Boolean   |
-| service_stack_types | is_runtime                      | Boolean   |
-| service_stack_types | is_managed                      | Boolean   |
-| service_stack_types | has_backup                      | Boolean   |
-| service_stack_types | has_access_details              | Boolean   |
-| service_stack_types | has_configuration               | Boolean   |
-| service_stack_types | os_list                         | Json      |
-| service_stack_types | mode_list                       | Json      |
-| service_stack_types | service_stack_type_version_list | Json      |
-| service_stack_types | created                         | Timestamp |
-| service_stack_types | last_update                     | Timestamp |
-| user_token          | id                              | Utf8      |
-| user_token          | name                            | Utf8      |
-| user_token          | created                         | Timestamp |
-| user_tokens         | id                              | Utf8      |
-| user_tokens         | name                            | Utf8      |
-| user_tokens         | created                         | Timestamp |
-+---------------------+---------------------------------+-----------+
++---------------------+---------------------------------+-----------+-------------+
+| table_name          | column_name                     | data_type | is_nullable |
++---------------------+---------------------------------+-----------+-------------+
+| regions             | name                            | Utf8      | false       |
+| regions             | address                         | Utf8      | false       |
+| regions             | is_default                      | Boolean   | false       |
+| service_stack_types | id                              | Utf8      | false       |
+| service_stack_types | name                            | Utf8      | false       |
+| service_stack_types | description                     | Utf8      | true        |
+| service_stack_types | category                        | Utf8      | true        |
+| service_stack_types | subcategory                     | Utf8      | false       |
+| service_stack_types | docs_url                        | Utf8      | false       |
+| service_stack_types | is_build                        | Boolean   | false       |
+| service_stack_types | is_runtime                      | Boolean   | false       |
+| service_stack_types | is_managed                      | Boolean   | false       |
+| service_stack_types | has_backup                      | Boolean   | false       |
+| service_stack_types | has_access_details              | Boolean   | false       |
+| service_stack_types | has_configuration               | Boolean   | false       |
+| service_stack_types | os_list                         | Json      | false       |
+| service_stack_types | mode_list                       | Json      | false       |
+| service_stack_types | service_stack_type_version_list | Json      | false       |
+| service_stack_types | created                         | Timestamp | false       |
+| service_stack_types | last_update                     | Timestamp | false       |
+| user_token          | id                              | Utf8      | false       |
+| user_token          | name                            | Utf8      | true        |
+| user_token          | created                         | Timestamp | false       |
+| user_tokens         | id                              | Utf8      | false       |
+| user_tokens         | name                            | Utf8      | true        |
+| user_tokens         | created                         | Timestamp | false       |
++---------------------+---------------------------------+-----------+-------------+
 ```
 
 #### Confirm input discovery
@@ -365,21 +378,44 @@ Output:
 Command:
 
 ```bash
-coral sql "SELECT id, name, category, is_runtime, is_managed, has_backup FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 5"
+coral sql "SELECT id, name, category, is_runtime, is_managed, has_backup FROM zerops.service_stack_types WHERE is_runtime = true ORDER BY id LIMIT 10"
 ```
 
 Output:
 
 ```text
-+--------+--------+----------+------------+------------+------------+
-| id     | name   | category | is_runtime | is_managed | has_backup |
-+--------+--------+----------+------------+------------+------------+
-| alpine | Alpine | USER     | true       | false      | false      |
-| bun    | Bun    | USER     | false      | false      | false      |
-| deno   | Deno   | USER     | true       | false      | false      |
-| docker | Docker | USER     | true       | false      | false      |
-| dotnet | .NET   | USER     | true       | false      | false      |
-+--------+--------+----------+------------+------------+------------+
++--------+--------------+----------+------------+------------+------------+
+| id     | name         | category | is_runtime | is_managed | has_backup |
++--------+--------------+----------+------------+------------+------------+
+| alpine | Alpine       | USER     | true       | false      | false      |
+| bun    | Bun          | USER     | true       | false      | false      |
+| deno   | Deno         | USER     | true       | false      | false      |
+| docker | Docker       | USER     | true       | false      | false      |
+| dotnet | .NET         | USER     | true       | false      | false      |
+| elixir | Elixir       | USER     | true       | false      | false      |
+| gleam  | Gleam        | USER     | true       | false      | false      |
+| golang | Golang       | USER     | true       | false      | false      |
+| java   | Java         | USER     | true       | false      | false      |
+| nginx  | Nginx static | USER     | true       | false      | false      |
++--------+--------------+----------+------------+------------+------------+
+```
+
+#### Run a live single service stack type query
+
+Command:
+
+```bash
+coral sql "SELECT id, name, category, is_runtime FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1"
+```
+
+Output:
+
+```text
++--------+--------+----------+------------+
+| id     | name   | category | is_runtime |
++--------+--------+----------+------------+
+| alpine | Alpine | USER     | true       |
++--------+--------+----------+------------+
 ```
 
 #### Run a live managed services query
@@ -473,6 +509,9 @@ Output:
 - The `service_stack_type_versions` are exposed as a nested JSON column on
   `service_stack_types`; a dedicated flattened versions table can be added in
   a follow-up version once the consumption pattern stabilizes.
+- The Zerops `service_stack_types.description` field is sometimes a literal
+  `"todo"` placeholder from the provider. This is a provider data quality
+  issue, not a source bug.
 - Available regions, service stack types, token metadata, and error responses
   depend on the Zerops account, the personal access token permissions, and the
   current provider API.

--- a/sources/community/zerops/README.md
+++ b/sources/community/zerops/README.md
@@ -469,25 +469,6 @@ Output:
 +----------------+----------------+----------------------+
 ```
 
-## Implementation notes
-
-- Uses Coral source-spec DSL v3 with the HTTP backend.
-- Uses `HeaderAuth` with `Authorization: Bearer {{input.ZEROPS_API_KEY}}`.
-- `base_url` defaults to `https://api.app-prg1.zerops.io/api/rest/public` and is
-  overridable via the `ZEROPS_BASE_URL` variable input for non-default regions.
-- Maps `GET /region` response rows from the `items` array into `zerops.regions`.
-- Maps `GET /settings` response rows from the `serviceStackList` array into
-  `zerops.service_stack_types`, including the nested
-  `serviceStackTypeVersionList` as a JSON column for downstream expansion.
-- Maps coralCase JSON keys (`isRuntime`, `hasBackup`, `docsUrl`, `lastUpdate`,
-  ...) onto snake_case columns through explicit `expr: path` entries.
-- Maps ISO 8601 `created` and `lastUpdate` timestamps into Arrow `Timestamp`
-  columns through `format_timestamp: input: iso8601` wrappers.
-- Maps `GET /user-token/list` response rows from the `list` array into
-  `zerops.user_tokens`, and `GET /user-token/{id}` directly into
-  `zerops.user_token`.
-- Does not require runtime, CLI, MCP, or UI changes.
-
 ## Limitations
 
 - This source is read/query oriented and does not manage Zerops projects or

--- a/sources/community/zerops/README.md
+++ b/sources/community/zerops/README.md
@@ -8,7 +8,7 @@ services Zerops supports, and audit their own access tokens through SQL.
 **Version:** 0.1.0
 **Backend:** HTTP
 **Tables:** 4
-**Base URL:** `https://api.app-prg1.zerops.io/api/rest/public`
+**Base URL (default):** `https://api.app-prg1.zerops.io/api/rest/public`
 
 ## Why this source
 
@@ -46,8 +46,10 @@ You can also copy `manifest.yaml` into another workspace and pass that path to
 
 Create a personal access token from the Zerops GUI:
 
-1. Log in to the Zerops dashboard at <https://app-prg1.zerops.io/> (the
-   default prg1 region; other regions use the same path on their own host).
+1. Log in to the Zerops dashboard. The default prg1 region is at
+   <https://app-prg1.zerops.io/>; the other supported regions are
+   <https://app-ny1.zerops.io/> (US East, ny1) and
+   <https://app-sea1.zerops.io/> (US West, sea1).
 2. Open the user menu and go to **Access Token management**.
 3. Create a new personal access token and copy it.
 
@@ -68,8 +70,16 @@ Interactive install also works:
 coral source add --interactive --file sources/community/zerops/manifest.yaml
 ```
 
-The default API base URL is `https://api.app-prg1.zerops.io/api/rest/public`.
-Set `ZEROPS_BASE_URL` to point Coral at a different region when needed.
+The default HTTP host is `api.app-prg1.zerops.io`. The full base URL is
+constructed by the manifest as `https://{ZEROPS_HOST}/api/rest/public`, so
+for a non-default region set `ZEROPS_HOST` to one of:
+
+- `api.app-prg1.zerops.io` (default)
+- `api.app-ny1.zerops.io`
+- `api.app-sea1.zerops.io`
+
+Do not include the scheme or the `/api/rest/public` path; the manifest
+prepends `https://` and appends the path automatically.
 
 ## Provider docs
 
@@ -90,7 +100,7 @@ Set `ZEROPS_BASE_URL` to point Coral at a different region when needed.
 ### `zerops.regions`
 
 Lists the regions Zerops exposes through `GET /region`. The `address` column
-is the API host for that region — pass it as `ZEROPS_BASE_URL` when targeting
+is the bare API host for that region — pass it as `ZEROPS_HOST` when targeting
 a non-default region.
 
 ```sql
@@ -303,25 +313,25 @@ Output:
 | service_stack_types | name                            | Utf8      | false       |
 | service_stack_types | description                     | Utf8      | true        |
 | service_stack_types | category                        | Utf8      | true        |
-| service_stack_types | subcategory                     | Utf8      | false       |
-| service_stack_types | docs_url                        | Utf8      | false       |
-| service_stack_types | is_build                        | Boolean   | false       |
-| service_stack_types | is_runtime                      | Boolean   | false       |
-| service_stack_types | is_managed                      | Boolean   | false       |
-| service_stack_types | has_backup                      | Boolean   | false       |
-| service_stack_types | has_access_details              | Boolean   | false       |
-| service_stack_types | has_configuration               | Boolean   | false       |
-| service_stack_types | os_list                         | Json      | false       |
-| service_stack_types | mode_list                       | Json      | false       |
-| service_stack_types | service_stack_type_version_list | Json      | false       |
-| service_stack_types | created                         | Timestamp | false       |
-| service_stack_types | last_update                     | Timestamp | false       |
+| service_stack_types | subcategory                     | Utf8      | true        |
+| service_stack_types | docs_url                        | Utf8      | true        |
+| service_stack_types | is_build                        | Boolean   | true        |
+| service_stack_types | is_runtime                      | Boolean   | true        |
+| service_stack_types | is_managed                      | Boolean   | true        |
+| service_stack_types | has_backup                      | Boolean   | true        |
+| service_stack_types | has_access_details              | Boolean   | true        |
+| service_stack_types | has_configuration               | Boolean   | true        |
+| service_stack_types | os_list                         | Json      | true        |
+| service_stack_types | mode_list                       | Json      | true        |
+| service_stack_types | service_stack_type_version_list | Json      | true        |
+| service_stack_types | created                         | Timestamp | true        |
+| service_stack_types | last_update                     | Timestamp | true        |
 | user_token          | id                              | Utf8      | false       |
 | user_token          | name                            | Utf8      | true        |
-| user_token          | created                         | Timestamp | false       |
+| user_token          | created                         | Timestamp | true        |
 | user_tokens         | id                              | Utf8      | false       |
 | user_tokens         | name                            | Utf8      | true        |
-| user_tokens         | created                         | Timestamp | false       |
+| user_tokens         | created                         | Timestamp | true        |
 +---------------------+---------------------------------+-----------+-------------+
 ```
 
@@ -336,12 +346,12 @@ coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'zer
 Output:
 
 ```text
-+-----------------+----------+----------+
-| key             | kind     | required |
-+-----------------+----------+----------+
-| ZEROPS_API_KEY  | secret   | true     |
-| ZEROPS_BASE_URL | variable | false    |
-+-----------------+----------+----------+
++----------------+----------+----------+
+| key            | kind     | required |
++----------------+----------+----------+
+| ZEROPS_API_KEY | secret   | true     |
+| ZEROPS_HOST    | variable | false    |
++----------------+----------+----------+
 ```
 
 #### Run a live regions query

--- a/sources/community/zerops/README.md
+++ b/sources/community/zerops/README.md
@@ -134,7 +134,7 @@ Looks up one personal access token by ID via `GET /user-token/{id}`.
 
 ```sql
 SELECT id, name, created FROM zerops.user_token
-WHERE id = 'MayA8Q6URQSwAoWAqqARmA';
+WHERE id = 'your_token_id';
 ```
 
 ## Validation
@@ -152,8 +152,7 @@ coral source test zerops
 ```
 
 The declared test queries cover region discovery, runtime stack filtering,
-a single service stack type lookup, a user-token list, and a
-single-user-token lookup:
+a single service stack type lookup, and a user-token list:
 
 ```sql
 SELECT name, address, is_default FROM zerops.regions;
@@ -168,10 +167,6 @@ WHERE id = 'alpine'
 LIMIT 1;
 
 SELECT id, name, created FROM zerops.user_tokens LIMIT 10;
-
-SELECT id, name, created FROM zerops.user_token
-WHERE id = 'MayA8Q6URQSwAoWAqqARmA'
-LIMIT 1;
 ```
 
 ### Live validation output
@@ -216,7 +211,7 @@ Validating source...
     ├─ user_token
     └─ user_tokens
     Query tests
-    5 declared · 5 passed · 0 failed
+    4 declared · 4 passed · 0 failed
 
     ✓ SELECT name, address, is_default FROM zerops.regions
       1 row
@@ -228,9 +223,6 @@ Validating source...
       1 row
 
     ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 10
-      1 row
-
-    ✓ SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1
       1 row
 ```
 
@@ -254,7 +246,7 @@ Output:
     ├─ user_token
     └─ user_tokens
     Query tests
-    5 declared · 5 passed · 0 failed
+    4 declared · 4 passed · 0 failed
 
     ✓ SELECT name, address, is_default FROM zerops.regions
       1 row
@@ -266,9 +258,6 @@ Output:
       1 row
 
     ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 10
-      1 row
-
-    ✓ SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1
       1 row
 ```
 
@@ -455,11 +444,11 @@ coral sql "SELECT id, name, created FROM zerops.user_tokens"
 Output:
 
 ```text
-+------------------------+-------+----------------------+
-| id                     | name  | created              |
-+------------------------+-------+----------------------+
-| MayA8Q6URQSwAoWAqqARmA | login | 2026-08-09T00:46:53Z |
-+------------------------+-------+----------------------+
++----------------+----------------+----------------------+
+| id             | name           | created              |
++----------------+----------------+----------------------+
+| your_token_id  | your_token_name | your_token_created   |
++----------------+----------------+----------------------+
 ```
 
 #### Run a live single user token query
@@ -467,17 +456,17 @@ Output:
 Command:
 
 ```bash
-coral sql "SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA'"
+coral sql "SELECT id, name, created FROM zerops.user_token WHERE id = 'your_token_id'"
 ```
 
 Output:
 
 ```text
-+------------------------+-------+----------------------+
-| id                     | name  | created              |
-+------------------------+-------+----------------------+
-| MayA8Q6URQSwAoWAqqARmA | login | 2026-08-09T00:46:53Z |
-+------------------------+-------+----------------------+
++----------------+----------------+----------------------+
+| id             | name           | created              |
++----------------+----------------+----------------------+
+| your_token_id  | your_token_name | your_token_created   |
++----------------+----------------+----------------------+
 ```
 
 ## Implementation notes

--- a/sources/community/zerops/manifest.yaml
+++ b/sources/community/zerops/manifest.yaml
@@ -1,0 +1,282 @@
+name: zerops
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query Zerops regions, supported service stack types, and personal access tokens.
+base_url: https://api.app-prg1.zerops.io/api/rest/public
+inputs:
+  ZEROPS_API_KEY:
+    kind: secret
+    hint: |
+      Zerops personal access token from the Zerops GUI
+      Access Token management section.
+
+      The token is sent as a Bearer token to the Zerops REST API.
+
+      See https://docs.zerops.io/references/api for the API reference.
+  ZEROPS_BASE_URL:
+    kind: variable
+    default: https://api.app-prg1.zerops.io/api/rest/public
+    hint: |
+      Base URL for the Zerops REST API region. Defaults to the prg1
+      region. Use the region that matches where your token was issued.
+      See https://docs.zerops.io/references/api for the list of regions.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: bearer
+      key: ZEROPS_API_KEY
+test_queries:
+  - SELECT name, address, is_default FROM zerops.regions
+  - "SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10"
+  - SELECT id, name, created FROM zerops.user_tokens LIMIT 10
+  - "SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1"
+tables:
+  - name: regions
+    description: Zerops datacenters/regions exposed by the region API.
+    guide: |
+      No required filters. Start with:
+        SELECT name, address, is_default FROM zerops.regions
+    request:
+      method: GET
+      path: /region
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Region identifier (for example prg1).
+      - name: address
+        type: Utf8
+        nullable: false
+        description: API host for the region.
+      - name: is_default
+        type: Boolean
+        nullable: false
+        description: Whether this region is the default region.
+        expr:
+          kind: path
+          path:
+            - isDefault
+  - name: service_stack_types
+    description: |
+      Supported Zerops service stack types (runtimes, databases, storage)
+      with their capabilities and nested version list.
+    guide: |
+      No required filters. Start with:
+        SELECT id, name, category, is_runtime, is_managed
+        FROM zerops.service_stack_types
+      Filter by capability:
+        SELECT id, name
+        FROM zerops.service_stack_types
+        WHERE is_managed = true AND has_backup = true
+    request:
+      method: GET
+      path: /settings
+    response:
+      rows_path:
+        - serviceStackList
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Service stack type identifier.
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Human-readable service stack type name.
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Long description of the service stack type.
+      - name: category
+        type: Utf8
+        nullable: true
+        description: Service stack category (USER, STANDARD, OBJECT_STORAGE, SHARED_STORAGE, BUILD, PREPARE_RUNTIME).
+      - name: subcategory
+        type: Utf8
+        nullable: true
+        description: Service stack subcategory.
+      - name: docs_url
+        type: Utf8
+        nullable: true
+        description: Link to the upstream documentation page.
+        expr:
+          kind: path
+          path:
+            - docsUrl
+      - name: is_build
+        type: Boolean
+        nullable: true
+        description: Whether this stack type is a build environment.
+        expr:
+          kind: path
+          path:
+            - isBuild
+      - name: is_runtime
+        type: Boolean
+        nullable: true
+        description: Whether this stack type runs user code.
+        expr:
+          kind: path
+          path:
+            - isRuntime
+      - name: is_managed
+        type: Boolean
+        nullable: true
+        description: Whether Zerops fully manages the service.
+        expr:
+          kind: path
+          path:
+            - isManaged
+      - name: has_backup
+        type: Boolean
+        nullable: true
+        description: Whether the service supports backups.
+        expr:
+          kind: path
+          path:
+            - hasBackup
+      - name: has_access_details
+        type: Boolean
+        nullable: true
+        description: Whether the service exposes access details.
+        expr:
+          kind: path
+          path:
+            - hasAccessDetails
+      - name: has_configuration
+        type: Boolean
+        nullable: true
+        description: Whether the service has user-configurable settings.
+        expr:
+          kind: path
+          path:
+            - hasConfiguration
+      - name: os_list
+        type: Json
+        nullable: true
+        description: Supported host OS identifiers (for example alpine, ubuntu).
+        expr:
+          kind: path
+          path:
+            - osList
+      - name: mode_list
+        type: Json
+        nullable: true
+        description: Supported service modes (for example ha, single).
+        expr:
+          kind: path
+          path:
+            - modeList
+      - name: service_stack_type_version_list
+        type: Json
+        nullable: true
+        description: Nested list of versions for this service stack type.
+        expr:
+          kind: path
+          path:
+            - serviceStackTypeVersionList
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the service stack type was registered (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: last_update
+        type: Timestamp
+        nullable: true
+        description: When the service stack type was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - lastUpdate
+  - name: user_tokens
+    description: Personal access tokens issued for the current Zerops user.
+    guide: |
+      No required filters. Start with:
+        SELECT id, name, created FROM zerops.user_tokens
+      Use the id to look up a single token:
+        SELECT id, name, created FROM zerops.user_token
+        WHERE id = 'your-token-id'
+    request:
+      method: GET
+      path: /user-token/list
+    response:
+      rows_path:
+        - list
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Token identifier.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User-defined token name.
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the token was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+  - name: user_token
+    description: A single Zerops personal access token by ID.
+    guide: |
+      id is required. List tokens first to find the id:
+        SELECT id, name FROM zerops.user_tokens LIMIT 10
+      Then look up one token:
+        SELECT id, name, created FROM zerops.user_token
+        WHERE id = 'your-token-id'
+    filters:
+      - name: id
+        required: true
+    request:
+      method: GET
+      path: /user-token/{{filter.id}}
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Token identifier.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User-defined token name.
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the token was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created

--- a/sources/community/zerops/manifest.yaml
+++ b/sources/community/zerops/manifest.yaml
@@ -22,18 +22,19 @@ inputs:
     kind: variable
     default: api.app-prg1.zerops.io
     hint: |
-      Zerops REST API host for your region. Defaults to the prg1 region
-      host. For other regions, set one of the supported hosts:
+      Zerops REST API host. The public region API currently reports a single
+      region (prg1), so the default host is the only host verified to work:
 
-      - prg1: api.app-prg1.zerops.io (default)
-      - ny1:  api.app-ny1.zerops.io
-      - sea1: api.app-sea1.zerops.io
+      - api.app-prg1.zerops.io (default)
+
+      Use the zerops.regions table to discover the hosts the region API
+      actually exposes instead of assuming additional hosts exist.
 
       Do not include the scheme or the /api/rest/public path — the
       manifest prepends `https://` and appends `/api/rest/public`
       automatically.
 
-      See https://docs.zerops.io/references/api for the list of regions.
+      See https://docs.zerops.io/references/api for the API reference.
 auth:
   type: HeaderAuth
   headers:

--- a/sources/community/zerops/manifest.yaml
+++ b/sources/community/zerops/manifest.yaml
@@ -104,7 +104,9 @@ tables:
       - name: category
         type: Utf8
         nullable: true
-        description: Service stack category (CORE, HTTP_L7_BALANCER, STANDARD, USER, SHARED_STORAGE, OBJECT_STORAGE, BUILD, INTERNAL, PREPARE_RUNTIME).
+        description: >
+          Service stack category (CORE, HTTP_L7_BALANCER, STANDARD, USER,
+          SHARED_STORAGE, OBJECT_STORAGE, BUILD, INTERNAL, PREPARE_RUNTIME).
       - name: subcategory
         type: Utf8
         nullable: false

--- a/sources/community/zerops/manifest.yaml
+++ b/sources/community/zerops/manifest.yaml
@@ -3,7 +3,7 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: Query Zerops regions, supported service stack types, and personal access tokens.
-base_url: "{{input.ZEROPS_BASE_URL}}"
+base_url: "https://{{input.ZEROPS_HOST}}/api/rest/public"
 inputs:
   ZEROPS_API_KEY:
     kind: secret
@@ -18,12 +18,21 @@ inputs:
       The token is sent as a Bearer token to the Zerops REST API.
 
       See https://docs.zerops.io/references/api for the API reference.
-  ZEROPS_BASE_URL:
+  ZEROPS_HOST:
     kind: variable
-    default: https://api.app-prg1.zerops.io/api/rest/public
+    default: api.app-prg1.zerops.io
     hint: |
-      Base URL for the Zerops REST API region. Defaults to the prg1
-      region. Use the region that matches where your token was issued.
+      Zerops REST API host for your region. Defaults to the prg1 region
+      host. For other regions, set one of the supported hosts:
+
+      - prg1: api.app-prg1.zerops.io (default)
+      - ny1:  api.app-ny1.zerops.io
+      - sea1: api.app-sea1.zerops.io
+
+      Do not include the scheme or the /api/rest/public path — the
+      manifest prepends `https://` and appends `/api/rest/public`
+      automatically.
+
       See https://docs.zerops.io/references/api for the list of regions.
 auth:
   type: HeaderAuth
@@ -35,7 +44,7 @@ test_queries:
   - SELECT name, address, is_default FROM zerops.regions
   - "SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10"
   - "SELECT id, name FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1"
-  - SELECT id, name, created FROM zerops.user_tokens LIMIT 10
+  - SELECT id, name, created FROM zerops.user_tokens LIMIT 5
 tables:
   - name: regions
     description: Zerops datacenters/regions exposed by the region API.
@@ -108,11 +117,11 @@ tables:
           SHARED_STORAGE, OBJECT_STORAGE, BUILD, INTERNAL, PREPARE_RUNTIME).
       - name: subcategory
         type: Utf8
-        nullable: false
+        nullable: true
         description: Service stack subcategory.
       - name: docs_url
         type: Utf8
-        nullable: false
+        nullable: true
         description: Link to the upstream documentation page.
         expr:
           kind: path
@@ -120,7 +129,7 @@ tables:
             - docsUrl
       - name: is_build
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether this stack type is a build environment.
         expr:
           kind: path
@@ -128,7 +137,7 @@ tables:
             - isBuild
       - name: is_runtime
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether this stack type runs user code.
         expr:
           kind: path
@@ -136,7 +145,7 @@ tables:
             - isRuntime
       - name: is_managed
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether Zerops fully manages the service.
         expr:
           kind: path
@@ -144,7 +153,7 @@ tables:
             - isManaged
       - name: has_backup
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether the service supports backups.
         expr:
           kind: path
@@ -152,7 +161,7 @@ tables:
             - hasBackup
       - name: has_access_details
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether the service exposes access details.
         expr:
           kind: path
@@ -160,7 +169,7 @@ tables:
             - hasAccessDetails
       - name: has_configuration
         type: Boolean
-        nullable: false
+        nullable: true
         description: Whether the service has user-configurable settings.
         expr:
           kind: path
@@ -168,7 +177,7 @@ tables:
             - hasConfiguration
       - name: os_list
         type: Json
-        nullable: false
+        nullable: true
         description: Supported host OS identifiers (for example alpine, ubuntu).
         expr:
           kind: path
@@ -176,7 +185,7 @@ tables:
             - osList
       - name: mode_list
         type: Json
-        nullable: false
+        nullable: true
         description: Supported service modes (for example ha, single).
         expr:
           kind: path
@@ -184,7 +193,7 @@ tables:
             - modeList
       - name: service_stack_type_version_list
         type: Json
-        nullable: false
+        nullable: true
         description: Nested list of versions for this service stack type.
         expr:
           kind: path
@@ -192,7 +201,7 @@ tables:
             - serviceStackTypeVersionList
       - name: created
         type: Timestamp
-        nullable: false
+        nullable: true
         description: When the service stack type was registered (ISO 8601).
         expr:
           kind: format_timestamp
@@ -203,7 +212,7 @@ tables:
               - created
       - name: last_update
         type: Timestamp
-        nullable: false
+        nullable: true
         description: When the service stack type was last updated (ISO 8601).
         expr:
           kind: format_timestamp
@@ -219,7 +228,7 @@ tables:
         SELECT id, name, created FROM zerops.user_tokens
       Use the id to look up a single token:
         SELECT id, name, created FROM zerops.user_token
-        WHERE id = 'your-token-id'
+        WHERE id = 'your_token_id'
     request:
       method: GET
       path: /user-token/list
@@ -239,7 +248,7 @@ tables:
         description: User-defined token name.
       - name: created
         type: Timestamp
-        nullable: false
+        nullable: true
         description: When the token was created (ISO 8601).
         expr:
           kind: format_timestamp
@@ -255,7 +264,7 @@ tables:
         SELECT id, name FROM zerops.user_tokens LIMIT 10
       Then look up one token:
         SELECT id, name, created FROM zerops.user_token
-        WHERE id = 'your-token-id'
+        WHERE id = 'your_token_id'
     filters:
       - name: id
         required: true
@@ -277,7 +286,7 @@ tables:
         description: User-defined token name.
       - name: created
         type: Timestamp
-        nullable: false
+        nullable: true
         description: When the token was created (ISO 8601).
         expr:
           kind: format_timestamp

--- a/sources/community/zerops/manifest.yaml
+++ b/sources/community/zerops/manifest.yaml
@@ -11,6 +11,10 @@ inputs:
       Zerops personal access token from the Zerops GUI
       Access Token management section.
 
+      For the default prg1 region the GUI lives at
+      https://app-prg1.zerops.io/ — open the user menu and choose
+      Access Token management to create a new personal access token.
+
       The token is sent as a Bearer token to the Zerops REST API.
 
       See https://docs.zerops.io/references/api for the API reference.
@@ -30,6 +34,7 @@ auth:
 test_queries:
   - SELECT name, address, is_default FROM zerops.regions
   - "SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10"
+  - "SELECT id, name FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1"
   - SELECT id, name, created FROM zerops.user_tokens LIMIT 10
   - "SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1"
 tables:
@@ -99,14 +104,14 @@ tables:
       - name: category
         type: Utf8
         nullable: true
-        description: Service stack category (USER, STANDARD, OBJECT_STORAGE, SHARED_STORAGE, BUILD, PREPARE_RUNTIME).
+        description: Service stack category (CORE, HTTP_L7_BALANCER, STANDARD, USER, SHARED_STORAGE, OBJECT_STORAGE, BUILD, INTERNAL, PREPARE_RUNTIME).
       - name: subcategory
         type: Utf8
-        nullable: true
+        nullable: false
         description: Service stack subcategory.
       - name: docs_url
         type: Utf8
-        nullable: true
+        nullable: false
         description: Link to the upstream documentation page.
         expr:
           kind: path
@@ -114,7 +119,7 @@ tables:
             - docsUrl
       - name: is_build
         type: Boolean
-        nullable: true
+        nullable: false
         description: Whether this stack type is a build environment.
         expr:
           kind: path
@@ -122,7 +127,7 @@ tables:
             - isBuild
       - name: is_runtime
         type: Boolean
-        nullable: true
+        nullable: false
         description: Whether this stack type runs user code.
         expr:
           kind: path
@@ -130,7 +135,7 @@ tables:
             - isRuntime
       - name: is_managed
         type: Boolean
-        nullable: true
+        nullable: false
         description: Whether Zerops fully manages the service.
         expr:
           kind: path
@@ -138,7 +143,7 @@ tables:
             - isManaged
       - name: has_backup
         type: Boolean
-        nullable: true
+        nullable: false
         description: Whether the service supports backups.
         expr:
           kind: path
@@ -146,7 +151,7 @@ tables:
             - hasBackup
       - name: has_access_details
         type: Boolean
-        nullable: true
+        nullable: false
         description: Whether the service exposes access details.
         expr:
           kind: path
@@ -154,7 +159,7 @@ tables:
             - hasAccessDetails
       - name: has_configuration
         type: Boolean
-        nullable: true
+        nullable: false
         description: Whether the service has user-configurable settings.
         expr:
           kind: path
@@ -162,7 +167,7 @@ tables:
             - hasConfiguration
       - name: os_list
         type: Json
-        nullable: true
+        nullable: false
         description: Supported host OS identifiers (for example alpine, ubuntu).
         expr:
           kind: path
@@ -170,7 +175,7 @@ tables:
             - osList
       - name: mode_list
         type: Json
-        nullable: true
+        nullable: false
         description: Supported service modes (for example ha, single).
         expr:
           kind: path
@@ -178,7 +183,7 @@ tables:
             - modeList
       - name: service_stack_type_version_list
         type: Json
-        nullable: true
+        nullable: false
         description: Nested list of versions for this service stack type.
         expr:
           kind: path
@@ -186,7 +191,7 @@ tables:
             - serviceStackTypeVersionList
       - name: created
         type: Timestamp
-        nullable: true
+        nullable: false
         description: When the service stack type was registered (ISO 8601).
         expr:
           kind: format_timestamp
@@ -197,7 +202,7 @@ tables:
               - created
       - name: last_update
         type: Timestamp
-        nullable: true
+        nullable: false
         description: When the service stack type was last updated (ISO 8601).
         expr:
           kind: format_timestamp
@@ -233,7 +238,7 @@ tables:
         description: User-defined token name.
       - name: created
         type: Timestamp
-        nullable: true
+        nullable: false
         description: When the token was created (ISO 8601).
         expr:
           kind: format_timestamp
@@ -271,7 +276,7 @@ tables:
         description: User-defined token name.
       - name: created
         type: Timestamp
-        nullable: true
+        nullable: false
         description: When the token was created (ISO 8601).
         expr:
           kind: format_timestamp

--- a/sources/community/zerops/manifest.yaml
+++ b/sources/community/zerops/manifest.yaml
@@ -3,7 +3,7 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: Query Zerops regions, supported service stack types, and personal access tokens.
-base_url: https://api.app-prg1.zerops.io/api/rest/public
+base_url: "{{input.ZEROPS_BASE_URL}}"
 inputs:
   ZEROPS_API_KEY:
     kind: secret
@@ -36,7 +36,6 @@ test_queries:
   - "SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10"
   - "SELECT id, name FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1"
   - SELECT id, name, created FROM zerops.user_tokens LIMIT 10
-  - "SELECT id, name, created FROM zerops.user_token WHERE id = 'MayA8Q6URQSwAoWAqqARmA' LIMIT 1"
 tables:
   - name: regions
     description: Zerops datacenters/regions exposed by the region API.


### PR DESCRIPTION
## Summary

Adds a `zerops` community source that lets Coral users query Zerops' public REST API through SQL: regions, supported service stack types with capability flags and nested version lists, and personal access tokens for audit and rotation workflows.

## What changed

- Added `sources/community/zerops/manifest.yaml`
- Added `sources/community/zerops/README.md`

## Source scope

| Table | Purpose | Required filters |
| --- | --- | --- |
| `zerops.regions` | Lists Zerops regions from `GET /region`. | None |
| `zerops.service_stack_types` | Lists supported service stack types from `GET /settings`. | None |
| `zerops.user_tokens` | Lists personal access tokens from `GET /user-token/list`. | None |
| `zerops.user_token` | Fetches one personal access token from `GET /user-token/{id}`. | `id` |

## Provider docs

- Zerops REST API reference: https://docs.zerops.io/references/api
- Zerops introduction: https://docs.zerops.io
- Zerops CLI (`zCLI`): https://docs.zerops.io/references/cli
- Zerops YAML spec: https://docs.zerops.io/zerops-yaml/specification

## Validation

Validated with a real `ZEROPS_API_KEY` against the prg1 region. The key is not
committed or printed. Account-specific identifiers (token IDs, names, and
creation timestamps) are replaced with `your_token_id` / `your_token_name` /
`your_token_created` placeholders in the proof output below.

### 1. Manifest lint

Command:

```bash
coral source lint sources/community/zerops/manifest.yaml
```

Output:

```text
Manifest is valid
```

### 2. Source add and declared query tests

Command:

```bash
coral source add --file sources/community/zerops/manifest.yaml
```

Output:

```text
Added source zerops (secrets: keychain)
Validating source...

  ✓ zerops connected successfully
  Secrets: keychain

    zerops (4 tables)
    ├─ regions
    ├─ service_stack_types
    ├─ user_token
    └─ user_tokens
    Query tests
    4 declared · 4 passed · 0 failed

    ✓ SELECT name, address, is_default FROM zerops.regions
      1 row

    ✓ SELECT id, name, category, is_runtime, is_managed FROM zerops.service_stack_types WHERE is_runtime = true LIMIT 10
      10 rows

    ✓ SELECT id, name FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1
      1 row

    ✓ SELECT id, name, created FROM zerops.user_tokens LIMIT 5
      1 row
```

### 3. Source test (same output, separate command)

Command:

```bash
coral source test zerops
```

Output: identical to step 2 above (4 declared · 4 passed · 0 failed).

### 4. Input discovery

Command:

```bash
coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'zerops' ORDER BY key"
```

Output:

```text
+----------------+----------+----------+
| key            | kind     | required |
+----------------+----------+----------+
| ZEROPS_API_KEY | secret   | true     |
| ZEROPS_HOST    | variable | false    |
+----------------+----------+----------+
```

### 5. Live runtime stack types query

Command:

```bash
coral sql "SELECT id, name, category, is_runtime, is_managed, has_backup FROM zerops.service_stack_types WHERE is_runtime = true ORDER BY id LIMIT 10"
```

Output:

```text
+--------+--------------+----------+------------+------------+------------+
| id     | name         | category | is_runtime | is_managed | has_backup |
+--------+--------------+----------+------------+------------+------------+
| alpine | Alpine       | USER     | true       | false      | false      |
| bun    | Bun          | USER     | true       | false      | false      |
| deno   | Deno         | USER     | true       | false      | false      |
| docker | Docker       | USER     | true       | false      | false      |
| dotnet | .NET         | USER     | true       | false      | false      |
| elixir | Elixir       | USER     | true       | false      | false      |
| gleam  | Gleam        | USER     | true       | false      | false      |
| golang | Golang       | USER     | true       | false      | false      |
| java   | Java         | USER     | true       | false      | false      |
| nginx  | Nginx static | USER     | true       | false      | false      |
+--------+--------------+----------+------------+------------+------------+
```

### 6. Live single service stack type query

Command:

```bash
coral sql "SELECT id, name, category, is_runtime FROM zerops.service_stack_types WHERE id = 'alpine' LIMIT 1"
```

Output:

```text
+--------+--------+----------+------------+
| id     | name   | category | is_runtime |
+--------+--------+----------+------------+
| alpine | Alpine | USER     | true       |
+--------+--------+----------+------------+
```

### 7. Live managed services query

Command:

```bash
coral sql "SELECT id, name, is_managed, has_backup FROM zerops.service_stack_types WHERE is_managed = true AND has_backup = true ORDER BY name"
```

Output:

```text
+----------------+----------------+------------+------------+
| id             | name           | is_managed | has_backup |
+----------------+----------------+------------+------------+
| clickhouse     | ClickHouse     | true       | true       |
| elasticsearch  | Elasticsearch  | true       | true       |
| mariadb        | MariaDB        | true       | true       |
| meilisearch    | Meilisearch    | true       | true       |
| nats           | NATS           | true       | true       |
| postgresql     | PostgreSQL     | true       | true       |
| qdrant         | Qdrant         | true       | true       |
| shared_storage | Shared Storage | true       | true       |
| valkey         | Valkey         | true       | true       |
+----------------+----------------+------------+------------+
```

### 8. Live user token queries

Command:

```bash
coral sql "SELECT id, name, created FROM zerops.user_tokens"
```

Output:

```text
+----------------+----------------+----------------------+
| id             | name           | created              |
+----------------+----------------+----------------------+
| your_token_id  | your_token_name | your_token_created   |
+----------------+----------------+----------------------+
```

Command:

```bash
coral sql "SELECT id, name, created FROM zerops.user_token WHERE id = 'your_token_id'"
```

Output:

```text
+----------------+----------------+----------------------+
| id             | name           | created              |
+----------------+----------------+----------------------+
| your_token_id  | your_token_name | your_token_created   |
+----------------+----------------+----------------------+
```

### 9. Column discovery

Command:

```bash
coral sql "SELECT table_name, column_name, data_type, is_nullable FROM coral.columns WHERE schema_name = 'zerops' ORDER BY table_name, ordinal_position"
```

Output:

```text
+---------------------+---------------------------------+-----------+-------------+
| table_name          | column_name                     | data_type | is_nullable |
+---------------------+---------------------------------+-----------+-------------+
| regions             | name                            | Utf8      | false       |
| regions             | address                         | Utf8      | false       |
| regions             | is_default                      | Boolean   | false       |
| service_stack_types | id                              | Utf8      | false       |
| service_stack_types | name                            | Utf8      | false       |
| service_stack_types | description                     | Utf8      | true        |
| service_stack_types | category                        | Utf8      | true        |
| service_stack_types | subcategory                     | Utf8      | true        |
| service_stack_types | docs_url                        | Utf8      | true        |
| service_stack_types | is_build                        | Boolean   | true        |
| service_stack_types | is_runtime                      | Boolean   | true        |
| service_stack_types | is_managed                      | Boolean   | true        |
| service_stack_types | has_backup                      | Boolean   | true        |
| service_stack_types | has_access_details              | Boolean   | true        |
| service_stack_types | has_configuration               | Boolean   | true        |
| service_stack_types | os_list                         | Json      | true        |
| service_stack_types | mode_list                       | Json      | true        |
| service_stack_types | service_stack_type_version_list | Json      | true        |
| service_stack_types | created                         | Timestamp | true        |
| service_stack_types | last_update                     | Timestamp | true        |
| user_token          | id                              | Utf8      | false       |
| user_token          | name                            | Utf8      | true        |
| user_token          | created                         | Timestamp | true        |
| user_tokens         | id                              | Utf8      | false       |
| user_tokens         | name                            | Utf8      | true        |
| user_tokens         | created                         | Timestamp | true        |
+---------------------+---------------------------------+-----------+-------------+
```

## Note on validation freshness

All validation proof in this PR description was re-captured against the current `add-zerops-source` branch tip (commit `871e8bc`) after the round-2 fixes that:

- Reverted 15 columns from `nullable: false` to `nullable: true` (subcategory, docs_url, is_build, is_runtime, is_managed, has_backup, has_access_details, has_configuration, os_list, mode_list, service_stack_type_version_list, created, last_update on `service_stack_types`; `created` on `user_tokens` / `user_token`).
- Restructured `ZEROPS_BASE_URL` into `ZEROPS_HOST` (host only) with `base_url: "https://{{input.ZEROPS_HOST}}/api/rest/public"`.
- Capped the `user_tokens` test query at `LIMIT 5`.

The round-3 change (commit `871e8bc`) dropped the unverified `ny1`/`sea1` API hosts from the `ZEROPS_HOST` hint and README: the public region API reports only `prg1` and the advertised `api.app-ny1.zerops.io` / `api.app-sea1.zerops.io` hosts do not resolve. It also documented provider-side data quirks surfaced verbatim (KeyDB/MongoDB/RabbitMQ `is_managed = false`, empty subcategories, empty `nodejs` `mode_list`) in the README limitations.

The proof output above was re-verified after this round and still matches the current manifest's `test_queries`, `coral.inputs`, `coral.columns`, and live SQL responses exactly (4 declared · 4 passed · 0 failed, single-row `regions`, 10-row runtime list, 9-row managed list). `coral source lint` is clean.

