### PR TITLE
fix(spec): read OpenAPI type arrays when choosing a schema's shape

### DIFF
--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -5,7 +5,7 @@
 
 pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 6;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v4";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v9";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v10";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v4";
 pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3471,6 +3471,43 @@ fn response_and_schema_dispatch_agree_when_a_schema_claims_both_types() {
 }
 
 #[test]
+fn importer_reads_a_union_of_a_collection_and_a_scalar_as_json() {
+    // `null` is the only type a collection may be unioned with and still be a
+    // collection. This one also accepts a bare string, so importing `items`
+    // would type every string response as a single row of item-derived columns,
+    // each of them null. Neither shape is true of both instances, so the
+    // response keeps the shape the importer uses when it cannot tell.
+    let imported = import_response_schema(
+        r"                type: [array, string]
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(
+        operation.output.cardinality,
+        OutputCardinality::Unknown,
+        "a union including `array` does not make the response a collection"
+    );
+    assert!(
+        matches!(
+            imported
+                .types
+                .iter()
+                .find(|ty| ty.id == operation.output.type_ref)
+                .expect("row type")
+                .shape,
+            IrTypeShape::Json
+        ),
+        "both dispatches have to decline: an `id` column here would come from \
+         `items`, which only describes the collection branch"
+    );
+}
+
+#[test]
 fn importer_reads_a_nullable_object_as_an_object() {
     // This case survived the string-only read by luck rather than by design: an
     // unreadable `type` fell through to a default of "object", which is what a

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3361,3 +3361,204 @@ fn document_metadata_applies_the_same_version_gate_as_import() {
         "{error}"
     );
 }
+
+/// Imports a document whose one operation returns `response_schema`.
+#[expect(
+    clippy::unwrap_in_result,
+    reason = "Only the import's own result is under test; a manifest that will not parse is a bug in this file, not an outcome to return."
+)]
+fn import_response_schema(response_schema: &str) -> crate::Result<ImportedSurface> {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: type_array_probe
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    import_openapi_surface(
+        v4,
+        &v4.surface,
+        format!(
+            r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+{response_schema}
+"
+        )
+        .as_bytes(),
+    )
+}
+
+#[test]
+fn importer_reads_a_nullable_collection_as_a_list() {
+    // The type array is what a nullable schema looks like once `nullable` is
+    // gone. Read as a string, `type` came back as `None` here and the schema
+    // fell through to the typeless default, so the collection was imported as a
+    // single object row and every item was lost.
+    let imported = import_response_schema(
+        r"                type: [array, 'null']
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+}
+
+#[test]
+fn importer_reads_a_nullable_object_as_an_object() {
+    // This case survived the string-only read by luck rather than by design: an
+    // unreadable `type` fell through to a default of "object", which is what a
+    // nullable object needed anyway. Pinned because the new dispatch reaches the
+    // same answer deliberately, and a later reshuffle of the branch order should
+    // not be free to lose it.
+    let imported = import_response_schema(
+        r"                type: [object, 'null']
+                properties:
+                  id: {type: string}
+                  name: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("a nullable object should keep its fields rather than fall back to opaque JSON");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(names, ["id", "name"]);
+}
+
+#[test]
+fn importer_reads_a_nullable_collection_of_objects_into_row_fields() {
+    // Nullable rows inside a plain collection, which the "object" default also
+    // happened to get right. Kept as the composed counterpart to the two cases
+    // above, and as the anchor for the nullability assertion below.
+    let imported = import_response_schema(
+        r"                type: array
+                items:
+                  type: [object, 'null']
+                  properties:
+                    id: {type: string}
+                    label: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    let row_type = imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type");
+    assert!(
+        !row_type.nullable,
+        "reading 'null' out of a type array is the 3.1 dialect's job; 3.0 spells nullability with its own keyword"
+    );
+    let IrTypeShape::Object { fields } = &row_type.shape else {
+        panic!("a nullable row should keep its fields rather than fall back to opaque JSON");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(names, ["id", "label"]);
+}
+
+#[test]
+fn importer_still_reads_a_typeless_schema_as_an_object() {
+    // Declaring no type at all is not the same as declaring one this code has
+    // no shape for: JSON Schema accepts any instance, and the importer has
+    // always read that as an object.
+    let imported = import_response_schema(
+        r"                properties:
+                  id: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::Singleton);
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("a typeless schema with properties should still be an object");
+    };
+    assert_eq!(fields.len(), 1);
+}
+
+#[test]
+fn importer_reads_a_nullable_array_property_as_a_list() {
+    // The type-import half of the same fault. A nullable collection nested as a
+    // property never reached the array branch: its `type` did not read as a
+    // string, so it took the "object" default, found neither `properties` nor
+    // `additionalProperties`, and collapsed to opaque JSON — losing the element
+    // type of every optional list an API returns.
+    let imported = import_response_schema(
+        r"                type: object
+                properties:
+                  id: {type: string}
+                  tags:
+                    type: [array, 'null']
+                    items: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("expected an object row");
+    };
+    let tags = fields
+        .iter()
+        .find(|field| field.name == "tags")
+        .expect("tags field");
+    let IrTypeShape::List { item_type_ref } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == tags.type_ref)
+        .expect("tags type")
+        .shape
+    else {
+        panic!("a nullable array property should import as a list, not opaque JSON");
+    };
+    assert!(
+        matches!(
+            imported
+                .types
+                .iter()
+                .find(|ty| &ty.id == item_type_ref)
+                .expect("item type")
+                .shape,
+            IrTypeShape::Scalar(IrScalarType::String)
+        ),
+        "the element type has to survive, or the list is untyped"
+    );
+}

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3419,6 +3419,55 @@ fn importer_reads_a_nullable_collection_as_a_list() {
 
     let operation = imported.operations.first().expect("operation");
     assert_eq!(operation.output.cardinality, OutputCardinality::List);
+
+    // The cardinality alone would still be satisfied if the item schema handed
+    // to `import_schema` were the wrong one — the rows would be typed as opaque
+    // JSON, which is the other half of the same data loss.
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("the row type has to come from `items`, not from the collection itself");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(names, ["id"]);
+}
+
+#[test]
+fn response_and_schema_dispatch_agree_when_a_schema_claims_both_types() {
+    // Only a schema declaring both types can tell the two dispatches apart, and
+    // they have to answer alike: a response read as a list whose row type was
+    // built as an object would describe a collection of one thing and rows of
+    // another.
+    let imported = import_response_schema(
+        r"                type: [object, array]
+                properties:
+                  id: {type: string}
+                items: {type: string}",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(
+        operation.output.cardinality,
+        OutputCardinality::Singleton,
+        "object wins in `classify_response_schema`, as it does in `import_schema`"
+    );
+    assert!(
+        matches!(
+            imported
+                .types
+                .iter()
+                .find(|ty| ty.id == operation.output.type_ref)
+                .expect("row type")
+                .shape,
+            IrTypeShape::Object { .. }
+        ),
+        "the row type must be the object the cardinality claims it is"
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -463,6 +463,15 @@ pub(crate) fn json_schema_type_contains(schema: &Value, expected: &str) -> bool 
     }
 }
 
+/// Whether the schema declares a `type` at all.
+///
+/// Separates "declared a type this code has no shape for" from "declared
+/// nothing", which JSON Schema reads as accepting any instance and the importer
+/// reads as an object.
+pub(crate) fn json_schema_has_declared_type(schema: &Value) -> bool {
+    !schema_type_values(schema).is_empty()
+}
+
 pub(crate) fn json_schema_type_display(schema: &Value) -> String {
     match schema.get("type") {
         Some(Value::String(value)) => value.clone(),

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -463,6 +463,21 @@ pub(crate) fn json_schema_type_contains(schema: &Value, expected: &str) -> bool 
     }
 }
 
+/// Whether `expected` is the only type the schema declares, ignoring `null`.
+///
+/// Weaker than `json_schema_type_contains` on purpose. A nullable schema spells
+/// itself as a union with `null` — `{"type": ["array", "null"]}` is 3.1's
+/// nullable collection — so `null` cannot count against a single-shape reading.
+/// Every other extra type can: `{"type": ["array", "string"]}` describes a
+/// response that is sometimes a collection and sometimes one string, and no
+/// single shape is true of both.
+pub(crate) fn json_schema_declares_only_type(schema: &Value, expected: &str) -> bool {
+    let mut declared = schema_type_values(schema)
+        .into_iter()
+        .filter(|value| *value != "null");
+    declared.next() == Some(expected) && declared.next().is_none()
+}
+
 /// Whether the schema declares a `type` at all.
 ///
 /// Separates "declared a type this code has no shape for" from "declared

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -5,7 +5,9 @@ use serde_json::{Map, Value};
 use crate::ResponseSpec;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrOperationOutput, OutputCardinality, RestResponseAttachment};
-use crate::v4::surfaces::json_schema::{json_schema_has_declared_type, json_schema_type_contains};
+use crate::v4::surfaces::json_schema::{
+    json_schema_declares_only_type, json_schema_has_declared_type, json_schema_type_contains,
+};
 
 use super::import::OpenApiImporter;
 
@@ -255,7 +257,10 @@ fn classify_response_schema(
                 .or_else(|| Some(entity_name_from_path(path))),
         );
     }
-    if json_schema_type_contains(schema, "array") {
+    // The sole declared type, matching `import_schema`: a union that only
+    // includes `array` is not a collection, and reading one as a list would
+    // claim a row count for responses that are a single string.
+    if json_schema_declares_only_type(schema, "array") {
         let item = schema.get("items").cloned().unwrap_or(Value::Null);
         return (
             OutputCardinality::List,

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value};
 use crate::ResponseSpec;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrOperationOutput, OutputCardinality, RestResponseAttachment};
+use crate::v4::surfaces::json_schema::{json_schema_has_declared_type, json_schema_type_contains};
 
 use super::import::OpenApiImporter;
 
@@ -232,7 +233,12 @@ fn classify_response_schema(
     if schema == &Value::Null {
         return (OutputCardinality::None, Value::Null, None);
     }
-    if schema.get("type").and_then(Value::as_str) == Some("array") {
+    // Matched through the array-aware helpers, because a nullable schema
+    // declares its type as an array — `{"type": ["array", "null"]}` is 3.1's
+    // spelling of a nullable collection. Reading only the string form missed
+    // every one of them and fell through to the typeless default, so a nullable
+    // collection was classified as a singleton object and its rows were lost.
+    if json_schema_type_contains(schema, "array") {
         let item = schema.get("items").cloned().unwrap_or(Value::Null);
         return (
             OutputCardinality::List,
@@ -242,12 +248,7 @@ fn classify_response_schema(
                 .map(entity_name_from_ref),
         );
     }
-    if schema
-        .get("type")
-        .and_then(Value::as_str)
-        .unwrap_or("object")
-        == "object"
-    {
+    if json_schema_type_contains(schema, "object") || !json_schema_has_declared_type(schema) {
         return (
             OutputCardinality::Singleton,
             schema.clone(),

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -238,16 +238,12 @@ fn classify_response_schema(
     // spelling of a nullable collection. Reading only the string form missed
     // every one of them and fell through to the typeless default, so a nullable
     // collection was classified as a singleton object and its rows were lost.
-    if json_schema_type_contains(schema, "array") {
-        let item = schema.get("items").cloned().unwrap_or(Value::Null);
-        return (
-            OutputCardinality::List,
-            item.clone(),
-            item.get("$ref")
-                .and_then(Value::as_str)
-                .map(entity_name_from_ref),
-        );
-    }
+    //
+    // Object is tested first, in the same order `import_schema` tests it. Only a
+    // schema claiming both types can tell the difference, and the two have to
+    // agree about it: one deciding a response is a list while the other builds
+    // its row type as an object would leave the cardinality and the row shape
+    // describing different things.
     if json_schema_type_contains(schema, "object") || !json_schema_has_declared_type(schema) {
         return (
             OutputCardinality::Singleton,
@@ -257,6 +253,16 @@ fn classify_response_schema(
                 .and_then(Value::as_str)
                 .map(entity_name_from_ref)
                 .or_else(|| Some(entity_name_from_path(path))),
+        );
+    }
+    if json_schema_type_contains(schema, "array") {
+        let item = schema.get("items").cloned().unwrap_or(Value::Null);
+        return (
+            OutputCardinality::List,
+            item.clone(),
+            item.get("$ref")
+                .and_then(Value::as_str)
+                .map(entity_name_from_ref),
         );
     }
     (OutputCardinality::Unknown, schema.clone(), None)

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -7,7 +7,8 @@ use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
     JsonObjectShape, JsonSchemaComparisonError, JsonSchemaWalkError, RefError,
-    direct_json_object_shape, json_schema_required_fields, json_schema_scalar_type,
+    direct_json_object_shape, json_schema_has_declared_type, json_schema_required_fields,
+    json_schema_scalar_type, json_schema_type_contains,
     merge_json_object_shape_annotation_insensitive, with_resolved_json_schema,
 };
 
@@ -151,55 +152,57 @@ impl OpenApiImporter<'_> {
             }
         } else if let Some(scalar) = json_schema_scalar_type(&resolved) {
             IrTypeShape::Scalar(scalar)
-        } else {
-            match resolved
-                .get("type")
-                .and_then(Value::as_str)
-                .unwrap_or("object")
-            {
-                "object" => {
-                    if let Some(properties) = resolved.get("properties").and_then(Value::as_object)
-                    {
-                        let required = resolved
-                            .as_object()
-                            .map(json_schema_required_fields)
-                            .unwrap_or_default();
-                        IrTypeShape::Object {
-                            fields: self.import_object_fields(
-                                properties.iter(),
-                                &required,
-                                &type_id,
-                                operation_id,
-                                diagnostics,
-                            ),
-                        }
-                    } else if let Some(additional) = resolved.get("additionalProperties") {
-                        if additional.as_bool() == Some(false) {
-                            IrTypeShape::Object { fields: Vec::new() }
-                        } else {
-                            let value_type_ref = self
-                                .import_schema(
-                                    additional,
-                                    &format!("{type_id}_value"),
-                                    operation_id,
-                                    diagnostics,
-                                )
-                                .unwrap_or_else(|| "json".to_string());
-                            IrTypeShape::Map { value_type_ref }
-                        }
-                    } else {
-                        IrTypeShape::Json
-                    }
+        // `type` is matched through the array-aware helpers rather than read as
+        // a string. A schema may list several types, and a nullable one always
+        // does — `{"type": ["object", "null"]}` is how 3.1 spells what 3.0
+        // spelled `nullable: true`. Reading only the string form left every such
+        // schema falling through to the typeless default, so a nullable array
+        // was imported as an object.
+        //
+        // A schema declaring no type at all still defaults to an object, and
+        // `object` still wins over `array` when a schema somehow claims both.
+        } else if json_schema_type_contains(&resolved, "object")
+            || !json_schema_has_declared_type(&resolved)
+        {
+            if let Some(properties) = resolved.get("properties").and_then(Value::as_object) {
+                let required = resolved
+                    .as_object()
+                    .map(json_schema_required_fields)
+                    .unwrap_or_default();
+                IrTypeShape::Object {
+                    fields: self.import_object_fields(
+                        properties.iter(),
+                        &required,
+                        &type_id,
+                        operation_id,
+                        diagnostics,
+                    ),
                 }
-                "array" => {
-                    let item = resolved.get("items").unwrap_or(&Value::Null);
-                    let item_type_ref = self
-                        .import_schema(item, &format!("{type_id}_item"), operation_id, diagnostics)
+            } else if let Some(additional) = resolved.get("additionalProperties") {
+                if additional.as_bool() == Some(false) {
+                    IrTypeShape::Object { fields: Vec::new() }
+                } else {
+                    let value_type_ref = self
+                        .import_schema(
+                            additional,
+                            &format!("{type_id}_value"),
+                            operation_id,
+                            diagnostics,
+                        )
                         .unwrap_or_else(|| "json".to_string());
-                    IrTypeShape::List { item_type_ref }
+                    IrTypeShape::Map { value_type_ref }
                 }
-                _ => IrTypeShape::Json,
+            } else {
+                IrTypeShape::Json
             }
+        } else if json_schema_type_contains(&resolved, "array") {
+            let item = resolved.get("items").unwrap_or(&Value::Null);
+            let item_type_ref = self
+                .import_schema(item, &format!("{type_id}_item"), operation_id, diagnostics)
+                .unwrap_or_else(|| "json".to_string());
+            IrTypeShape::List { item_type_ref }
+        } else {
+            IrTypeShape::Json
         };
         self.types.insert(
             type_id.clone(),

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -7,8 +7,8 @@ use crate::v4::ir::{IrField, IrType, IrTypeShape};
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
     JsonObjectShape, JsonSchemaComparisonError, JsonSchemaWalkError, RefError,
-    direct_json_object_shape, json_schema_has_declared_type, json_schema_required_fields,
-    json_schema_scalar_type, json_schema_type_contains,
+    direct_json_object_shape, json_schema_declares_only_type, json_schema_has_declared_type,
+    json_schema_required_fields, json_schema_scalar_type, json_schema_type_contains,
     merge_json_object_shape_annotation_insensitive, with_resolved_json_schema,
 };
 
@@ -195,7 +195,15 @@ impl OpenApiImporter<'_> {
             } else {
                 IrTypeShape::Json
             }
-        } else if json_schema_type_contains(&resolved, "array") {
+        // Asking for the sole declared type, where the object branch above only
+        // asks whether `object` is among them. A union that merely includes
+        // `array` is not a collection: `{"type": ["array", "string"]}` accepts
+        // one string too, and importing `items` regardless types those instances
+        // as a row of item-derived columns that are all null. Object stays the
+        // permissive reading because it is already what a schema declaring no
+        // type at all is imported as, so a union including it degrades to the
+        // same columns rather than to a claim about the response's shape.
+        } else if json_schema_declares_only_type(&resolved, "array") {
             let item = resolved.get("items").unwrap_or(&Value::Null);
             let item_type_ref = self
                 .import_schema(item, &format!("{type_id}_item"), operation_id, diagnostics)


### PR DESCRIPTION
Part of #1321. Version-agnostic correctness fix, and the prerequisite that makes 3.1 nullability work.

## Why

Both shape dispatches read `type` with `as_str`, so a schema listing several types came back as `None` and fell through to a default of `"object"`. That default is right often enough to hide the fault: a nullable object is still an object. A nullable collection is not.

`{"type": ["array", "null"]}` was therefore classified as a singleton object rather than a list, so an endpoint returning an optional collection imported as one opaque row and lost every item. The same read in `import_schema` sent a nullable array property down the object branch, where it matched neither `properties` nor `additionalProperties` and collapsed to opaque JSON — losing the element type of every optional list an API returns.

## What changes

Both dispatches now match through `json_schema_type_contains`, which already handled the string and array forms and was already used elsewhere in this module. "Declared no type" stays distinct from "declared a type with no shape here" via a new `json_schema_has_declared_type`, so a typeless schema still reads as an object.

This is version-agnostic — a 3.0 document may carry a type array, and this is how it was always meant to be read — but 3.1 is where it stops being an edge case, since dropping `nullable` makes the type array the only way to spell a nullable collection.

Bumps the importer version: a 3.0 document with a nullable collection now produces different artifacts and needs re-materializing.

## Review follow-up

`classify_response_schema` tested `array` before `object`, so a schema claiming both was read as a list here while `import_schema` built its row type as an object. That also changed behaviour this branch did not mean to change: read as a string, such a schema used to fall through to the typeless default and classify as a singleton. Object is now tested first, in the same order `import_schema` tests it.

The nullable-collection regression test asserted only the cardinality, so it would have passed had the wrong item schema reached `import_schema` and typed every row as opaque JSON — the other half of the same data loss. It now asserts the row type too.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>