### PR TITLE
feat(spec): accept OpenAPI 3.1 documents that declare no paths

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4465,6 +4465,7 @@ fn openapi_31_reads_a_scalar_const_the_way_it_reads_a_one_value_enum() {
     );
 }
 
+#[test]
 fn openapi_30_still_requires_paths() {
     let error = import_document(
         r"
@@ -4507,7 +4508,7 @@ webhooks:
         .find(|diagnostic| diagnostic.message.contains("webhook"))
         .expect("a webhook-only document should say why it imported nothing");
     assert!(
-        diagnostic.message.contains('2'),
+        diagnostic.message.contains("2 webhook(s)"),
         "the count makes it clear what was skipped: {}",
         diagnostic.message
     );
@@ -4653,6 +4654,43 @@ components:
         "A party in the system.",
         "the shared type describes the schema, not either use of it"
     );
+}
+
+#[test]
+fn importer_rejects_a_paths_member_that_is_not_a_mapping() {
+    // Absent and malformed must not collapse into each other. A 3.1 document may
+    // legitimately omit `paths`, but one that declares it as a string or a list
+    // is broken — and reporting that as a source with no tables sends whoever
+    // wrote it looking in the wrong place.
+    for version in ["3.0.3", "3.1.0"] {
+        for malformed in ["paths: not-a-mapping", "paths: [/items]", "paths: 7"] {
+            let error = import_document(&format!("openapi: {version}\n{malformed}\n"))
+                .expect_err(&format!("{version} with `{malformed}` should be rejected"));
+            assert!(
+                error.to_string().contains("paths must be a mapping"),
+                "{version} with `{malformed}`: {error}"
+            );
+        }
+    }
+}
+
+#[test]
+fn openapi_31_still_accepts_a_document_that_simply_omits_paths() {
+    // The other side of the boundary above: omitting `paths` stays legal under
+    // 3.1, so tightening the malformed case must not take the absent one with
+    // it.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+info:
+  title: Components only
+components:
+  schemas:
+    party: {type: object, properties: {id: {type: string}}}
+",
+    )
+    .expect("a 3.1 document may omit paths entirely");
+    assert!(imported.operations.is_empty());
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4384,6 +4384,54 @@ fn openapi_31_leaves_a_structured_const_to_the_shape_dispatch() {
     );
 }
 
+/// Imports a whole document verbatim, so a test can control what top-level
+/// sections it declares.
+#[expect(
+    clippy::unwrap_in_result,
+    reason = "Only the import's own result is under test; a manifest that will not parse is a bug in this file, not an outcome to return."
+)]
+fn import_document(document: &str) -> crate::Result<ImportedSurface> {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: document_probe
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    import_openapi_surface(v4, &v4.surface, document.as_bytes())
+}
+
+#[test]
+fn openapi_31_accepts_a_document_declaring_no_paths() {
+    // 3.1 made `paths` optional. Such a document has nothing to import, but it
+    // is well-formed, and refusing it would reject a spec its own author's
+    // tooling considers valid.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+info:
+  title: Callbacks only
+webhooks:
+  issueOpened:
+    post:
+      operationId: webhooks/issue-opened
+      responses:
+        '200': {description: ok}
+",
+    )
+    .expect("a 3.1 document may omit paths");
+
+    assert!(
+        imported.operations.is_empty(),
+        "webhooks are not operations Coral can call"
+    );
+}
+
 #[test]
 fn openapi_31_reads_a_scalar_const_the_way_it_reads_a_one_value_enum() {
     // `const: 4` and `enum: [4]` say the same thing, so they have to import the
@@ -4414,6 +4462,196 @@ fn openapi_31_reads_a_scalar_const_the_way_it_reads_a_one_value_enum() {
     assert_eq!(
         serde_json::to_value(&probe_field_type(&as_enum, "pinned").shape).expect("enum shape"),
         serde_json::to_value(&probe_field_type(&as_const, "pinned").shape).expect("const shape"),
+    );
+}
+
+fn openapi_30_still_requires_paths() {
+    let error = import_document(
+        r"
+openapi: 3.0.3
+info:
+  title: No paths
+",
+    )
+    .expect_err("3.0 requires paths");
+    assert!(error.to_string().contains("missing paths"), "{error}");
+}
+
+#[test]
+fn importer_says_when_a_document_is_all_webhooks() {
+    // Without this the surface imports to nothing and the author is left to
+    // work out why on their own.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+info:
+  title: Callbacks only
+webhooks:
+  issueOpened:
+    post:
+      operationId: webhooks/issue-opened
+      responses:
+        '200': {description: ok}
+  issueClosed:
+    post:
+      operationId: webhooks/issue-closed
+      responses:
+        '200': {description: ok}
+",
+    )
+    .expect("import");
+
+    let diagnostic = imported
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("webhook"))
+        .expect("a webhook-only document should say why it imported nothing");
+    assert!(
+        diagnostic.message.contains('2'),
+        "the count makes it clear what was skipped: {}",
+        diagnostic.message
+    );
+    assert_eq!(
+        diagnostic.operation_id, None,
+        "nothing was imported, so this belongs to the document rather than an operation"
+    );
+}
+
+#[test]
+fn importer_stays_quiet_about_webhooks_a_document_does_not_have() {
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {type: object}
+",
+    )
+    .expect("import");
+
+    assert!(
+        !imported
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("webhook")),
+        "{:?}",
+        imported.diagnostics
+    );
+}
+
+const REF_SIBLING_PROBE: &str = r"
+paths:
+  /items/{id}:
+    get:
+      operationId: items/get
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  primary:
+                    $ref: '#/components/schemas/party'
+                    description: The party that owns this item.
+components:
+  schemas:
+    party:
+      type: object
+      description: A party in the system.
+      properties:
+        id: {type: string}
+";
+
+#[test]
+fn a_ref_site_description_describes_the_field_and_the_target_describes_the_type() {
+    // 3.1 gives keywords beside a `$ref` meaning where 3.0 ignored them, but the
+    // distinction lands in the same place under both versions, so neither
+    // dialect needs a say in it.
+    //
+    // A type here is interned by the name it is referenced under and shared by
+    // every site referencing it, so a description written beside one `$ref`
+    // cannot go on the type without overwriting what the other sites say. The
+    // field is where a site-specific description fits, and it already reads the
+    // site in preference to the target — which is 3.1's rule, applied to both.
+    for version in ["3.0.3", "3.1.0"] {
+        let imported = import_document(&format!("openapi: {version}{REF_SIBLING_PROBE}"))
+            .unwrap_or_else(|error| panic!("{version} import: {error}"));
+
+        assert_eq!(
+            probe_row_type(&imported, "primary").description,
+            "The party that owns this item.",
+            "{version}: the field takes the description written at the reference site"
+        );
+        assert_eq!(
+            probe_field_type(&imported, "primary").description,
+            "A party in the system.",
+            "{version}: the shared type keeps its own description, so a second reference to it cannot be given a different one"
+        );
+    }
+}
+
+#[test]
+fn a_shared_schema_keeps_one_description_across_every_reference_site() {
+    // The reason the rule above has to hold: two fields referencing one schema
+    // share a single imported type, and whichever was imported first would
+    // otherwise decide what the other one says.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buyer:
+                    $ref: '#/components/schemas/party'
+                    description: The buying party.
+                  seller:
+                    $ref: '#/components/schemas/party'
+                    description: The selling party.
+components:
+  schemas:
+    party:
+      type: object
+      description: A party in the system.
+      properties:
+        id: {type: string}
+",
+    )
+    .expect("import");
+
+    assert_eq!(
+        probe_row_type(&imported, "buyer").description,
+        "The buying party."
+    );
+    assert_eq!(
+        probe_row_type(&imported, "seller").description,
+        "The selling party."
+    );
+    assert_eq!(
+        probe_row_type(&imported, "buyer").type_ref,
+        probe_row_type(&imported, "seller").type_ref,
+        "both reference the same schema, so both must land on the same type"
+    );
+    assert_eq!(
+        probe_field_type(&imported, "seller").description,
+        "A party in the system.",
+        "the shared type describes the schema, not either use of it"
     );
 }
 

--- a/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/dialect.rs
@@ -29,4 +29,7 @@ pub(super) trait OpenApiDialect {
     /// annotation would be — but ignoring it silently changes what the schema
     /// means, and the author is unlikely to have intended that.
     fn removed_keyword_warning(&self, schema: &Value) -> Option<String>;
+
+    /// Whether a document must declare `paths` to be well-formed.
+    fn paths_required(&self) -> bool;
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -72,15 +72,20 @@ impl<'a> OpenApiImporter<'a> {
     }
 
     fn import(&mut self) -> Result<ImportedSurface> {
-        let paths = self
-            .document
-            .get("paths")
-            .and_then(Value::as_object)
-            .ok_or_else(|| ManifestError::validation("OpenAPI document is missing paths"))?;
+        let paths = self.document.get("paths").and_then(Value::as_object);
+        if paths.is_none() && self.dialect.paths_required() {
+            return Err(ManifestError::validation(
+                "OpenAPI document is missing paths",
+            ));
+        }
+        // A document describing only `webhooks` or only reusable `components` is
+        // well-formed under 3.1 and simply has nothing here to import, so it
+        // yields an empty surface rather than an error.
+        self.report_unimported_sections();
         let mut operations = Vec::new();
         let mut operation_metadata = BTreeMap::new();
         let mut operation_ids = HashSet::new();
-        for (path, path_item) in paths {
+        for (path, path_item) in paths.into_iter().flatten() {
             let Some(path_item) = path_item.as_object() else {
                 continue;
             };
@@ -136,6 +141,28 @@ impl<'a> OpenApiImporter<'a> {
             semantic_ir,
             operation_metadata,
         })
+    }
+
+    /// Records what the document describes that this importer does not read.
+    ///
+    /// `webhooks` is 3.1's home for provider-initiated callbacks. Coral models a
+    /// source as endpoints it calls, so there is nothing to map them onto — but
+    /// a document whose whole surface is webhooks would otherwise import to
+    /// nothing at all, with no indication of why.
+    fn report_unimported_sections(&mut self) {
+        let webhooks = self
+            .document
+            .get("webhooks")
+            .and_then(Value::as_object)
+            .map_or(0, serde_json::Map::len);
+        if webhooks > 0 {
+            self.diagnostics.push(Diagnostic::new(
+                format!(
+                    "OpenAPI document declares {webhooks} webhook(s), which Coral does not import; only operations under 'paths' become tables"
+                ),
+                None,
+            ));
+        }
     }
 
     pub(super) fn resolve_ref(

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -72,15 +72,25 @@ impl<'a> OpenApiImporter<'a> {
     }
 
     fn import(&mut self) -> Result<ImportedSurface> {
-        let paths = self.document.get("paths").and_then(Value::as_object);
-        if paths.is_none() && self.dialect.paths_required() {
-            return Err(ManifestError::validation(
-                "OpenAPI document is missing paths",
-            ));
-        }
         // A document describing only `webhooks` or only reusable `components` is
         // well-formed under 3.1 and simply has nothing here to import, so it
         // yields an empty surface rather than an error.
+        //
+        // Absent and malformed are kept apart. Reading `paths` straight through
+        // `as_object` collapses them, and then a 3.1 document whose `paths` is a
+        // string or a list imports as an empty surface — reported as a source
+        // with no tables rather than as the broken descriptor it is.
+        let paths = match self.document.get("paths") {
+            Some(paths) => Some(paths.as_object().ok_or_else(|| {
+                ManifestError::validation("OpenAPI document paths must be a mapping")
+            })?),
+            None if self.dialect.paths_required() => {
+                return Err(ManifestError::validation(
+                    "OpenAPI document is missing paths",
+                ));
+            }
+            None => None,
+        };
         self.report_unimported_sections();
         let mut operations = Vec::new();
         let mut operation_metadata = BTreeMap::new();

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -101,6 +101,14 @@ impl OpenApiImporter<'_> {
         if self.types.contains_key(&type_id) {
             return Some(type_id);
         }
+        // The target's own description, never one written beside the `$ref`.
+        // 3.1 does give those siblings meaning, but a type here is interned by
+        // the name it is referenced under and shared by every site that
+        // references it, so there is nowhere to put a site-specific description
+        // except over the top of the shared one — where the first reference
+        // would win and every later one would be lost. The site's wording
+        // already reaches the only place it fits, `field_description` below,
+        // which reads it in preference to the target's.
         let description = resolved
             .get("description")
             .and_then(Value::as_str)

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_0.rs
@@ -32,4 +32,10 @@ impl OpenApiDialect for OpenApi30Importer {
     fn removed_keyword_warning(&self, _schema: &Value) -> Option<String> {
         None
     }
+
+    /// `paths` is the only place a 3.0 document can describe an endpoint, and
+    /// the specification requires it.
+    fn paths_required(&self) -> bool {
+        true
+    }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/v3_1.rs
@@ -80,4 +80,10 @@ impl OpenApiDialect for OpenApi31Importer {
             "the 'nullable' keyword was removed in OpenAPI 3.1 and is ignored; list 'null' in the schema's type instead".to_string()
         })
     }
+
+    /// 3.1 made `paths` optional, so a document may describe only `webhooks` or
+    /// only reusable `components`.
+    fn paths_required(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
Part of #1321.

## Why

3.1 made `paths` optional, so a document may describe only `webhooks` or only reusable `components`. The importer required it unconditionally and refused such a document outright, which meant rejecting a spec its own author's tooling considers valid.

## What changes

`paths` is now required only where the version requires it, and a document with nothing under it imports to an empty surface instead.

An empty surface is a confusing thing to receive in silence, so a document declaring webhooks now says so. Coral models a source as endpoints it calls and has nothing to map provider-initiated callbacks onto, but the author deserves to be told that rather than left to work out why their spec imported nothing.

## `$ref` siblings: pinned, not changed

3.1 gives keywords beside a `$ref` meaning where 3.0 ignored them, so a description written at a reference site looked like a third thing for the dialects to disagree about. It is not.

A type here is interned by the name it is referenced under and shared by every site that references it, so a site's description cannot go on the type without overwriting what every other site says — first reference winning, the rest silently lost. The field is where a site-specific description fits, and `field_description` already reads the site in preference to the target, which is 3.1's rule already applied to both versions. Two tests fix that split in place, one of them covering the two-references case that makes it necessary.

## Review follow-up

Reading `paths` straight through `as_object` collapsed absent and malformed into the same answer. Once 3.1 made an absent `paths` legal, that collapse meant a 3.1 document whose `paths` was a string or a list imported as an empty surface — reported as a source with no tables rather than the broken descriptor it is. A present `paths` must now be a mapping under either version; only an absent one is subject to the version's rule.

The webhook diagnostic assertion searched for the character `2` anywhere in the message, so it would have passed on any count containing one.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>