### PR TITLE
feat(traces): expose retained Search responses

### DIFF
--- a/apps/coral-ui/buf.gen.yaml
+++ b/apps/coral-ui/buf.gen.yaml
@@ -14,6 +14,7 @@ inputs:
       - ../../crates/coral-api/proto/coral/v1/functions.proto
       - ../../crates/coral-api/proto/coral/v1/gui_onboarding.proto
       - ../../crates/coral-api/proto/coral/v1/query.proto
+      - ../../crates/coral-api/proto/coral/v1/search.proto
       - ../../crates/coral-api/proto/coral/v1/sources.proto
       - ../../crates/coral-api/proto/coral/v1/task.proto
       - ../../crates/coral-api/proto/coral/v1/traces.proto

--- a/crates/coral-api/proto/coral/v1/traces.proto
+++ b/crates/coral-api/proto/coral/v1/traces.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package coral.v1;
 
 import "coral/v1/resources.proto";
+import "coral/v1/search.proto";
 
 // Query status derived from locally captured spans.
 enum TraceStatus {
@@ -173,12 +174,29 @@ message TraceSpan {
   bool is_remote = 22;
 }
 
+// Marker returned when the successful Search response exceeded the local
+// history retention cap.
+message TraceSearchResponseTooLarge {}
+
+// Historical Search outcome retained for one exact Search execution.
+message TraceSearchResponse {
+  // Retained outcome for the historical Search execution.
+  oneof outcome {
+    // Complete public Search response returned by the historical execution.
+    SearchResponse response = 1;
+    // The response was successful but too large to retain.
+    TraceSearchResponseTooLarge too_large = 2;
+  }
+}
+
 // Trace detail for timeline and diagnostic views.
 message GetTraceResponse {
   // Summary for the trace.
   TraceSummary summary = 1;
   // Spans ordered by start time.
   repeated TraceSpan spans = 2;
+  // Historical Search response for a workspace-scoped Query Stream Search.
+  TraceSearchResponse search_response = 3;
 }
 
 // Local trace inspection APIs.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1,9 +1,10 @@
 //! Builds and runs the Coral gRPC server.
 
 use std::net::{Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::feature_service_server::FeatureServiceServer;
@@ -352,9 +353,11 @@ impl ServerBuilder {
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store, &layout).await?;
         let coral_db = Arc::new(coral_db);
-        let (telemetry_config, active_trace_store) =
-            init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
-        let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
+        let telemetry = init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
+        let active_trace_store_dir = telemetry
+            .active_trace_store
+            .as_ref()
+            .map(|store| store.dir.clone());
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -387,7 +390,8 @@ impl ServerBuilder {
         let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
         let task_activity = crate::task::activity::TaskActivityRecorder::new(Arc::clone(&coral_db));
         let query_runtime_context = env.query_runtime_context().with_body_capture_max_bytes(
-            telemetry_config
+            telemetry
+                .config
                 .trace_history
                 .http_body_recording_max_bytes(),
         );
@@ -416,12 +420,8 @@ impl ServerBuilder {
             CatalogDiscovery::new(query_manager.clone()),
             workspace_lifecycle_lock.clone(),
         );
-        let trace_components = init_trace_components(
-            active_trace_store,
-            Arc::clone(&coral_db),
-            workspace_lifecycle_lock,
-            &telemetry_config,
-        );
+        let trace_components =
+            init_trace_components(telemetry, Arc::clone(&coral_db), workspace_lifecycle_lock);
         let dependencies = ServerDependencies {
             gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
             source: source_manager,
@@ -438,35 +438,97 @@ impl ServerBuilder {
     }
 }
 
+struct InitializedServerTelemetry {
+    config: TelemetryConfig,
+    active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
+    search_response_history_binding: SearchResponseHistoryBinding,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchResponseHistoryBinding {
+    Disabled,
+    CaptureOnly,
+    Attached,
+    Incompatible,
+}
+
+impl SearchResponseHistoryBinding {
+    fn capture_enabled(self) -> bool {
+        matches!(self, Self::CaptureOnly | Self::Attached)
+    }
+
+    fn reader_enabled(self) -> bool {
+        self == Self::Attached
+    }
+}
+
 fn init_server_telemetry(
     layout: &AppStateLayout,
     enable_stderr_logs: bool,
-) -> Result<
-    (
-        TelemetryConfig,
-        Option<crate::telemetry::InstalledLocalTraceStore>,
-    ),
-    AppError,
-> {
+) -> Result<InitializedServerTelemetry, AppError> {
     let config = TelemetryConfig::load(layout)?;
     let local_trace_store_dir = config
         .trace_history
         .enabled
         .then(|| layout.local_trace_store_dir());
     let installed_trace_store =
-        crate::telemetry::init_tracing(&config, enable_stderr_logs, local_trace_store_dir)?;
+        crate::telemetry::init_tracing(&config, enable_stderr_logs, local_trace_store_dir.clone())?;
     let active_trace_store = config
         .trace_history
         .enabled
         .then_some(installed_trace_store)
         .flatten();
-    Ok((config, active_trace_store))
+    let configured_retention = config.trace_history.retention();
+    let search_response_history_binding = search_response_history_binding(
+        local_trace_store_dir.as_deref(),
+        configured_retention,
+        active_trace_store.as_ref(),
+    );
+    if let (Some(configured_dir), Some(active_store)) = (
+        local_trace_store_dir.as_deref(),
+        active_trace_store.as_ref(),
+    ) && search_response_history_binding == SearchResponseHistoryBinding::Incompatible
+    {
+        tracing::warn!(
+            configured_trace_store_dir = %configured_dir.display(),
+            active_trace_store_dir = %active_store.dir.display(),
+            ?configured_retention,
+            active_retention = ?active_store.retention,
+            "Search response history is disabled because this server does not match the process-owned trace store"
+        );
+    }
+    Ok(InitializedServerTelemetry {
+        config,
+        active_trace_store,
+        search_response_history_binding,
+    })
+}
+
+fn search_response_history_binding(
+    configured_trace_store_dir: Option<&Path>,
+    configured_retention: Duration,
+    active_trace_store: Option<&crate::telemetry::InstalledLocalTraceStore>,
+) -> SearchResponseHistoryBinding {
+    match (configured_trace_store_dir, active_trace_store) {
+        (None, _) => SearchResponseHistoryBinding::Disabled,
+        (Some(_configured_dir), None) => SearchResponseHistoryBinding::CaptureOnly,
+        (Some(configured_dir), Some(active_store))
+            if configured_dir == active_store.dir
+                && configured_retention == active_store.retention =>
+        {
+            SearchResponseHistoryBinding::Attached
+        }
+        (Some(_configured_dir), Some(_active_store)) => SearchResponseHistoryBinding::Incompatible,
+    }
 }
 
 fn trace_components_for_store(
     active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
+    coral_db: Arc<CoralDb>,
+    search_response_history_retention: Duration,
     search_response_history: SearchResponseHistory,
     search_response_history_worker: SearchResponseHistoryWorker,
+    attach_search_response_history_reader: bool,
 ) -> TraceServerComponents {
     match active_trace_store {
         None => TraceServerComponents {
@@ -474,32 +536,50 @@ fn trace_components_for_store(
             search_response_history_worker: Some(search_response_history_worker),
             ..TraceServerComponents::default()
         },
-        Some(store) => TraceServerComponents {
-            local_trace_store_dir: Some(store.dir.clone()),
-            service: Some(TraceService::new(TraceManager::new(
-                store.dir,
-                store.retention,
-            ))),
-            search_response_history: Some(search_response_history),
-            search_response_history_worker: Some(search_response_history_worker),
-        },
+        Some(store) => {
+            let trace_manager = TraceManager::new(store.dir.clone(), store.retention);
+            let trace_manager = if attach_search_response_history_reader {
+                trace_manager
+                    .with_search_response_history(coral_db, search_response_history_retention)
+            } else {
+                trace_manager
+            };
+            TraceServerComponents {
+                local_trace_store_dir: Some(store.dir),
+                service: Some(TraceService::new(trace_manager)),
+                search_response_history: Some(search_response_history),
+                search_response_history_worker: Some(search_response_history_worker),
+            }
+        }
     }
 }
 
 fn init_trace_components(
-    active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
+    telemetry: InitializedServerTelemetry,
     coral_db: Arc<CoralDb>,
     workspace_lifecycle_lock: WorkspaceLifecycleLock,
-    telemetry_config: &TelemetryConfig,
 ) -> TraceServerComponents {
-    let trace_history = &telemetry_config.trace_history;
+    let InitializedServerTelemetry {
+        config,
+        active_trace_store,
+        search_response_history_binding,
+    } = telemetry;
+    let trace_history = &config.trace_history;
+    let search_response_history_retention = trace_history.retention();
     let (history, worker) = SearchResponseHistory::start(
-        coral_db,
+        Arc::clone(&coral_db),
         workspace_lifecycle_lock,
-        trace_history.enabled,
-        trace_history.retention(),
+        search_response_history_binding.capture_enabled(),
+        search_response_history_retention,
     );
-    trace_components_for_store(active_trace_store, history, worker)
+    trace_components_for_store(
+        active_trace_store,
+        coral_db,
+        search_response_history_retention,
+        history,
+        worker,
+        search_response_history_binding.reader_enabled(),
+    )
 }
 
 async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
@@ -868,7 +948,7 @@ mod tests {
 
     use std::future::Future as _;
     use std::net::{Ipv4Addr, SocketAddr, TcpListener};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
     use std::task::Poll;
     use std::time::Duration;
@@ -891,8 +971,8 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        RunningServer, ServerBuilder, ServerDependencies, ServerMode, TraceServerComponents,
-        start_server,
+        RunningServer, SearchResponseHistoryBinding, ServerBuilder, ServerDependencies, ServerMode,
+        TraceServerComponents, search_response_history_binding, start_server,
     };
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
@@ -921,6 +1001,78 @@ mod tests {
 
     fn default_workspace() -> Workspace {
         workspace_to_proto(&WorkspaceName::default())
+    }
+
+    #[test]
+    fn search_response_history_uses_the_matching_process_trace_store() {
+        let configured_dir = PathBuf::from("matching-trace-store");
+        let configured_retention = Duration::from_mins(1);
+        let active_store = crate::telemetry::InstalledLocalTraceStore {
+            dir: configured_dir.clone(),
+            retention: configured_retention,
+        };
+
+        let binding = search_response_history_binding(
+            Some(configured_dir.as_path()),
+            configured_retention,
+            Some(&active_store),
+        );
+
+        assert_eq!(binding, SearchResponseHistoryBinding::Attached);
+        assert!(binding.capture_enabled());
+        assert!(binding.reader_enabled());
+    }
+
+    #[test]
+    fn search_response_history_rejects_a_different_process_trace_store() {
+        let configured_dir = PathBuf::from("configured-trace-store");
+        let configured_retention = Duration::from_mins(1);
+        let active_store = crate::telemetry::InstalledLocalTraceStore {
+            dir: PathBuf::from("process-trace-store"),
+            retention: configured_retention,
+        };
+
+        let binding = search_response_history_binding(
+            Some(configured_dir.as_path()),
+            configured_retention,
+            Some(&active_store),
+        );
+
+        assert_eq!(binding, SearchResponseHistoryBinding::Incompatible);
+        assert!(!binding.capture_enabled());
+        assert!(!binding.reader_enabled());
+    }
+
+    #[test]
+    fn search_response_history_still_captures_without_a_coral_trace_store() {
+        let binding = search_response_history_binding(
+            Some(Path::new("configured-trace-store")),
+            Duration::from_mins(1),
+            None,
+        );
+
+        assert_eq!(binding, SearchResponseHistoryBinding::CaptureOnly);
+        assert!(binding.capture_enabled());
+        assert!(!binding.reader_enabled());
+    }
+
+    #[test]
+    fn search_response_history_rejects_different_process_retention() {
+        let configured_dir = PathBuf::from("matching-trace-store");
+        let active_store = crate::telemetry::InstalledLocalTraceStore {
+            dir: configured_dir.clone(),
+            retention: Duration::from_mins(1),
+        };
+
+        let binding = search_response_history_binding(
+            Some(configured_dir.as_path()),
+            Duration::from_mins(2),
+            Some(&active_store),
+        );
+
+        assert_eq!(binding, SearchResponseHistoryBinding::Incompatible);
+        assert!(!binding.capture_enabled());
+        assert!(!binding.reader_enabled());
     }
 
     fn disable_internal_tracing(config_dir: &Path) {

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -40,7 +40,7 @@ use crate::search::sqlite_store::{
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
-use crate::telemetry::{app_error_type, record_local_only_span_attribute};
+use crate::telemetry::{SEARCH_SPAN_NAME, app_error_type, record_local_only_span_attribute};
 use crate::workspaces::{
     WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName,
 };
@@ -698,11 +698,11 @@ fn search_execution_identity(span: &tracing::Span) -> Option<SearchExecutionIden
 
 fn create_search_span(request: &SearchRequest, task_id: Option<&TaskId>) -> tracing::Span {
     let span = tracing::info_span!(
-        "coral.search",
+        SEARCH_SPAN_NAME,
         coral.stream.entry = true,
         coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_SEARCH,
         coral.stream.name = "search",
-        otel.name = "coral.search",
+        otel.name = SEARCH_SPAN_NAME,
         operation = "search",
         workspace = field::Empty,
         query_len_bytes = request.query.len(),

--- a/crates/coral-app/src/state/db/repositories/trace_search_responses.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_search_responses.rs
@@ -22,10 +22,6 @@ where
         Self { session }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "next stack layer wires trace reads")
-    )]
     pub(in crate::state::db) async fn get(
         &mut self,
         workspace_id: &str,

--- a/crates/coral-app/src/state/db/trace_search_response_state.rs
+++ b/crates/coral-app/src/state/db/trace_search_response_state.rs
@@ -180,10 +180,6 @@ impl CoralDb {
             .await
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "next stack layer wires trace reads")
-    )]
     pub(crate) async fn get_trace_search_response(
         &self,
         workspace_id: &str,
@@ -301,6 +297,25 @@ impl CoralDb {
             Some(mutation_barrier),
         )
         .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn drop_trace_search_responses_for_test(&self) -> Result<(), DbError> {
+        use super::backend::CoralDbBackend;
+
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                sqlx::query("DROP TABLE trace_search_responses")
+                    .execute(&db.pool)
+                    .await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                sqlx::query("DROP TABLE trace_search_responses")
+                    .execute(&db.pool)
+                    .await?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -1827,7 +1827,7 @@ fn parse_attributes(attributes_json: &str) -> Option<JsonValue> {
     serde_json::from_str(attributes_json).ok()
 }
 
-fn attributes_match_workspace(attributes_json: &str, workspace_name: &str) -> bool {
+pub(super) fn attributes_match_workspace(attributes_json: &str, workspace_name: &str) -> bool {
     workspace_attribute(attributes_json).is_some_and(|workspace| workspace == workspace_name)
 }
 

--- a/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
@@ -8,6 +8,7 @@ use coral_telemetry::{
 use serde_json::Value as JsonValue;
 
 use super::super::{StoredTraceInvocationKind, StoredTraceOperationKind, attr_bool, attr_string};
+use crate::telemetry::SEARCH_SPAN_NAME;
 
 const MCP_METHOD_ATTRIBUTE: &str = "mcp.method";
 const MCP_TOOL_NAME_ATTRIBUTE: &str = "mcp.tool.name";
@@ -77,7 +78,7 @@ fn legacy_query_stream_metadata(
     }
     let (kind, default_name) = match span_name {
         "coral.query" => (StoredTraceOperationKind::Query, "sql"),
-        "coral.search" => (StoredTraceOperationKind::Search, "search"),
+        SEARCH_SPAN_NAME => (StoredTraceOperationKind::Search, "search"),
         _ => return None,
     };
     let name = attributes

--- a/crates/coral-app/src/telemetry/manager.rs
+++ b/crates/coral-app/src/telemetry/manager.rs
@@ -1,10 +1,17 @@
 //! App-level orchestration for local trace inspection.
 
+use std::fmt;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::local_store::{TraceDetailRecord, TraceStore, TraceStoreError, TraceSummaryRecord};
+use crate::state::db::CoralDb;
 use crate::workspaces::WorkspaceName;
+
+mod search_response_history;
+
+use search_response_history::SearchResponseHistoryReader;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TraceListView {
@@ -33,6 +40,30 @@ pub(crate) struct GetTraceQuery {
     pub(crate) view: TraceListView,
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum RetainedSearchResponse {
+    Response(Vec<u8>),
+    TooLarge,
+}
+
+impl fmt::Debug for RetainedSearchResponse {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Response(response_proto) => formatter
+                .debug_struct("Response")
+                .field("response_proto_bytes", &response_proto.len())
+                .finish(),
+            Self::TooLarge => formatter.write_str("TooLarge"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TraceDetail {
+    pub(crate) trace: TraceDetailRecord,
+    pub(crate) search_response: Option<RetainedSearchResponse>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TraceManagerError {
     #[error("trace '{trace_id}' not found")]
@@ -52,14 +83,25 @@ impl From<TraceStoreError> for TraceManagerError {
 
 #[derive(Debug, Clone)]
 pub(crate) struct TraceManager {
+    search_response_history: Option<SearchResponseHistoryReader>,
     traces: TraceStore,
 }
 
 impl TraceManager {
     pub(crate) fn new(trace_store_dir: PathBuf, retention: Duration) -> Self {
         Self {
+            search_response_history: None,
             traces: TraceStore::with_retention(trace_store_dir, retention),
         }
+    }
+
+    pub(crate) fn with_search_response_history(
+        mut self,
+        db: Arc<CoralDb>,
+        retention: Duration,
+    ) -> Self {
+        self.search_response_history = Some(SearchResponseHistoryReader::new(db, retention));
+        self
     }
 
     pub(crate) async fn list_traces(
@@ -102,29 +144,37 @@ impl TraceManager {
     pub(crate) async fn get_trace(
         &self,
         query: GetTraceQuery,
-    ) -> Result<TraceDetailRecord, TraceManagerError> {
+    ) -> Result<TraceDetail, TraceManagerError> {
         let GetTraceQuery {
             trace_id,
             workspace,
             view,
         } = query;
         let workspace = workspace.map(|workspace| workspace.as_str().to_string());
-        match view {
-            TraceListView::All => match workspace {
+        let trace = match view {
+            TraceListView::All => match workspace.as_deref() {
                 Some(workspace) => {
                     self.traces
-                        .get_trace_for_workspace(trace_id, workspace)
+                        .get_trace_for_workspace(trace_id, workspace.to_string())
                         .await
                 }
                 None => self.traces.get_trace(trace_id).await,
             },
             TraceListView::QueryStream => {
                 self.traces
-                    .get_query_stream_trace(trace_id, workspace)
+                    .get_query_stream_trace(trace_id, workspace.clone())
                     .await
             }
         }
-        .map_err(TraceManagerError::from)
+        .map_err(TraceManagerError::from)?;
+        let search_response = match &self.search_response_history {
+            Some(reader) => reader.read(&trace, view, workspace.as_deref()).await,
+            None => None,
+        };
+        Ok(TraceDetail {
+            trace,
+            search_response,
+        })
     }
 }
 
@@ -135,8 +185,22 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
-    use super::{GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError};
+    use super::{
+        GetTraceQuery, ListTracesQuery, RetainedSearchResponse, TraceListView, TraceManager,
+        TraceManagerError,
+    };
     use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn retained_search_response_debug_redacts_payload() {
+        let payload = b"private-search-response".to_vec();
+        let raw_payload_debug = format!("{payload:?}");
+        let debug_output = format!("{:?}", RetainedSearchResponse::Response(payload));
+
+        assert!(!debug_output.contains("private-search-response"));
+        assert!(!debug_output.contains(&raw_payload_debug));
+        assert!(debug_output.contains("response_proto_bytes: 23"));
+    }
 
     #[tokio::test]
     async fn manager_scopes_and_paginates_all_trace_lists() {
@@ -197,7 +261,7 @@ mod tests {
             })
             .await
             .expect("unscoped beta trace");
-        assert_eq!(detail.summary.trace_id, "beta");
+        assert_eq!(detail.trace.summary.trace_id, "beta");
 
         let error = manager
             .get_trace(GetTraceQuery {

--- a/crates/coral-app/src/telemetry/manager/search_response_history.rs
+++ b/crates/coral-app/src/telemetry/manager/search_response_history.rs
@@ -1,0 +1,211 @@
+//! Read-side coordination for retained Search responses.
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use super::{RetainedSearchResponse, TraceListView};
+use crate::state::db::{
+    CoralDb, DbError, TraceSearchResponseOutcome, now_unix_nanos_i64,
+    trace_search_response_retention_bounds,
+};
+use crate::telemetry::SEARCH_SPAN_NAME;
+use crate::telemetry::local_store::{
+    StoredTraceInvocationKind, StoredTraceOperationKind, TraceDetailRecord, TraceSpanRecord,
+    attributes_match_workspace,
+};
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone)]
+pub(super) struct SearchResponseHistoryReader {
+    db: Arc<CoralDb>,
+    retention: Duration,
+    warnings: Arc<ReadWarnings>,
+}
+
+#[derive(Debug, Default)]
+struct ReadWarnings {
+    invalid_clock: AtomicBool,
+    read_failure: AtomicBool,
+}
+
+#[derive(Debug)]
+enum ReadError {
+    Database(DbError),
+    TimedOut,
+}
+
+impl SearchResponseHistoryReader {
+    pub(super) fn new(db: Arc<CoralDb>, retention: Duration) -> Self {
+        Self {
+            db,
+            retention,
+            warnings: Arc::new(ReadWarnings::default()),
+        }
+    }
+
+    pub(super) async fn read(
+        &self,
+        trace: &TraceDetailRecord,
+        view: TraceListView,
+        workspace: Option<&str>,
+    ) -> Option<RetainedSearchResponse> {
+        let workspace = workspace?;
+        let search_span = selected_search_execution(trace, view, workspace)?;
+        let now_unix_nanos = match now_unix_nanos_i64() {
+            Ok(now) => {
+                self.warnings.invalid_clock.store(false, Ordering::Relaxed);
+                now
+            }
+            Err(error) => {
+                if !self.warnings.invalid_clock.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        error = ?error,
+                        "failed to apply Search response history retention"
+                    );
+                }
+                return None;
+            }
+        };
+        let retention_bounds =
+            trace_search_response_retention_bounds(now_unix_nanos, self.retention);
+        let outcome = match bounded_read(
+            self.db.get_trace_search_response(
+                workspace,
+                &trace.summary.trace_id,
+                &search_span.span_id,
+                retention_bounds,
+            ),
+            READ_TIMEOUT,
+        )
+        .await
+        {
+            Ok(outcome) => {
+                self.warnings.read_failure.store(false, Ordering::Relaxed);
+                outcome?
+            }
+            Err(read_error) => {
+                if !self.warnings.read_failure.swap(true, Ordering::Relaxed) {
+                    match read_error {
+                        ReadError::Database(error) => {
+                            tracing::warn!(
+                                error = ?error,
+                                workspace,
+                                trace_id = %trace.summary.trace_id,
+                                search_span_id = %search_span.span_id,
+                                "failed to read Search response history"
+                            );
+                        }
+                        ReadError::TimedOut => {
+                            tracing::warn!(
+                                timeout = ?READ_TIMEOUT,
+                                workspace,
+                                trace_id = %trace.summary.trace_id,
+                                search_span_id = %search_span.span_id,
+                                "timed out reading Search response history"
+                            );
+                        }
+                    }
+                }
+                return None;
+            }
+        };
+        Some(retained_response(outcome))
+    }
+}
+
+async fn bounded_read<F>(
+    read: F,
+    timeout: Duration,
+) -> Result<Option<TraceSearchResponseOutcome>, ReadError>
+where
+    F: Future<Output = Result<Option<TraceSearchResponseOutcome>, DbError>>,
+{
+    tokio::time::timeout(timeout, read)
+        .await
+        .map_err(|_elapsed| ReadError::TimedOut)?
+        .map_err(ReadError::Database)
+}
+
+fn retained_response(outcome: TraceSearchResponseOutcome) -> RetainedSearchResponse {
+    match outcome {
+        TraceSearchResponseOutcome::Response(response) => {
+            RetainedSearchResponse::Response(response)
+        }
+        TraceSearchResponseOutcome::TooLarge { bytes: _ } => RetainedSearchResponse::TooLarge,
+    }
+}
+
+fn selected_search_execution<'a>(
+    trace: &'a TraceDetailRecord,
+    view: TraceListView,
+    workspace: &str,
+) -> Option<&'a TraceSpanRecord> {
+    if view != TraceListView::QueryStream
+        || trace.summary.operation_kind != StoredTraceOperationKind::Search
+    {
+        return None;
+    }
+
+    let selected = match trace.summary.invocation_kind {
+        StoredTraceInvocationKind::Direct => trace.spans.iter().find(|span| {
+            span.span_id == trace.summary.root_span_id && span.name == SEARCH_SPAN_NAME
+        }),
+        StoredTraceInvocationKind::Mcp => nearest_reachable_search_descendant(trace),
+        StoredTraceInvocationKind::Unspecified => None,
+    }?;
+    attributes_match_workspace(&selected.attributes_json, workspace).then_some(selected)
+}
+
+fn nearest_reachable_search_descendant(trace: &TraceDetailRecord) -> Option<&TraceSpanRecord> {
+    // Query Stream attributes descendants of an explicit MCP entry to that root. Detail records do
+    // not retain projector owner IDs, so recover the Search execution through the same parent edges.
+    let spans_by_id = trace
+        .spans
+        .iter()
+        .map(|span| (span.span_id.as_str(), span))
+        .collect::<HashMap<_, _>>();
+    trace
+        .spans
+        .iter()
+        .filter(|span| span.name == SEARCH_SPAN_NAME)
+        .filter_map(|span| {
+            descendant_depth(span, &trace.summary.root_span_id, &spans_by_id)
+                .map(|depth| (depth, span))
+        })
+        .min_by(|(left_depth, left), (right_depth, right)| {
+            left_depth
+                .cmp(right_depth)
+                .then_with(|| left.start_time_unix_nanos.cmp(&right.start_time_unix_nanos))
+                .then_with(|| left.span_id.cmp(&right.span_id))
+        })
+        .map(|(_depth, span)| span)
+}
+
+fn descendant_depth(
+    span: &TraceSpanRecord,
+    root_span_id: &str,
+    spans_by_id: &HashMap<&str, &TraceSpanRecord>,
+) -> Option<usize> {
+    if span.span_id == root_span_id {
+        return Some(0);
+    }
+    let mut depth = 0usize;
+    let mut current = span;
+    let mut visited = HashSet::new();
+    while visited.insert(current.span_id.as_str()) {
+        let parent_span_id = current.parent_span_id.as_deref()?;
+        depth = depth.saturating_add(1);
+        if parent_span_id == root_span_id {
+            return Some(depth);
+        }
+        current = spans_by_id.get(parent_span_id)?;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/telemetry/manager/search_response_history/tests.rs
+++ b/crates/coral-app/src/telemetry/manager/search_response_history/tests.rs
@@ -1,0 +1,540 @@
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use super::{
+    READ_TIMEOUT, ReadError, SearchResponseHistoryReader, bounded_read, selected_search_execution,
+};
+use crate::state::AppStateLayout;
+use crate::state::db::{
+    CoralDb, DatabaseConfig, DbError, DbRepos, ResolvedDatabaseConfig, TraceSearchResponseCapture,
+    TraceSearchResponseInsertResult, TraceSearchResponseOutcome, now_unix_nanos_i64,
+};
+use crate::telemetry::local_store::{
+    StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
+    TraceSpanRecord, TraceSummaryRecord,
+};
+use crate::telemetry::manager::{
+    GetTraceQuery, RetainedSearchResponse, TraceListView, TraceManager,
+};
+use crate::workspaces::WorkspaceName;
+
+#[tokio::test(start_paused = true)]
+async fn read_times_out_at_budget() {
+    let started_at = tokio::time::Instant::now();
+    let result = bounded_read(
+        std::future::pending::<Result<Option<TraceSearchResponseOutcome>, DbError>>(),
+        READ_TIMEOUT,
+    )
+    .await;
+
+    assert!(matches!(result, Err(ReadError::TimedOut)));
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started_at),
+        READ_TIMEOUT
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn read_returns_completed_result() {
+    let outcome = TraceSearchResponseOutcome::Response(vec![1, 2, 3]);
+    let started_at = tokio::time::Instant::now();
+    let result = bounded_read(std::future::ready(Ok(Some(outcome.clone()))), READ_TIMEOUT).await;
+
+    assert_eq!(result.expect("completed history read"), Some(outcome));
+    assert_eq!(tokio::time::Instant::now(), started_at);
+}
+
+#[test]
+fn direct_search_uses_only_the_selected_root_and_requires_its_workspace() {
+    let trace = search_trace(
+        StoredTraceInvocationKind::Direct,
+        "search-root",
+        vec![search_span("search-root", None, 10, "alpha")],
+    );
+    assert_eq!(
+        selected_search_execution(&trace, TraceListView::QueryStream, "alpha")
+            .map(|span| span.span_id.as_str()),
+        Some("search-root")
+    );
+    assert_eq!(
+        selected_search_execution(&trace, TraceListView::QueryStream, "beta"),
+        None
+    );
+    assert_eq!(
+        selected_search_execution(&trace, TraceListView::All, "alpha"),
+        None
+    );
+}
+
+#[test]
+fn mcp_search_selection_follows_parent_edges_and_is_deterministic() {
+    let mut remote_bridge = operation_span("bridge", Some("tool-root"), "grpc.server", 2, "alpha");
+    remote_bridge.parent_span_is_remote = true;
+    let trace = search_trace(
+        StoredTraceInvocationKind::Mcp,
+        "tool-root",
+        vec![
+            operation_span(
+                "tool-root",
+                Some("remote-parent"),
+                "coral.mcp.call_tool",
+                1,
+                "alpha",
+            ),
+            remote_bridge,
+            search_span("z-search", Some("bridge"), 10, "alpha"),
+            search_span("a-search", Some("bridge"), 10, "alpha"),
+            search_span("earlier-search", Some("bridge"), 9, "alpha"),
+            search_span("sibling-search", Some("other-root"), 0, "alpha"),
+        ],
+    );
+
+    assert_eq!(
+        selected_search_execution(&trace, TraceListView::QueryStream, "alpha")
+            .map(|span| span.span_id.as_str()),
+        Some("earlier-search")
+    );
+}
+
+#[test]
+fn nearest_mcp_search_workspace_mismatch_does_not_fall_through() {
+    let trace = search_trace(
+        StoredTraceInvocationKind::Mcp,
+        "tool-root",
+        vec![
+            operation_span("tool-root", None, "coral.mcp.call_tool", 1, "alpha"),
+            search_span("nearest-wrong-workspace", Some("tool-root"), 2, "beta"),
+            operation_span("bridge", Some("tool-root"), "grpc.client", 3, "alpha"),
+            search_span("deeper-right-workspace", Some("bridge"), 4, "alpha"),
+        ],
+    );
+
+    assert_eq!(
+        selected_search_execution(&trace, TraceListView::QueryStream, "alpha"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn mcp_remote_parent_reads_only_the_selected_search_response() {
+    let temp = TempDir::new().expect("temp dir");
+    let db = open_test_db(&temp).await;
+    ensure_workspace(&db).await;
+    let reader = SearchResponseHistoryReader::new(Arc::clone(&db), Duration::from_hours(1));
+
+    let mut remote_trace = search_trace(
+        StoredTraceInvocationKind::Mcp,
+        "tool-root",
+        vec![
+            operation_span(
+                "tool-root",
+                Some("remote-parent"),
+                "coral.mcp.call_tool",
+                1,
+                "alpha",
+            ),
+            search_span("selected-search", Some("tool-root"), 2, "alpha"),
+        ],
+    );
+    remote_trace.summary.trace_id = "remote-trace".to_string();
+    insert_history_row(&db, "remote-trace", "selected-search", vec![1, 2, 3]).await;
+    assert_eq!(
+        reader
+            .read(&remote_trace, TraceListView::QueryStream, Some("alpha"))
+            .await,
+        Some(RetainedSearchResponse::Response(vec![1, 2, 3]))
+    );
+
+    let mut no_fallback_trace = search_trace(
+        StoredTraceInvocationKind::Mcp,
+        "tool-root",
+        vec![
+            operation_span("tool-root", None, "coral.mcp.call_tool", 1, "alpha"),
+            search_span("selected-without-row", Some("tool-root"), 2, "alpha"),
+            operation_span("bridge", Some("tool-root"), "grpc.client", 3, "alpha"),
+            search_span("deeper-with-row", Some("bridge"), 4, "alpha"),
+        ],
+    );
+    no_fallback_trace.summary.trace_id = "no-fallback-trace".to_string();
+    insert_history_row(&db, "no-fallback-trace", "deeper-with-row", vec![4, 5, 6]).await;
+    assert_eq!(
+        reader
+            .read(
+                &no_fallback_trace,
+                TraceListView::QueryStream,
+                Some("alpha"),
+            )
+            .await,
+        None
+    );
+}
+
+#[tokio::test]
+async fn future_search_response_is_hidden_without_latching_read_failure() {
+    let temp = TempDir::new().expect("temp dir");
+    let trace_store = temp.path().join("trace-store");
+    std::fs::create_dir_all(&trace_store).expect("trace store dir");
+    let record = search_trace_record("future-search-trace", "alpha", 10, 20);
+    std::fs::write(
+        trace_store.join("spans-search.jsonl"),
+        format!("{record}\n"),
+    )
+    .expect("write search trace");
+
+    let db = open_test_db(&temp).await;
+    ensure_workspace(&db).await;
+    let two_minutes_nanos =
+        i64::try_from(Duration::from_mins(2).as_nanos()).expect("duration fits i64");
+    insert_history_row_at(
+        &db,
+        "future-search-trace",
+        "future-search-trace-span",
+        vec![7, 8, 9],
+        now_unix_nanos_i64()
+            .expect("current time")
+            .saturating_add(two_minutes_nanos),
+    )
+    .await;
+    let manager = TraceManager::new(trace_store, Duration::from_hours(3))
+        .with_search_response_history(Arc::clone(&db), Duration::from_hours(1));
+
+    let detail = manager
+        .get_trace(GetTraceQuery {
+            trace_id: "future-search-trace".to_string(),
+            workspace: Some(WorkspaceName::parse("alpha").expect("workspace")),
+            view: TraceListView::QueryStream,
+        })
+        .await
+        .expect("future response does not hide trace detail");
+
+    assert_eq!(detail.search_response, None);
+    assert_eq!(detail.trace.spans.len(), 1);
+    assert!(
+        !manager
+            .search_response_history
+            .as_ref()
+            .expect("history reader")
+            .warnings
+            .read_failure
+            .load(Ordering::Relaxed)
+    );
+}
+
+#[tokio::test]
+async fn retained_response_is_read_only_for_scoped_query_stream_search() {
+    let temp = TempDir::new().expect("temp dir");
+    let trace_store = temp.path().join("trace-store");
+    std::fs::create_dir_all(&trace_store).expect("trace store dir");
+    let record = search_trace_record("search-trace", "alpha", 10, 20);
+    let expired_record = search_trace_record("expired-search-trace", "alpha", 30, 40);
+    let oversized_record = search_trace_record("oversized-search-trace", "alpha", 50, 60);
+    std::fs::write(
+        trace_store.join("spans-search.jsonl"),
+        format!("{record}\n{expired_record}\n{oversized_record}\n"),
+    )
+    .expect("write search trace");
+
+    let db = open_test_db(&temp).await;
+    ensure_workspace(&db).await;
+    insert_history_row(&db, "search-trace", "search-trace-span", vec![1, 2, 3]).await;
+    let two_hours_nanos =
+        i64::try_from(Duration::from_hours(2).as_nanos()).expect("duration fits i64");
+    insert_history_row_at(
+        &db,
+        "expired-search-trace",
+        "expired-search-trace-span",
+        vec![4, 5, 6],
+        now_unix_nanos_i64()
+            .expect("current time")
+            .saturating_sub(two_hours_nanos),
+    )
+    .await;
+    insert_oversized_history_row(
+        &db,
+        "oversized-search-trace",
+        "oversized-search-trace-span",
+        1_048_577,
+    )
+    .await;
+    let manager = TraceManager::new(trace_store, Duration::from_hours(3))
+        .with_search_response_history(Arc::clone(&db), Duration::from_hours(1));
+
+    let scoped = manager
+        .get_trace(GetTraceQuery {
+            trace_id: "search-trace".to_string(),
+            workspace: Some(WorkspaceName::parse("alpha").expect("workspace")),
+            view: TraceListView::QueryStream,
+        })
+        .await
+        .expect("scoped Query Stream detail");
+    assert_eq!(
+        scoped.search_response,
+        Some(RetainedSearchResponse::Response(vec![1, 2, 3]))
+    );
+
+    let expired = manager
+        .get_trace(GetTraceQuery {
+            trace_id: "expired-search-trace".to_string(),
+            workspace: Some(WorkspaceName::parse("alpha").expect("workspace")),
+            view: TraceListView::QueryStream,
+        })
+        .await
+        .expect("expired response does not hide trace detail");
+    assert_eq!(expired.search_response, None);
+    assert_eq!(expired.trace.spans.len(), 1);
+
+    let oversized = manager
+        .get_trace(GetTraceQuery {
+            trace_id: "oversized-search-trace".to_string(),
+            workspace: Some(WorkspaceName::parse("alpha").expect("workspace")),
+            view: TraceListView::QueryStream,
+        })
+        .await
+        .expect("oversized response does not hide trace detail");
+    assert_eq!(
+        oversized.search_response,
+        Some(RetainedSearchResponse::TooLarge)
+    );
+    assert_eq!(oversized.trace.spans.len(), 1);
+
+    assert_history_absent_for_unscoped_views(&manager).await;
+
+    db.drop_trace_search_responses_for_test()
+        .await
+        .expect("force response history read failure");
+    let read_failure = manager
+        .get_trace(GetTraceQuery {
+            trace_id: "search-trace".to_string(),
+            workspace: Some(WorkspaceName::parse("alpha").expect("workspace")),
+            view: TraceListView::QueryStream,
+        })
+        .await
+        .expect("response history read failure does not hide trace detail");
+    assert_eq!(read_failure.search_response, None);
+    assert_eq!(read_failure.trace.spans.len(), 1);
+    assert!(
+        manager
+            .search_response_history
+            .as_ref()
+            .expect("history reader")
+            .warnings
+            .read_failure
+            .load(Ordering::Relaxed)
+    );
+}
+
+async fn assert_history_absent_for_unscoped_views(manager: &TraceManager) {
+    for (view, workspace) in [
+        (TraceListView::QueryStream, None),
+        (
+            TraceListView::All,
+            Some(WorkspaceName::parse("alpha").expect("workspace")),
+        ),
+    ] {
+        let detail = manager
+            .get_trace(GetTraceQuery {
+                trace_id: "search-trace".to_string(),
+                workspace,
+                view,
+            })
+            .await
+            .expect("detail remains available");
+        assert_eq!(detail.search_response, None);
+        assert_eq!(detail.trace.spans.len(), 1);
+    }
+}
+
+async fn open_test_db(temp: &TempDir) -> Arc<CoralDb> {
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+    let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config") else {
+        panic!("default test database must be SQLite");
+    };
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open SQLite"),
+    );
+    db.migrate().await.expect("migrate SQLite");
+    db
+}
+
+async fn ensure_workspace(db: &CoralDb) {
+    let mut tx = db.begin().await.expect("workspace tx");
+    tx.workspaces().ensure("alpha", 1).await.expect("workspace");
+    tx.commit().await.expect("commit workspace");
+}
+
+async fn insert_history_row(
+    db: &CoralDb,
+    trace_id: &str,
+    search_span_id: &str,
+    response_proto: Vec<u8>,
+) {
+    insert_history_row_at(
+        db,
+        trace_id,
+        search_span_id,
+        response_proto,
+        now_unix_nanos_i64().expect("current time"),
+    )
+    .await;
+}
+
+async fn insert_history_row_at(
+    db: &CoralDb,
+    trace_id: &str,
+    search_span_id: &str,
+    response_proto: Vec<u8>,
+    recorded_at_unix_nanos: i64,
+) {
+    assert_eq!(
+        db.insert_trace_search_response(TraceSearchResponseCapture {
+            workspace_id: "alpha".to_string(),
+            trace_id: trace_id.to_string(),
+            search_span_id: search_span_id.to_string(),
+            recorded_at_unix_nanos,
+            outcome: TraceSearchResponseOutcome::Response(response_proto),
+        })
+        .await
+        .expect("insert Search response history"),
+        TraceSearchResponseInsertResult::Inserted
+    );
+}
+
+async fn insert_oversized_history_row(
+    db: &CoralDb,
+    trace_id: &str,
+    search_span_id: &str,
+    oversized_bytes: i64,
+) {
+    assert_eq!(
+        db.insert_trace_search_response(TraceSearchResponseCapture {
+            workspace_id: "alpha".to_string(),
+            trace_id: trace_id.to_string(),
+            search_span_id: search_span_id.to_string(),
+            recorded_at_unix_nanos: now_unix_nanos_i64().expect("current time"),
+            outcome: TraceSearchResponseOutcome::TooLarge {
+                bytes: oversized_bytes,
+            },
+        })
+        .await
+        .expect("insert oversized Search response history"),
+        TraceSearchResponseInsertResult::Inserted
+    );
+}
+
+fn search_trace(
+    invocation_kind: StoredTraceInvocationKind,
+    root_span_id: &str,
+    spans: Vec<TraceSpanRecord>,
+) -> TraceDetailRecord {
+    TraceDetailRecord {
+        summary: TraceSummaryRecord {
+            trace_id: "trace".to_string(),
+            root_span_id: root_span_id.to_string(),
+            name: "Search".to_string(),
+            query: "repository search".to_string(),
+            status: StoredTraceStatus::Ok,
+            start_time_unix_nanos: 1,
+            end_time_unix_nanos: 20,
+            duration_nanos: 19,
+            span_count: u32::try_from(spans.len()).expect("span count"),
+            row_count: 0,
+            row_count_recorded: false,
+            operation_kind: StoredTraceOperationKind::Search,
+            operation_name: "search".to_string(),
+            invocation_kind,
+        },
+        spans,
+    }
+}
+
+fn search_span(
+    span_id: &str,
+    parent_span_id: Option<&str>,
+    start_time_unix_nanos: i64,
+    workspace: &str,
+) -> TraceSpanRecord {
+    operation_span(
+        span_id,
+        parent_span_id,
+        "coral.search",
+        start_time_unix_nanos,
+        workspace,
+    )
+}
+
+fn operation_span(
+    span_id: &str,
+    parent_span_id: Option<&str>,
+    name: &str,
+    start_time_unix_nanos: i64,
+    workspace: &str,
+) -> TraceSpanRecord {
+    TraceSpanRecord {
+        trace_id: "trace".to_string(),
+        span_id: span_id.to_string(),
+        parent_span_id: parent_span_id.map(str::to_string),
+        parent_span_is_remote: parent_span_id == Some("remote-parent"),
+        name: name.to_string(),
+        kind: "internal".to_string(),
+        status: StoredTraceStatus::Ok,
+        status_message: None,
+        start_time_unix_nanos,
+        end_time_unix_nanos: start_time_unix_nanos + 1,
+        duration_nanos: 1,
+        attributes_json: json!({ "workspace": workspace }).to_string(),
+        events_json: "[]".to_string(),
+        links_json: "[]".to_string(),
+        resource_json: "{}".to_string(),
+        scope_name: "test".to_string(),
+        scope_version: None,
+        scope_schema_url: None,
+        scope_attributes_json: "{}".to_string(),
+        trace_flags: 0,
+        trace_state: String::new(),
+        is_remote: false,
+    }
+}
+
+fn search_trace_record(
+    trace_id: &str,
+    workspace: &str,
+    start_time_unix_nanos: i64,
+    end_time_unix_nanos: i64,
+) -> serde_json::Value {
+    json!({
+        "trace_id": trace_id,
+        "span_id": format!("{trace_id}-span"),
+        "parent_span_id": null,
+        "parent_span_is_remote": false,
+        "name": "coral.search",
+        "kind": "internal",
+        "status": "ok",
+        "status_message": null,
+        "start_time_unix_nanos": start_time_unix_nanos,
+        "end_time_unix_nanos": end_time_unix_nanos,
+        "duration_nanos": end_time_unix_nanos - start_time_unix_nanos,
+        "attributes_json": json!({
+            "coral.stream.entry": true,
+            "coral.stream.kind": "search",
+            "coral.stream.name": "search",
+            "workspace": workspace,
+            "status": "ok",
+        }).to_string(),
+        "events_json": "[]",
+        "links_json": "[]",
+        "resource_json": "{}",
+        "scope_name": "test",
+        "scope_version": null,
+        "scope_schema_url": null,
+        "scope_attributes_json": "{}",
+        "trace_flags": 0,
+        "trace_state": "",
+        "is_remote": false
+    })
+}

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -54,6 +54,8 @@ const LOCAL_TRACE_EXCLUDED_RPC_SERVICES: &[&str] = &["coral.v1.TraceService"];
 pub(crate) const QUERY_TRACE_SOURCES_ATTR: &str = "coral.query.sources";
 pub(crate) const QUERY_TRACE_TABLES_ATTR: &str = "coral.query.tables";
 pub(crate) const QUERY_TRACE_TABLE_FUNCTIONS_ATTR: &str = "coral.query.table_functions";
+/// Stable span name for Universal Search executions.
+pub(crate) const SEARCH_SPAN_NAME: &str = "coral.search";
 
 pub(crate) fn app_error_type(error: &AppError) -> &'static str {
     match error {

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,19 +1,26 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use coral_api::v1::trace_search_response::Outcome as TraceSearchResponseOutcome;
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
-    GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceInvocationKind,
-    TraceOperationKind, TraceSpan, TraceStatus, TraceSummary, TraceView, Workspace,
+    GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, SearchResponse,
+    TraceInvocationKind, TraceOperationKind, TraceSearchResponse, TraceSearchResponseTooLarge,
+    TraceSpan, TraceStatus, TraceSummary, TraceView, Workspace,
 };
+use prost::Message as _;
 use tonic::{Code, Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::telemetry::local_store::{
-    StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
-    TraceSpanRecord, TraceSummaryRecord,
+    StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceSpanRecord,
+    TraceSummaryRecord,
 };
 use crate::telemetry::manager::{
-    GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError,
+    GetTraceQuery, ListTracesQuery, RetainedSearchResponse, TraceDetail, TraceListView,
+    TraceManager, TraceManagerError,
 };
 use crate::transport::{grpc_span, instrument_grpc};
 use crate::workspaces::WorkspaceName;
@@ -23,12 +30,19 @@ const MAX_TRACE_PAGE_SIZE: usize = 200;
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
+    warnings: Arc<TraceServiceWarnings>,
     traces: TraceManager,
+}
+
+#[derive(Debug, Default)]
+struct TraceServiceWarnings {
+    malformed_search_response: AtomicBool,
 }
 
 impl TraceService {
     pub(crate) fn new(trace_manager: TraceManager) -> Self {
         Self {
+            warnings: Arc::new(TraceServiceWarnings::default()),
             traces: trace_manager,
         }
     }
@@ -77,6 +91,7 @@ impl TraceServiceApi for TraceService {
     ) -> Result<Response<GetTraceResponse>, Status> {
         let span = grpc_span(&request);
         let traces = self.traces.clone();
+        let warnings = Arc::clone(&self.warnings);
         instrument_grpc(span, async move {
             let request = request.into_inner();
             if request.trace_id.trim().is_empty() {
@@ -95,7 +110,7 @@ impl TraceServiceApi for TraceService {
                 })
                 .await
                 .map_err(trace_manager_status)?;
-            Ok(Response::new(trace_detail_to_proto(trace)))
+            Ok(Response::new(trace_detail_to_proto(trace, &warnings)))
         })
         .await
     }
@@ -151,11 +166,52 @@ fn trace_manager_status(error: TraceManagerError) -> Status {
     }
 }
 
-fn trace_detail_to_proto(trace: TraceDetailRecord) -> GetTraceResponse {
+fn trace_detail_to_proto(detail: TraceDetail, warnings: &TraceServiceWarnings) -> GetTraceResponse {
+    let TraceDetail {
+        trace,
+        search_response,
+    } = detail;
     GetTraceResponse {
         summary: Some(trace_summary_to_proto(trace.summary)),
         spans: trace.spans.into_iter().map(trace_span_to_proto).collect(),
+        search_response: retained_search_response_to_proto(search_response, warnings),
     }
+}
+
+fn retained_search_response_to_proto(
+    retained: Option<RetainedSearchResponse>,
+    warnings: &TraceServiceWarnings,
+) -> Option<TraceSearchResponse> {
+    let outcome = match retained? {
+        RetainedSearchResponse::Response(encoded) => {
+            match SearchResponse::decode(encoded.as_slice()) {
+                Ok(response) => {
+                    warnings
+                        .malformed_search_response
+                        .store(false, Ordering::Relaxed);
+                    TraceSearchResponseOutcome::Response(response)
+                }
+                Err(error) => {
+                    if !warnings
+                        .malformed_search_response
+                        .swap(true, Ordering::Relaxed)
+                    {
+                        tracing::warn!(
+                            error = ?error,
+                            "ignored malformed retained Search response"
+                        );
+                    }
+                    return None;
+                }
+            }
+        }
+        RetainedSearchResponse::TooLarge => {
+            TraceSearchResponseOutcome::TooLarge(TraceSearchResponseTooLarge {})
+        }
+    };
+    Some(TraceSearchResponse {
+        outcome: Some(outcome),
+    })
 }
 
 fn trace_summary_to_proto(summary: TraceSummaryRecord) -> TraceSummary {
@@ -236,16 +292,19 @@ mod tests {
 
     use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
     use coral_api::v1::{
-        GetTraceRequest, ListTracesRequest, TraceInvocationKind, TraceOperationKind, TraceView,
-        Workspace,
+        GetTraceRequest, ListTracesRequest, SearchResponse, TraceInvocationKind,
+        TraceOperationKind, TraceView, Workspace,
     };
+    use prost::Message as _;
     use serde_json::json;
     use tempfile::TempDir;
     use tonic::{Code, Request};
 
     use super::{
-        TraceService, normalize_page_size, parse_page_token, trace_invocation_kind_to_proto,
+        TraceService, TraceServiceWarnings, normalize_page_size, parse_page_token,
+        retained_search_response_to_proto, trace_invocation_kind_to_proto,
     };
+    use crate::telemetry::manager::RetainedSearchResponse;
     use crate::telemetry::{TraceManager, local_store::StoredTraceInvocationKind};
 
     #[test]
@@ -277,6 +336,45 @@ mod tests {
             trace_invocation_kind_to_proto(StoredTraceInvocationKind::Mcp),
             TraceInvocationKind::Mcp
         );
+    }
+
+    #[test]
+    fn retained_response_decode_warning_recovers_and_too_large_is_preserved() {
+        let warnings = TraceServiceWarnings::default();
+        assert_eq!(
+            retained_search_response_to_proto(
+                Some(RetainedSearchResponse::Response(vec![0xff])),
+                &warnings,
+            ),
+            None
+        );
+        assert!(
+            warnings
+                .malformed_search_response
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+
+        let valid = SearchResponse::default().encode_to_vec();
+        assert!(
+            retained_search_response_to_proto(
+                Some(RetainedSearchResponse::Response(valid)),
+                &warnings,
+            )
+            .is_some()
+        );
+        assert!(
+            !warnings
+                .malformed_search_response
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+
+        let too_large =
+            retained_search_response_to_proto(Some(RetainedSearchResponse::TooLarge), &warnings)
+                .expect("too-large outcome");
+        assert!(matches!(
+            too_large.outcome,
+            Some(coral_api::v1::trace_search_response::Outcome::TooLarge(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
+++ b/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
@@ -7,10 +7,13 @@
 
 use std::path::{Path, PathBuf};
 
+use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::trace_service_client::TraceServiceClient;
-use coral_api::v1::{ListTracesRequest, TraceView};
-use coral_client::local::ServerBuilder;
+use coral_api::v1::{ListTracesRequest, SearchRequest, TraceView};
+use coral_client::{default_workspace, local::ServerBuilder};
 use serde_json::json;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::{Connection as _, SqliteConnection};
 use tempfile::TempDir;
 use tonic::Request;
 use tonic::transport::Endpoint;
@@ -55,10 +58,17 @@ async fn repeated_starts_read_the_process_local_trace_store() {
         "second server should not read from its own unwritten trace store: {trace_ids:?}"
     );
 
+    search(second_server.endpoint_uri()).await;
+
     second_server
         .shutdown()
         .await
         .expect("shutdown second server");
+    assert_eq!(
+        retained_response_count(&second_config_dir.join("coral.db")).await,
+        0,
+        "the second database must not retain responses for the process-owned first trace store"
+    );
 }
 
 fn enable_local_tracing(config_dir: &Path) {
@@ -132,4 +142,33 @@ async fn list_trace_ids(endpoint_uri: &str) -> Vec<String> {
         .into_iter()
         .map(|trace| trace.trace_id)
         .collect()
+}
+
+async fn search(endpoint_uri: &str) {
+    let channel = Endpoint::from_shared(endpoint_uri.to_string())
+        .expect("endpoint")
+        .connect()
+        .await
+        .expect("connect");
+    SearchServiceClient::new(channel)
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "history".to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect("search second server");
+}
+
+async fn retained_response_count(database_path: &Path) -> i64 {
+    let options = SqliteConnectOptions::new()
+        .filename(database_path)
+        .read_only(true);
+    let mut connection = SqliteConnection::connect_with(&options)
+        .await
+        .expect("open second database");
+    sqlx::query_scalar("SELECT COUNT(*) FROM trace_search_responses")
+        .fetch_one(&mut connection)
+        .await
+        .expect("count retained Search responses")
 }


### PR DESCRIPTION
## Summary

- extend `GetTrace` with the retained `SearchResponse` or an explicit `TOO_LARGE` outcome
- select the exact owned Search execution for direct and MCP traces using rooted ancestry, deterministic ordering, and workspace matching
- make history reads and protobuf decoding best-effort so malformed or unavailable history never hides the Timeline or spans
- add the Reef protobuf generation input required by the additive trace API

## Stack goal

The goal of this stack is to bring a clearer Search UI to Query Stream, improving visibility into Search responses and making Search behavior easier to debug from retained trace history.

## Data and retention policy

When trace history is enabled, Coral returns and retains the same Search response after applying the observed-values credential scrubber to matching-value evidence. Search responses are retained for 30 days in the operator-configured `CoralDb`, including PostgreSQL. This suppresses obvious credentials but is not general PII redaction. Retention is best-effort and does not wait on `CoralDb` in the Search request path.

Depends on #2130. Next: #2120 renders the historical response in Query Stream.

## Testing

- `make rust-checks` — 2,582 tests passed, 10 skipped; formatting, Clippy, and rustdoc passed
- `cargo test --locked -p coral-app telemetry:: --lib` — 83 passed before the current-main restack
- `make lint-proto`
- local end-to-end Search and historical trace retrieval using an isolated copy of the local Coral config
- `cargo fmt --all -- --check`
- `git diff --check`
