### PR TITLE
feat(reef): show Search results in Query Stream

### DIFF
--- a/apps/coral-ui/app/components/query-detail/index.ts
+++ b/apps/coral-ui/app/components/query-detail/index.ts
@@ -1,6 +1,13 @@
-export { QueryDetailSummary } from './query-detail-summary'
+export { QueryDetailStats, QueryDetailSummary } from './query-detail-summary'
 export { QueryDetailResults } from './query-detail-results'
+export { SearchResponseResults } from './search-response-results'
 export type { QueryDetailResultsProps } from './query-detail-results'
+export type { SearchResponseResultsProps } from './search-response-results'
+export {
+  mapTraceSearchResponse,
+  searchResultsTabLabel,
+  type SearchResultsView,
+} from './search-response'
 export type {
   QueryDetailStat,
   QueryDetailStatusTone,

--- a/apps/coral-ui/app/components/query-detail/query-detail-summary.tsx
+++ b/apps/coral-ui/app/components/query-detail/query-detail-summary.tsx
@@ -65,16 +65,22 @@ export function QueryDetailSummary({
       <ScrollArea className={styles.scrollBody} constrainWidth fade="none" fillContent>
         <div className={styles.content}>
           <CodeBlock code={sql} language={codeLanguage} />
-          {stats.length > 0 ? (
-            <div className={styles.statGrid}>
-              {stats.map((stat) => (
-                <QueryDetailStatCard key={stat.label} label={stat.label} value={stat.value} />
-              ))}
-            </div>
-          ) : null}
+          <QueryDetailStats stats={stats} />
           {children}
         </div>
       </ScrollArea>
+    </div>
+  )
+}
+
+export function QueryDetailStats({ stats }: { stats: QueryDetailStat[] }) {
+  if (stats.length === 0) return null
+
+  return (
+    <div className={styles.statGrid}>
+      {stats.map((stat) => (
+        <QueryDetailStatCard key={stat.label} label={stat.label} value={stat.value} />
+      ))}
     </div>
   )
 }

--- a/apps/coral-ui/app/components/query-detail/search-response-results.css.ts
+++ b/apps/coral-ui/app/components/query-detail/search-response-results.css.ts
@@ -1,0 +1,105 @@
+import { style } from '@vanilla-extract/css'
+
+import { breakpoints } from '@/styles/theme.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const root = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 16,
+  minHeight: 0,
+  minWidth: 0,
+  overflowY: 'auto',
+  paddingInlineEnd: 4,
+})
+
+export const resultTable = style({
+  flexShrink: 0,
+  maxWidth: '100%',
+  minWidth: 0,
+})
+
+export const disclosureCell = style({ justifyContent: 'center' })
+
+export const disclosureSpacer = style({ height: 22, width: 22 })
+
+export const providerBadges = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 6,
+  minWidth: 0,
+})
+
+export const resultDetailRow = style({ backgroundColor: theme.surface.onMainContentSubtle })
+
+export const resultDetailCell = style({ minWidth: 0 })
+
+export const resultBody = style({
+  display: 'grid',
+  gap: 16,
+  minWidth: 0,
+  paddingBlock: 8,
+  width: '100%',
+})
+
+export const section = style({ display: 'grid', gap: 6, minWidth: 0 })
+
+export const sectionTitle = style({ margin: 0 })
+
+export const bodyCopy = style({ margin: 0 })
+
+export const requiredStar = style({
+  color: theme.content.error,
+  cursor: 'help',
+  display: 'inline-flex',
+  flexShrink: 0,
+  font: 'inherit',
+  marginInlineStart: 4,
+  outlineOffset: 2,
+})
+
+export const matchingValues = style({
+  display: 'grid',
+  gap: 6,
+  margin: 0,
+})
+
+export const matchingValueRow = style({
+  alignItems: 'baseline',
+  display: 'grid',
+  gap: 12,
+  gridTemplateColumns: 'max-content minmax(0, 1fr)',
+  minWidth: 0,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gap: 4,
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
+  },
+})
+
+export const matchingValueField = style({
+  maxWidth: 'min(320px, 40vw)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const matchingValueCopy = style({
+  margin: 0,
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+})
+
+export const resultState = style({
+  alignItems: 'center',
+  border: `1px dashed ${theme.stroke.primary}`,
+  borderRadius: 8,
+  display: 'flex',
+  justifyContent: 'center',
+  minHeight: 140,
+  padding: 24,
+  textAlign: 'center',
+})

--- a/apps/coral-ui/app/components/query-detail/search-response-results.stories.tsx
+++ b/apps/coral-ui/app/components/query-detail/search-response-results.stories.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import type { SearchResultsView } from './search-response'
+import { SearchResponseResults } from './search-response-results'
+
+const groupedView: SearchResultsView = {
+  results: [
+    {
+      description: 'Workflow jobs and their current conclusions.',
+      fields: [
+        { dataType: 'Utf8', name: 'owner', required: true },
+        { dataType: 'Utf8', name: 'conclusion', required: false },
+        { dataType: 'Utf8', name: 'repository', required: false },
+      ],
+      guide: 'Filter by owner before querying recent jobs.',
+      kind: 'table',
+      matchingValues: [
+        { field: 'owner', values: ['withcoral'] },
+        { field: 'conclusion', values: ['success', 'failure'] },
+      ],
+      omittedMatchingFieldCount: 2,
+      providers: [
+        { label: 'Catalog', tone: 'catalog' },
+        { label: 'Observed values', tone: 'observed' },
+      ],
+      sqlReference: '"github"."repo_action_jobs"',
+    },
+    {
+      arguments: [
+        { dataType: 'Utf8', name: 'query', required: true },
+        {
+          dataType: 'Struct<repository_owner_namespace_with_a_very_long_nested_type_name>',
+          name: 'required_argument_with_a_very_long_unbroken_name_that_wraps',
+          required: true,
+        },
+        { dataType: 'Int64', name: 'z_limit', required: false },
+      ],
+      description: 'Searches issues using a provider-native function.',
+      guide: '',
+      kind: 'function',
+      matchingValues: [],
+      omittedMatchingFieldCount: 0,
+      providers: [{ label: 'Native fanout', tone: 'neutral' }],
+      returns: [
+        { dataType: 'Int64', name: 'issue_id', required: false },
+        { dataType: 'Utf8', name: 'title', required: false },
+      ],
+      sqlReference:
+        '"Warehouse-Prod"."analytics"."Search Issues"(query, required_argument_with_a_very_long_unbroken_name_that_wraps, ...)',
+    },
+    { kind: 'unknown' },
+  ],
+  state: 'available',
+  truncation: {
+    maxResults: 3,
+    note: 'More candidates were available.',
+    returnedCount: 3,
+    truncated: true,
+  },
+}
+
+const withinLimitView = {
+  ...groupedView,
+  truncation: {
+    maxResults: 10,
+    note: '',
+    returnedCount: 3,
+    truncated: false,
+  },
+} satisfies SearchResultsView
+
+function ExpandedResults({ view }: { view: SearchResultsView }) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    rootRef.current
+      ?.querySelectorAll<HTMLButtonElement>('button[aria-expanded="false"]')
+      .forEach((button) => {
+        button.click()
+      })
+  }, [view])
+  return (
+    <div ref={rootRef}>
+      <SearchResponseResults view={view} />
+    </div>
+  )
+}
+
+const meta = {
+  args: { view: groupedView },
+  component: SearchResponseResults,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  title: 'Components/QueryDetail/SearchResponseResults',
+} satisfies Meta<typeof SearchResponseResults>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Grouped: Story = {}
+
+export const GroupedExpanded: Story = {
+  render: ({ view }) => <ExpandedResults view={view} />,
+}
+
+export const WithinLimit: Story = {
+  args: { view: withinLimitView },
+}
+
+export const Empty: Story = {
+  args: { view: { results: [], state: 'available' } },
+}
+
+export const Unavailable: Story = {
+  args: { view: { state: 'unavailable' } },
+}
+
+export const TooLarge: Story = {
+  args: { view: { state: 'tooLarge' } },
+}

--- a/apps/coral-ui/app/components/query-detail/search-response-results.tsx
+++ b/apps/coral-ui/app/components/query-detail/search-response-results.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useId, useState } from 'react'
+
+import { Banner, Button, Table } from '@/wax/components'
+import { Pill, type PillColor } from '@/wax/components/pill'
+import { Tooltip } from '@/wax/components/tooltip'
+import { Typography } from '@/wax/components/typography'
+
+import type {
+  SearchFieldView,
+  SearchFunctionResultView,
+  SearchKnownResultViewBase,
+  SearchMatchingValuesView,
+  SearchProviderView,
+  SearchResultView,
+  SearchResultsView,
+  SearchTableResultView,
+  SearchTruncationView,
+} from './search-response'
+import * as styles from './search-response-results.css'
+
+export interface SearchResponseResultsProps {
+  view: SearchResultsView
+}
+
+const RESULT_COLUMNS: Table.Column[] = [
+  { ariaLabel: 'Result details', label: '', width: 46 },
+  { align: 'right', ariaLabel: 'Result rank', label: '#', width: 44 },
+  { label: 'type', width: 'content' },
+  { label: 'result', width: 'fill' },
+  { label: 'found via', width: 'content' },
+]
+
+const FIELD_COLUMNS: Table.Column[] = [
+  { label: 'name', width: 'content' },
+  { label: 'type', width: 'content' },
+]
+
+function providerColor(provider: SearchProviderView): PillColor {
+  if (provider.tone === 'catalog') return 'blue'
+  if (provider.tone === 'observed') return 'purple'
+  return 'graySubtle'
+}
+
+function ProviderBadge({ provider }: { provider: SearchProviderView }) {
+  return (
+    <Pill as="span" color={providerColor(provider)}>
+      {provider.label}
+    </Pill>
+  )
+}
+
+function ProviderBadges({ providers }: { providers: SearchProviderView[] }) {
+  if (providers.length === 0) {
+    return <Typography.BodySmall variant="tertiary">—</Typography.BodySmall>
+  }
+
+  return (
+    <span className={styles.providerBadges}>
+      {providers.map((provider, index) => (
+        <ProviderBadge key={`${provider.label}-${index}`} provider={provider} />
+      ))}
+    </span>
+  )
+}
+
+function Fields({
+  fields,
+  requiredLabel,
+  title,
+}: {
+  fields: SearchFieldView[]
+  requiredLabel?: string
+  title: string
+}) {
+  if (fields.length === 0) return null
+  return (
+    <section className={styles.section}>
+      <Typography.BodySmallStrong as="h3" className={styles.sectionTitle}>
+        {title}
+      </Typography.BodySmallStrong>
+      <Table.Container ariaLabel={title} columns={FIELD_COLUMNS} density="compact">
+        <Table.Head />
+        <Table.Body>
+          {fields.map((field, index) => (
+            <Table.Row key={`${field.name}-${index}`}>
+              <Table.Cell mono>
+                {field.name}
+                {field.required && requiredLabel ? (
+                  <Tooltip content={requiredLabel} side="top">
+                    <span aria-label={requiredLabel} className={styles.requiredStar} tabIndex={0}>
+                      *
+                    </span>
+                  </Tooltip>
+                ) : null}
+              </Table.Cell>
+              <Table.Cell mono>{field.dataType || 'Type unavailable'}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Container>
+    </section>
+  )
+}
+
+function MatchingValues({ groups }: { groups: SearchMatchingValuesView[] }) {
+  if (groups.length === 0) return null
+  return (
+    <section className={styles.section}>
+      <Typography.BodySmallStrong as="h3" className={styles.sectionTitle}>
+        Matching values
+      </Typography.BodySmallStrong>
+      <dl className={styles.matchingValues}>
+        {groups.map((group, index) => (
+          <div className={styles.matchingValueRow} key={`${group.field}-${index}`}>
+            <Typography.CodeSmallInlineStrong as="dt" className={styles.matchingValueField}>
+              {group.field}
+            </Typography.CodeSmallInlineStrong>
+            <Typography.BodySmall as="dd" className={styles.matchingValueCopy} variant="secondary">
+              {group.values.length > 0 ? group.values.join(', ') : 'No values retained'}
+            </Typography.BodySmall>
+          </div>
+        ))}
+      </dl>
+    </section>
+  )
+}
+
+function ResultDescription({ result }: { result: SearchKnownResultViewBase }) {
+  if (!result.description) return null
+  return (
+    <Typography.Body as="p" className={styles.bodyCopy} variant="secondary">
+      {result.description}
+    </Typography.Body>
+  )
+}
+
+function CommonResultSections({ result }: { result: SearchKnownResultViewBase }) {
+  return (
+    <>
+      <MatchingValues groups={result.matchingValues} />
+      {result.omittedMatchingFieldCount > 0 ? (
+        <Typography.BodySmall as="p" className={styles.bodyCopy} variant="tertiary">
+          {result.omittedMatchingFieldCount} more matching field
+          {result.omittedMatchingFieldCount === 1 ? '' : 's'} not shown.
+        </Typography.BodySmall>
+      ) : null}
+      {result.guide ? (
+        <section className={styles.section}>
+          <Typography.BodySmallStrong as="h3" className={styles.sectionTitle}>
+            Guide
+          </Typography.BodySmallStrong>
+          <Typography.Body as="p" className={styles.bodyCopy} variant="secondary">
+            {result.guide}
+          </Typography.Body>
+        </section>
+      ) : null}
+    </>
+  )
+}
+
+function TableResultBody({ result }: { result: SearchTableResultView }) {
+  return (
+    <>
+      <ResultDescription result={result} />
+      <Fields fields={result.fields} requiredLabel="Required filter" title="Fields" />
+      <CommonResultSections result={result} />
+    </>
+  )
+}
+
+function FunctionResultBody({ result }: { result: SearchFunctionResultView }) {
+  return (
+    <>
+      <ResultDescription result={result} />
+      <Fields fields={result.arguments} requiredLabel="Required argument" title="Arguments" />
+      <Fields fields={result.returns} title="Returns" />
+      <CommonResultSections result={result} />
+    </>
+  )
+}
+
+function KnownResultRows({
+  expanded,
+  onToggle,
+  rank,
+  result,
+}: {
+  expanded: boolean
+  onToggle: () => void
+  rank: number
+  result: SearchFunctionResultView | SearchTableResultView
+}) {
+  const detailsId = useId()
+  const resultLabel = result.kind === 'table' ? 'Table' : 'Function'
+
+  return (
+    <>
+      <Table.Row>
+        <Table.Cell className={styles.disclosureCell}>
+          <Button.IconButton
+            aria-controls={expanded ? detailsId : undefined}
+            aria-expanded={expanded}
+            ariaLabel={`${expanded ? 'Hide' : 'Show'} details for ${result.sqlReference}`}
+            name={expanded ? 'ChevronDown' : 'ChevronRight'}
+            onClick={onToggle}
+            size="22"
+            variant="bare"
+          />
+        </Table.Cell>
+        <Table.Cell mono>{rank}</Table.Cell>
+        <Table.Cell>
+          <Pill as="span" color={result.kind === 'table' ? 'green' : 'orange'}>
+            {resultLabel}
+          </Pill>
+        </Table.Cell>
+        <Table.Cell mono title={result.sqlReference}>
+          {result.sqlReference}
+        </Table.Cell>
+        <Table.Cell wrap>
+          <ProviderBadges providers={result.providers} />
+        </Table.Cell>
+      </Table.Row>
+      {expanded ? (
+        <Table.Row className={styles.resultDetailRow}>
+          <Table.Cell className={styles.resultDetailCell} fullWidth wrap>
+            <div className={styles.resultBody} id={detailsId}>
+              {result.kind === 'table' ? (
+                <TableResultBody result={result} />
+              ) : (
+                <FunctionResultBody result={result} />
+              )}
+            </div>
+          </Table.Cell>
+        </Table.Row>
+      ) : null}
+    </>
+  )
+}
+
+function UnknownResultRow({ rank }: { rank: number }) {
+  return (
+    <Table.Row>
+      <Table.Cell>
+        <span aria-hidden className={styles.disclosureSpacer} />
+      </Table.Cell>
+      <Table.Cell mono>{rank}</Table.Cell>
+      <Table.Cell>
+        <Pill as="span" color="graySubtle">
+          Unknown
+        </Pill>
+      </Table.Cell>
+      <Table.Cell>Unknown result</Table.Cell>
+      <Table.Cell>
+        <Typography.BodySmall variant="tertiary">—</Typography.BodySmall>
+      </Table.Cell>
+    </Table.Row>
+  )
+}
+
+function ResultRows({
+  expanded,
+  onToggle,
+  rank,
+  result,
+}: {
+  expanded: boolean
+  onToggle: () => void
+  rank: number
+  result: SearchResultView
+}) {
+  return result.kind === 'unknown' ? (
+    <UnknownResultRow rank={rank} />
+  ) : (
+    <KnownResultRows expanded={expanded} onToggle={onToggle} rank={rank} result={result} />
+  )
+}
+
+function Truncation({ truncation }: { truncation: SearchTruncationView }) {
+  return (
+    <Banner title="Results truncated">
+      <Typography.BodySmall as="p">
+        Showing {truncation.returnedCount} {truncation.returnedCount === 1 ? 'result' : 'results'}.
+        The result limit was {truncation.maxResults}.
+      </Typography.BodySmall>
+      {truncation.note ? (
+        <Typography.BodySmall as="p" variant="tertiary">
+          {truncation.note}
+        </Typography.BodySmall>
+      ) : null}
+    </Banner>
+  )
+}
+
+function ResultState({ children }: { children: string }) {
+  return (
+    <div className={styles.resultState}>
+      <Typography.Body variant="tertiary">{children}</Typography.Body>
+    </div>
+  )
+}
+
+function AvailableResults({ view }: { view: Extract<SearchResultsView, { state: 'available' }> }) {
+  const [expandedResults, setExpandedResults] = useState<Set<number>>(() => new Set())
+
+  useEffect(() => setExpandedResults(new Set()), [view])
+
+  const toggleResult = (index: number) => {
+    setExpandedResults((current) => {
+      const next = new Set(current)
+      if (next.has(index)) next.delete(index)
+      else next.add(index)
+      return next
+    })
+  }
+
+  return (
+    <div className={styles.root}>
+      {view.results.length > 0 ? (
+        <Table.Container
+          ariaLabel="Search results"
+          className={styles.resultTable}
+          columns={RESULT_COLUMNS}
+          density="compact"
+          variant="card"
+        >
+          <Table.Head />
+          <Table.Body>
+            {view.results.map((result, index) => (
+              <ResultRows
+                expanded={expandedResults.has(index)}
+                key={index}
+                onToggle={() => toggleResult(index)}
+                rank={index + 1}
+                result={result}
+              />
+            ))}
+          </Table.Body>
+        </Table.Container>
+      ) : (
+        <ResultState>No results found for this search.</ResultState>
+      )}
+      {view.truncation?.truncated ? <Truncation truncation={view.truncation} /> : null}
+    </div>
+  )
+}
+
+export function SearchResponseResults({ view }: SearchResponseResultsProps) {
+  if (view.state === 'unavailable') {
+    return (
+      <div className={styles.root}>
+        <ResultState>Results are unavailable for this search.</ResultState>
+      </div>
+    )
+  }
+  if (view.state === 'tooLarge') {
+    return (
+      <div className={styles.root}>
+        <ResultState>This result response was too large to retain.</ResultState>
+      </div>
+    )
+  }
+
+  return <AvailableResults view={view} />
+}

--- a/apps/coral-ui/app/components/query-detail/search-response.ts
+++ b/apps/coral-ui/app/components/query-detail/search-response.ts
@@ -1,0 +1,198 @@
+import {
+  SearchProvider,
+  type SearchField,
+  type SearchFieldValues,
+  type SearchResult,
+  type SearchResultTruncation,
+  type SearchSurfaceRef,
+} from '@/generated/coral/v1/search_pb'
+import type { TraceSearchResponse } from '@/generated/coral/v1/traces_pb'
+
+type RetainedProtoData<T> = T extends readonly (infer Item)[]
+  ? readonly RetainedProtoData<Item>[]
+  : T extends object
+    ? {
+        readonly [Key in keyof T as Key extends '$typeName' | '$unknown'
+          ? never
+          : Key]: RetainedProtoData<T[Key]>
+      }
+    : T
+
+export type TraceSearchResponseData = RetainedProtoData<TraceSearchResponse>
+
+export interface SearchFieldView {
+  dataType: string
+  name: string
+  required: boolean
+}
+
+export interface SearchMatchingValuesView {
+  field: string
+  values: string[]
+}
+
+export interface SearchProviderView {
+  label: string
+  tone: 'catalog' | 'neutral' | 'observed'
+}
+
+export interface SearchTruncationView {
+  maxResults: number
+  note: string
+  returnedCount: number
+  truncated: boolean
+}
+
+export interface SearchKnownResultViewBase {
+  description: string
+  guide: string
+  matchingValues: SearchMatchingValuesView[]
+  omittedMatchingFieldCount: number
+  providers: SearchProviderView[]
+  sqlReference: string
+}
+
+export interface SearchTableResultView extends SearchKnownResultViewBase {
+  fields: SearchFieldView[]
+  kind: 'table'
+}
+
+export interface SearchFunctionResultView extends SearchKnownResultViewBase {
+  arguments: SearchFieldView[]
+  kind: 'function'
+  returns: SearchFieldView[]
+}
+
+export interface SearchUnknownResultView {
+  kind: 'unknown'
+}
+
+export type SearchResultView =
+  | SearchFunctionResultView
+  | SearchTableResultView
+  | SearchUnknownResultView
+
+export type SearchResultsView =
+  | {
+      results: SearchResultView[]
+      state: 'available'
+      truncation?: SearchTruncationView
+    }
+  | { state: 'tooLarge' }
+  | { state: 'unavailable' }
+
+function mapFields(fields: readonly RetainedProtoData<SearchField>[]): SearchFieldView[] {
+  return fields.map((field) => ({
+    dataType: field.dataType,
+    name: field.name,
+    required: field.required,
+  }))
+}
+
+function mapMatchingValues(
+  values: readonly RetainedProtoData<SearchFieldValues>[],
+): SearchMatchingValuesView[] {
+  return values.map((entry) => ({ field: entry.field, values: [...entry.values] }))
+}
+
+export function formatSearchSqlIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`
+}
+
+export function formatSearchSqlReference(surface: RetainedProtoData<SearchSurfaceRef>): string {
+  return [surface.catalogName, surface.schemaName, surface.name]
+    .filter((part) => part.length > 0)
+    .map(formatSearchSqlIdentifier)
+    .join('.')
+}
+
+function mapProvider(provider: SearchProvider): SearchProviderView {
+  if (provider === SearchProvider.CATALOG_METADATA) {
+    return { label: 'Catalog', tone: 'catalog' }
+  }
+  if (provider === SearchProvider.OBSERVED_VALUES) {
+    return { label: 'Observed values', tone: 'observed' }
+  }
+  if (provider === SearchProvider.NATIVE_FANOUT) {
+    return { label: 'Native fanout', tone: 'neutral' }
+  }
+  return { label: 'Unknown provider', tone: 'neutral' }
+}
+
+function mapTruncation(
+  truncation: RetainedProtoData<SearchResultTruncation>,
+): SearchTruncationView {
+  return {
+    maxResults: truncation.maxResults,
+    note: truncation.note,
+    returnedCount: truncation.returnedCount,
+    truncated: truncation.truncated,
+  }
+}
+
+function knownResultBase(
+  result: RetainedProtoData<SearchResult>,
+  surface: RetainedProtoData<SearchSurfaceRef>,
+) {
+  return {
+    description: result.description,
+    guide: result.guide,
+    matchingValues: mapMatchingValues(result.matchingValues),
+    omittedMatchingFieldCount: result.omittedMatchingFieldCount,
+    providers: result.providers.map(mapProvider),
+    sqlReference: formatSearchSqlReference(surface),
+  }
+}
+
+function formatFunctionArguments(functionArguments: SearchFieldView[]): string {
+  const argumentsToShow = functionArguments
+    .filter((argument) => argument.required)
+    .map((argument) => argument.name)
+  if (functionArguments.some((argument) => !argument.required)) argumentsToShow.push('...')
+  return `(${argumentsToShow.join(', ')})`
+}
+
+function mapResult(result: RetainedProtoData<SearchResult>): SearchResultView {
+  if (!result.surface) return { kind: 'unknown' }
+
+  if (result.shape.case === 'table') {
+    return {
+      ...knownResultBase(result, result.surface),
+      fields: mapFields(result.shape.value.fields),
+      kind: 'table',
+    }
+  }
+
+  if (result.shape.case === 'function') {
+    const functionArguments = mapFields(result.shape.value.arguments)
+    return {
+      ...knownResultBase(result, result.surface),
+      arguments: functionArguments,
+      kind: 'function',
+      returns: mapFields(result.shape.value.returns),
+      sqlReference: `${formatSearchSqlReference(result.surface)}${formatFunctionArguments(functionArguments)}`,
+    }
+  }
+
+  return { kind: 'unknown' }
+}
+
+export function mapTraceSearchResponse(
+  searchResponse?: TraceSearchResponseData,
+): SearchResultsView {
+  if (!searchResponse) return { state: 'unavailable' }
+  if (searchResponse.outcome.case === 'tooLarge') return { state: 'tooLarge' }
+  if (searchResponse.outcome.case !== 'response') return { state: 'unavailable' }
+
+  const response = searchResponse.outcome.value
+  const view: Extract<SearchResultsView, { state: 'available' }> = {
+    results: response.results.map(mapResult),
+    state: 'available',
+  }
+  if (response.truncation) view.truncation = mapTruncation(response.truncation)
+  return view
+}
+
+export function searchResultsTabLabel(view: SearchResultsView): string {
+  return view.state === 'available' ? `Results ${view.results.length}` : 'Results'
+}

--- a/apps/coral-ui/app/views/traces/trace-detail-policy.ts
+++ b/apps/coral-ui/app/views/traces/trace-detail-policy.ts
@@ -1,0 +1,38 @@
+import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+
+import { isSearchOperation, type TraceSummaryData } from './trace-utils'
+
+export interface PrimaryDetailTab {
+  id: 'results' | 'timeline'
+  label: string
+}
+
+export interface TraceDetailPolicy {
+  defaultTab: 'results' | 'timeline'
+  primaryTabs: PrimaryDetailTab[]
+}
+
+export function traceDetailPolicy(
+  summary: TraceSummaryData,
+  resultsLabel: string,
+  showSearchTrace: boolean,
+): TraceDetailPolicy {
+  if (isSearchOperation(summary)) {
+    return {
+      defaultTab: showSearchTrace && summary.status === TraceStatus.ERROR ? 'timeline' : 'results',
+      primaryTabs: [
+        { id: 'results', label: resultsLabel },
+        ...(showSearchTrace ? [{ id: 'timeline' as const, label: 'Trace' }] : []),
+      ],
+    }
+  }
+
+  return {
+    defaultTab: 'timeline',
+    primaryTabs: [{ id: 'timeline', label: 'Trace' }],
+  }
+}
+
+export function timelineShortcutsEnabled(summary: TraceSummaryData, activeTab: string): boolean {
+  return !isSearchOperation(summary) || activeTab === 'timeline'
+}

--- a/apps/coral-ui/app/views/traces/trace-detail.tsx
+++ b/apps/coral-ui/app/views/traces/trace-detail.tsx
@@ -5,9 +5,16 @@ import { useLocation, useNavigate, useOutletContext } from 'react-router'
 import { Button, ScrollArea } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
+import { Tooltip } from '@/wax/components/tooltip'
 import { Typography } from '@/wax/components/typography'
 import { EmptyPage } from '@/components/empty-page'
-import { QueryDetailSummary } from '@/components/query-detail'
+import {
+  QueryDetailSummary,
+  SearchResponseResults,
+  mapTraceSearchResponse,
+  searchResultsTabLabel,
+  type QueryDetailStat,
+} from '@/components/query-detail'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 import { formatDuration, formatDurationFromNanos, nanosToMs } from '@/utils/format-time'
 
@@ -17,9 +24,12 @@ import { traceLocation } from './trace-location'
 import type { TracesOutletContext } from './traces-index'
 import { routePath } from '@/routing/routemap'
 import { useTimelineTree, type TimelineRow } from './use-timeline-tree'
+import { timelineShortcutsEnabled, traceDetailPolicy } from './trace-detail-policy'
 import {
+  formatInvocation,
   formatRows,
   isHttpSpan,
+  isSearchOperation,
   operationCodeLanguage,
   operationDetailLabel,
   operationDetailText,
@@ -33,7 +43,7 @@ import {
   type TraceSummaryData,
 } from './trace-utils'
 
-export type DetailTab = 'timeline' | 'api'
+export type DetailTab = 'results' | 'timeline' | 'api'
 type WaterfallTone = 'query' | 'http' | 'span' | 'error'
 
 const WATERFALL_LABEL_PADDING_INLINE_PX = 10
@@ -59,9 +69,17 @@ function focusSpanRow(spanId: string) {
 }
 
 export interface ExtraDetailTab {
+  description?: string
   id: string
   label: string
   content: React.ReactNode
+  show?: boolean
+}
+
+interface DetailTabPresentation {
+  description?: string
+  id: string
+  label: string
   show?: boolean
 }
 
@@ -358,6 +376,7 @@ function TimelineWaterfall({
   expandedHttpSpanId,
   onExpandedHttpSpanIdChange,
   onNavigableSpanIdsChange,
+  proMode,
   spans,
   summary,
 }: {
@@ -366,10 +385,10 @@ function TimelineWaterfall({
     spanId: string | null | ((current: string | null) => string | null),
   ) => void
   onNavigableSpanIdsChange: (spanIds: string[]) => void
+  proMode: boolean
   spans: TraceSpanData[]
   summary?: TraceSummaryData
 }) {
-  const proMode = useProMode()
   const timelineSpans = useMemo(
     () => (proMode ? spans : spans.filter(isHttpSpan)),
     [proMode, spans],
@@ -621,33 +640,85 @@ function TimelineWaterfall({
   )
 }
 
+function tabDomId(tabId: string): string {
+  return tabId.replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
 function DetailTabs({
   activeTab,
-  extraTabs,
+  idPrefix,
   onTab,
+  tabs,
 }: {
   activeTab: string
-  extraTabs?: ExtraDetailTab[]
+  idPrefix: string
   onTab: (tab: string) => void
+  tabs: DetailTabPresentation[]
 }) {
-  const tabs = [
-    { id: 'timeline', label: 'Trace', show: true },
-    ...(extraTabs ?? []).map((tab) => ({ id: tab.id, label: tab.label, show: tab.show ?? true })),
-  ]
+  const visibleTabs = tabs.filter((tab) => tab.show ?? true)
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+
+    const tabButtons = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    )
+    const currentIndex = tabButtons.indexOf(document.activeElement as HTMLButtonElement)
+    if (currentIndex < 0) return
+
+    let nextIndex = currentIndex
+    if (event.key === 'ArrowLeft') {
+      nextIndex = (currentIndex - 1 + visibleTabs.length) % visibleTabs.length
+    } else if (event.key === 'ArrowRight') {
+      nextIndex = (currentIndex + 1) % visibleTabs.length
+    } else if (event.key === 'Home') {
+      nextIndex = 0
+    } else if (event.key === 'End') {
+      nextIndex = visibleTabs.length - 1
+    }
+
+    event.preventDefault()
+    onTab(visibleTabs[nextIndex].id)
+    tabButtons[nextIndex].focus()
+  }
+
   return (
-    <div className={s.tabList}>
-      {tabs
-        .filter((tab) => tab.show)
-        .map((tab) => (
+    <div
+      aria-label="Operation details"
+      className={s.tabList}
+      onKeyDown={handleKeyDown}
+      role="tablist"
+    >
+      {visibleTabs.map((tab) => (
+        <div className={s.tabItem} key={tab.id} role="presentation">
           <button
+            aria-controls={`${idPrefix}-panel-${tabDomId(tab.id)}`}
+            aria-describedby={
+              tab.description ? `${idPrefix}-description-${tabDomId(tab.id)}` : undefined
+            }
+            aria-selected={activeTab === tab.id}
             className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
-            key={tab.id}
+            id={`${idPrefix}-tab-${tabDomId(tab.id)}`}
             onClick={() => onTab(tab.id)}
+            role="tab"
+            tabIndex={activeTab === tab.id ? 0 : -1}
             type="button"
           >
             <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
           </button>
-        ))}
+          {tab.description ? (
+            <>
+              <Tooltip content={tab.description} side="bottom">
+                <span aria-hidden="true" className={s.tabInfo}>
+                  <Icon name="Info" size="16" />
+                </span>
+              </Tooltip>
+              <span className={s.visuallyHidden} id={`${idPrefix}-description-${tabDomId(tab.id)}`}>
+                {tab.description}
+              </span>
+            </>
+          ) : null}
+        </div>
+      ))}
     </div>
   )
 }
@@ -673,13 +744,30 @@ function TraceDetailContent({
   onSelectTrace?: (traceId: string) => void
   traceId: string
 }) {
-  const [activeTab, setActiveTab] = useState<string>('timeline')
+  const proMode = useProMode()
+  const summary = detail?.summary ?? initialSummary
+  const searchResultsView = useMemo(
+    () => mapTraceSearchResponse(detail?.searchResponse),
+    [detail?.searchResponse],
+  )
+  const searchOperation = Boolean(summary && isSearchOperation(summary))
+  const showSearchDiagnosticSpans = Boolean(
+    searchOperation &&
+    (summary?.status === TraceStatus.ERROR ||
+      (detail !== null && searchResultsView.state !== 'available')),
+  )
+  const showSearchTrace = Boolean(
+    searchOperation && (proMode || showSearchDiagnosticSpans || detail?.spans.some(isHttpSpan)),
+  )
+  const detailPolicy = summary
+    ? traceDetailPolicy(summary, searchResultsTabLabel(searchResultsView), showSearchTrace)
+    : null
+  const defaultTab = detailPolicy?.defaultTab ?? 'timeline'
+  const [activeTab, setActiveTab] = useState<string>(() => defaultTab)
+  const activeTabChangedByUser = useRef(false)
   const [expandedHttpSpanId, setExpandedHttpSpanId] = useState<string | null>(null)
   const [navigableSpanIds, setNavigableSpanIds] = useState<string[]>([])
-  useEffect(() => {
-    setActiveTab('timeline')
-    setExpandedHttpSpanId(null)
-  }, [traceId])
+  const tabIdPrefix = `trace-detail-${tabDomId(traceId)}`
 
   const selectAdjacentSpan = useCallback(
     (direction: -1 | 1) => {
@@ -713,14 +801,14 @@ function TraceDetailContent({
 
   const handleEscapeShortcut = useCallback(
     (event: KeyboardEvent) => {
-      if (expandedHttpSpanId) {
+      if (activeTab === 'timeline' && expandedHttpSpanId) {
         event.preventDefault()
         setExpandedHttpSpanId(null)
         return
       }
       onClose()
     },
-    [expandedHttpSpanId, onClose],
+    [activeTab, expandedHttpSpanId, onClose],
   )
 
   const focusFirstSpan = useCallback(
@@ -762,13 +850,24 @@ function TraceDetailContent({
     () => handleSpanArrowShortcut(1),
     [handleSpanArrowShortcut],
   )
-  const summary = detail?.summary ?? initialSummary
   const httpSpans = useMemo(() => detail?.spans.filter(isHttpSpan) ?? [], [detail?.spans])
   const sources = useMemo(() => sourceNames(detail?.spans ?? []), [detail?.spans])
   const resolvedExtraTabs = useMemo(
     () => (detail ? (extraTabs?.(detail) ?? []) : []),
     [detail, extraTabs],
   )
+  const activeTabAvailable = Boolean(
+    detailPolicy?.primaryTabs.some((tab) => tab.id === activeTab) ||
+    resolvedExtraTabs.some((tab) => (tab.show ?? true) && tab.id === activeTab),
+  )
+  useEffect(() => {
+    if (!activeTabAvailable) {
+      activeTabChangedByUser.current = false
+      setActiveTab(defaultTab)
+      return
+    }
+    if (!activeTabChangedByUser.current) setActiveTab(defaultTab)
+  }, [activeTabAvailable, defaultTab])
 
   if (loadError)
     return (
@@ -796,7 +895,48 @@ function TraceDetailContent({
     )
   }
 
-  const activeExtraTab = resolvedExtraTabs.find((tab) => tab.id === activeTab)
+  const primaryTabs = detailPolicy?.primaryTabs ?? [{ id: 'timeline', label: 'Trace' }]
+  const tabs: DetailTabPresentation[] = [
+    ...primaryTabs,
+    ...resolvedExtraTabs.map((tab) => ({
+      description: tab.description,
+      id: tab.id,
+      label: tab.label,
+      show: tab.show,
+    })),
+  ]
+  const visibleTabs = tabs.filter((tab) => tab.show ?? true)
+  const activePanelTab =
+    visibleTabs.find((tab) => tab.id === activeTab) ??
+    visibleTabs.find((tab) => tab.id === defaultTab) ??
+    visibleTabs[0]
+  const showTabList = !isSearchOperation(summary) || visibleTabs.length > 1
+  const sharedTraceStats: QueryDetailStat[] = [
+    { label: 'Duration', value: formatDurationFromNanos(summary.durationNanos) },
+    { label: 'Rows', value: formatRows(summary) },
+    { label: 'Table scans', value: detail ? sources.length : '—' },
+    { label: 'API requests', value: detail ? httpSpans.length : '—' },
+  ]
+  const searchTraceStats: QueryDetailStat[] = [
+    { label: 'Duration', value: formatDurationFromNanos(summary.durationNanos) },
+    { label: 'Invocation', value: formatInvocation(summary.invocationKind) },
+    { label: 'Table scans', value: detail ? sources.length : '—' },
+    { label: 'API requests', value: detail ? httpSpans.length : '—' },
+  ]
+  const handleTab = (nextTab: string) => {
+    activeTabChangedByUser.current = true
+    setActiveTab(nextTab)
+  }
+  const timelineWaterfall = detail ? (
+    <TimelineWaterfall
+      expandedHttpSpanId={expandedHttpSpanId}
+      onExpandedHttpSpanIdChange={setExpandedHttpSpanId}
+      onNavigableSpanIdsChange={setNavigableSpanIds}
+      proMode={proMode || showSearchDiagnosticSpans}
+      spans={detail.spans}
+      summary={summary}
+    />
+  ) : null
 
   return (
     <QueryDetailSummary
@@ -836,7 +976,11 @@ function TraceDetailContent({
           <KeyboardShortcut
             handler={handleEscapeShortcut}
             shortcut="Escape"
-            tooltipContent={expandedHttpSpanId ? 'Close span inspector' : 'Close operation details'}
+            tooltipContent={
+              activeTab === 'timeline' && expandedHttpSpanId
+                ? 'Close span inspector'
+                : 'Close operation details'
+            }
             tooltipSide="bottom"
           >
             <Button.IconButton
@@ -850,18 +994,15 @@ function TraceDetailContent({
         </>
       }
       shortcuts={
-        <>
-          <KeyboardShortcut handler={handlePreviousSpanShortcut} shortcut="ArrowUp" />
-          <KeyboardShortcut handler={handleNextSpanShortcut} shortcut="ArrowDown" />
-        </>
+        timelineShortcutsEnabled(summary, activeTab) ? (
+          <>
+            <KeyboardShortcut handler={handlePreviousSpanShortcut} shortcut="ArrowUp" />
+            <KeyboardShortcut handler={handleNextSpanShortcut} shortcut="ArrowDown" />
+          </>
+        ) : undefined
       }
       sql={operationDetailText(summary)}
-      stats={[
-        { label: 'Duration', value: formatDurationFromNanos(summary.durationNanos) },
-        { label: 'Rows', value: formatRows(summary) },
-        { label: 'Table scans', value: detail ? sources.length : '—' },
-        { label: 'API requests', value: detail ? httpSpans.length : '—' },
-      ]}
+      stats={isSearchOperation(summary) ? searchTraceStats : sharedTraceStats}
       statusLabel={statusLabel(summary.status)}
       statusTone={statusTone(summary.status)}
       title={
@@ -880,20 +1021,38 @@ function TraceDetailContent({
         </>
       }
     >
-      <DetailTabs activeTab={activeTab} extraTabs={resolvedExtraTabs} onTab={setActiveTab} />
-      <div className={s.tabContent}>
-        {activeTab === 'timeline' &&
-          (detail ? (
-            <TimelineWaterfall
-              expandedHttpSpanId={expandedHttpSpanId}
-              onExpandedHttpSpanIdChange={setExpandedHttpSpanId}
-              onNavigableSpanIdsChange={setNavigableSpanIds}
-              spans={detail.spans}
-              summary={summary}
-            />
-          ) : null)}
-        {activeExtraTab?.content}
-      </div>
+      {showTabList ? (
+        <DetailTabs
+          activeTab={activePanelTab?.id ?? activeTab}
+          idPrefix={tabIdPrefix}
+          onTab={handleTab}
+          tabs={tabs}
+        />
+      ) : null}
+      {visibleTabs.map((tab) => {
+        const isActive = tab.id === activePanelTab?.id
+        const extraTab = resolvedExtraTabs.find((candidate) => candidate.id === tab.id)
+
+        return (
+          <div
+            aria-label={showTabList ? undefined : tab.label}
+            aria-labelledby={showTabList ? `${tabIdPrefix}-tab-${tabDomId(tab.id)}` : undefined}
+            className={s.tabContent}
+            hidden={!isActive}
+            id={`${tabIdPrefix}-panel-${tabDomId(tab.id)}`}
+            key={tab.id}
+            role={showTabList ? 'tabpanel' : 'region'}
+          >
+            {isActive ? (
+              <>
+                {tab.id === 'results' ? <SearchResponseResults view={searchResultsView} /> : null}
+                {tab.id === 'timeline' ? timelineWaterfall : null}
+                {extraTab?.content}
+              </>
+            ) : null}
+          </div>
+        )
+      })}
     </QueryDetailSummary>
   )
 }
@@ -923,6 +1082,7 @@ export function TraceDetail({
   return (
     <div className={s.detailOverlay}>
       <TraceDetailContent
+        key={traceId}
         detail={detail}
         extraTabs={extraTabs}
         initialSummary={initialSummary}

--- a/apps/coral-ui/app/views/traces/trace-utils.ts
+++ b/apps/coral-ui/app/views/traces/trace-utils.ts
@@ -1,4 +1,6 @@
+import type { TraceSearchResponseData } from '@/components/query-detail/search-response'
 import {
+  TraceInvocationKind,
   TraceOperationKind,
   TraceStatus,
   type TraceSpan,
@@ -10,6 +12,7 @@ export type JsonObject = Record<string, unknown>
 export type TraceSpanData = Omit<TraceSpan, '$typeName' | '$unknown'>
 export type TraceSummaryData = Omit<TraceSummary, '$typeName' | '$unknown'>
 export interface TraceDetailData {
+  searchResponse?: TraceSearchResponseData
   spans: TraceSpanData[]
   summary?: TraceSummaryData
 }
@@ -20,6 +23,12 @@ export function startMs(trace: TraceSummaryData): number {
 
 export function formatRows(trace: TraceSummaryData): string {
   return trace.rowCountRecorded ? trace.rowCount.toString() : '—'
+}
+
+export function formatInvocation(invocation: TraceInvocationKind): string {
+  if (invocation === TraceInvocationKind.DIRECT) return 'Direct'
+  if (invocation === TraceInvocationKind.MCP) return 'MCP'
+  return '—'
 }
 
 export function statusLabel(status: TraceStatus): string {

--- a/apps/coral-ui/app/views/traces/traces.css.ts
+++ b/apps/coral-ui/app/views/traces/traces.css.ts
@@ -276,23 +276,13 @@ export const sqlBlock = style({
   overflow: 'hidden',
   position: 'relative',
 })
-export const statGrid = style({ display: 'flex', flexWrap: 'wrap', gap: 12 })
-export const statCard = style({
-  backgroundColor: theme.surface.onMainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: 12,
-  display: 'flex',
-  flexDirection: 'column',
-  flexShrink: 0,
-  minWidth: 100,
-  paddingBlock: 12,
-  paddingInline: 16,
-})
 export const tabList = style({
+  alignItems: 'center',
   borderBlockEnd: `1px solid ${theme.stroke.primary}`,
   display: 'flex',
   gap: 4,
 })
+export const tabItem = style({ alignItems: 'center', display: 'flex' })
 export const tabTrigger = style({
   background: 'none',
   border: 'none',
@@ -307,12 +297,21 @@ export const tabTrigger = style({
   paddingInline: 12,
   selectors: {
     '&:focus': { outline: 'none' },
-    '&:focus-visible': { outline: 'none' },
+    '&:focus-visible': {
+      outline: `1px solid ${theme.stroke.focused}`,
+      outlineOffset: -2,
+    },
   },
 })
 export const tabTriggerActive = style({
   borderBlockEndColor: theme.pill.green.color,
   color: theme.content.primary,
+})
+export const tabInfo = style({
+  alignItems: 'center',
+  color: theme.content.tertiary,
+  display: 'inline-flex',
+  marginInlineStart: -6,
 })
 export const tabContent = style({
   display: 'flex',
@@ -321,6 +320,18 @@ export const tabContent = style({
   minHeight: 280,
   overflow: 'hidden',
   paddingBlockStart: 16,
+  selectors: { '&[hidden]': { display: 'none' } },
+})
+export const visuallyHidden = style({
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: 1,
+  margin: -1,
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  width: 1,
 })
 
 export const waterfallRoot = style({


### PR DESCRIPTION
## ![image.png](https://app.graphite.com/user-attachments/assets/dccc8164-33d5-4cc6-8031-7a1cfb6bee1d.png)

![image.png](https://app.graphite.com/user-attachments/assets/4c5cdf09-d036-415f-9c87-2a35ca44b07a.png)

![image.png](https://app.graphite.com/user-attachments/assets/14c00982-d0c4-4e03-aec8-4da9c24f3217.png)



  
Summary

- show retained ranked Search results directly in Query Stream without rerunning Search or parsing private span attributes
- render compact expandable table/function rows with descriptions, fields, arguments, return types, guides, and matching values
- show per-result provider provenance separately from request-wide provider status and coverage
- handle empty, unavailable, truncated, unknown, and oversized response states
- keep long field and argument names contained, and mark required inputs inline using Reef's existing accessible convention
- preserve the existing Query and Tool detail behavior

## Stack goal

The goal of this stack is to bring a clearer Search UI to Query Stream, improving visibility into Search responses and making Search behavior easier to debug from retained trace history.

## Data and retention policy

When trace history is enabled, Coral returns and retains the same Search response after applying the observed-values credential scrubber to matching-value evidence. Search responses are retained for 30 days in the operator-configured `CoralDb`, including PostgreSQL. This suppresses obvious credentials but is not general PII redaction. Retention is best-effort and does not wait on `CoralDb` in the Search request path.

Depends on #2119.

## Testing

- `npm run check --prefix apps/coral-ui`
- `npm run typecheck --prefix apps/coral-ui`
- `npm test --prefix apps/coral-ui` — 38 files, 398 tests
- `npm run build --prefix apps/coral-ui`
- `npm run test:server --prefix apps/coral-ui` — 7 tests
- `npm run build-storybook --prefix apps/coral-ui`
- `cargo build --locked -p coral-cli`
- live end-to-end inspection against the local Coral configuration, covering successful and failed Search traces, default tabs, keyboard navigation, tab-state preservation and reset, result scrolling, long identifiers, provider counts, and truncation copy
- `git diff --check`