### PR TITLE
fix(spec): read a union of a schema and null as that schema

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4909,6 +4909,230 @@ components:
         serde_json::to_value(&probe_field_type(imported, "buyer").shape).expect("shape")
     };
     assert_eq!(shape_of(&as_30), shape_of(&as_31));
+
+    // Where the two stop agreeing, stated rather than left for someone to
+    // discover. `IrType.nullable` is a property of the type, and the versions
+    // put nullability in different places: 3.0 writes it on the shared schema,
+    // 3.1 writes it at each use site. A type here is interned by the name it is
+    // referenced under, so a use-site fact has nowhere to live on it that the
+    // next reference would not overwrite — the same reason a `$ref` sibling
+    // description stays off the type.
+    //
+    // Nothing downstream reads it: `IrField.nullable` is set for every field
+    // regardless, and every projected column is nullable. Were that to change,
+    // this assertion is what will fail and say why.
+    assert!(probe_field_type(&as_30, "buyer").nullable);
+    assert!(
+        !probe_field_type(&as_31, "buyer").nullable,
+        "3.1 puts nullability at the use site, which a shared type cannot carry"
+    );
+}
+
+#[test]
+fn a_union_that_refers_back_to_itself_terminates() {
+    // `resolve_ref` follows one hop and tracks nothing, so a union whose branch
+    // resolves to the same union has no natural end. The interning check is what
+    // stops every other `$ref` cycle here, and it only engages if the type keeps
+    // the identity of the reference it was reached by.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /nodes:
+    get:
+      operationId: nodes/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  node: {$ref: '#/components/schemas/node'}
+components:
+  schemas:
+    node:
+      anyOf:
+        - type: 'null'
+        - $ref: '#/components/schemas/node'
+",
+    )
+    .expect("a self-referential union must import rather than hang");
+
+    assert!(
+        matches!(probe_field_type(&imported, "node").shape, IrTypeShape::Json),
+        "a union with nowhere to unwrap to keeps its own reading"
+    );
+}
+
+#[test]
+fn a_union_reached_through_itself_terminates() {
+    // The inline variant, which has no second `$ref` to notice repeating: the
+    // branch is an object whose own field points back at the union. Each pass
+    // would otherwise be handed a fresh suggested id — `node_row_child`,
+    // `node_row_child_child` — and never meet a type it had already interned.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /nodes:
+    get:
+      operationId: nodes/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  node: {$ref: '#/components/schemas/node'}
+components:
+  schemas:
+    node:
+      anyOf:
+        - type: 'null'
+        - type: object
+          properties:
+            name: {type: string}
+            child: {$ref: '#/components/schemas/node'}
+",
+    )
+    .expect("a recursive nullable type must import rather than hang");
+
+    let IrTypeShape::Object { fields } = &probe_field_type(&imported, "node").shape else {
+        panic!("the branch's shape should still be read");
+    };
+    let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, ["name", "child"]);
+}
+
+#[test]
+fn a_nullable_collection_response_is_still_a_collection() {
+    // The union declares no type of its own, so classifying the wrapper reads it
+    // as a singleton while the row type is built from the branch — publishing
+    // one row that holds the entire list.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /issues:
+    get:
+      operationId: issues/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: 'null'
+                  - type: array
+                    items: {$ref: '#/components/schemas/issue'}
+components:
+  schemas:
+    issue:
+      type: object
+      properties:
+        id: {type: string}
+        title: {type: string}
+",
+    )
+    .expect("import");
+
+    let operation = imported.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    let IrTypeShape::Object { fields } = &imported
+        .types
+        .iter()
+        .find(|ty| ty.id == operation.output.type_ref)
+        .expect("row type")
+        .shape
+    else {
+        panic!("the rows are the items of the branch, not the union");
+    };
+    let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, ["id", "title"]);
+}
+
+#[test]
+fn a_nullable_reference_keeps_the_referenced_description() {
+    // The wrapper carries no description of its own, so reading only the wrapper
+    // left the column without the one the referenced schema declares — metadata
+    // the same field written as a bare `$ref` keeps.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /invoices:
+    get:
+      operationId: invoices/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buyer:
+                    anyOf:
+                      - type: 'null'
+                      - $ref: '#/components/schemas/party'
+components:
+  schemas:
+    party:
+      type: object
+      description: A party in the system.
+      properties:
+        id: {type: string}
+",
+    )
+    .expect("import");
+
+    assert_eq!(
+        probe_row_type(&imported, "buyer").description,
+        "A party in the system."
+    );
+}
+
+#[test]
+fn a_null_branch_written_as_a_constant_is_still_a_null_branch() {
+    // 2020-12 spells "only null" three ways. Missing the constant forms would
+    // leave the union looking like a choice between two real shapes and send the
+    // reference back to opaque JSON.
+    for null_branch in ["type: 'null'", "const: null", "enum: [null]"] {
+        let imported = import_document(&format!(
+            r"
+openapi: 3.1.0
+paths:
+  /invoices:
+    get:
+      operationId: invoices/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buyer:
+                    anyOf:
+                      - {null_branch}
+                      - $ref: '#/components/schemas/party'
+components:
+  schemas:
+    party:
+      type: object
+      properties:
+        id: {{type: string}}
+"
+        ))
+        .unwrap_or_else(|error| panic!("`{null_branch}`: {error}"));
+
+        let IrTypeShape::Object { fields } = &probe_field_type(&imported, "buyer").shape else {
+            panic!("`{null_branch}` should be recognised as the null branch");
+        };
+        let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, ["id"], "`{null_branch}`");
+    }
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -5184,3 +5184,100 @@ fn a_structured_const_leaves_a_neighbouring_enum_to_be_read() {
     };
     assert_eq!(values, &["compact", "roomy"]);
 }
+
+#[test]
+fn a_recursive_nullable_reference_reached_through_a_wrapper_terminates() {
+    // A self-referential type whose recursion is wrapped at the use site. The
+    // walk unwraps `node` to its inline branch, which carries no `$ref` of its
+    // own, so before the walk reported the reference it had crossed every
+    // nested `child` was interned under the suggested id instead — a fresh
+    // `node_child_child…` on each pass, which the interning check could never
+    // match. The import recursed until the stack ran out.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /trees:
+    get:
+      operationId: trees/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  root:
+                    anyOf:
+                      - type: 'null'
+                      - $ref: '#/components/schemas/node'
+components:
+  schemas:
+    node:
+      anyOf:
+        - type: 'null'
+        - type: object
+          properties:
+            label: {type: string}
+            child:
+              anyOf:
+                - type: 'null'
+                - $ref: '#/components/schemas/node'
+",
+    )
+    .expect("import");
+
+    // The recursive type is interned once, under the name it is referenced by,
+    // and the field reaches it. One copy is what ends the recursion; the name is
+    // what makes the copy findable.
+    assert_eq!(probe_row_type(&imported, "root").type_ref, "node");
+    assert_eq!(
+        imported
+            .types
+            .iter()
+            .filter(|ty| ty.id.starts_with("node"))
+            .count(),
+        2,
+        "the recursive type and its one scalar field, not a chain of copies: {:?}",
+        imported.types.iter().map(|ty| &ty.id).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn a_chain_of_nullable_wrappers_yields_its_description_at_any_depth() {
+    // The description lookup steps through wrappers iteratively, so no depth of
+    // nesting puts it on the stack. Depths either side of the import walk's own
+    // budget are checked together: that budget bounds a walk that follows
+    // `$ref`s and so can be led in circles, and borrowing it here would have
+    // quietly dropped the description of anything nested past it.
+    for depth in [1usize, 8, 12] {
+        let mut wrapper = "{type: string, description: The item's label.}".to_string();
+        for _ in 0..depth {
+            wrapper = format!("{{anyOf: [{{type: 'null'}}, {wrapper}]}}");
+        }
+        let imported = import_document(&format!(
+            r"
+openapi: 3.1.0
+paths:
+  /items:
+    get:
+      operationId: items/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deep: {wrapper}
+"
+        ))
+        .expect("import");
+
+        assert_eq!(
+            probe_row_type(&imported, "deep").description,
+            "The item's label.",
+            "at depth {depth}"
+        );
+    }
+}

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4761,6 +4761,156 @@ components:
     );
 }
 
+const NULL_UNION_PROBE: &str = r"
+paths:
+  /invoices:
+    get:
+      operationId: invoices/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buyer:
+                    anyOf:
+                      - type: 'null'
+                      - $ref: '#/components/schemas/party'
+                  seller:
+                    oneOf:
+                      - $ref: '#/components/schemas/party'
+                      - type: 'null'
+                  status:
+                    anyOf:
+                      - type: 'null'
+                      - type: string
+components:
+  schemas:
+    party:
+      type: object
+      properties:
+        id: {type: string}
+        name: {type: string}
+";
+
+#[test]
+fn a_union_of_a_ref_and_null_imports_as_the_referenced_type() {
+    // Once `nullable` is gone a `$ref` has no type of its own to list `null` in,
+    // so this is how 3.1 documents spell a nullable reference — 217 times in
+    // GitHub's own 3.1 publication. Matching no arm of the shape dispatch, it
+    // imported as opaque JSON and took every field of the target with it.
+    let imported = import_document(&format!("openapi: 3.1.0{NULL_UNION_PROBE}")).expect("import");
+
+    for field in ["buyer", "seller"] {
+        let IrTypeShape::Object { fields } = &probe_field_type(&imported, field).shape else {
+            panic!("{field}: a union of a $ref and null has to keep the target's fields");
+        };
+        let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, ["id", "name"], "{field}");
+    }
+
+    // Both sides of the union land on the shared type rather than a copy under
+    // the field's own name. Expanding the target per site would duplicate it,
+    // and every inline schema beneath it, once for each nullable reference.
+    assert_eq!(
+        probe_row_type(&imported, "buyer").type_ref,
+        probe_row_type(&imported, "seller").type_ref,
+        "anyOf and oneOf spell the same thing and must resolve alike"
+    );
+    assert_eq!(probe_row_type(&imported, "buyer").type_ref, "party");
+
+    assert!(
+        matches!(
+            probe_field_type(&imported, "status").shape,
+            IrTypeShape::Scalar(IrScalarType::String)
+        ),
+        "an inline branch keeps its scalar type too"
+    );
+}
+
+#[test]
+fn a_union_of_two_real_branches_stays_opaque() {
+    // A genuine choice between shapes is not a nullable schema. Coral has no
+    // union type, and reading the first branch while discarding the rest would
+    // describe columns the response does not always carry.
+    let imported = import_document(
+        r"
+openapi: 3.1.0
+paths:
+  /events:
+    get:
+      operationId: events/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payload:
+                    anyOf:
+                      - $ref: '#/components/schemas/push'
+                      - $ref: '#/components/schemas/release'
+                      - type: 'null'
+components:
+  schemas:
+    push: {type: object, properties: {ref: {type: string}}}
+    release: {type: object, properties: {tag: {type: string}}}
+",
+    )
+    .expect("import");
+
+    assert!(
+        matches!(
+            probe_field_type(&imported, "payload").shape,
+            IrTypeShape::Json
+        ),
+        "two real branches remain a choice this IR cannot express"
+    );
+}
+
+#[test]
+fn both_spellings_of_a_nullable_reference_import_alike() {
+    // The 3.0 document says `allOf` plus `nullable`; the 3.1 one says `anyOf`
+    // with a null branch. They describe the same field, so they have to import
+    // to the same shape — that equivalence is the whole reason for reading the
+    // union at all.
+    let as_31 = import_document(&format!("openapi: 3.1.0{NULL_UNION_PROBE}")).expect("3.1");
+    let as_30 = import_document(
+        r"
+openapi: 3.0.3
+paths:
+  /invoices:
+    get:
+      operationId: invoices/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buyer:
+                    $ref: '#/components/schemas/party'
+components:
+  schemas:
+    party:
+      type: object
+      nullable: true
+      properties:
+        id: {type: string}
+        name: {type: string}
+",
+    )
+    .expect("3.0");
+
+    let shape_of = |imported: &ImportedSurface| {
+        serde_json::to_value(&probe_field_type(imported, "buyer").shape).expect("shape")
+    };
+    assert_eq!(shape_of(&as_30), shape_of(&as_31));
+}
+
 #[test]
 fn a_const_narrows_the_enum_it_is_declared_beside() {
     // How a 2020-12 document pins one branch of a union: the branch re-declares

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -106,8 +106,7 @@ impl OpenApiImporter<'_> {
         // For a collection that published one row holding the whole list.
         let resolved = self
             .schema_through_null_unions(&resolved, operation_id, diagnostics)
-            .and_then(|site| self.resolve_ref(&site, operation_id, diagnostics))
-            .unwrap_or(resolved);
+            .map_or(resolved, |walk| walk.resolved);
         let (cardinality, row_schema, schema_entity_name) =
             classify_response_schema(path, &resolved);
         // Only when the classification set this schema aside. A singleton hands

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -99,6 +99,15 @@ impl OpenApiImporter<'_> {
                 },
             );
         };
+        // Classified through the same unwrapping `import_schema` does. A
+        // nullable response — `anyOf: [{type: 'null'}, {$ref: ...}]` — otherwise
+        // has its cardinality read off the union, which declares no type and so
+        // looks like a singleton, while the row type is built from the branch.
+        // For a collection that published one row holding the whole list.
+        let resolved = self
+            .schema_through_null_unions(&resolved, operation_id, diagnostics)
+            .and_then(|site| self.resolve_ref(&site, operation_id, diagnostics))
+            .unwrap_or(resolved);
         let (cardinality, row_schema, schema_entity_name) =
             classify_response_schema(path, &resolved);
         // Only when the classification set this schema aside. A singleton hands

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -94,6 +94,23 @@ impl OpenApiImporter<'_> {
             return self.import_schema(&composed, suggested_id, operation_id, diagnostics);
         }
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
+        // A union of one real branch and `null` is imported as that branch.
+        //
+        // It is how a nullable reference has to be written once `nullable` is
+        // gone: a `$ref` carries no type of its own to list `null` in, so 3.1
+        // documents spell it `anyOf: [{type: 'null'}, {$ref: ...}]`. Left alone
+        // it matches no arm of the shape dispatch below and imports as opaque
+        // JSON, taking every field of the referenced type with it.
+        //
+        // Handing the branch back to this function rather than inlining its
+        // shape here is what keeps a `$ref` branch on the type id it already
+        // has. Expanding it under this site's name instead would copy the whole
+        // target — and every inline schema beneath it — once per site that
+        // references it nullably, which on GitHub's 3.1 descriptor is the
+        // difference between 15k imported types and 25k.
+        if let Some(branch) = null_union_branch(&resolved).cloned() {
+            return self.import_schema(&branch, suggested_id, operation_id, diagnostics);
+        }
         let type_id = schema.get("$ref").and_then(Value::as_str).map_or_else(
             || normalize_identifier(suggested_id, "type"),
             type_id_from_ref,
@@ -532,6 +549,43 @@ impl OpenApiImporter<'_> {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string()
+    }
+}
+
+/// The single real branch of a union between a schema and `null`.
+///
+/// Only a union that reduces to exactly one real branch is unwrapped. Two or
+/// more is a genuine choice between shapes, which Coral has no type for and
+/// which has to keep importing as opaque JSON — reading the first branch and
+/// discarding the rest would describe a column the response does not have.
+fn null_union_branch(schema: &Value) -> Option<&Value> {
+    for keyword in ["anyOf", "oneOf"] {
+        let Some(branches) = schema.get(keyword).and_then(Value::as_array) else {
+            continue;
+        };
+        // A union has to have lost something to `null` to be one of these; a
+        // single-branch `anyOf` is just a wrapper and keeps its own reading.
+        if branches.len() < 2 {
+            continue;
+        }
+        let mut real = branches.iter().filter(|branch| !declares_only_null(branch));
+        let only = real.next()?;
+        if real.next().is_some() {
+            return None;
+        }
+        return Some(only);
+    }
+    None
+}
+
+/// Whether a branch admits nothing but `null`.
+fn declares_only_null(schema: &Value) -> bool {
+    match schema.get("type") {
+        Some(Value::String(value)) => value == "null",
+        Some(Value::Array(values)) => {
+            !values.is_empty() && values.iter().all(|value| value.as_str() == Some("null"))
+        }
+        _ => false,
     }
 }
 

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -65,6 +65,42 @@ const COMPOSABLE_REF_SIBLINGS: [&str; 3] = ["properties", "required", "additiona
 /// for ever.
 const MAX_NULL_UNION_DEPTH: usize = 8;
 
+/// Where a walk through a chain of `[T, null]` unions ended.
+pub(super) struct NullUnionWalk {
+    /// The schema carrying the shape, with the walk's last `$ref` hop already
+    /// followed.
+    pub(super) resolved: Value,
+    /// The reference the result is interned under, when the walk crossed one.
+    ///
+    /// The site the walk ended on supplies this, so a chain of aliases still
+    /// interns under the name it finally arrived at and every route to that
+    /// name shares one type. Only when the walk ends somewhere unnamed — a
+    /// union whose real branch is written inline — does the first reference it
+    /// crossed stand in.
+    ///
+    /// That fallback is what terminates a recursive nullable reference. A
+    /// self-referential type reached through a wrapper — `node: anyOf: [null,
+    /// {type: object, properties: {child: {anyOf: [null, {$ref: node}]}}}]` —
+    /// ends its walk on the inline branch, and without a name to intern under
+    /// every nested `child` took the suggested id instead, growing a fresh
+    /// `node_child_child…` that the interning check could never match until the
+    /// stack ran out.
+    pub(super) reference: Option<String>,
+}
+
+impl NullUnionWalk {
+    fn ending_at(site: &Value, resolved: Value, first_reference: Option<String>) -> Self {
+        Self {
+            reference: site
+                .get("$ref")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+                .or(first_reference),
+            resolved,
+        }
+    }
+}
+
 /// Why folding a schema's `allOf` tree stopped.
 enum AllOfMergeError {
     /// A branch could not be resolved. A diagnostic naming it has already been
@@ -106,29 +142,30 @@ impl OpenApiImporter<'_> {
         // documents spell it `anyOf: [{type: 'null'}, {$ref: ...}]`. Left alone
         // it matches no arm of the shape dispatch below and imports as opaque
         // JSON, taking every field of the referenced type with it.
-        let site = self.schema_through_null_unions(schema, operation_id, diagnostics)?;
-        let resolved = self.resolve_ref(&site, operation_id, diagnostics)?;
+        let walk = self.schema_through_null_unions(schema, operation_id, diagnostics)?;
+        let resolved = walk.resolved;
         // The type id still comes from the reference this was reached by, and
-        // only falls back to the branch's own. That ordering is what ends a
-        // cycle: `Node: anyOf: [{type: 'null'}, {$ref: Node}]` unwraps to a
-        // schema that resolves back to the same union, and taking the branch's
+        // only falls back to what the walk arrived at. That ordering is what
+        // ends a cycle: `Node: anyOf: [{type: 'null'}, {$ref: Node}]` unwraps to
+        // a schema that resolves back to the same union, and taking the branch's
         // identity instead would leave the interning check below — the thing
         // that terminates every other `$ref` cycle here — with a name that never
         // repeats, growing a fresh `root_child_child…` on each pass until the
         // stack ran out.
         //
-        // Preferring the branch's id when this site has none is what keeps a
-        // nullable reference on the type it already has, rather than copying the
-        // target and every inline schema beneath it once per referring site —
-        // on GitHub's 3.1 descriptor, the difference between 15k imported types
-        // and 25k.
+        // Preferring a reference over the suggested id when this site has none
+        // is what keeps a nullable reference on the type it already has, rather
+        // than copying the target and every inline schema beneath it once per
+        // referring site — on GitHub's 3.1 descriptor, the difference between
+        // 15k imported types and 25k.
         let type_id = schema
             .get("$ref")
-            .or_else(|| site.get("$ref"))
             .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .or(walk.reference)
             .map_or_else(
                 || normalize_identifier(suggested_id, "type"),
-                type_id_from_ref,
+                |reference| type_id_from_ref(&reference),
             );
         if self.types.contains_key(&type_id) {
             return Some(type_id);
@@ -551,9 +588,9 @@ impl OpenApiImporter<'_> {
     /// Follows a chain of unions between a schema and `null` to the schema that
     /// carries the shape, returning the one given when it is not such a union.
     ///
-    /// The referencing site is returned rather than what it resolves to, so the
-    /// caller can still see the `$ref` and keep the type identity that comes
-    /// with it.
+    /// Both halves of what the caller needs come back together: the resolved
+    /// schema, so the one `$ref` hop the walk already followed is not followed
+    /// again on the hot path, and the reference to intern the result under.
     ///
     /// Bounded twice over, because `resolve_ref` follows one hop and tracks
     /// nothing: a branch leading back to a reference already followed stops the
@@ -565,37 +602,51 @@ impl OpenApiImporter<'_> {
         schema: &Value,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> Option<Value> {
+    ) -> Option<NullUnionWalk> {
         let mut site = schema.clone();
         let mut followed = BTreeSet::new();
+        let mut first_reference = None;
         if let Some(reference) = site.get("$ref").and_then(Value::as_str) {
             followed.insert(reference.to_string());
+            first_reference = Some(reference.to_string());
         }
         for _ in 0..MAX_NULL_UNION_DEPTH {
             let resolved = self.resolve_ref(&site, operation_id, diagnostics)?;
             let Some(branch) = null_union_branch(&resolved).cloned() else {
-                return Some(site);
+                return Some(NullUnionWalk::ending_at(&site, resolved, first_reference));
             };
-            if let Some(reference) = branch.get("$ref").and_then(Value::as_str)
-                && !followed.insert(reference.to_string())
-            {
-                return Some(site);
+            if let Some(reference) = branch.get("$ref").and_then(Value::as_str) {
+                first_reference.get_or_insert_with(|| reference.to_string());
+                if !followed.insert(reference.to_string()) {
+                    return Some(NullUnionWalk::ending_at(&site, resolved, first_reference));
+                }
             }
             site = branch;
         }
-        Some(site)
+        let resolved = self.resolve_ref(&site, operation_id, diagnostics)?;
+        Some(NullUnionWalk::ending_at(&site, resolved, first_reference))
     }
 
     fn field_description(&self, schema: &Value) -> String {
-        if let Some(description) = schema.get("description").and_then(Value::as_str) {
-            return description.to_string();
-        }
-        // A nullable spelling wraps the schema that has the description. The
-        // wrapper says nothing itself, so without this a field written
-        // `anyOf: [{type: 'null'}, {$ref: ...}]` lost the column description
-        // that the same field written as a bare `$ref` keeps.
-        if let Some(branch) = null_union_branch(schema) {
-            return self.field_description(branch);
+        // Iterative rather than recursive, so no chain of wrappers can put this
+        // lookup on the stack. It needs no depth budget the way the import walk
+        // above does: that one follows `$ref`s, which can lead anywhere and
+        // back, while this only ever steps to a branch written inside the schema
+        // it is already holding. Each step is strictly further into one finite
+        // tree, so the loop ends because the document does.
+        let mut schema = schema;
+        loop {
+            if let Some(description) = schema.get("description").and_then(Value::as_str) {
+                return description.to_string();
+            }
+            // A nullable spelling wraps the schema that has the description. The
+            // wrapper says nothing itself, so without this a field written
+            // `anyOf: [{type: 'null'}, {$ref: ...}]` lost the column description
+            // that the same field written as a bare `$ref` keeps.
+            let Some(branch) = null_union_branch(schema) else {
+                break;
+            };
+            schema = branch;
         }
         let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
             return String::new();

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -59,6 +59,12 @@ const REF_SIBLING_ANNOTATIONS: [&str; 11] = [
 /// describe.
 const COMPOSABLE_REF_SIBLINGS: [&str; 3] = ["properties", "required", "additionalProperties"];
 
+/// Ceiling on how many nested `[T, null]` unions are followed before the schema
+/// is left to import as written. A nullable schema is one union deep in every
+/// document seen so far; this only has to stop a pathological one from walking
+/// for ever.
+const MAX_NULL_UNION_DEPTH: usize = 8;
+
 /// Why folding a schema's `allOf` tree stopped.
 enum AllOfMergeError {
     /// A branch could not be resolved. A diagnostic naming it has already been
@@ -93,7 +99,6 @@ impl OpenApiImporter<'_> {
         if let Some(composed) = self.ref_siblings_composed(schema, operation_id, diagnostics) {
             return self.import_schema(&composed, suggested_id, operation_id, diagnostics);
         }
-        let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
         // A union of one real branch and `null` is imported as that branch.
         //
         // It is how a nullable reference has to be written once `nullable` is
@@ -101,20 +106,30 @@ impl OpenApiImporter<'_> {
         // documents spell it `anyOf: [{type: 'null'}, {$ref: ...}]`. Left alone
         // it matches no arm of the shape dispatch below and imports as opaque
         // JSON, taking every field of the referenced type with it.
+        let site = self.schema_through_null_unions(schema, operation_id, diagnostics)?;
+        let resolved = self.resolve_ref(&site, operation_id, diagnostics)?;
+        // The type id still comes from the reference this was reached by, and
+        // only falls back to the branch's own. That ordering is what ends a
+        // cycle: `Node: anyOf: [{type: 'null'}, {$ref: Node}]` unwraps to a
+        // schema that resolves back to the same union, and taking the branch's
+        // identity instead would leave the interning check below — the thing
+        // that terminates every other `$ref` cycle here — with a name that never
+        // repeats, growing a fresh `root_child_child…` on each pass until the
+        // stack ran out.
         //
-        // Handing the branch back to this function rather than inlining its
-        // shape here is what keeps a `$ref` branch on the type id it already
-        // has. Expanding it under this site's name instead would copy the whole
-        // target — and every inline schema beneath it — once per site that
-        // references it nullably, which on GitHub's 3.1 descriptor is the
-        // difference between 15k imported types and 25k.
-        if let Some(branch) = null_union_branch(&resolved).cloned() {
-            return self.import_schema(&branch, suggested_id, operation_id, diagnostics);
-        }
-        let type_id = schema.get("$ref").and_then(Value::as_str).map_or_else(
-            || normalize_identifier(suggested_id, "type"),
-            type_id_from_ref,
-        );
+        // Preferring the branch's id when this site has none is what keeps a
+        // nullable reference on the type it already has, rather than copying the
+        // target and every inline schema beneath it once per referring site —
+        // on GitHub's 3.1 descriptor, the difference between 15k imported types
+        // and 25k.
+        let type_id = schema
+            .get("$ref")
+            .or_else(|| site.get("$ref"))
+            .and_then(Value::as_str)
+            .map_or_else(
+                || normalize_identifier(suggested_id, "type"),
+                type_id_from_ref,
+            );
         if self.types.contains_key(&type_id) {
             return Some(type_id);
         }
@@ -533,9 +548,54 @@ impl OpenApiImporter<'_> {
             .collect()
     }
 
+    /// Follows a chain of unions between a schema and `null` to the schema that
+    /// carries the shape, returning the one given when it is not such a union.
+    ///
+    /// The referencing site is returned rather than what it resolves to, so the
+    /// caller can still see the `$ref` and keep the type identity that comes
+    /// with it.
+    ///
+    /// Bounded twice over, because `resolve_ref` follows one hop and tracks
+    /// nothing: a branch leading back to a reference already followed stops the
+    /// walk, and [`MAX_NULL_UNION_DEPTH`] backs that up for a chain that nests
+    /// without repeating. A union stopped either way keeps its own reading and
+    /// imports as opaque JSON, which is what every union did before this.
+    pub(super) fn schema_through_null_unions(
+        &self,
+        schema: &Value,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Value> {
+        let mut site = schema.clone();
+        let mut followed = BTreeSet::new();
+        if let Some(reference) = site.get("$ref").and_then(Value::as_str) {
+            followed.insert(reference.to_string());
+        }
+        for _ in 0..MAX_NULL_UNION_DEPTH {
+            let resolved = self.resolve_ref(&site, operation_id, diagnostics)?;
+            let Some(branch) = null_union_branch(&resolved).cloned() else {
+                return Some(site);
+            };
+            if let Some(reference) = branch.get("$ref").and_then(Value::as_str)
+                && !followed.insert(reference.to_string())
+            {
+                return Some(site);
+            }
+            site = branch;
+        }
+        Some(site)
+    }
+
     fn field_description(&self, schema: &Value) -> String {
         if let Some(description) = schema.get("description").and_then(Value::as_str) {
             return description.to_string();
+        }
+        // A nullable spelling wraps the schema that has the description. The
+        // wrapper says nothing itself, so without this a field written
+        // `anyOf: [{type: 'null'}, {$ref: ...}]` lost the column description
+        // that the same field written as a bare `$ref` keeps.
+        if let Some(branch) = null_union_branch(schema) {
+            return self.field_description(branch);
         }
         let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
             return String::new();
@@ -579,14 +639,25 @@ fn null_union_branch(schema: &Value) -> Option<&Value> {
 }
 
 /// Whether a branch admits nothing but `null`.
+///
+/// `type` is the usual spelling, but 2020-12 gives two more ways to say the same
+/// thing, and a branch written either of them is the same nullable reference —
+/// missing it would leave the union looking like a choice between two real
+/// shapes and send it back to opaque JSON.
 fn declares_only_null(schema: &Value) -> bool {
-    match schema.get("type") {
+    let declares_null_type = match schema.get("type") {
         Some(Value::String(value)) => value == "null",
         Some(Value::Array(values)) => {
             !values.is_empty() && values.iter().all(|value| value.as_str() == Some("null"))
         }
         _ => false,
-    }
+    };
+    let is_null_constant = schema.get("const").is_some_and(Value::is_null)
+        || schema
+            .get("enum")
+            .and_then(Value::as_array)
+            .is_some_and(|values| !values.is_empty() && values.iter().all(Value::is_null));
+    declares_null_type || is_null_constant
 }
 
 pub(super) fn enum_value(value: &Value) -> String {


### PR DESCRIPTION
Part of #1321. Found while investigating a review comment on #2124; it is the largest single fidelity gap on the 3.1 path.

## Why

Once 3.1 removed `nullable`, a nullable reference had nowhere to say so: a `$ref` carries no type of its own to list `null` in. Documents spell it as a union instead — `anyOf: [{type: 'null'}, {$ref: ...}]` — which GitHub's 3.1 publication uses 217 times.

That matched no arm of the shape dispatch, so every one of them imported as opaque JSON and lost every field of the referenced type.

## Measured impact

Against GitHub's own two publications of the same API (`descriptions` is 3.0.3, `descriptions-next` is 3.1.0):

| | 3.0.3 | 3.1.0 before | 3.1.0 after |
|---|---|---|---|
| opaque JSON types | 237 | 621 | 234 |
| object types | 2,000 | 1,965 | 1,976 |

Parity, on a document whose every nullable reference is spelled this way.

## What changes

A union that reduces to exactly one real branch is imported as that branch. The branch is handed back to `import_schema` rather than having its shape inlined, which keeps a `$ref` branch on the type id it already has — expanding it under the referring site's name instead would copy the target, and every inline schema beneath it, once per nullable reference: 25k imported types against 15k for the same API.

Two or more real branches is a genuine choice between shapes, which this IR has no type for and which keeps importing as opaque JSON. Reading the first branch and discarding the rest would describe columns the response does not always carry.

The six bundled 3.0 descriptors are unaffected: no inferred row path, pagination contract, or lookup key changes on any of them.

## Review follow-ups

Four, all from review, in the second commit.

**Unbounded recursion.** Unwrapping discarded the identity of the reference it arrived by, which took the type id with it — and the type id is what ends a `$ref` cycle here, through the interning check. `Node: anyOf: [{type: 'null'}, {$ref: Node}]` unwrapped to a schema resolving back to the same union, and the inline variant grew a fresh `node_row_child_child…` on every pass, so neither ever met a type it had already interned. Both overflowed the stack on documents that imported fine before unions were read at all. The id now comes from the referring site first and the branch's own only as a fallback, and the walk is bounded twice over: a branch leading back to a reference already followed stops it, with a depth cap behind that.

**Response classification.** It was left reading the wrapper. The union declares no type of its own, so a nullable collection looked like a singleton while its row type was built from the branch — publishing one row holding the whole list. It now unwraps through the same walk.

**Lost descriptions.** A nullable reference lost the referenced schema's description, because the wrapper has neither a description nor a `$ref` for `field_description` to follow. It now describes the branch that carries the shape.

**Other null spellings.** `declares_only_null` recognised only the `type` spelling, so `const: null` and `enum: [null]` branches — both valid — made the union look like a choice between two real shapes and sent it back to opaque JSON.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>