### PR TITLE
refactor(spec): route OpenAPI import through a version dialect

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3302,7 +3302,19 @@ fn importer_accepts_every_spelling_of_a_supported_version() {
 
 #[test]
 fn importer_rejects_unsupported_versions_by_name() {
-    for version in ["2.0", "3.1.0", "3.2.0", "4.0.0", "3"] {
+    for version in [
+        "2.0",
+        "3.1.0",
+        "3.2.0",
+        "4.0.0",
+        "3",
+        // Well-formed prefix, malformed remainder. The version field holds one
+        // optional numeric patch component and nothing else.
+        "3.0.",
+        "3.0.banana",
+        "3.0.1.2",
+        "3.0.1-rc1",
+    ] {
         let error = import_version_probe(&format!("openapi: '{version}'"))
             .expect_err(&format!("version {version} should be rejected"));
         assert!(

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3232,3 +3232,120 @@ components:
         "the inherited columns must survive two levels of composition"
     );
 }
+
+/// A minimal but complete document whose first line the caller chooses, so a
+/// version test varies the version and nothing else.
+fn version_probe_document(first_line: &str) -> String {
+    format!(
+        r"{first_line}
+info:
+  title: Demo
+  description: Query demo data.
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {{type: string}}
+"
+    )
+}
+
+#[expect(
+    clippy::unwrap_in_result,
+    reason = "Only the import's own result is under test; a manifest that will not parse is a bug in this file, not an outcome to return."
+)]
+fn import_version_probe(first_line: &str) -> crate::Result<ImportedSurface> {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: version_probe
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    import_openapi_surface(
+        v4,
+        &v4.surface,
+        version_probe_document(first_line).as_bytes(),
+    )
+}
+
+#[test]
+fn importer_accepts_every_spelling_of_a_supported_version() {
+    // `3.0` carries no patch component, which the field's grammar allows and a
+    // `"3.0."` prefix test rejected.
+    for version in ["3.0.0", "3.0.3", "3.0.4", "3.0"] {
+        let imported = import_version_probe(&format!("openapi: '{version}'"))
+            .unwrap_or_else(|error| panic!("version {version} should import: {error}"));
+        assert_eq!(
+            imported.operations.len(),
+            1,
+            "version {version} should import its one operation"
+        );
+    }
+}
+
+#[test]
+fn importer_rejects_unsupported_versions_by_name() {
+    for version in ["2.0", "3.1.0", "3.2.0", "4.0.0", "3"] {
+        let error = import_version_probe(&format!("openapi: '{version}'"))
+            .expect_err(&format!("version {version} should be rejected"));
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("unsupported version '{version}'")),
+            "version {version} should be named in its own rejection: {error}"
+        );
+    }
+}
+
+#[test]
+fn importer_names_swagger_documents_rather_than_reporting_a_missing_field() {
+    let error = import_version_probe("swagger: '2.0'").expect_err("Swagger should be rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("Swagger version '2.0'"),
+        "a Swagger document deserves to be told what it is: {message}"
+    );
+}
+
+#[test]
+fn importer_rejects_documents_declaring_no_version() {
+    let error =
+        import_version_probe("x-unversioned: true").expect_err("missing version should reject");
+    assert!(
+        error.to_string().contains("missing openapi version"),
+        "{error}"
+    );
+}
+
+#[test]
+fn document_metadata_applies_the_same_version_gate_as_import() {
+    let metadata = openapi_document_metadata(version_probe_document("openapi: '3.0'").as_bytes())
+        .expect("3.0 metadata");
+    assert_eq!(metadata.description.as_deref(), Some("Query demo data."));
+
+    // Both entry points read the version, so they have to agree on the answer:
+    // describing a document the importer would refuse is the confusing outcome.
+    let error = openapi_document_metadata(version_probe_document("openapi: '3.1.0'").as_bytes())
+        .expect_err("3.1 metadata should be rejected while import rejects it");
+    assert!(
+        error.to_string().contains("unsupported version '3.1.0'"),
+        "{error}"
+    );
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
@@ -1,0 +1,13 @@
+use serde_json::Value;
+
+/// The rules that differ between the `OpenAPI` versions the importer supports.
+///
+/// The traversal itself is shared: response selection, pagination detection,
+/// row-path inference, and `allOf` folding all read a 3.1 document exactly as
+/// they read a 3.0 one. Only the few keywords the versions genuinely disagree
+/// about route through here, which keeps each version's rules readable as one
+/// implementation instead of as `match` arms spread across the traversal.
+pub(super) trait OpenApiDialect {
+    /// Whether a schema admits `null`.
+    fn schema_nullable(&self, schema: &Value) -> bool;
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/document.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/document.rs
@@ -2,6 +2,8 @@ use serde_json::{Map, Value};
 
 use crate::{ManifestError, Result};
 
+use super::version::parse_openapi_version;
+
 pub fn normalize_source_document(bytes: &[u8]) -> Result<String> {
     let value: Value = serde_yaml::from_slice(bytes).map_err(ManifestError::parse_yaml)?;
     serde_yaml::to_string(&value).map_err(ManifestError::serialize_yaml)
@@ -16,15 +18,11 @@ pub struct OpenApiDocumentMetadata {
 pub fn openapi_document_metadata(document_bytes: &[u8]) -> Result<OpenApiDocumentMetadata> {
     let document: Value =
         serde_yaml::from_slice(document_bytes).map_err(ManifestError::parse_yaml)?;
-    let openapi = document
-        .get("openapi")
-        .and_then(Value::as_str)
-        .ok_or_else(|| ManifestError::validation("OpenAPI document is missing openapi version"))?;
-    if !openapi.starts_with("3.0.") {
-        return Err(ManifestError::validation(format!(
-            "OpenAPI document uses unsupported version '{openapi}'"
-        )));
-    }
+    // Validated but otherwise unused: everything read below is spelled the same
+    // in every supported version, so this needs no dialect. Rejecting here keeps
+    // metadata extraction and import agreeing on what Coral will accept, rather
+    // than describing a document the importer would go on to refuse.
+    parse_openapi_version(&document)?;
     Ok(OpenApiDocumentMetadata {
         description: trimmed_string_at(&document, &["info", "description"]),
         server_url: document

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -12,6 +12,10 @@ use crate::v4::{
 };
 use crate::{ManifestError, Result};
 
+use super::dialect::OpenApiDialect;
+use super::v3_0::OpenApi30Importer;
+use super::version::{OpenApiVersion, parse_openapi_version};
+
 pub fn import_openapi_surface(
     manifest: &V4SourceManifest,
     surface: &V4Surface,
@@ -19,17 +23,11 @@ pub fn import_openapi_surface(
 ) -> Result<ImportedSurface> {
     let document: Value =
         serde_yaml::from_slice(document_bytes).map_err(ManifestError::parse_yaml)?;
-    let openapi = document
-        .get("openapi")
-        .and_then(Value::as_str)
-        .ok_or_else(|| ManifestError::validation("OpenAPI document is missing openapi version"))?;
-    if !openapi.starts_with("3.0.") {
-        return Err(ManifestError::validation(format!(
-            "OpenAPI document uses unsupported version '{openapi}'"
-        )));
-    }
+    let dialect: &dyn OpenApiDialect = match parse_openapi_version(&document)? {
+        OpenApiVersion::V3_0 => &OpenApi30Importer,
+    };
 
-    let mut importer = OpenApiImporter::new(manifest, surface, &document);
+    let mut importer = OpenApiImporter::new(manifest, surface, &document, dialect);
     importer.import()
 }
 
@@ -37,6 +35,7 @@ pub(super) struct OpenApiImporter<'a> {
     pub(super) manifest: &'a V4SourceManifest,
     pub(super) surface: &'a V4Surface,
     pub(super) document: &'a Value,
+    pub(super) dialect: &'a dyn OpenApiDialect,
     pub(super) types: BTreeMap<String, IrType>,
     pub(super) diagnostics: Vec<Diagnostic>,
 }
@@ -47,11 +46,17 @@ pub(super) enum RefDiagnosticContext<'a> {
 }
 
 impl<'a> OpenApiImporter<'a> {
-    fn new(manifest: &'a V4SourceManifest, surface: &'a V4Surface, document: &'a Value) -> Self {
+    fn new(
+        manifest: &'a V4SourceManifest,
+        surface: &'a V4Surface,
+        document: &'a Value,
+        dialect: &'a dyn OpenApiDialect,
+    ) -> Self {
         Self {
             manifest,
             surface,
             document,
+            dialect,
             types: BTreeMap::new(),
             diagnostics: Vec::new(),
         }

--- a/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
@@ -1,8 +1,11 @@
+mod dialect;
 mod document;
 mod import;
 mod operations;
 mod responses;
 mod schemas;
+mod v3_0;
+mod version;
 
 pub use document::{OpenApiDocumentMetadata, normalize_source_document, openapi_document_metadata};
 pub use import::import_openapi_surface;

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -70,10 +70,7 @@ impl OpenApiImporter<'_> {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
-        let nullable = resolved
-            .get("nullable")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
+        let nullable = self.dialect.schema_nullable(&resolved);
         self.types.insert(
             type_id.clone(),
             IrType {

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
@@ -1,0 +1,17 @@
+use serde_json::Value;
+
+use super::dialect::OpenApiDialect;
+
+/// Rules for documents declaring `OpenAPI` 3.0.x.
+pub(super) struct OpenApi30Importer;
+
+impl OpenApiDialect for OpenApi30Importer {
+    /// 3.0 predates JSON Schema's `null` type and spells nullability as its own
+    /// `nullable` keyword.
+    fn schema_nullable(&self, schema: &Value) -> bool {
+        schema
+            .get("nullable")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/version.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/version.rs
@@ -35,11 +35,32 @@ pub(super) fn parse_openapi_version(document: &Value) -> Result<OpenApiVersion> 
             "OpenAPI document is missing openapi version",
         ));
     };
-    let mut components = declared.trim().split('.');
-    match (components.next(), components.next()) {
-        (Some("3"), Some("0")) => Ok(OpenApiVersion::V3_0),
-        _ => Err(ManifestError::validation(format!(
+    let unsupported = || {
+        ManifestError::validation(format!(
             "OpenAPI document uses unsupported version '{declared}'"
-        ))),
+        ))
+    };
+    let mut components = declared.trim().split('.');
+    let version = match (components.next(), components.next()) {
+        (Some("3"), Some("0")) => OpenApiVersion::V3_0,
+        _ => return Err(unsupported()),
+    };
+    // The patch component is optional, but a present one has to be a number and
+    // has to be the last thing in the string. Matching only the first two
+    // components would take `3.0.banana`, `3.0.` and `3.0.1.2` for well-formed
+    // 3.0 and import them, and this is the one place left that reads the
+    // version — so it is the place to say what the field may hold.
+    //
+    // Both remaining components are taken up front, mirroring the match above:
+    // deciding this in a guard would leave whether `3.0.1.2` is rejected resting
+    // on a mid-match side effect, which is not something a reader should have to
+    // trace.
+    let is_numeric = |component: &str| {
+        !component.is_empty() && component.bytes().all(|byte| byte.is_ascii_digit())
+    };
+    match (components.next(), components.next()) {
+        (None, _) => Ok(version),
+        (Some(patch), None) if is_numeric(patch) => Ok(version),
+        _ => Err(unsupported()),
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/version.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/version.rs
@@ -1,0 +1,45 @@
+use serde_json::Value;
+
+use crate::{ManifestError, Result};
+
+/// A specification version the `OpenAPI` importer has a dialect for.
+///
+/// Only the major and minor components are modelled. The patch component
+/// separates editorial revisions of one specification — 3.0.0 through 3.0.4 —
+/// and nothing the importer does varies across them.
+///
+/// 3.1 joins this as its dialect lands. Recognising a version here is the same
+/// statement as supporting it, so an unsupported version is rejected by the
+/// parse rather than admitted and turned away later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OpenApiVersion {
+    V3_0,
+}
+
+/// Reads a document's declared `openapi` version.
+///
+/// Matches on major and minor rather than testing a `"3.0."` prefix, which read
+/// the patch separator as mandatory and so rejected a bare `3.0` — a spelling
+/// the field's own grammar allows.
+pub(super) fn parse_openapi_version(document: &Value) -> Result<OpenApiVersion> {
+    let Some(declared) = document.get("openapi").and_then(Value::as_str) else {
+        // A Swagger 2 document carries `swagger` where this one looks for
+        // `openapi`. It is a common enough input to name for what it is rather
+        // than report as a missing field.
+        if let Some(swagger) = document.get("swagger").and_then(Value::as_str) {
+            return Err(ManifestError::validation(format!(
+                "document declares Swagger version '{swagger}'; Coral requires OpenAPI 3.0"
+            )));
+        }
+        return Err(ManifestError::validation(
+            "OpenAPI document is missing openapi version",
+        ));
+    };
+    let mut components = declared.trim().split('.');
+    match (components.next(), components.next()) {
+        (Some("3"), Some("0")) => Ok(OpenApiVersion::V3_0),
+        _ => Err(ManifestError::validation(format!(
+            "OpenAPI document uses unsupported version '{declared}'"
+        ))),
+    }
+}


### PR DESCRIPTION
Part of #1321. First of six — this one is groundwork and adds no 3.1 support of its own.

## Why

The 3.0-only version guard was duplicated byte-for-byte between `import_openapi_surface` and `openapi_document_metadata`, and had no test coverage at all. Adding 3.1 on top of that meant editing the same check twice and hoping the two stayed in step.

## What changes

Both call sites now share one `parse_openapi_version`. The importer reaches its one genuinely version-dependent decision — whether a schema admits `null` — through an `OpenApiDialect` trait rather than reading the 3.0 `nullable` keyword directly.

The traversal itself stays shared. Response selection, pagination detection, row-path inference, and `allOf` folding read a 3.1 document exactly as they read a 3.0 one, so only the keywords the versions disagree about need a dialect. `OpenApi31Importer` lands in #2124 as the second implementation.

## Behaviour changes

Two small ones fall out of replacing the `"3.0."` prefix test with a major/minor match:

- A bare `3.0` is now accepted. The patch component is optional in the field's own grammar, and the prefix test read its separator as mandatory.
- A Swagger 2 document is named as one, instead of being reported as missing an `openapi` field — which is what it looked like when the check only knew one key.

Neither changes the artifacts a document that already imported produces, so the importer version is left alone.

## Review follow-up

Matching only the first two dot-separated components accepted `3.0.banana`, `3.0.`, `3.0.1-rc1` and `3.0.1.2` as well-formed. The prefix test this replaced was equally lenient, so nothing regressed — but this is now the one place that reads the version, which makes it the place to say what the field may hold: an optional patch component, numeric, and last.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>