### PR TITLE
feat(spec): import OpenAPI 3.1 documents

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3938,6 +3938,161 @@ fn openapi_31_reads_const_as_a_single_value_enum() {
     assert_eq!(values, &["open", "paid"]);
 }
 
+/// Imports a document at `version` whose response is `$ref: Base` carrying
+/// `siblings` beside it, so a test can hold the shape fixed and vary the
+/// dialect that decides whether those siblings apply.
+#[expect(
+    clippy::unwrap_in_result,
+    reason = "Only the import's own result is under test; a manifest that will not parse is a bug in this file, not an outcome to return."
+)]
+fn import_ref_with_siblings(version: &str, siblings: &str) -> crate::Result<ImportedSurface> {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: ref_siblings_probe
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    import_openapi_surface(
+        v4,
+        &v4.surface,
+        format!(
+            r"
+openapi: {version}
+paths:
+  /items:
+    get:
+      operationId: items/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Base'
+{siblings}
+components:
+  schemas:
+    Base:
+      type: object
+      properties:
+        id: {{type: string}}
+"
+        )
+        .as_bytes(),
+    )
+}
+
+#[test]
+fn openapi_31_composes_assertions_written_beside_a_ref() {
+    // 2020-12 made `$ref` an ordinary keyword, so this schema is `Base` *and*
+    // `extra`. Resolving through the reference answered `Base` alone and the
+    // column was gone from the IR and from every projection over it.
+    let imported = import_ref_with_siblings(
+        "3.1.0",
+        r"                properties:
+                  extra: {type: string}
+                required: [extra]",
+    )
+    .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("expected an object row");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["extra", "id"],
+        "the reference contributes `id` and the sibling contributes `extra`"
+    );
+}
+
+#[test]
+fn openapi_30_ignores_members_written_beside_a_ref() {
+    // The same document under the other dialect. 3.0 defines a Reference Object
+    // as a `$ref` and nothing else, so reading these siblings would import
+    // constraints the document does not have.
+    let imported = import_ref_with_siblings(
+        "3.0.3",
+        r"                properties:
+                  extra: {type: string}
+                required: [extra]",
+    )
+    .expect("3.0 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("expected an object row");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(names, ["id"], "3.0 reads the reference alone");
+}
+
+#[test]
+fn openapi_31_reports_a_ref_sibling_it_cannot_compose() {
+    // `allOf` merges properties and answers with an object, so folding this one
+    // through it would put an object with no fields where the referenced shape
+    // was. It is left out — but said, which is the whole complaint.
+    let imported = import_ref_with_siblings("3.1.0", "                maxProperties: 4")
+        .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let warning = operation
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("maxProperties"))
+        .expect("a constraint that is dropped has to be reported");
+    assert!(
+        warning.message.contains("does not compose"),
+        "the warning should say what happened to it: {}",
+        warning.message
+    );
+}
+
+#[test]
+fn openapi_31_leaves_an_annotated_ref_as_the_reference() {
+    // A `description` beside a `$ref` documents the field that holds it and
+    // admits no different instances, so the schema is still exactly `Base` —
+    // composing here would name a second type for no reason.
+    let imported = import_ref_with_siblings("3.1.0", "                description: the item")
+        .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("expected an object row");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(names, ["id"], "the schema is still what the reference says");
+    assert!(
+        operation.diagnostics.is_empty(),
+        "an annotation is not a dropped constraint: {:?}",
+        operation.diagnostics
+    );
+}
+
 /// Imports a document at `version` that declares `dialect_declaration` at its
 /// root, so a test can vary the dialect against a schema the importer would
 /// otherwise read without complaint.

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3844,6 +3844,53 @@ fn openapi_31_reads_const_as_a_single_value_enum() {
 }
 
 #[test]
+fn openapi_31_reads_nullability_out_of_const_and_enum() {
+    // Neither of these names a type, so `type` had nothing to say about them
+    // and the columns came out non-nullable while the document was constraining
+    // them to a value that is null, or to a set that includes it.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  always_null:
+                    const: null
+                  sometimes_null:
+                    enum: [null, open]
+                  never_null:
+                    enum: [open, paid]",
+    )
+    .expect("3.1 should import");
+
+    assert!(
+        probe_field_type(&imported, "always_null").nullable,
+        "a schema constrained to null admits null"
+    );
+    assert!(
+        probe_field_type(&imported, "sometimes_null").nullable,
+        "an enum listing null admits null"
+    );
+    assert!(
+        !probe_field_type(&imported, "never_null").nullable,
+        "an enum that does not list null still forbids it"
+    );
+
+    // The shapes are the other half: deriving nullability must not change what
+    // the values themselves import as.
+    let IrTypeShape::Enum { values } = &probe_field_type(&imported, "sometimes_null").shape else {
+        panic!("an enum listing null is still an enum");
+    };
+    assert_eq!(values, &["null", "open"]);
+    assert!(
+        matches!(
+            probe_field_type(&imported, "always_null").shape,
+            IrTypeShape::Json
+        ),
+        "a null constant constrains the value, not the shape, and `const_enum_values` \
+         already declines to read it as a one-value enum"
+    );
+}
+
+#[test]
 fn openapi_30_leaves_const_alone() {
     // `const` is not a 3.0 keyword, so a 3.0 document using it gets no special
     // reading — the schema is typeless and stays opaque.

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3802,6 +3802,101 @@ fn openapi_31_warns_when_a_document_still_carries_nullable() {
 }
 
 #[test]
+fn openapi_31_warns_about_a_removed_keyword_on_every_schema_path() {
+    // Three placements the type import never sees. A parameter resolves to a
+    // scalar without reaching `import_schema`, and a collection response hands
+    // it `items` — so the schema carrying the keyword is set aside in both, and
+    // the warning was dropped with it.
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: removed_keywords
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let imported = import_openapi_surface(
+        v4,
+        &v4.surface,
+        r"
+openapi: 3.1.0
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: since, in: query, schema: {type: string, nullable: true}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let warnings: Vec<&str> = operation
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.message.contains("'nullable'"))
+        .map(|diagnostic| diagnostic.message.as_str())
+        .collect();
+    assert!(
+        warnings
+            .iter()
+            .any(|message| message.contains("parameter 'since'")),
+        "a parameter schema carrying the keyword has to be reported: {warnings:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|message| message.contains("response schema")),
+        "a collection response carrying the keyword has to be reported: {warnings:?}"
+    );
+    assert_eq!(
+        warnings.len(),
+        2,
+        "one report each, and none for the item schema, which does not carry it: {warnings:?}"
+    );
+}
+
+#[test]
+fn openapi_31_reports_a_singleton_response_keyword_once() {
+    // The counterpart to setting the schema aside: a singleton hands
+    // `import_schema` the very schema the response resolved to, so both would
+    // report the same keyword in the same place.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                nullable: true
+                properties:
+                  id: {type: string}",
+    )
+    .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let warnings: Vec<&str> = operation
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.message.contains("'nullable'"))
+        .map(|diagnostic| diagnostic.message.as_str())
+        .collect();
+    assert_eq!(warnings.len(), 1, "said once, not twice: {warnings:?}");
+}
+
+#[test]
 fn openapi_30_does_not_warn_about_nullable() {
     let imported = import_versioned_response_schema("3.0.3", NULLABILITY_PROBE_SCHEMA)
         .expect("3.0 should import");

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use super::*;
+use crate::v4::test_support::github_openapi_at_version;
 use crate::{
     ManifestDataType, PaginationMode, PaginationSpec, SourceTableFunctionKind,
     parse_source_manifest_yaml,
@@ -3289,7 +3290,7 @@ surface:
 fn importer_accepts_every_spelling_of_a_supported_version() {
     // `3.0` carries no patch component, which the field's grammar allows and a
     // `"3.0."` prefix test rejected.
-    for version in ["3.0.0", "3.0.3", "3.0.4", "3.0"] {
+    for version in ["3.0.0", "3.0.3", "3.0.4", "3.0", "3.1.0", "3.1.1", "3.1"] {
         let imported = import_version_probe(&format!("openapi: '{version}'"))
             .unwrap_or_else(|error| panic!("version {version} should import: {error}"));
         assert_eq!(
@@ -3302,18 +3303,21 @@ fn importer_accepts_every_spelling_of_a_supported_version() {
 
 #[test]
 fn importer_rejects_unsupported_versions_by_name() {
+    // 3.2 was ratified in April 2026 but is not yet widely adopted, so it stays
+    // out until there is something to import that uses it.
     for version in [
         "2.0",
-        "3.1.0",
         "3.2.0",
         "4.0.0",
         "3",
         // Well-formed prefix, malformed remainder. The version field holds one
-        // optional numeric patch component and nothing else.
+        // optional numeric patch component and nothing else, under either
+        // supported version.
         "3.0.",
         "3.0.banana",
         "3.0.1.2",
-        "3.0.1-rc1",
+        "3.1.1-rc1",
+        "3.1.x",
     ] {
         let error = import_version_probe(&format!("openapi: '{version}'"))
             .expect_err(&format!("version {version} should be rejected"));
@@ -3352,12 +3356,22 @@ fn document_metadata_applies_the_same_version_gate_as_import() {
         .expect("3.0 metadata");
     assert_eq!(metadata.description.as_deref(), Some("Query demo data."));
 
-    // Both entry points read the version, so they have to agree on the answer:
-    // describing a document the importer would refuse is the confusing outcome.
-    let error = openapi_document_metadata(version_probe_document("openapi: '3.1.0'").as_bytes())
-        .expect_err("3.1 metadata should be rejected while import rejects it");
+    // Nothing read here is spelled differently in 3.1, so metadata extraction
+    // needs no dialect — but it does have to accept exactly what import accepts.
+    // Describing a document the importer would refuse, or refusing one it would
+    // take, is the confusing outcome either way.
+    let metadata = openapi_document_metadata(version_probe_document("openapi: '3.1.0'").as_bytes())
+        .expect("3.1 metadata");
+    assert_eq!(metadata.description.as_deref(), Some("Query demo data."));
+    assert_eq!(
+        metadata.server_url.as_deref(),
+        Some("https://api.example.com/v1")
+    );
+
+    let error = openapi_document_metadata(version_probe_document("openapi: '3.2.0'").as_bytes())
+        .expect_err("3.2 metadata should be rejected while import rejects it");
     assert!(
-        error.to_string().contains("unsupported version '3.1.0'"),
+        error.to_string().contains("unsupported version '3.2.0'"),
         "{error}"
     );
 }
@@ -3646,5 +3660,308 @@ fn importer_reads_a_nullable_array_property_as_a_list() {
             IrTypeShape::Scalar(IrScalarType::String)
         ),
         "the element type has to survive, or the list is untyped"
+    );
+}
+
+/// Imports a document at `version` whose one operation returns
+/// `response_schema`, so a test can hold the schema fixed and vary the dialect.
+#[expect(
+    clippy::unwrap_in_result,
+    reason = "Only the import's own result is under test; a manifest that will not parse is a bug in this file, not an outcome to return."
+)]
+fn import_versioned_response_schema(
+    version: &str,
+    response_schema: &str,
+) -> crate::Result<ImportedSurface> {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: dialect_probe
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    import_openapi_surface(
+        v4,
+        &v4.surface,
+        format!(
+            r"
+openapi: {version}
+paths:
+  /items:
+    get:
+      operationId: items/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+{response_schema}
+"
+        )
+        .as_bytes(),
+    )
+}
+
+fn probe_row_type<'a>(imported: &'a ImportedSurface, field: &str) -> &'a IrField {
+    let operation = imported.operations.first().expect("operation");
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("expected an object row");
+    };
+    fields
+        .iter()
+        .find(|candidate| candidate.name == field)
+        .unwrap_or_else(|| panic!("field {field}"))
+}
+
+fn probe_field_type<'a>(imported: &'a ImportedSurface, field: &str) -> &'a IrType {
+    let type_ref = &probe_row_type(imported, field).type_ref;
+    imported
+        .types
+        .iter()
+        .find(|ty| &ty.id == type_ref)
+        .expect("field type")
+}
+
+const NULLABILITY_PROBE_SCHEMA: &str = r"                type: object
+                properties:
+                  by_type_array:
+                    type: [string, 'null']
+                  by_keyword:
+                    type: string
+                    nullable: true";
+
+#[test]
+fn openapi_31_reads_nullability_out_of_the_type_array() {
+    let imported = import_versioned_response_schema("3.1.0", NULLABILITY_PROBE_SCHEMA)
+        .expect("3.1 should import");
+
+    assert!(
+        probe_field_type(&imported, "by_type_array").nullable,
+        "3.1 spells nullability by listing 'null' in the type"
+    );
+    // The scalar still has to survive the extra type: a nullable string is a
+    // string column, not an untyped one.
+    assert!(
+        matches!(
+            probe_field_type(&imported, "by_type_array").shape,
+            IrTypeShape::Scalar(IrScalarType::String)
+        ),
+        "a nullable string is still a string"
+    );
+    assert!(
+        !probe_field_type(&imported, "by_keyword").nullable,
+        "3.1 gives the 'nullable' keyword no meaning, so it must not confer nullability"
+    );
+}
+
+#[test]
+fn openapi_30_reads_nullability_out_of_the_nullable_keyword() {
+    // The same schema under the other dialect, to pin that the two disagree in
+    // exactly the way the specifications do rather than one being a superset.
+    let imported = import_versioned_response_schema("3.0.3", NULLABILITY_PROBE_SCHEMA)
+        .expect("3.0 should import");
+
+    assert!(
+        probe_field_type(&imported, "by_keyword").nullable,
+        "3.0 spells nullability with its own keyword"
+    );
+    assert!(
+        !probe_field_type(&imported, "by_type_array").nullable,
+        "3.0 has no 'null' type to read"
+    );
+}
+
+#[test]
+fn openapi_31_warns_when_a_document_still_carries_nullable() {
+    let imported = import_versioned_response_schema("3.1.0", NULLABILITY_PROBE_SCHEMA)
+        .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    let warning = operation
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("'nullable'"))
+        .expect("a 3.1 document carrying 'nullable' should say so");
+    assert!(
+        warning.message.contains("removed in OpenAPI 3.1"),
+        "the warning should name the version that removed it: {}",
+        warning.message
+    );
+    assert_eq!(warning.operation_id.as_deref(), Some("items_get"));
+}
+
+#[test]
+fn openapi_30_does_not_warn_about_nullable() {
+    let imported = import_versioned_response_schema("3.0.3", NULLABILITY_PROBE_SCHEMA)
+        .expect("3.0 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert!(
+        !operation
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("'nullable'")),
+        "'nullable' is how 3.0 spells this: {:?}",
+        operation.diagnostics
+    );
+}
+
+#[test]
+fn openapi_31_reads_const_as_a_single_value_enum() {
+    // 3.1 documents pin a discriminator with `const` where a 3.0 one wrote a
+    // one-element `enum`.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  kind:
+                    const: invoice
+                  status:
+                    enum: [open, paid]",
+    )
+    .expect("3.1 should import");
+
+    let IrTypeShape::Enum { values } = &probe_field_type(&imported, "kind").shape else {
+        panic!("a const should import as the enum it is equivalent to");
+    };
+    assert_eq!(values, &["invoice"]);
+
+    let IrTypeShape::Enum { values } = &probe_field_type(&imported, "status").shape else {
+        panic!("enum should still import as an enum");
+    };
+    assert_eq!(values, &["open", "paid"]);
+}
+
+#[test]
+fn openapi_30_leaves_const_alone() {
+    // `const` is not a 3.0 keyword, so a 3.0 document using it gets no special
+    // reading — the schema is typeless and stays opaque.
+    let imported = import_versioned_response_schema(
+        "3.0.3",
+        r"                type: object
+                properties:
+                  kind:
+                    const: invoice",
+    )
+    .expect("3.0 should import");
+
+    assert!(
+        matches!(probe_field_type(&imported, "kind").shape, IrTypeShape::Json),
+        "3.0 has no const, so nothing should read one"
+    );
+}
+
+#[test]
+fn openapi_31_imports_a_realistic_document_exactly_as_30_does() {
+    // The point of the dialect split is that only the keywords the versions
+    // disagree about are version-specific. Everything else — `$ref` resolution,
+    // response selection, wrapped-list row paths, pagination detection,
+    // `format: date-time` — is one traversal, so a document using none of the
+    // contested keywords has to import identically under both.
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: github
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.github.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+
+    let as_30 = import_openapi_surface(
+        v4,
+        &v4.surface,
+        github_openapi_at_version("3.0.3").as_bytes(),
+    )
+    .expect("3.0 import");
+    let as_31 = import_openapi_surface(
+        v4,
+        &v4.surface,
+        github_openapi_at_version("3.1.0").as_bytes(),
+    )
+    .expect("3.1 import");
+
+    let operation_ids = |imported: &ImportedSurface| {
+        imported
+            .operations
+            .iter()
+            .map(|operation| operation.id.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(operation_ids(&as_30), operation_ids(&as_31));
+    assert!(
+        !operation_ids(&as_31).is_empty(),
+        "a fixture importing nothing would make this vacuous"
+    );
+
+    let type_ids = |imported: &ImportedSurface| {
+        imported
+            .types
+            .iter()
+            .map(|ty| ty.id.clone())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(type_ids(&as_30), type_ids(&as_31));
+
+    // Serializing the metadata catalog compares row paths, pagination, and
+    // lookup keys in one assertion, so an inference that quietly changed under
+    // 3.1 shows up here rather than needing its own case.
+    assert_eq!(
+        serde_json::to_value(&as_30.operation_metadata).expect("3.0 metadata"),
+        serde_json::to_value(&as_31.operation_metadata).expect("3.1 metadata"),
+    );
+
+    // Pinned rather than merely compared: an inference that silently stopped
+    // firing under both versions would satisfy every equality above.
+    assert_eq!(
+        imported_row_path(&as_31, "search_issues_and_pull_requests"),
+        ["items"],
+        "the wrapped-list row path has to survive under 3.1"
+    );
+    assert_eq!(
+        imported_rest_pagination(&as_31, "issues_list_for_repo").mode,
+        PaginationMode::Page,
+        "page pagination has to be detected under 3.1"
+    );
+}
+
+#[test]
+fn openapi_31_stays_quiet_about_a_leftover_nullable_false() {
+    // `nullable: false` asked for the default under 3.0 too, so ignoring it
+    // changes nothing and the author has lost nothing. Worth pinning because
+    // real documents carry these: GitHub's own 3.1 publication has five, and
+    // warning on each would be noise on every import of it.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  html_url:
+                    type: string
+                    nullable: false",
+    )
+    .expect("3.1 should import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert!(
+        !operation
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("'nullable'")),
+        "a no-op keyword is not worth a diagnostic: {:?}",
+        operation.diagnostics
     );
 }

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3895,31 +3895,21 @@ surface:
     )
     .expect("3.1 import");
 
-    let operation_ids = |imported: &ImportedSurface| {
-        imported
-            .operations
-            .iter()
-            .map(|operation| operation.id.clone())
-            .collect::<Vec<_>>()
-    };
-    assert_eq!(operation_ids(&as_30), operation_ids(&as_31));
     assert!(
-        !operation_ids(&as_31).is_empty(),
+        !as_31.operations.is_empty() && !as_31.types.is_empty(),
         "a fixture importing nothing would make this vacuous"
     );
 
-    let type_ids = |imported: &ImportedSurface| {
-        imported
-            .types
-            .iter()
-            .map(|ty| ty.id.clone())
-            .collect::<Vec<_>>()
-    };
-    assert_eq!(type_ids(&as_30), type_ids(&as_31));
-
-    // Serializing the metadata catalog compares row paths, pagination, and
-    // lookup keys in one assertion, so an inference that quietly changed under
-    // 3.1 shows up here rather than needing its own case.
+    // Serialized whole rather than compared by id. Names matching says only that
+    // both versions found the same operations and types — it would hold just as
+    // well if 3.1 gave every one of those types a different shape, different
+    // nullability, or different fields, which is exactly the kind of divergence
+    // this test exists to catch. The same for the metadata catalog, which
+    // carries row paths, pagination, and lookup keys.
+    assert_eq!(
+        serde_json::to_value(&as_30.semantic_ir).expect("3.0 semantic IR"),
+        serde_json::to_value(&as_31.semantic_ir).expect("3.1 semantic IR"),
+    );
     assert_eq!(
         serde_json::to_value(&as_30.operation_metadata).expect("3.0 metadata"),
         serde_json::to_value(&as_31.operation_metadata).expect("3.1 metadata"),
@@ -3963,5 +3953,74 @@ fn openapi_31_stays_quiet_about_a_leftover_nullable_false() {
             .any(|diagnostic| diagnostic.message.contains("'nullable'")),
         "a no-op keyword is not worth a diagnostic: {:?}",
         operation.diagnostics
+    );
+}
+
+#[test]
+fn openapi_31_leaves_a_structured_const_to_the_shape_dispatch() {
+    // `const` may hold any JSON value. An object or array one describes a shape
+    // rather than a value, so reading it as an enum would stand the stringified
+    // constant where the declared fields belong and drop every column.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  settings:
+                    type: object
+                    const: {theme: dark}
+                    properties:
+                      theme: {type: string}
+                  tags:
+                    type: array
+                    const: [a, b]
+                    items: {type: string}",
+    )
+    .expect("3.1 should import");
+
+    let IrTypeShape::Object { fields } = &probe_field_type(&imported, "settings").shape else {
+        panic!("an object with a const still declares fields, and they have to survive");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(names, ["theme"]);
+
+    assert!(
+        matches!(
+            probe_field_type(&imported, "tags").shape,
+            IrTypeShape::List { .. }
+        ),
+        "an array with a const is still a list"
+    );
+}
+
+#[test]
+fn openapi_31_reads_a_scalar_const_the_way_it_reads_a_one_value_enum() {
+    // `const: 4` and `enum: [4]` say the same thing, so they have to import the
+    // same way — the newer keyword does not get its own reading of a value.
+    let as_const = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  pinned:
+                    type: integer
+                    const: 4",
+    )
+    .expect("const import");
+    let as_enum = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  pinned:
+                    type: integer
+                    enum: [4]",
+    )
+    .expect("enum import");
+
+    let IrTypeShape::Enum { values } = &probe_field_type(&as_const, "pinned").shape else {
+        panic!("a scalar const is a single-value enum");
+    };
+    assert_eq!(values, &["4"]);
+    assert_eq!(
+        serde_json::to_value(&probe_field_type(&as_enum, "pinned").shape).expect("enum shape"),
+        serde_json::to_value(&probe_field_type(&as_const, "pinned").shape).expect("const shape"),
     );
 }

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3938,6 +3938,101 @@ fn openapi_31_reads_const_as_a_single_value_enum() {
     assert_eq!(values, &["open", "paid"]);
 }
 
+/// Imports a document at `version` that declares `dialect_declaration` at its
+/// root, so a test can vary the dialect against a schema the importer would
+/// otherwise read without complaint.
+#[expect(
+    clippy::unwrap_in_result,
+    reason = "Only the import's own result is under test; a manifest that will not parse is a bug in this file, not an outcome to return."
+)]
+fn import_document_declaring_dialect(
+    version: &str,
+    dialect_declaration: &str,
+) -> crate::Result<ImportedSurface> {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: dialect_declaration_probe
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    import_openapi_surface(
+        v4,
+        &v4.surface,
+        format!(
+            r"
+openapi: {version}
+{dialect_declaration}
+paths:
+  /items:
+    get:
+      operationId: items/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  kind: {{const: invoice}}
+"
+        )
+        .as_bytes(),
+    )
+}
+
+#[test]
+fn openapi_31_rejects_a_dialect_it_does_not_read() {
+    // `const` is the keyword at stake: draft-04 does not have it, so this
+    // document does not mean by it what the importer would persist — the closed
+    // enum `["invoice"]` on a column the author left unconstrained.
+    let error = import_document_declaring_dialect(
+        "3.1.0",
+        "jsonSchemaDialect: http://json-schema.org/draft-04/schema#",
+    )
+    .expect_err("a dialect Coral cannot read has to be refused, not guessed at");
+    assert!(
+        error.to_string().contains("draft-04"),
+        "the message should name the dialect that was asked for: {error}"
+    );
+}
+
+#[test]
+fn openapi_31_imports_the_dialects_it_is_written_in() {
+    for declaration in [
+        "jsonSchemaDialect: https://spec.openapis.org/oas/3.1/dialect/base",
+        "jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema",
+        "",
+    ] {
+        let imported = import_document_declaring_dialect("3.1.0", declaration)
+            .unwrap_or_else(|error| panic!("'{declaration}' should import: {error}"));
+        let IrTypeShape::Enum { values } = &probe_field_type(&imported, "kind").shape else {
+            panic!("'{declaration}' selects the dialect `const` is read in");
+        };
+        assert_eq!(values, &["invoice"]);
+    }
+}
+
+#[test]
+fn openapi_30_ignores_a_dialect_declaration() {
+    // 3.0's schema object is its own dialect, fixed by that specification. The
+    // keyword selects nothing there, and `const` is not read either way.
+    let imported = import_document_declaring_dialect(
+        "3.0.3",
+        "jsonSchemaDialect: http://json-schema.org/draft-04/schema#",
+    )
+    .expect("3.0 has no dialect to choose");
+    assert!(
+        matches!(probe_field_type(&imported, "kind").shape, IrTypeShape::Json),
+        "3.0 leaves `const` alone whatever the document declares"
+    );
+}
+
 #[test]
 fn openapi_31_reads_nullability_out_of_const_and_enum() {
     // Neither of these names a type, so `type` had nothing to say about them

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4024,3 +4024,53 @@ fn openapi_31_reads_a_scalar_const_the_way_it_reads_a_one_value_enum() {
         serde_json::to_value(&probe_field_type(&as_const, "pinned").shape).expect("const shape"),
     );
 }
+
+#[test]
+fn a_const_narrows_the_enum_it_is_declared_beside() {
+    // How a 2020-12 document pins one branch of a union: the branch re-declares
+    // the discriminator it shares with the rest of the family — `enum` listing
+    // every tag — and adds the `const` saying which one it is. Both constrain
+    // the schema, so the narrower has to win; reading `enum` first left the
+    // branch claiming every tag in the family instead of its own.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  kind:
+                    type: string
+                    enum: [invoice, receipt, credit_note]
+                    const: invoice",
+    )
+    .expect("3.1 should import");
+
+    let IrTypeShape::Enum { values } = &probe_field_type(&imported, "kind").shape else {
+        panic!("a pinned discriminator is still an enum");
+    };
+    assert_eq!(
+        values,
+        &["invoice"],
+        "the const pins the branch; the enum only says what the family allows"
+    );
+}
+
+#[test]
+fn a_structured_const_leaves_a_neighbouring_enum_to_be_read() {
+    // The other side of that ordering. `const_enum_values` reads only scalars,
+    // so a structured constant must fall past it to the `enum` arm rather than
+    // shadowing it — otherwise moving `const` ahead of `enum` would lose the
+    // values a schema declaring both had before.
+    let imported = import_versioned_response_schema(
+        "3.1.0",
+        r"                type: object
+                properties:
+                  layout:
+                    enum: [compact, roomy]
+                    const: {theme: dark}",
+    )
+    .expect("3.1 should import");
+
+    let IrTypeShape::Enum { values } = &probe_field_type(&imported, "layout").shape else {
+        panic!("the enum is still the readable constraint here");
+    };
+    assert_eq!(values, &["compact", "roomy"]);
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
@@ -10,4 +10,15 @@ use serde_json::Value;
 pub(super) trait OpenApiDialect {
     /// Whether a schema admits `null`.
     fn schema_nullable(&self, schema: &Value) -> bool;
+
+    /// The values a schema's `const` constrains it to, if this version has that
+    /// keyword and the schema uses it.
+    fn const_enum_values(&self, schema: &Value) -> Option<Vec<String>>;
+
+    /// What to warn about a schema reaching for a keyword this version removed.
+    ///
+    /// Such a keyword is not an error — it is ignored, exactly as an unknown
+    /// annotation would be — but ignoring it silently changes what the schema
+    /// means, and the author is unlikely to have intended that.
+    fn removed_keyword_warning(&self, schema: &Value) -> Option<String>;
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
@@ -15,6 +15,14 @@ pub(super) trait OpenApiDialect {
     /// keyword and the schema uses it.
     fn const_enum_values(&self, schema: &Value) -> Option<Vec<String>>;
 
+    /// Whether keywords written beside a `$ref` constrain the schema it
+    /// resolves to, or are ignored in its favour.
+    ///
+    /// The versions genuinely disagree: 3.0 defines a Reference Object as an
+    /// object whose other members are ignored, while 3.1 follows 2020-12, where
+    /// `$ref` is one keyword among the rest and every sibling still applies.
+    fn ref_siblings_apply(&self) -> bool;
+
     /// What to warn about a schema reaching for a keyword this version removed.
     ///
     /// Such a keyword is not an error — it is ignored, exactly as an unknown

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -13,6 +13,7 @@ use crate::v4::{
 use crate::{ManifestError, Result};
 
 use super::dialect::OpenApiDialect;
+use super::json_schema_dialect::validate_json_schema_dialect;
 use super::v3_0::OpenApi30Importer;
 use super::v3_1::OpenApi31Importer;
 use super::version::{OpenApiVersion, parse_openapi_version};
@@ -26,7 +27,13 @@ pub fn import_openapi_surface(
         serde_yaml::from_slice(document_bytes).map_err(ManifestError::parse_yaml)?;
     let dialect: &dyn OpenApiDialect = match parse_openapi_version(&document)? {
         OpenApiVersion::V3_0 => &OpenApi30Importer,
-        OpenApiVersion::V3_1 => &OpenApi31Importer,
+        OpenApiVersion::V3_1 => {
+            // Only 3.1 can choose a dialect. 3.0's schema object is its own,
+            // fixed by that specification, so neither keyword means anything
+            // there and a document carrying one is not selecting anything.
+            validate_json_schema_dialect(&document)?;
+            &OpenApi31Importer
+        }
     };
 
     let mut importer = OpenApiImporter::new(manifest, surface, &document, dialect);

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -14,6 +14,7 @@ use crate::{ManifestError, Result};
 
 use super::dialect::OpenApiDialect;
 use super::v3_0::OpenApi30Importer;
+use super::v3_1::OpenApi31Importer;
 use super::version::{OpenApiVersion, parse_openapi_version};
 
 pub fn import_openapi_surface(
@@ -25,6 +26,7 @@ pub fn import_openapi_surface(
         serde_yaml::from_slice(document_bytes).map_err(ManifestError::parse_yaml)?;
     let dialect: &dyn OpenApiDialect = match parse_openapi_version(&document)? {
         OpenApiVersion::V3_0 => &OpenApi30Importer,
+        OpenApiVersion::V3_1 => &OpenApi31Importer,
     };
 
     let mut importer = OpenApiImporter::new(manifest, surface, &document, dialect);

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -149,6 +149,33 @@ impl<'a> OpenApiImporter<'a> {
         }
     }
 
+    /// Reports a schema reaching for a keyword its document's version removed.
+    ///
+    /// Every path that reads a schema has to ask, not just the one that imports
+    /// a type from it. A parameter resolves to a scalar through
+    /// `import_parameter_scalar` and never reaches `import_schema`, and a
+    /// top-level collection response hands `import_schema` its `items` and sets
+    /// the schema carrying the keyword aside — so a `nullable: true` in either
+    /// place was dropped with nothing said, which is the silence this diagnostic
+    /// exists to break.
+    ///
+    /// `subject` names what carries the keyword — a type, a parameter, a
+    /// response — because the operation alone does not locate it.
+    pub(super) fn warn_removed_keywords(
+        &self,
+        schema: &Value,
+        subject: &str,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if let Some(warning) = self.dialect.removed_keyword_warning(schema) {
+            diagnostics.push(Diagnostic::new(
+                format!("{subject} in operation '{operation_id}': {warning}"),
+                Some(operation_id.to_string()),
+            ));
+        }
+    }
+
     pub(super) fn ref_error_diagnostic(
         error: RefError<'_>,
         context: &RefDiagnosticContext<'_>,

--- a/crates/coral-spec/src/v4/surfaces/openapi/json_schema_dialect.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/json_schema_dialect.rs
@@ -1,0 +1,158 @@
+use serde_json::Value;
+
+use crate::{ManifestError, Result};
+
+/// The dialects the 3.1 importer's reading of a schema is true of.
+///
+/// 3.1 aligned its schema object with JSON Schema 2020-12 and named that as the
+/// default, but it also let a document choose another: `jsonSchemaDialect`
+/// declares one for the whole document, and `$schema` declares one for a schema
+/// resource within it. The keywords the importer reads are not spelled the same
+/// way in every dialect — draft-04 has no `const` at all, so a document
+/// declaring it means something different by `{type: string, const: 4}` than
+/// the closed enum `["4"]` this importer would persist.
+///
+/// The OAS base dialect is 2020-12 plus the vocabulary describing the keywords
+/// `OpenAPI` adds — `discriminator`, `xml`, `externalDocs`, `example` — none of
+/// which changes how anything read here is written.
+const SUPPORTED_DIALECTS: [&str; 2] = [
+    "https://json-schema.org/draft/2020-12/schema",
+    "https://spec.openapis.org/oas/3.1/dialect/base",
+];
+
+/// Keywords whose values are instances rather than schemas.
+///
+/// The walk below reads every `$schema` string it passes as a dialect
+/// declaration, and under these keywords that would be wrong: they hold example
+/// and default *data*, which is free to contain a field called `$schema` that
+/// declares nothing about how this document is to be read. A JSON Schema
+/// document used as an example of itself is the obvious case.
+const INSTANCE_KEYWORDS: [&str; 5] = ["example", "examples", "default", "const", "enum"];
+
+/// Rejects a 3.1 document that declares a dialect this importer does not read.
+///
+/// Rejecting rather than warning, because the alternative is importing a
+/// document under rules its author did not choose and persisting the result:
+/// a surface whose columns are wrong is worse than one that does not exist,
+/// and unlike a diagnostic it cannot be noticed after the fact.
+pub(super) fn validate_json_schema_dialect(document: &Value) -> Result<()> {
+    if let Some(declared) = document.get("jsonSchemaDialect").and_then(Value::as_str) {
+        reject_unsupported(declared, "document's 'jsonSchemaDialect'")?;
+    }
+    // `$schema` may appear on any schema resource, so where the declaration sits
+    // is not something the traversal can know up front — a single schema deep
+    // inside `components` can select a dialect for itself alone.
+    validate_schema_keywords(document)
+}
+
+fn validate_schema_keywords(value: &Value) -> Result<()> {
+    match value {
+        Value::Object(members) => {
+            if let Some(declared) = members.get("$schema").and_then(Value::as_str) {
+                reject_unsupported(declared, "schema's '$schema'")?;
+            }
+            members
+                .iter()
+                .filter(|(name, _)| !INSTANCE_KEYWORDS.contains(&name.as_str()))
+                .try_for_each(|(_, member)| validate_schema_keywords(member))
+        }
+        Value::Array(members) => members.iter().try_for_each(validate_schema_keywords),
+        _ => Ok(()),
+    }
+}
+
+fn reject_unsupported(declared: &str, source: &str) -> Result<()> {
+    // Trailing-slash and empty-fragment spellings of the same URI are the same
+    // dialect. `https://json-schema.org/draft/2020-12/schema#` is how a document
+    // that copied the identifier out of the specification's own `$id` line
+    // writes it.
+    let normalized = declared.trim().trim_end_matches('#').trim_end_matches('/');
+    if SUPPORTED_DIALECTS.contains(&normalized) {
+        return Ok(());
+    }
+    Err(ManifestError::validation(format!(
+        "{source} selects JSON Schema dialect '{declared}', which Coral does not read; \
+         OpenAPI 3.1 schemas are read as JSON Schema 2020-12"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn accepts_the_dialects_openapi_31_is_written_in() {
+        for dialect in [
+            "https://json-schema.org/draft/2020-12/schema",
+            "https://json-schema.org/draft/2020-12/schema#",
+            "https://spec.openapis.org/oas/3.1/dialect/base",
+        ] {
+            validate_json_schema_dialect(&json!({"jsonSchemaDialect": dialect}))
+                .unwrap_or_else(|error| panic!("{dialect} should be accepted: {error}"));
+        }
+    }
+
+    #[test]
+    fn rejects_a_dialect_whose_keywords_read_differently() {
+        let error = validate_json_schema_dialect(&json!({
+            "jsonSchemaDialect": "http://json-schema.org/draft-04/schema#",
+        }))
+        .expect_err("draft-04 has no 'const' to read");
+        assert!(
+            error.to_string().contains("draft-04"),
+            "the message should name the dialect: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_dialect_selected_by_a_single_schema() {
+        validate_json_schema_dialect(&json!({
+            "components": {
+                "schemas": {
+                    "Item": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "type": "object",
+                    },
+                },
+            },
+        }))
+        .expect_err("a schema may select a dialect for itself alone");
+    }
+
+    #[test]
+    fn reads_a_property_named_schema_as_the_property_it_is() {
+        // `$schema` in this position is a field of the described object, and its
+        // value is a schema rather than a dialect identifier.
+        validate_json_schema_dialect(&json!({
+            "components": {
+                "schemas": {
+                    "Meta": {
+                        "type": "object",
+                        "properties": {"$schema": {"type": "string"}},
+                    },
+                },
+            },
+        }))
+        .expect("a property called '$schema' declares nothing");
+    }
+
+    #[test]
+    fn reads_example_data_as_data() {
+        // The document describes JSON Schema documents, so its examples are
+        // JSON Schema documents. Nothing in here selects a dialect for it.
+        validate_json_schema_dialect(&json!({
+            "components": {
+                "schemas": {
+                    "Schema": {
+                        "type": "object",
+                        "example": {"$schema": "http://json-schema.org/draft-04/schema#"},
+                        "default": {"$schema": "http://json-schema.org/draft-04/schema#"},
+                    },
+                },
+            },
+        }))
+        .expect("an example is data, not a declaration");
+    }
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
@@ -1,6 +1,7 @@
 mod dialect;
 mod document;
 mod import;
+mod json_schema_dialect;
 mod operations;
 mod responses;
 mod schemas;

--- a/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
@@ -5,6 +5,7 @@ mod operations;
 mod responses;
 mod schemas;
 mod v3_0;
+mod v3_1;
 mod version;
 
 pub use document::{OpenApiDocumentMetadata, normalize_source_document, openapi_document_metadata};

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -234,6 +234,12 @@ impl OpenApiImporter<'_> {
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<IrScalarType> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
+        self.warn_removed_keywords(
+            &resolved,
+            &format!("parameter '{name}'"),
+            operation_id,
+            diagnostics,
+        );
         let Some(scalar) = json_schema_scalar_type_or_string(&resolved) else {
             diagnostics.push(Diagnostic::new(
                 format!(

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -69,7 +69,14 @@ impl OpenApiImporter<'_> {
             );
         };
 
-        let Some(resolved) = self.resolve_ref(&selected.schema, operation_id, diagnostics) else {
+        // Composed before the reference is resolved, because this is where a
+        // response written as a `$ref` with assertions beside it would lose
+        // them: the schema handed on from here is the resolved one, so
+        // `import_schema` never sees the siblings to ask about them.
+        let selected_schema = self
+            .ref_siblings_composed(&selected.schema, operation_id, diagnostics)
+            .unwrap_or_else(|| selected.schema.clone());
+        let Some(resolved) = self.resolve_ref(&selected_schema, operation_id, diagnostics) else {
             diagnostics.push(Diagnostic::new(
                 format!("operation '{operation_id}' response schema could not be resolved"),
                 Some(operation_id.to_string()),

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -94,6 +94,14 @@ impl OpenApiImporter<'_> {
         };
         let (cardinality, row_schema, schema_entity_name) =
             classify_response_schema(path, &resolved);
+        // Only when the classification set this schema aside. A singleton hands
+        // `import_schema` the very schema resolved here, which asks the same
+        // question — reporting it here as well would say it twice. A collection
+        // hands over `items` instead, so this is the one place its own keywords
+        // are ever read.
+        if row_schema != resolved {
+            self.warn_removed_keywords(&resolved, "response schema", operation_id, diagnostics);
+        }
         let type_ref = self
             .import_schema(
                 &row_schema,

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
@@ -30,6 +30,35 @@ const MAX_ALL_OF_DEPTH: usize = 8;
 /// type. Matches the MCP importer's ceiling for the same comparison.
 const MAX_PROPERTY_COMPARISON_DEPTH: usize = 64;
 
+/// Keywords beside a `$ref` that describe it rather than narrow it.
+///
+/// An annotation says nothing about which instances the schema admits, so it
+/// cannot make the reference mean something the reference does not already
+/// mean — a `description` written beside a `$ref` documents the field that
+/// holds it, and the schema is still exactly what it resolves to.
+const REF_SIBLING_ANNOTATIONS: [&str; 11] = [
+    "description",
+    "title",
+    "summary",
+    "example",
+    "examples",
+    "deprecated",
+    "readOnly",
+    "writeOnly",
+    "externalDocs",
+    "xml",
+    "$comment",
+];
+
+/// Assertions beside a `$ref` that the `allOf` fold can compose.
+///
+/// The fold merges properties and answers with an object, so these are the
+/// keywords whose composition it actually implements. Anything else — a
+/// `maxLength` narrowing a referenced string, a `type` contradicting the
+/// reference — is reported instead of being folded into a shape it does not
+/// describe.
+const COMPOSABLE_REF_SIBLINGS: [&str; 3] = ["properties", "required", "additionalProperties"];
+
 /// Why folding a schema's `allOf` tree stopped.
 enum AllOfMergeError {
     /// A branch could not be resolved. A diagnostic naming it has already been
@@ -58,6 +87,12 @@ impl OpenApiImporter<'_> {
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<String> {
+        // Before the reference is resolved, because resolving it is what loses
+        // the assertions written beside it. The rewrite carries no `$ref` of its
+        // own, so this re-entry cannot repeat.
+        if let Some(composed) = self.ref_siblings_composed(schema, operation_id, diagnostics) {
+            return self.import_schema(&composed, suggested_id, operation_id, diagnostics);
+        }
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
         let type_id = schema.get("$ref").and_then(Value::as_str).map_or_else(
             || normalize_identifier(suggested_id, "type"),
@@ -240,6 +275,68 @@ impl OpenApiImporter<'_> {
             },
         );
         Some(type_id)
+    }
+
+    /// Rewrites a `$ref` carrying assertions beside it as the `allOf` it means.
+    ///
+    /// Under 3.1, `{$ref: Base, properties: {extra}, required: [extra]}`
+    /// describes `Base` *and* `extra`. Resolving straight through the reference
+    /// answered `Base` alone, so `extra` was gone from the IR and from every
+    /// projection over it with nothing said — the schema silently narrowed to
+    /// its base.
+    ///
+    /// Composed as `allOf` rather than merged here, so the fold already written
+    /// for that keyword — with its depth ceiling, its cycle guard and its
+    /// conflict reporting — is what does the work.
+    pub(super) fn ref_siblings_composed(
+        &self,
+        schema: &Value,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Value> {
+        if !self.dialect.ref_siblings_apply() {
+            return None;
+        }
+        let members = schema.as_object()?;
+        let reference = members.get("$ref")?;
+        let assertions: Map<String, Value> = members
+            .iter()
+            .filter(|(name, _)| {
+                name.as_str() != "$ref" && !REF_SIBLING_ANNOTATIONS.contains(&name.as_str())
+            })
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect();
+        if assertions.is_empty() {
+            return None;
+        }
+        // Only the keywords describing an object can be composed this way: the
+        // `allOf` fold merges properties and answers with an object, so routing
+        // `{$ref: Name, maxLength: 5}` through it would replace a string column
+        // with an object that has no fields. Reporting the ones left out keeps
+        // this from being the same silence one keyword along.
+        if let Some(unsupported) = assertions
+            .keys()
+            .find(|name| !COMPOSABLE_REF_SIBLINGS.contains(&name.as_str()))
+        {
+            diagnostics.push(Diagnostic::new(
+                format!(
+                    "schema in operation '{operation_id}' narrows a '$ref' with '{unsupported}', which Coral does not compose; the reference is imported without it"
+                ),
+                Some(operation_id.to_string()),
+            ));
+            return None;
+        }
+        let mut reference_branch = Map::new();
+        reference_branch.insert("$ref".to_string(), reference.clone());
+        let mut composed = Map::new();
+        composed.insert(
+            "allOf".to_string(),
+            Value::Array(vec![
+                Value::Object(reference_branch),
+                Value::Object(assertions),
+            ]),
+        );
+        Some(Value::Object(composed))
     }
 
     /// Folds a schema's own properties together with those of every `allOf`

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -152,12 +152,22 @@ impl OpenApiImporter<'_> {
                     diagnostics,
                 ),
             }
+        // `const` is read before `enum`, because a schema carrying both is
+        // constrained by both and `const` is the narrower of the two. That pair
+        // is how a 2020-12 document pins one branch of a union: the branch
+        // re-declares the shared discriminator it inherits — `enum` listing
+        // every tag in the family — and adds the single `const` that says which
+        // of them this branch is. Reading `enum` first published all of them,
+        // leaving each branch claiming the whole family's tags.
+        //
+        // A structured `const` still falls through to `enum` and then to the
+        // shape dispatch, because `const_enum_values` reads only scalars.
+        } else if let Some(values) = self.dialect.const_enum_values(&resolved) {
+            IrTypeShape::Enum { values }
         } else if let Some(values) = resolved.get("enum").and_then(Value::as_array) {
             IrTypeShape::Enum {
                 values: values.iter().map(enum_value).collect(),
             }
-        } else if let Some(values) = self.dialect.const_enum_values(&resolved) {
-            IrTypeShape::Enum { values }
         } else if let Some(scalar) = json_schema_scalar_type(&resolved) {
             IrTypeShape::Scalar(scalar)
         // `type` is matched through the array-aware helpers rather than read as

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -72,6 +72,12 @@ impl OpenApiImporter<'_> {
             .unwrap_or_default()
             .to_string();
         let nullable = self.dialect.schema_nullable(&resolved);
+        if let Some(warning) = self.dialect.removed_keyword_warning(&resolved) {
+            diagnostics.push(Diagnostic::new(
+                format!("type '{type_id}' in operation '{operation_id}': {warning}"),
+                Some(operation_id.to_string()),
+            ));
+        }
         self.types.insert(
             type_id.clone(),
             IrType {
@@ -150,6 +156,8 @@ impl OpenApiImporter<'_> {
             IrTypeShape::Enum {
                 values: values.iter().map(enum_value).collect(),
             }
+        } else if let Some(values) = self.dialect.const_enum_values(&resolved) {
+            IrTypeShape::Enum { values }
         } else if let Some(scalar) = json_schema_scalar_type(&resolved) {
             IrTypeShape::Scalar(scalar)
         // `type` is matched through the array-aware helpers rather than read as
@@ -412,7 +420,7 @@ impl OpenApiImporter<'_> {
     }
 }
 
-fn enum_value(value: &Value) -> String {
+pub(super) fn enum_value(value: &Value) -> String {
     value
         .as_str()
         .map_or_else(|| value.to_string(), ToString::to_string)

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -72,12 +72,12 @@ impl OpenApiImporter<'_> {
             .unwrap_or_default()
             .to_string();
         let nullable = self.dialect.schema_nullable(&resolved);
-        if let Some(warning) = self.dialect.removed_keyword_warning(&resolved) {
-            diagnostics.push(Diagnostic::new(
-                format!("type '{type_id}' in operation '{operation_id}': {warning}"),
-                Some(operation_id.to_string()),
-            ));
-        }
+        self.warn_removed_keywords(
+            &resolved,
+            &format!("type '{type_id}'"),
+            operation_id,
+            diagnostics,
+        );
         self.types.insert(
             type_id.clone(),
             IrType {

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
@@ -14,4 +14,15 @@ impl OpenApiDialect for OpenApi30Importer {
             .and_then(Value::as_bool)
             .unwrap_or(false)
     }
+
+    /// `const` arrived with 3.1. A 3.0 document spelling the same thing wrote a
+    /// one-element `enum`, which the shared dispatch already reads.
+    fn const_enum_values(&self, _schema: &Value) -> Option<Vec<String>> {
+        None
+    }
+
+    /// 3.0 is the oldest version supported here, so it has removed nothing.
+    fn removed_keyword_warning(&self, _schema: &Value) -> Option<String> {
+        None
+    }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
@@ -21,6 +21,13 @@ impl OpenApiDialect for OpenApi30Importer {
         None
     }
 
+    /// 3.0's Reference Object is a `$ref` and nothing else: any member written
+    /// beside it is ignored, so composing them here would read constraints into
+    /// a document that does not have them.
+    fn ref_siblings_apply(&self) -> bool {
+        false
+    }
+
     /// 3.0 is the oldest version supported here, so it has removed nothing.
     fn removed_keyword_warning(&self, _schema: &Value) -> Option<String> {
         None

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
@@ -18,8 +18,23 @@ pub(super) struct OpenApi31Importer;
 impl OpenApiDialect for OpenApi31Importer {
     /// 3.1 dropped `nullable` in favour of JSON Schema's own `null` type, which
     /// a schema admits by listing it alongside the type it otherwise is.
+    ///
+    /// `type` is not the only keyword that admits it, though, and a schema
+    /// constraining its value can say so without naming a type at all: `{const:
+    /// null}` and `{enum: [null, ...]}` each accept a null instance. Reading
+    /// only `type` left those columns marked non-nullable while the document
+    /// said the opposite — and for the typeless spellings, nothing else in the
+    /// schema said anything about them either.
     fn schema_nullable(&self, schema: &Value) -> bool {
         json_schema_type_contains(schema, "null")
+            || schema.get("const").is_some_and(Value::is_null)
+            // Any null member, not only a lone one: `enum: [null, 'a']` admits
+            // null exactly as `enum: [null]` does, and the values themselves are
+            // what the shape dispatch reads.
+            || schema
+                .get("enum")
+                .and_then(Value::as_array)
+                .is_some_and(|values| values.iter().any(Value::is_null))
     }
 
     /// `const` is 2020-12's single-value constraint, and 3.1 documents reach for

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
@@ -1,0 +1,48 @@
+use serde_json::Value;
+
+use crate::v4::surfaces::json_schema::json_schema_type_contains;
+
+use super::dialect::OpenApiDialect;
+use super::schemas::enum_value;
+
+/// Rules for documents declaring `OpenAPI` 3.1.x.
+///
+/// 3.1 realigned its schema object with JSON Schema 2020-12 instead of carrying
+/// its own dialect of it. Most of that realignment costs the importer nothing —
+/// `$defs` resolves through the same JSON Pointer walk as any other local
+/// reference, and the keywords 3.1 gained for describing binary payloads only
+/// matter to file uploads, which Coral does not support. What is left is the
+/// handful of spellings below.
+pub(super) struct OpenApi31Importer;
+
+impl OpenApiDialect for OpenApi31Importer {
+    /// 3.1 dropped `nullable` in favour of JSON Schema's own `null` type, which
+    /// a schema admits by listing it alongside the type it otherwise is.
+    fn schema_nullable(&self, schema: &Value) -> bool {
+        json_schema_type_contains(schema, "null")
+    }
+
+    /// `const` is 2020-12's single-value constraint, and 3.1 documents reach for
+    /// it where a 3.0 one wrote a one-element `enum` — most often to pin a
+    /// discriminator on each branch of a union. Read as the enum it is
+    /// equivalent to, so those branches keep their fixed value.
+    fn const_enum_values(&self, schema: &Value) -> Option<Vec<String>> {
+        schema.get("const").map(|value| vec![enum_value(value)])
+    }
+
+    /// A 3.1 document still carrying `nullable` is usually a 3.0 one whose
+    /// version string was raised without converting its schemas. Reading it
+    /// would be wrong — 3.1 gives the keyword no meaning — but dropping it in
+    /// silence turns every one of those columns non-nullable with nothing said,
+    /// so say it.
+    fn removed_keyword_warning(&self, schema: &Value) -> Option<String> {
+        // Only `nullable: true` is worth reporting. `nullable: false` asked for
+        // the default under 3.0 as well, so ignoring it changes nothing — and
+        // real documents carry leftover `false`s that would otherwise be pure
+        // noise. GitHub's own 3.1 publication has five of them and not one
+        // `true`.
+        (schema.get("nullable").and_then(Value::as_bool) == Some(true)).then(|| {
+            "the 'nullable' keyword was removed in OpenAPI 3.1 and is ignored; list 'null' in the schema's type instead".to_string()
+        })
+    }
+}

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
@@ -26,8 +26,22 @@ impl OpenApiDialect for OpenApi31Importer {
     /// it where a 3.0 one wrote a one-element `enum` — most often to pin a
     /// discriminator on each branch of a union. Read as the enum it is
     /// equivalent to, so those branches keep their fixed value.
+    ///
+    /// Only a scalar constant is read this way. `const` may hold any JSON value,
+    /// and an object or array one describes a shape rather than a value: taking
+    /// `{type: object, properties: {...}, const: {...}}` for an enum would stand
+    /// the stringified constant where the declared fields should be and drop
+    /// every column. Those fall through to the shape dispatch instead, which is
+    /// what describes them.
     fn const_enum_values(&self, schema: &Value) -> Option<Vec<String>> {
-        schema.get("const").map(|value| vec![enum_value(value)])
+        let value = schema.get("const")?;
+        // Scalars are stringified exactly as `enum` members already are, so
+        // `const: 4` and `enum: [4]` agree rather than the newer keyword
+        // inventing its own reading. `null` is excluded with the structured
+        // values: it constrains the schema to hold nothing, which the type
+        // already says better than a one-value enum of "null" would.
+        matches!(value, Value::String(_) | Value::Number(_) | Value::Bool(_))
+            .then(|| vec![enum_value(value)])
     }
 
     /// A 3.1 document still carrying `nullable` is usually a 3.0 one whose

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
@@ -59,6 +59,12 @@ impl OpenApiDialect for OpenApi31Importer {
             .then(|| vec![enum_value(value)])
     }
 
+    /// 2020-12 made `$ref` an ordinary keyword, so a 3.1 schema may write one
+    /// alongside the assertions that narrow what it resolves to.
+    fn ref_siblings_apply(&self) -> bool {
+        true
+    }
+
     /// A 3.1 document still carrying `nullable` is usually a 3.0 one whose
     /// version string was raised without converting its schemas. Reading it
     /// would be wrong — 3.1 gives the keyword no meaning — but dropping it in

--- a/crates/coral-spec/src/v4/surfaces/openapi/version.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/version.rs
@@ -8,12 +8,13 @@ use crate::{ManifestError, Result};
 /// separates editorial revisions of one specification — 3.0.0 through 3.0.4 —
 /// and nothing the importer does varies across them.
 ///
-/// 3.1 joins this as its dialect lands. Recognising a version here is the same
-/// statement as supporting it, so an unsupported version is rejected by the
-/// parse rather than admitted and turned away later.
+/// Recognising a version here is the same statement as supporting it, so an
+/// unsupported version is rejected by the parse rather than admitted and turned
+/// away later.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum OpenApiVersion {
     V3_0,
+    V3_1,
 }
 
 /// Reads a document's declared `openapi` version.
@@ -28,7 +29,7 @@ pub(super) fn parse_openapi_version(document: &Value) -> Result<OpenApiVersion> 
         // than report as a missing field.
         if let Some(swagger) = document.get("swagger").and_then(Value::as_str) {
             return Err(ManifestError::validation(format!(
-                "document declares Swagger version '{swagger}'; Coral requires OpenAPI 3.0"
+                "document declares Swagger version '{swagger}'; Coral requires OpenAPI 3.0 or 3.1"
             )));
         }
         return Err(ManifestError::validation(
@@ -43,12 +44,13 @@ pub(super) fn parse_openapi_version(document: &Value) -> Result<OpenApiVersion> 
     let mut components = declared.trim().split('.');
     let version = match (components.next(), components.next()) {
         (Some("3"), Some("0")) => OpenApiVersion::V3_0,
+        (Some("3"), Some("1")) => OpenApiVersion::V3_1,
         _ => return Err(unsupported()),
     };
     // The patch component is optional, but a present one has to be a number and
     // has to be the last thing in the string. Matching only the first two
-    // components would take `3.0.banana`, `3.0.` and `3.0.1.2` for well-formed
-    // 3.0 and import them, and this is the one place left that reads the
+    // components would take `3.1.banana`, `3.1.` and `3.1.1.2` for well-formed
+    // 3.1 and import them, and this is the one place left that reads the
     // version — so it is the place to say what the field may hold.
     //
     // Both remaining components are taken up front, mirroring the match above:

--- a/crates/coral-spec/src/v4/test_support.rs
+++ b/crates/coral-spec/src/v4/test_support.rs
@@ -1,6 +1,18 @@
-pub(super) fn github_openapi() -> &'static str {
-    r"
-openapi: 3.0.3
+pub(super) fn github_openapi() -> String {
+    github_openapi_at_version("3.0.3")
+}
+
+/// The same fixture under a different specification version.
+///
+/// Nothing below is spelled differently across 3.0 and 3.1 — no `nullable`, no
+/// `const`, no type arrays — so holding the document fixed and varying only the
+/// version isolates the claim that the shared traversal reads both alike, and a
+/// difference in the imported result is a difference the dialects introduced.
+pub(super) fn github_openapi_at_version(version: &str) -> String {
+    format!("openapi: {version}{GITHUB_OPENAPI_BODY}")
+}
+
+const GITHUB_OPENAPI_BODY: &str = r"
 paths:
   /repos/{owner}/{repo}/issues:
     get:
@@ -74,5 +86,4 @@ components:
         updated_at: {type: string, format: date-time}
         body: {type: string}
         user: {type: object}
-"
-}
+";


### PR DESCRIPTION
Part of #1321. This is the PR that actually accepts 3.1.

## Why

DSL v4 rejected 3.1 outright, so a document Coral could otherwise hydrate and discover was turned away at import.

## What changes

`OpenApi31Importer` joins the 3.0 dialect and the version dispatch routes to it.

3.1 realigned its schema object with JSON Schema 2020-12 rather than carrying its own dialect of it, and most of that costs the importer nothing: `$defs` resolves through the same JSON Pointer walk as any other local reference, and the keywords 3.1 gained for binary payloads only matter to file uploads, which Coral does not support. Two spellings do need reading:

- **Nullability.** 3.1 dropped `nullable` for JSON Schema's `null` type, so the dialect reads it out of the type array. The two versions genuinely disagree here rather than one being a superset, and the tests pin both directions: a 3.0 document does not get nullability from a type array, and a 3.1 one does not get it from the keyword.
- **`const`**, which 3.1 documents use to pin a discriminator where a 3.0 one wrote a one-element `enum`. It imports as the enum it is equivalent to.

A 3.1 document still carrying `nullable` now gets a diagnostic. It is usually a 3.0 document whose version string was raised without converting its schemas, and 3.1 gives the keyword no meaning — but dropping it in silence turns every one of those columns non-nullable with nothing said. Only `nullable: true` is reported; `nullable: false` asked for the default under 3.0 as well, and real documents carry leftover `false`s (GitHub's own 3.1 publication has five, and not one `true`).

3.2 stays rejected. It was ratified in April 2026 and is not yet widely adopted.

## Verification

The GitHub fixture is now parameterized by version and imported under both. A document using none of the contested keywords produces identical operations, types, and metadata either way — the claim the dialect split rests on: `$ref` resolution, response selection, wrapped-list row paths, and pagination detection stay one traversal.

## Review follow-up

`const_enum_values` fired for any schema carrying `const`, whatever it held. `const` may hold any JSON value, so `{type: object, properties: {...}, const: {...}}` — legal 3.1 — imported as a one-value enum whose single value was the stringified object, standing where the declared fields should have been and dropping every column. Only string, number and boolean constants are read as enums now; the rest fall through to the shape dispatch. Scalars are still stringified exactly as `enum` members already are, so `const: 4` and `enum: [4]` agree.

The cross-version test compared operation and type ids, which would have held just as well if 3.1 gave every one of those types a different shape. It now compares the whole serialized semantic IR.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>