### PR TITLE
fix(spec): treat OpenAPI 3.0 'example' as an annotation

### DIFF
--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -5,8 +5,8 @@
 
 pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 6;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v4";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v10";
-pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v4";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v11";
+pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v5";
 pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";
 

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4694,6 +4694,74 @@ components:
 }
 
 #[test]
+fn a_property_redeclared_only_to_change_its_example_is_not_a_conflict() {
+    // Composed types routinely re-declare an inherited property to narrow an
+    // annotation, and `example` is 3.0's spelling of the one 3.1 calls
+    // `examples`. Reading the singular form as a constraint made those
+    // re-declarations look like genuine disagreements, and a conflict discards
+    // the whole type — so the composed object collapsed to opaque JSON and took
+    // every nested type it owned with it.
+    let imported = import_document(
+        r"
+openapi: 3.0.3
+paths:
+  /invoices:
+    get:
+      operationId: invoices/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/base'
+                  - type: object
+                    properties:
+                      reference:
+                        type: string
+                        example: INV-2026-004
+                      total: {type: integer}
+components:
+  schemas:
+    base:
+      type: object
+      properties:
+        reference:
+          type: string
+          example: INV-0001
+        issued_at: {type: string, format: date-time}
+",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert!(
+        !operation
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("conflicts")),
+        "differing examples are not a disagreement about validation: {:?}",
+        operation.diagnostics
+    );
+
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("the composed type should survive rather than collapse to opaque JSON");
+    };
+    let names: Vec<&str> = fields.iter().map(|field| field.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["issued_at", "reference", "total"],
+        "every branch's columns have to survive the fold"
+    );
+}
+
+#[test]
 fn a_const_narrows_the_enum_it_is_declared_beside() {
     // How a 2020-12 document pins one branch of a union: the branch re-declares
     // the discriminator it shares with the rest of the family — `enum` listing

--- a/crates/coral-spec/src/v4/surfaces/json_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/json_schema.rs
@@ -4,7 +4,22 @@ use serde_json::Value;
 
 use crate::v4::ir::IrScalarType;
 
-const ANNOTATION_KEYS: &[&str] = &["$comment", "default", "description", "examples", "title"];
+/// Keywords that describe a schema without constraining what validates against
+/// it, and so cannot make two declarations of one property disagree.
+///
+/// `example` and `examples` are the same annotation under two spellings:
+/// `examples` is JSON Schema's, which 3.1 adopted, and `example` is the
+/// singular one 3.0 defined on its own schema object. Both have to be here, or
+/// a property re-declared only to carry a different `example` reads as a
+/// genuine conflict.
+const ANNOTATION_KEYS: &[&str] = &[
+    "$comment",
+    "default",
+    "description",
+    "example",
+    "examples",
+    "title",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RefError<'a> {


### PR DESCRIPTION
Part of #1321. Drive-by — not needed for 3.1, and droppable if it muddies the stack.

## Why

`ANNOTATION_KEYS` listed `examples` but not `example`. They are the same annotation under two spellings — `examples` is JSON Schema's, which 3.1 adopted, and `example` is the singular one 3.0 defined on its own schema object — so reading only the plural form left the singular one counting as a constraint.

Composed types routinely re-declare an inherited property to narrow an annotation. Where that annotation was a 3.0 `example`, the fold read the re-declaration as a genuine disagreement about validation, and a property conflict discards the whole type: the composed object collapsed to opaque JSON and took every nested type it owned with it.

## Verification

Measured against the six bundled v4 descriptors, this recovers one type in GitHub's spec and the 22 nested types it owned — 15,364 imported types to 15,387. The other five are unaffected, and no inferred row path, pagination contract, or lookup key changes on any of them.

## Note on the version bumps

Bumps both importer versions. The fingerprint this feeds is shared with the MCP importer, which is unaffected in practice — 2020-12 has no singular `example` — but its artifacts are keyed on the same comparison and should not be read back under the old version.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>