### PR TITLE
feat(search): retain Search response history

### DIFF
--- a/apps/docs/guides/observe-with-opentelemetry.mdx
+++ b/apps/docs/guides/observe-with-opentelemetry.mdx
@@ -20,9 +20,11 @@ The `endpoint` is the OTLP/HTTP base URL. Coral automatically appends `/v1/trace
 
 ## Trace History
 
-Coral keeps a local trace history for the UI by default. Local traces include query, source-loading, HTTP, and DataFusion spans. They also include DataFusion optimizer-rule spans so the trace view can show the planning work that happened for a query. This local filter is separate from `trace_filter`, which only controls OTLP span export.
+Coral keeps trace history for the UI by default. Local trace files include query, source-loading, HTTP, and DataFusion spans. They also include DataFusion optimizer-rule spans so the trace view can show the planning work that happened for a query. This local filter is separate from `trace_filter`, which only controls OTLP span export.
 
-By default, Coral retains seven days of local spans. To change that window:
+For Search operations, Coral also retains the same response it returns to the caller after credential scrubbing its matching-value evidence. Up to 1 MiB per Search response is stored in the operator-configured Coral database; larger responses retain only an unavailable marker. Scrubbing suppresses obvious credentials using the observed-values safety policy, but it is not general PII redaction. Search-response retention is best-effort and never waits for database persistence in the Search request path.
+
+By default, Coral retains 30 days of local spans and Search responses. To change that window:
 
 ```toml
 [trace_history]
@@ -63,8 +65,8 @@ External OpenTelemetry export settings live under `[otel]` in `config.toml`. Cor
 
 | Key                   | Type    | Default | Description                                                                       |
 | --------------------- | ------- | ------- | --------------------------------------------------------------------------------- |
-| `enabled`             | boolean | `true`  | Enables trace history without requiring an OTLP collector.                        |
-| `retention_days`      | integer | `7`     | Number of days of local trace spans to retain.                                    |
+| `enabled`             | boolean | `true`  | Enables local trace spans and Search-response history without requiring an OTLP collector. |
+| `retention_days`      | integer | `30`    | Number of days of local trace spans and Search responses to retain.                |
 | `record_http_bodies`  | boolean | `false` | Records HTTP request and response bodies, and MCP tool-call argument and result payloads, in local traces when local tracing is enabled. |
 | `http_body_max_bytes` | integer | `65536` | Maximum request or response body bytes recorded in a local trace. Applies to both HTTP body previews and MCP tool-call payload previews. |
 

--- a/apps/docs/guides/search-with-coral.mdx
+++ b/apps/docs/guides/search-with-coral.mdx
@@ -64,7 +64,7 @@ status column.
 Coral builds this memory from values produced by HTTP- and MCP-backed sources while executing SQL queries. It does not crawl your sources in the background or query them when you search.
 
 <Callout icon="lock" color="#30A46C">
-The observed-values index and its stored values stay in the workspace's local search database. Coral does not upload them to a remote search service. Search matches are still returned to the CLI or MCP client that requested them.
+The observed-values index stays in the workspace's local search database; Coral does not upload it to a remote search service. Search matches are returned to the requesting client. When trace history is enabled, the same credential-scrubbed Search response is also retained in the configured Coral database, including PostgreSQL, for Query Stream debugging.
 </Callout>
 
 <Note>
@@ -89,7 +89,7 @@ Ask for the result you want; you do not need to name the `search` tool:
 
 ## Manage observed-value storage
 
-Observed values stay in the workspace's local search database. Coral skips columns with common credential-like names and values that match common secret formats. Source authors can also set `do_not_index: true` on a column to exclude that field before Coral inspects or persists its values. This suppression is best effort, so treat the search database like other local query data.
+The observed-values index stays in the workspace's local search database. Coral skips columns with common credential-like names and values that match common secret formats. Source authors can also set `do_not_index: true` on a column to exclude that field before Coral inspects or persists its values. Coral reapplies the credential scrubber to matching-value evidence before returning and retaining a Search response. This suppression is best effort and is not general PII redaction, so treat both the search database and configured Coral database like other query data.
 
 Collection is automatic when the feature is enabled and a supported source scan runs. Disabling `observed_values_search` stops collection, retrieval, and maintenance, but does not delete observations already stored locally. `do_not_index` remains the field-level source policy for excluding particular columns.
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -311,7 +311,9 @@ Trace history settings are configured under `[trace_history]`.
 ```toml
 [trace_history]
 enabled = true
-retention_days = 7
+retention_days = 30
 ```
+
+When you enable trace history, Coral retains local trace spans and the credential-scrubbed Search responses shown in Query Stream. Search responses are stored best-effort in your configured Coral database; credential scrubbing is not general PII redaction.
 
 See [Observe with OpenTelemetry](/guides/observe-with-opentelemetry) for the full telemetry setup guide.

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -29,6 +29,7 @@ opentelemetry.workspace = true
 opentelemetry-appender-tracing.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
+prost.workspace = true
 regex.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
@@ -73,7 +74,6 @@ zbus-secret-service-keyring-store.workspace = true
 
 [dev-dependencies]
 coral-client.workspace = true
-prost.workspace = true
 opentelemetry-proto.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tempfile.workspace = true

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -52,6 +52,7 @@ use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
+use crate::search::response_history::{SearchResponseHistory, SearchResponseHistoryWorker};
 use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
@@ -342,8 +343,8 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
         let mode = self.config.resolved_mode(&layout)?;
-        let principal_provider = self.config.principal_provider.clone();
-        let grpc_listener = self.config.grpc_listener.clone();
+        let principal = self.config.principal_provider.clone();
+        let listener = self.config.grpc_listener.clone();
         layout.ensure()?;
         let feature_store = FeatureStore::from_layout(layout.clone());
         let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
@@ -385,13 +386,11 @@ impl ServerBuilder {
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
         let task_activity = crate::task::activity::TaskActivityRecorder::new(Arc::clone(&coral_db));
-        let body_capture_max_bytes = telemetry_config
-            .trace_history
-            .http_body_recording_max_bytes();
-        let query_runtime_context = env
-            .query_runtime_context()
-            .with_body_capture_max_bytes(body_capture_max_bytes);
-
+        let query_runtime_context = env.query_runtime_context().with_body_capture_max_bytes(
+            telemetry_config
+                .trace_history
+                .http_body_recording_max_bytes(),
+        );
         let query_manager = QueryManager::with_diagnostic_reporter(
             config_store.clone(),
             workspace_manager.clone(),
@@ -415,28 +414,27 @@ impl ServerBuilder {
             observed_values_search_enabled,
             diagnostic_reporter,
             CatalogDiscovery::new(query_manager.clone()),
-            workspace_lifecycle_lock,
+            workspace_lifecycle_lock.clone(),
         );
-        let trace_components = trace_components_for_store(active_trace_store);
-        start_server(
-            ServerDependencies {
-                gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
-                source: source_manager,
-                workspace: workspace_manager,
-                query: query_manager,
-                search: search_manager,
-                search_observations,
-                feedback: feedback_manager,
-                task: task_manager,
-                feature_store,
-                active_features: features,
-            },
-            trace_components,
-            principal_provider,
-            mode,
-            grpc_listener,
-        )
-        .await
+        let trace_components = init_trace_components(
+            active_trace_store,
+            Arc::clone(&coral_db),
+            workspace_lifecycle_lock,
+            &telemetry_config,
+        );
+        let dependencies = ServerDependencies {
+            gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
+            source: source_manager,
+            workspace: workspace_manager,
+            query: query_manager,
+            search: search_manager,
+            search_observations,
+            feedback: feedback_manager,
+            task: task_manager,
+            feature_store,
+            active_features: features,
+        };
+        start_server(dependencies, trace_components, principal, mode, listener).await
     }
 }
 
@@ -467,16 +465,41 @@ fn init_server_telemetry(
 
 fn trace_components_for_store(
     active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
+    search_response_history: SearchResponseHistory,
+    search_response_history_worker: SearchResponseHistoryWorker,
 ) -> TraceServerComponents {
-    active_trace_store.map_or_else(TraceServerComponents::default, |store| {
-        TraceServerComponents {
+    match active_trace_store {
+        None => TraceServerComponents {
+            search_response_history: Some(search_response_history.clone()),
+            search_response_history_worker: Some(search_response_history_worker),
+            ..TraceServerComponents::default()
+        },
+        Some(store) => TraceServerComponents {
             local_trace_store_dir: Some(store.dir.clone()),
             service: Some(TraceService::new(TraceManager::new(
                 store.dir,
                 store.retention,
             ))),
-        }
-    })
+            search_response_history: Some(search_response_history),
+            search_response_history_worker: Some(search_response_history_worker),
+        },
+    }
+}
+
+fn init_trace_components(
+    active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
+    coral_db: Arc<CoralDb>,
+    workspace_lifecycle_lock: WorkspaceLifecycleLock,
+    telemetry_config: &TelemetryConfig,
+) -> TraceServerComponents {
+    let trace_history = &telemetry_config.trace_history;
+    let (history, worker) = SearchResponseHistory::start(
+        coral_db,
+        workspace_lifecycle_lock,
+        trace_history.enabled,
+        trace_history.retention(),
+    );
+    trace_components_for_store(active_trace_store, history, worker)
 }
 
 async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
@@ -517,6 +540,7 @@ pub struct RunningServer {
     local_trace_store_dir: Option<PathBuf>,
     search: SearchManager,
     search_observations: Mutex<Option<SearchObservationHandle>>,
+    search_response_history_worker: Mutex<Option<SearchResponseHistoryWorker>>,
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     task_finished: watch::Receiver<bool>,
     task: Mutex<Option<JoinHandle<Result<(), tonic::transport::Error>>>>,
@@ -590,9 +614,21 @@ impl RunningServer {
             None => Ok(()),
         };
         let search_observations_result = self.shutdown_search_observations().await;
+        self.shutdown_search_response_history().await;
         task_result?;
         search_observations_result?;
         Ok(())
+    }
+
+    async fn shutdown_search_response_history(&self) {
+        let worker = self
+            .search_response_history_worker
+            .lock()
+            .expect("Search response history worker mutex poisoned")
+            .take();
+        if let Some(worker) = worker {
+            worker.shutdown().await;
+        }
     }
 
     async fn shutdown_search_observations(&self) -> Result<(), AppError> {
@@ -632,6 +668,8 @@ impl Drop for RunningServer {
 struct TraceServerComponents {
     service: Option<TraceService>,
     local_trace_store_dir: Option<PathBuf>,
+    search_response_history: Option<SearchResponseHistory>,
+    search_response_history_worker: Option<SearchResponseHistoryWorker>,
 }
 
 struct ServerDependencies {
@@ -654,6 +692,7 @@ struct ServerDependencies {
 fn application_routes(
     dependencies: ServerDependencies,
     trace_service: Option<TraceService>,
+    search_response_history: Option<SearchResponseHistory>,
 ) -> (Routes, QueryManager) {
     let ServerDependencies {
         gui_onboarding,
@@ -680,7 +719,7 @@ fn application_routes(
     let catalog_service = CatalogService::new(query.clone(), task.clone());
     let function_service = FunctionService::new(query.clone());
     let query_service = QueryService::new(query, task.clone());
-    let search_service = SearchService::new(search, task.clone());
+    let search_service = configured_search_service(search, task.clone(), search_response_history);
     let feedback_service = FeedbackService::new(feedback, task.clone());
     let feature_service = FeatureService::new(feature_store, active_features);
     let task_service = TaskService::new(task);
@@ -727,11 +766,14 @@ async fn start_server(
     let TraceServerComponents {
         service: trace_service,
         local_trace_store_dir,
+        search_response_history,
+        search_response_history_worker,
     } = trace_components;
     // `RunningServer` owns both for shutdown; the routes only borrow them.
     let search = dependencies.search.clone();
     let search_observations = dependencies.search_observations.clone();
-    let (application_routes, health_queries) = application_routes(dependencies, trace_service);
+    let (application_routes, health_queries) =
+        application_routes(dependencies, trace_service, search_response_history);
     let routes = Routes::from(
         application_routes
             .into_axum_router()
@@ -770,10 +812,23 @@ async fn start_server(
         local_trace_store_dir,
         search,
         search_observations: Mutex::new(search_observations),
+        search_response_history_worker: Mutex::new(search_response_history_worker),
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         task_finished,
         task: Mutex::new(Some(task)),
     })
+}
+
+fn configured_search_service(
+    search: SearchManager,
+    task: TaskManager,
+    response_history: Option<SearchResponseHistory>,
+) -> SearchService {
+    let service = SearchService::new(search, task);
+    match response_history {
+        Some(history) => service.with_response_history(history),
+        None => service,
+    }
 }
 
 fn start_grpc_server(
@@ -1012,6 +1067,7 @@ enabled = false
             local_trace_store_dir: None,
             search,
             search_observations: Mutex::new(Some(search_observations)),
+            search_response_history_worker: Mutex::new(None),
             shutdown_tx: Mutex::new(None),
             task_finished,
             task: Mutex::new(Some(task)),
@@ -1587,6 +1643,8 @@ backend = "unsupported"
             TraceServerComponents {
                 service: Some(trace_service),
                 local_trace_store_dir: None,
+                search_response_history: None,
+                search_response_history_worker: None,
             },
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -3,7 +3,7 @@
 use std::future::Future;
 use std::time::{Duration, Instant};
 
-use opentelemetry::trace::Status as OtelStatus;
+use opentelemetry::trace::{Status as OtelStatus, TraceContextExt as _};
 use tokio::task;
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
@@ -31,7 +31,8 @@ use crate::search::provider::{
     LocalSearchWriteCoordinator, SearchExecutionContext, SearchProviderRegistry,
 };
 use crate::search::result::{
-    SearchManagerError, SearchProviderKind, SearchRequest, SearchResponse,
+    SearchExecution, SearchExecutionIdentity, SearchManagerError, SearchProviderKind,
+    SearchRequest, SearchResponse,
 };
 use crate::search::sqlite_store::{
     SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
@@ -75,6 +76,11 @@ enum CatalogPreload {
         resolution: Result<CatalogResolution, QueryManagerError>,
     },
     WorkspaceChanged,
+}
+
+struct CompletedSearch {
+    response: SearchResponse,
+    workspace_lifecycle_revision: WorkspaceLifecycleRevision,
 }
 
 impl SearchManager {
@@ -139,7 +145,7 @@ impl SearchManager {
         &self,
         request: &SearchRequest,
         attribution: &QueryAttribution,
-    ) -> Result<SearchResponse, SearchManagerError> {
+    ) -> Result<SearchExecution, SearchManagerError> {
         // The retry/preload path makes this future large enough to trigger
         // Clippy's `large_futures` lint when it is awaited inline.
         Box::pin(run_search_operation(
@@ -164,6 +170,7 @@ impl SearchManager {
                     else {
                         continue;
                     };
+                    let workspace_lifecycle_revision = lifecycle_lease.revision();
                     let (observed_values_policy, lifecycle_lease) =
                         if self.observed_values_search_enabled {
                             let search = self.clone();
@@ -185,7 +192,10 @@ impl SearchManager {
                         resolution,
                         observed_values_policy,
                     );
-                    return Ok(self.engine.search(context).await);
+                    return Ok(CompletedSearch {
+                        response: self.engine.search(context).await,
+                        workspace_lifecycle_revision,
+                    });
                 }
                 Err(workspace_changed_error("searching"))
             },
@@ -646,17 +656,17 @@ async fn run_search_operation<F>(
     request: &SearchRequest,
     task_id: Option<&TaskId>,
     operation: F,
-) -> Result<SearchResponse, SearchManagerError>
+) -> Result<SearchExecution, SearchManagerError>
 where
-    F: Future<Output = Result<SearchResponse, SearchManagerError>>,
+    F: Future<Output = Result<CompletedSearch, SearchManagerError>>,
 {
     let span = create_search_span(request, task_id);
     let result = operation.instrument(span.clone()).await;
     match &result {
-        Ok(response) => {
+        Ok(completed) => {
             span.record(
                 "result_count",
-                u64::try_from(response.results.len()).unwrap_or(u64::MAX),
+                u64::try_from(completed.response.results.len()).unwrap_or(u64::MAX),
             );
             span.record("status", "ok");
             span.set_status(OtelStatus::Ok);
@@ -669,7 +679,21 @@ where
             );
         }
     }
-    result
+    let identity = search_execution_identity(&span);
+    result.map(|completed| SearchExecution {
+        response: completed.response,
+        identity,
+        workspace_lifecycle_revision: completed.workspace_lifecycle_revision,
+    })
+}
+
+fn search_execution_identity(span: &tracing::Span) -> Option<SearchExecutionIdentity> {
+    let context = span.context();
+    let span_context = context.span().span_context().clone();
+    span_context.is_valid().then(|| SearchExecutionIdentity {
+        trace_id: span_context.trace_id().to_string(),
+        span_id: span_context.span_id().to_string(),
+    })
 }
 
 fn create_search_span(request: &SearchRequest, task_id: Option<&TaskId>) -> tracing::Span {
@@ -826,19 +850,22 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::{
-        REBUILD_SEARCH_INDEX_OPERATION, SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE,
-        SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE, SEARCH_TELEMETRY_ERROR_MESSAGE,
-        run_search_maintenance_operation, run_search_operation, search_manager_error_message,
+        CompletedSearch, REBUILD_SEARCH_INDEX_OPERATION,
+        SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE, SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE,
+        SEARCH_TELEMETRY_ERROR_MESSAGE, run_search_maintenance_operation, run_search_operation,
+        search_manager_error_message,
     };
     use crate::bootstrap::AppError;
     use crate::search::maintenance::{
         RebuildSearchIndexResponse, SearchMaintenanceResult, SearchMaintenanceState,
     };
     use crate::search::result::{
-        SearchManagerError, SearchProviderKind, SearchRequest, SearchResponse, SearchTruncation,
+        CatalogSurface, FieldValues, SearchManagerError, SearchProviderKind, SearchRequest,
+        SearchResponse, SearchResult, SearchSurfaceId, SearchSurfaceKind, SearchTruncation,
+        SurfaceShape,
     };
     use crate::task::id::TaskId;
-    use crate::workspaces::WorkspaceName;
+    use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName};
 
     #[tokio::test(flavor = "current_thread")]
     async fn search_maintenance_operation_marks_the_outer_query_stream_entry() {
@@ -988,6 +1015,63 @@ mod tests {
         assert!(!format!("{maintenance_span:?}").contains(failure_detail));
     }
 
+    fn response_with_sentinel(request: &SearchRequest, sentinel: &str) -> SearchResponse {
+        SearchResponse {
+            results: vec![SearchResult {
+                surface: CatalogSurface {
+                    id: SearchSurfaceId {
+                        catalog_name: None,
+                        schema_name: "private".to_string(),
+                        name: "surface".to_string(),
+                        kind: SearchSurfaceKind::Table,
+                    },
+                    description: sentinel.to_string(),
+                    guide: sentinel.to_string(),
+                    shape: SurfaceShape::Table { fields: Vec::new() },
+                },
+                providers: vec![SearchProviderKind::CatalogMetadata],
+                matching_values: vec![FieldValues {
+                    field: "secret".to_string(),
+                    values: vec![sentinel.to_string()],
+                }],
+                omitted_matching_field_count: 0,
+            }],
+            provider_statuses: Vec::new(),
+            truncation: SearchTruncation {
+                truncated: false,
+                returned_count: 1,
+                max_results: request.limit,
+                note: "all results returned".to_string(),
+            },
+        }
+    }
+
+    fn active_lifecycle_revision(workspace: &WorkspaceName) -> WorkspaceLifecycleRevision {
+        WorkspaceLifecycleLock::default()
+            .revision_if_active(workspace)
+            .expect("workspace starts active")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn search_operation_preserves_workspace_lifecycle_revision() {
+        let request =
+            SearchRequest::new(WorkspaceName::default(), "query", 7).expect("valid search request");
+        let workspace_lifecycle_revision = active_lifecycle_revision(&request.workspace_name);
+        let completed = CompletedSearch {
+            response: response_with_sentinel(&request, "sentinel"),
+            workspace_lifecycle_revision,
+        };
+
+        let execution = run_search_operation(&request, None, async { Ok(completed) })
+            .await
+            .expect("search operation");
+
+        assert_eq!(
+            execution.workspace_lifecycle_revision,
+            workspace_lifecycle_revision
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn search_operation_records_safe_summary_metadata() {
         let exporter = InMemorySpanExporter::default();
@@ -1003,18 +1087,15 @@ mod tests {
         let request = SearchRequest::new(WorkspaceName::default(), raw_query, 7)
             .expect("valid search request");
         let task_id = TaskId::parse("550e8400-e29b-41d4-a716-446655440000").expect("valid task id");
-        let response = SearchResponse {
-            results: Vec::new(),
-            provider_statuses: Vec::new(),
-            truncation: SearchTruncation {
-                truncated: false,
-                returned_count: 0,
-                max_results: request.limit,
-                note: "all results returned".to_string(),
-            },
-        };
+        let response_sentinel = "SENSITIVE_SEARCH_RESPONSE_MARKER";
+        let response = response_with_sentinel(&request, response_sentinel);
+        let workspace_lifecycle_revision = active_lifecycle_revision(&request.workspace_name);
 
-        run_search_operation(&request, Some(&task_id), async { Ok(response) })
+        let completed = CompletedSearch {
+            response,
+            workspace_lifecycle_revision,
+        };
+        let execution = run_search_operation(&request, Some(&task_id), async { Ok(completed) })
             .await
             .expect("search operation");
 
@@ -1024,6 +1105,15 @@ mod tests {
             .iter()
             .find(|span| span.name == "coral.search")
             .expect("coral.search span recorded");
+        let execution_identity = execution.identity.expect("valid Search span identity");
+        assert_eq!(
+            execution_identity.trace_id,
+            search_span.span_context.trace_id().to_string()
+        );
+        assert_eq!(
+            execution_identity.span_id,
+            search_span.span_context.span_id().to_string()
+        );
         let attribute = |name: &str| {
             search_span
                 .attributes
@@ -1082,6 +1172,10 @@ mod tests {
             }),
             "a subscriber not installed by Coral must not receive local-only attributes"
         );
+        assert!(
+            !format!("{search_span:?}").contains(response_sentinel),
+            "Search response contents must not be attached to the operation span"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1100,7 +1194,7 @@ mod tests {
         let request =
             SearchRequest::new(WorkspaceName::default(), query, 7).expect("valid search request");
         let error = run_search_operation(&request, None, async {
-            Err::<SearchResponse, SearchManagerError>(
+            Err::<CompletedSearch, SearchManagerError>(
                 AppError::Internal(format!("failed while handling {error_sentinel}")).into(),
             )
         })

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod maintenance;
 pub(crate) mod manager;
 pub(crate) mod observed;
 pub(crate) mod provider;
+pub(crate) mod response_history;
+pub(crate) mod response_safety;
 pub(crate) mod result;
 pub(crate) mod service;
 pub(crate) mod sqlite_store;

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -12,7 +12,9 @@ use arrow::util::display::array_value_to_string;
 use coral_spec::DO_NOT_INDEX_COLUMN_METADATA_KEY;
 
 use crate::hash::sha256_hex;
-use crate::search::observed::sensitive::{is_sensitive_column, sanitize_observed_value};
+use crate::search::observed::sensitive::{
+    DEFAULT_OBSERVED_VALUE_BYTES_LIMIT, is_sensitive_column, sanitize_observed_value,
+};
 use crate::search::observed::sqlite_queue::{ObservedValueCandidate, ObservedValuesQueuePayload};
 
 #[derive(Debug, Clone, Default)]
@@ -108,7 +110,6 @@ pub(crate) struct ObservedValuesCollectionBudget {
 const DEFAULT_CANDIDATE_LIMIT: usize = 10_000;
 const DEFAULT_INSPECTED_CELL_LIMIT: usize = 10_000;
 const DEFAULT_CANDIDATE_BYTES_LIMIT: usize = 8 * 1024 * 1024;
-const DEFAULT_VALUE_BYTES_LIMIT: usize = 4 * 1024;
 const DEFAULT_JOB_BYTES_LIMIT: usize = 1024 * 1024;
 
 impl Default for ObservedValuesCollectionBudget {
@@ -117,7 +118,7 @@ impl Default for ObservedValuesCollectionBudget {
             candidate_limit: DEFAULT_CANDIDATE_LIMIT,
             inspected_cell_limit: DEFAULT_INSPECTED_CELL_LIMIT,
             candidate_bytes_limit: DEFAULT_CANDIDATE_BYTES_LIMIT,
-            value_bytes_limit: DEFAULT_VALUE_BYTES_LIMIT,
+            value_bytes_limit: DEFAULT_OBSERVED_VALUE_BYTES_LIMIT,
             job_bytes_limit: DEFAULT_JOB_BYTES_LIMIT,
         }
     }

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -19,6 +19,9 @@ pub(crate) use policy::{
     ObservedValuesLiveScope, ObservedValuesLiveScopeLoadFailure, ObservedValuesRetrievalPolicy,
 };
 pub(crate) use publisher::{SearchObservationHandle, SearchObservationSource};
+pub(in crate::search) use sensitive::{
+    DEFAULT_OBSERVED_VALUE_BYTES_LIMIT, is_sensitive_column, sanitize_observed_value,
+};
 pub(crate) use sqlite_projection::ObservedValuesDrainBudget;
 pub(crate) use sqlite_store::{
     ObservedValuesClearResult, clear_observed_source_in_transaction,

--- a/crates/coral-app/src/search/observed/sensitive.rs
+++ b/crates/coral-app/src/search/observed/sensitive.rs
@@ -22,8 +22,10 @@ const SENSITIVE_COLUMN_NAMES: &[&str] = &[
     "token",
 ];
 
+pub(in crate::search) const DEFAULT_OBSERVED_VALUE_BYTES_LIMIT: usize = 4 * 1024;
+
 /// Returns whether a field name resembles a credential-bearing field.
-pub(super) fn is_sensitive_column(column_name: &str) -> bool {
+pub(in crate::search) fn is_sensitive_column(column_name: &str) -> bool {
     let normalized = column_name
         .chars()
         .filter(char::is_ascii_alphanumeric)
@@ -50,7 +52,10 @@ pub(super) fn is_sensitive_value(value: &str) -> bool {
 /// Removes recognized secret-bearing fields while preserving safe structured content.
 ///
 /// This is a best-effort heuristic and does not classify arbitrary sensitive data.
-pub(super) fn sanitize_observed_value(value: String, max_value_bytes: usize) -> Option<String> {
+pub(in crate::search) fn sanitize_observed_value(
+    value: String,
+    max_value_bytes: usize,
+) -> Option<String> {
     let sanitized = match sanitize_json(&value)
         .or_else(|| sanitize_url(&value))
         .or_else(|| sanitize_form(&value))

--- a/crates/coral-app/src/search/response_history.rs
+++ b/crates/coral-app/src/search/response_history.rs
@@ -1,0 +1,996 @@
+//! Bounded, best-effort retention of successful public Search responses.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use coral_api::v1::SearchResponse;
+use prost::Message as _;
+use tokio::sync::mpsc::{self, Receiver, Sender, error::TrySendError};
+use tokio::task::JoinHandle;
+
+use crate::search::result::SearchExecutionIdentity;
+use crate::state::db::{
+    CoralDb, TraceSearchResponseCapture, TraceSearchResponseInsertResult,
+    TraceSearchResponseOutcome, now_unix_nanos_i64, trace_search_response_retention_bounds,
+};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName};
+
+pub(crate) const SEARCH_RESPONSE_HISTORY_MAX_BYTES: usize = 1024 * 1024;
+const SEARCH_RESPONSE_HISTORY_SLOW_WRITE: Duration = Duration::from_millis(500);
+const SEARCH_RESPONSE_HISTORY_SLOW_PRUNE: Duration = Duration::from_secs(1);
+const SEARCH_RESPONSE_HISTORY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const SEARCH_RESPONSE_HISTORY_PRUNE_INTERVAL: Duration = Duration::from_hours(1);
+const SEARCH_RESPONSE_HISTORY_PRUNE_RETRY_INTERVAL: Duration = Duration::from_mins(1);
+const SEARCH_RESPONSE_HISTORY_QUEUE_CAPACITY: usize = 16;
+
+#[derive(Clone)]
+pub(crate) struct SearchResponseHistory {
+    enabled: bool,
+    sender: Sender<SearchResponseHistoryWork>,
+    warnings: Arc<SearchResponseHistoryWarnings>,
+}
+
+#[derive(Default)]
+struct SearchResponseHistoryWarnings {
+    invalid_clock: AtomicBool,
+    missing_identity: AtomicBool,
+    queue_full: AtomicBool,
+    worker_closed: AtomicBool,
+}
+
+pub(crate) struct SearchResponseHistoryWorker {
+    join_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for SearchResponseHistoryWorker {
+    fn drop(&mut self) {
+        if let Some(join_handle) = self.join_handle.take() {
+            join_handle.abort();
+        }
+    }
+}
+
+impl SearchResponseHistoryWorker {
+    pub(crate) async fn shutdown(mut self) {
+        let Some(mut join_handle) = self.join_handle.take() else {
+            return;
+        };
+        match tokio::time::timeout(SEARCH_RESPONSE_HISTORY_SHUTDOWN_TIMEOUT, &mut join_handle).await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    error = %error,
+                    "Search response history background writer stopped unexpectedly"
+                );
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    timeout_ms = SEARCH_RESPONSE_HISTORY_SHUTDOWN_TIMEOUT.as_millis(),
+                    "aborting Search response history background writer during shutdown"
+                );
+                join_handle.abort();
+                drop(join_handle.await);
+            }
+        }
+    }
+}
+
+enum SearchResponseHistoryWork {
+    Capture(QueuedSearchResponseCapture),
+    #[cfg(test)]
+    Flush(tokio::sync::oneshot::Sender<()>),
+    #[cfg(test)]
+    Pause {
+        started: tokio::sync::oneshot::Sender<()>,
+        release: tokio::sync::oneshot::Receiver<()>,
+    },
+}
+
+struct QueuedSearchResponseCapture {
+    workspace_name: WorkspaceName,
+    workspace_lifecycle_revision: WorkspaceLifecycleRevision,
+    row: TraceSearchResponseCapture,
+}
+
+struct SearchResponseHistoryWorkerState {
+    db: Arc<CoralDb>,
+    lifecycle_lock: WorkspaceLifecycleLock,
+    retention: Duration,
+    next_prune_at: Option<Instant>,
+    slow_write_active: bool,
+    write_failure_active: bool,
+}
+
+impl SearchResponseHistory {
+    pub(crate) fn start(
+        db: Arc<CoralDb>,
+        lifecycle_lock: WorkspaceLifecycleLock,
+        enabled: bool,
+        retention: Duration,
+    ) -> (Self, SearchResponseHistoryWorker) {
+        let (sender, receiver) = mpsc::channel(SEARCH_RESPONSE_HISTORY_QUEUE_CAPACITY);
+        let worker = tokio::spawn(
+            SearchResponseHistoryWorkerState {
+                db,
+                lifecycle_lock,
+                retention,
+                next_prune_at: None,
+                slow_write_active: false,
+                write_failure_active: false,
+            }
+            .run(receiver),
+        );
+        (
+            Self {
+                enabled,
+                sender,
+                warnings: Arc::new(SearchResponseHistoryWarnings::default()),
+            },
+            SearchResponseHistoryWorker {
+                join_handle: Some(worker),
+            },
+        )
+    }
+
+    pub(crate) fn capture(
+        &self,
+        workspace_name: &WorkspaceName,
+        workspace_lifecycle_revision: WorkspaceLifecycleRevision,
+        identity: Option<&SearchExecutionIdentity>,
+        response: &SearchResponse,
+    ) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        let Some(identity) = identity else {
+            if !self.warnings.missing_identity.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    "Search response history is enabled, but the operation span had no valid trace identity"
+                );
+            }
+            return false;
+        };
+        let Ok(recorded_at_unix_nanos) = now_unix_nanos_i64() else {
+            if !self.warnings.invalid_clock.swap(true, Ordering::Relaxed) {
+                tracing::warn!(
+                    "Search response history is enabled, but the system clock cannot produce a durable timestamp"
+                );
+            }
+            return false;
+        };
+
+        let permit = match self.sender.clone().try_reserve_owned() {
+            Ok(permit) => {
+                self.warnings.queue_full.store(false, Ordering::Relaxed);
+                permit
+            }
+            Err(TrySendError::Full(_sender)) => {
+                if !self.warnings.queue_full.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        queue_capacity = SEARCH_RESPONSE_HISTORY_QUEUE_CAPACITY,
+                        "dropping Search response history because its background queue is full"
+                    );
+                }
+                return false;
+            }
+            Err(TrySendError::Closed(_sender)) => {
+                if !self.warnings.worker_closed.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        "dropping Search response history because its background writer is unavailable"
+                    );
+                }
+                return false;
+            }
+        };
+
+        let encoded_len = response.encoded_len();
+        let outcome = if encoded_len <= SEARCH_RESPONSE_HISTORY_MAX_BYTES {
+            TraceSearchResponseOutcome::Response(response.encode_to_vec())
+        } else {
+            TraceSearchResponseOutcome::TooLarge {
+                bytes: i64::try_from(encoded_len).unwrap_or(i64::MAX),
+            }
+        };
+        permit.send(SearchResponseHistoryWork::Capture(
+            QueuedSearchResponseCapture {
+                workspace_name: workspace_name.clone(),
+                workspace_lifecycle_revision,
+                row: TraceSearchResponseCapture {
+                    workspace_id: workspace_name.to_string(),
+                    trace_id: identity.trace_id.clone(),
+                    search_span_id: identity.span_id.clone(),
+                    recorded_at_unix_nanos,
+                    outcome,
+                },
+            },
+        ));
+        true
+    }
+
+    #[cfg(test)]
+    async fn flush(&self) {
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .send(SearchResponseHistoryWork::Flush(finished_tx))
+            .await
+            .expect("Search response history worker remains available");
+        finished_rx
+            .await
+            .expect("Search response history flush completes");
+    }
+
+    #[cfg(test)]
+    async fn pause_worker(&self) -> tokio::sync::oneshot::Sender<()> {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .send(SearchResponseHistoryWork::Pause {
+                started: started_tx,
+                release: release_rx,
+            })
+            .await
+            .expect("Search response history worker remains available");
+        started_rx
+            .await
+            .expect("Search response history worker reaches pause");
+        release_tx
+    }
+}
+
+impl SearchResponseHistoryWorkerState {
+    async fn run(mut self, mut receiver: Receiver<SearchResponseHistoryWork>) {
+        self.prune_now().await;
+        while let Some(work) = receiver.recv().await {
+            match work {
+                SearchResponseHistoryWork::Capture(capture) => {
+                    self.retain(capture).await;
+                    self.prune_if_due().await;
+                }
+                #[cfg(test)]
+                SearchResponseHistoryWork::Flush(finished) => {
+                    let _finished = finished.send(());
+                }
+                #[cfg(test)]
+                SearchResponseHistoryWork::Pause { started, release } => {
+                    let _started = started.send(());
+                    let _released = release.await;
+                }
+            }
+        }
+    }
+
+    async fn retain(&mut self, queued: QueuedSearchResponseCapture) {
+        let Some(lifecycle_lease) = self
+            .lifecycle_lock
+            .read_lease_if_unchanged(queued.workspace_lifecycle_revision, &queued.workspace_name)
+            .await
+        else {
+            tracing::debug!(
+                workspace = %queued.workspace_name,
+                "discarded stale Search response history capture"
+            );
+            return;
+        };
+        let capture = queued.row;
+        let workspace_id = capture.workspace_id.clone();
+        let trace_id = capture.trace_id.clone();
+        let search_span_id = capture.search_span_id.clone();
+        let insert = self.db.insert_trace_search_response(capture);
+        tokio::pin!(insert);
+        let slow_warning = tokio::time::sleep(SEARCH_RESPONSE_HISTORY_SLOW_WRITE);
+        tokio::pin!(slow_warning);
+        let result = tokio::select! {
+            result = &mut insert => {
+                self.slow_write_active = false;
+                result
+            }
+            () = &mut slow_warning => {
+                if !self.slow_write_active {
+                    tracing::warn!(
+                        workspace_id,
+                        trace_id,
+                        search_span_id,
+                        slow_after_ms = SEARCH_RESPONSE_HISTORY_SLOW_WRITE.as_millis(),
+                        "Search response history database write is slow"
+                    );
+                    self.slow_write_active = true;
+                }
+                insert.await
+            }
+        };
+        drop(lifecycle_lease);
+        match result {
+            Ok(
+                TraceSearchResponseInsertResult::Inserted
+                | TraceSearchResponseInsertResult::AlreadyExists,
+            ) => self.write_failure_active = false,
+            Ok(TraceSearchResponseInsertResult::WorkspaceNotFound) => {
+                self.write_failure_active = false;
+                tracing::debug!(
+                    workspace_id,
+                    trace_id,
+                    search_span_id,
+                    "Search response history skipped because its workspace no longer exists"
+                );
+            }
+            Err(error) => {
+                if !self.write_failure_active {
+                    tracing::warn!(
+                        error = ?error,
+                        workspace_id,
+                        trace_id,
+                        search_span_id,
+                        "failed to retain Search response history"
+                    );
+                    self.write_failure_active = true;
+                }
+            }
+        }
+    }
+
+    async fn prune_if_due(&mut self) {
+        if self
+            .next_prune_at
+            .is_some_and(|next_prune_at| Instant::now() < next_prune_at)
+        {
+            return;
+        }
+        self.prune_now().await;
+    }
+
+    async fn prune_now(&mut self) {
+        let succeeded = prune_search_response_history(&self.db, self.retention).await;
+        self.next_prune_at = Instant::now().checked_add(prune_retry_after(succeeded));
+    }
+}
+
+const fn prune_retry_after(succeeded: bool) -> Duration {
+    if succeeded {
+        SEARCH_RESPONSE_HISTORY_PRUNE_INTERVAL
+    } else {
+        SEARCH_RESPONSE_HISTORY_PRUNE_RETRY_INTERVAL
+    }
+}
+
+async fn prune_search_response_history(db: &CoralDb, retention: Duration) -> bool {
+    let Ok(now_unix_nanos) = now_unix_nanos_i64() else {
+        tracing::warn!(
+            "Search response history pruning skipped because the system clock was invalid"
+        );
+        return false;
+    };
+    let retention_bounds = trace_search_response_retention_bounds(now_unix_nanos, retention);
+    let prune = db.prune_trace_search_responses_outside_retention(retention_bounds);
+    tokio::pin!(prune);
+    let slow_warning = tokio::time::sleep(SEARCH_RESPONSE_HISTORY_SLOW_PRUNE);
+    tokio::pin!(slow_warning);
+    let result = tokio::select! {
+        result = &mut prune => result,
+        () = &mut slow_warning => {
+            tracing::warn!(
+                slow_after_ms = SEARCH_RESPONSE_HISTORY_SLOW_PRUNE.as_millis(),
+                "Search response history pruning is slow"
+            );
+            prune.await
+        }
+    };
+    match result {
+        Ok(_deleted) => true,
+        Err(error) => {
+            tracing::warn!(error = ?error, "failed to prune Search response history outside retention");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use coral_api::v1::search_result::Shape;
+    use coral_api::v1::{
+        SearchField, SearchFieldValues, SearchFunctionShape, SearchProvider,
+        SearchProviderCoverage, SearchProviderState, SearchProviderStatus, SearchResponse,
+        SearchResult, SearchResultTruncation, SearchSurfaceRef, SearchTableShape,
+    };
+    use prost::Message as _;
+    use tempfile::tempdir;
+
+    use super::{
+        SEARCH_RESPONSE_HISTORY_MAX_BYTES, SEARCH_RESPONSE_HISTORY_PRUNE_INTERVAL,
+        SEARCH_RESPONSE_HISTORY_PRUNE_RETRY_INTERVAL, SEARCH_RESPONSE_HISTORY_QUEUE_CAPACITY,
+        SearchResponseHistory, SearchResponseHistoryWorker, prune_retry_after,
+    };
+    use crate::search::result::SearchExecutionIdentity;
+    use crate::state::AppStateLayout;
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig, TraceSearchResponseCapture,
+        TraceSearchResponseInsertResult, TraceSearchResponseOutcome,
+        TraceSearchResponseRetentionBounds,
+    };
+    use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
+
+    #[tokio::test]
+    async fn one_mebibyte_boundary_is_measured_before_encoding_and_stored_complete() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let (history, worker, lifecycle) = start_history(&db, true, test_retention());
+        history.flush().await;
+        let mut response = empty_response();
+        resize_note_to_encoded_len(&mut response, SEARCH_RESPONSE_HISTORY_MAX_BYTES);
+        assert_eq!(response.encoded_len(), SEARCH_RESPONSE_HISTORY_MAX_BYTES);
+        let boundary_identity = identity("trace-boundary", "span-boundary");
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&boundary_identity),
+            &response,
+        ));
+        history.flush().await;
+        let outcome = get_record(&db, &boundary_identity)
+            .await
+            .expect("captured boundary response");
+        let TraceSearchResponseOutcome::Response(response_proto) = outcome else {
+            panic!("boundary response must be stored complete");
+        };
+        assert_eq!(response_proto.len(), SEARCH_RESPONSE_HISTORY_MAX_BYTES);
+
+        response
+            .truncation
+            .as_mut()
+            .expect("truncation")
+            .note
+            .push('x');
+        assert!(response.encoded_len() > SEARCH_RESPONSE_HISTORY_MAX_BYTES);
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn startup_pruning_runs_independently_of_capture_enablement() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let expired_identity = identity("trace-startup-expired", "span-startup-expired");
+        insert_raw_response(&db, &expired_identity, 1).await;
+        let future_identity = identity("trace-startup-future", "span-startup-future");
+        insert_raw_response(&db, &future_identity, i64::MAX).await;
+
+        let (history, worker, lifecycle) = start_history(&db, false, Duration::ZERO);
+        history.flush().await;
+
+        assert_eq!(get_record(&db, &expired_identity).await, None);
+        assert_eq!(get_record(&db, &future_identity).await, None);
+        let disabled_identity = identity("trace-disabled-after-prune", "span-disabled-after-prune");
+        assert!(!capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&disabled_identity),
+            &empty_response(),
+        ));
+        history.flush().await;
+        assert_eq!(get_record(&db, &disabled_identity).await, None);
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn capture_prunes_opportunistically_at_most_once_per_hour() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let first_expired = identity("trace-first-expired", "span-first-expired");
+        insert_raw_response(&db, &first_expired, 1).await;
+        let (history, worker, lifecycle) = start_history(&db, true, Duration::from_hours(1));
+        history.flush().await;
+        assert_eq!(get_record(&db, &first_expired).await, None);
+
+        let second_expired = identity("trace-second-expired", "span-second-expired");
+        insert_raw_response(&db, &second_expired, 1).await;
+        let second_fresh = identity("trace-second-fresh", "span-second-fresh");
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&second_fresh),
+            &empty_response(),
+        ));
+        history.flush().await;
+        assert!(get_record(&db, &second_expired).await.is_some());
+        shutdown_history(history, worker).await;
+    }
+
+    #[test]
+    fn prune_failures_retry_before_the_normal_interval() {
+        assert_eq!(prune_retry_after(false), Duration::from_mins(1));
+        assert_eq!(prune_retry_after(true), Duration::from_hours(1));
+        assert_eq!(
+            SEARCH_RESPONSE_HISTORY_PRUNE_RETRY_INTERVAL,
+            Duration::from_mins(1)
+        );
+        assert_eq!(
+            SEARCH_RESPONSE_HISTORY_PRUNE_INTERVAL,
+            Duration::from_hours(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_grouped_response_and_zero_result_response_round_trip() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let (history, worker, lifecycle) = start_history(&db, true, test_retention());
+        history.flush().await;
+        let response = grouped_response();
+        let complete_identity = identity("trace-complete", "span-complete");
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&complete_identity),
+            &response,
+        ));
+        history.flush().await;
+
+        let outcome = get_record(&db, &complete_identity)
+            .await
+            .expect("captured response");
+        let TraceSearchResponseOutcome::Response(encoded) = outcome else {
+            panic!("complete response must store its protobuf");
+        };
+        assert_eq!(
+            SearchResponse::decode(encoded.as_slice()).expect("decode retained response"),
+            response
+        );
+
+        let zero_identity = identity("trace-zero", "span-zero");
+        let zero_response = empty_response();
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&zero_identity),
+            &zero_response,
+        ));
+        history.flush().await;
+        let zero_outcome = get_record(&db, &zero_identity)
+            .await
+            .expect("captured zero-result response");
+        let TraceSearchResponseOutcome::Response(zero_response_proto) = zero_outcome else {
+            panic!("zero-result response must store its protobuf");
+        };
+        assert_eq!(
+            SearchResponse::decode(zero_response_proto.as_slice())
+                .expect("decode zero-result response"),
+            zero_response
+        );
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn disabled_capture_is_absent() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+
+        let disabled_identity = identity("trace-disabled", "span-disabled");
+        let (history, worker, lifecycle) = start_history(&db, false, test_retention());
+        history.flush().await;
+        assert!(!capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&disabled_identity),
+            &empty_response(),
+        ));
+        assert_eq!(get_record(&db, &disabled_identity).await, None);
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn oversized_response_stores_only_its_original_encoded_size() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let (history, worker, lifecycle) = start_history(&db, true, test_retention());
+        history.flush().await;
+        let identity = identity("trace-large", "span-large");
+        let mut response = empty_response();
+        resize_note_to_encoded_len(&mut response, SEARCH_RESPONSE_HISTORY_MAX_BYTES + 1);
+        let encoded_len = response.encoded_len();
+
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&identity),
+            &response,
+        ));
+        history.flush().await;
+
+        assert_eq!(
+            get_record(&db, &identity).await,
+            Some(TraceSearchResponseOutcome::TooLarge {
+                bytes: i64::try_from(encoded_len).expect("encoded size fits i64"),
+            })
+        );
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn full_queue_drops_capture_without_waiting_for_the_worker() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let (history, worker, lifecycle) = start_history(&db, true, test_retention());
+        history.flush().await;
+        let release = history.pause_worker().await;
+
+        for index in 0..SEARCH_RESPONSE_HISTORY_QUEUE_CAPACITY {
+            let queued_identity = identity(
+                &format!("trace-queued-{index}"),
+                &format!("span-queued-{index}"),
+            );
+            assert!(capture(
+                &history,
+                &lifecycle,
+                "alpha",
+                Some(&queued_identity),
+                &empty_response(),
+            ));
+        }
+        let dropped_identity = identity("trace-dropped", "span-dropped");
+        assert!(!capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&dropped_identity),
+            &empty_response(),
+        ));
+
+        release.send(()).expect("release history worker");
+        history.flush().await;
+        assert_eq!(get_record(&db, &dropped_identity).await, None);
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn queued_capture_for_recreated_workspace_is_discarded() {
+        let (_temp, db) = open_sqlite().await;
+        let workspace = WorkspaceName::parse("alpha").expect("workspace name");
+        ensure_workspace(&db, workspace.as_str()).await;
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let (history, worker) = SearchResponseHistory::start(
+            Arc::clone(&db),
+            lifecycle.clone(),
+            true,
+            test_retention(),
+        );
+        history.flush().await;
+        let original_revision = lifecycle
+            .revision_if_active(&workspace)
+            .expect("workspace starts active");
+        let release = history.pause_worker().await;
+        let stale_identity = identity("trace-stale", "span-stale");
+        assert!(history.capture(
+            &workspace,
+            original_revision,
+            Some(&stale_identity),
+            &empty_response(),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let deletion_marker = lifecycle
+                .mark_workspace_deleting(&workspace)
+                .await
+                .expect("mark workspace deleting");
+            db.begin_workspace_deletion(workspace.as_str())
+                .await
+                .expect("begin workspace deletion")
+                .expect("workspace exists")
+                .commit()
+                .await
+                .expect("commit workspace deletion");
+            drop(deletion_marker);
+            {
+                let _lifecycle_guard = lifecycle.lock_async().await;
+                ensure_workspace(&db, workspace.as_str()).await;
+            }
+
+            release.send(()).expect("release history worker");
+            history.flush().await;
+            assert_eq!(get_record(&db, &stale_identity).await, None);
+        })
+        .await
+        .expect("workspace delete and recreate completes without a lifecycle deadlock");
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn database_contention_does_not_block_capture_and_the_worker_eventually_persists() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let (history, worker, lifecycle) = start_history(&db, true, test_retention());
+        history.flush().await;
+        let mut blocker = db.begin().await.expect("begin blocking transaction");
+        assert!(
+            blocker
+                .workspaces()
+                .hold_for_child_mutation("alpha")
+                .await
+                .expect("hold workspace writer")
+        );
+
+        let captured_identity = identity("trace-contended", "span-contended");
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&captured_identity),
+            &empty_response(),
+        ));
+        assert_eq!(get_record(&db, &captured_identity).await, None);
+
+        blocker.commit().await.expect("release workspace writer");
+        history.flush().await;
+        assert!(get_record(&db, &captured_identity).await.is_some());
+        shutdown_history(history, worker).await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_accepted_capture() {
+        let (_temp, db) = open_sqlite().await;
+        ensure_workspace(&db, "alpha").await;
+        let (history, worker, lifecycle) = start_history(&db, true, test_retention());
+        let captured_identity = identity("trace-shutdown", "span-shutdown");
+        assert!(capture(
+            &history,
+            &lifecycle,
+            "alpha",
+            Some(&captured_identity),
+            &empty_response(),
+        ));
+
+        drop(history);
+        worker.shutdown().await;
+
+        assert!(get_record(&db, &captured_identity).await.is_some());
+    }
+
+    fn empty_response() -> SearchResponse {
+        SearchResponse {
+            results: Vec::new(),
+            provider_statuses: Vec::new(),
+            truncation: Some(SearchResultTruncation {
+                truncated: false,
+                returned_count: 0,
+                max_results: 10,
+                note: String::new(),
+            }),
+        }
+    }
+
+    fn grouped_response() -> SearchResponse {
+        SearchResponse {
+            results: vec![
+                SearchResult {
+                    surface: Some(SearchSurfaceRef {
+                        schema_name: "github".to_string(),
+                        name: "repositories".to_string(),
+                        catalog_name: String::new(),
+                    }),
+                    description: "Repository metadata".to_string(),
+                    guide: "Filter by owner and name.".to_string(),
+                    shape: Some(Shape::Table(SearchTableShape {
+                        fields: vec![
+                            SearchField {
+                                name: "owner".to_string(),
+                                data_type: "Utf8".to_string(),
+                                required: true,
+                            },
+                            SearchField {
+                                name: "description".to_string(),
+                                data_type: "Utf8".to_string(),
+                                required: false,
+                            },
+                        ],
+                    })),
+                    matching_values: vec![SearchFieldValues {
+                        field: "owner".to_string(),
+                        values: vec!["withcoral".to_string()],
+                    }],
+                    omitted_matching_field_count: 2,
+                    providers: vec![
+                        SearchProvider::CatalogMetadata as i32,
+                        SearchProvider::ObservedValues as i32,
+                    ],
+                },
+                SearchResult {
+                    surface: Some(SearchSurfaceRef {
+                        schema_name: "github".to_string(),
+                        name: "search_issues".to_string(),
+                        catalog_name: "remote-data".to_string(),
+                    }),
+                    description: "Search repository issues".to_string(),
+                    guide: "Supply the query argument.".to_string(),
+                    shape: Some(Shape::Function(SearchFunctionShape {
+                        arguments: vec![SearchField {
+                            name: "query".to_string(),
+                            data_type: "Utf8".to_string(),
+                            required: true,
+                        }],
+                        returns: vec![SearchField {
+                            name: "title".to_string(),
+                            data_type: "Utf8".to_string(),
+                            required: false,
+                        }],
+                    })),
+                    matching_values: Vec::new(),
+                    omitted_matching_field_count: 0,
+                    providers: vec![SearchProvider::CatalogMetadata as i32],
+                },
+            ],
+            provider_statuses: vec![
+                SearchProviderStatus {
+                    provider: SearchProvider::CatalogMetadata as i32,
+                    state: SearchProviderState::ResultsFound as i32,
+                    note: "catalog returned candidates".to_string(),
+                    coverage: Some(SearchProviderCoverage {
+                        eligible_units: 8,
+                        searched_units: 8,
+                        failed_units: 0,
+                        returned_count: 2,
+                        has_more: false,
+                        budget_exhausted: false,
+                        timed_out: false,
+                        stale_index: false,
+                    }),
+                },
+                SearchProviderStatus {
+                    provider: SearchProvider::ObservedValues as i32,
+                    state: SearchProviderState::ResultsFound as i32,
+                    note: "observed values contributed evidence".to_string(),
+                    coverage: Some(SearchProviderCoverage {
+                        eligible_units: 4,
+                        searched_units: 4,
+                        failed_units: 0,
+                        returned_count: 1,
+                        has_more: true,
+                        budget_exhausted: false,
+                        timed_out: false,
+                        stale_index: false,
+                    }),
+                },
+            ],
+            truncation: Some(SearchResultTruncation {
+                truncated: true,
+                returned_count: 2,
+                max_results: 2,
+                note: "More results were available.".to_string(),
+            }),
+        }
+    }
+
+    fn identity(trace_id: &str, span_id: &str) -> SearchExecutionIdentity {
+        SearchExecutionIdentity {
+            trace_id: trace_id.to_string(),
+            span_id: span_id.to_string(),
+        }
+    }
+
+    fn test_retention() -> Duration {
+        Duration::from_hours(7 * 24)
+    }
+
+    fn start_history(
+        db: &Arc<CoralDb>,
+        enabled: bool,
+        retention: Duration,
+    ) -> (
+        SearchResponseHistory,
+        SearchResponseHistoryWorker,
+        WorkspaceLifecycleLock,
+    ) {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let (history, worker) =
+            SearchResponseHistory::start(Arc::clone(db), lifecycle.clone(), enabled, retention);
+        (history, worker, lifecycle)
+    }
+
+    fn capture(
+        history: &SearchResponseHistory,
+        lifecycle: &WorkspaceLifecycleLock,
+        workspace_id: &str,
+        identity: Option<&SearchExecutionIdentity>,
+        response: &SearchResponse,
+    ) -> bool {
+        let workspace = WorkspaceName::parse(workspace_id).expect("workspace name");
+        let revision = lifecycle
+            .revision_if_active(&workspace)
+            .expect("workspace is active");
+        history.capture(&workspace, revision, identity, response)
+    }
+
+    async fn shutdown_history(history: SearchResponseHistory, worker: SearchResponseHistoryWorker) {
+        drop(history);
+        worker.shutdown().await;
+    }
+
+    async fn open_sqlite() -> (tempfile::TempDir, Arc<CoralDb>) {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default test database must be SQLite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open SQLite"),
+        );
+        db.migrate().await.expect("migrate SQLite");
+        (temp, db)
+    }
+
+    async fn ensure_workspace(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin workspace transaction");
+        tx.workspaces()
+            .ensure(workspace_id, 1)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit workspace");
+    }
+
+    async fn get_record(
+        db: &CoralDb,
+        identity: &SearchExecutionIdentity,
+    ) -> Option<TraceSearchResponseOutcome> {
+        db.get_trace_search_response(
+            "alpha",
+            &identity.trace_id,
+            &identity.span_id,
+            TraceSearchResponseRetentionBounds {
+                oldest_inclusive_unix_nanos: i64::MIN,
+                newest_inclusive_unix_nanos: i64::MAX,
+            },
+        )
+        .await
+        .expect("read Search response history")
+    }
+
+    async fn insert_raw_response(
+        db: &CoralDb,
+        identity: &SearchExecutionIdentity,
+        recorded_at_unix_nanos: i64,
+    ) {
+        assert_eq!(
+            db.insert_trace_search_response(TraceSearchResponseCapture {
+                workspace_id: "alpha".to_string(),
+                trace_id: identity.trace_id.clone(),
+                search_span_id: identity.span_id.clone(),
+                recorded_at_unix_nanos,
+                outcome: TraceSearchResponseOutcome::Response(Vec::new()),
+            })
+            .await
+            .expect("insert raw Search response"),
+            TraceSearchResponseInsertResult::Inserted
+        );
+    }
+
+    fn resize_note_to_encoded_len(response: &mut SearchResponse, target: usize) {
+        for _attempt in 0..16 {
+            let current = response.encoded_len();
+            if current == target {
+                return;
+            }
+            let note = &mut response.truncation.as_mut().expect("truncation").note;
+            if current < target {
+                note.extend(std::iter::repeat_n('x', target - current));
+            } else {
+                note.truncate(
+                    note.len()
+                        .checked_sub(current - target)
+                        .expect("fixture note can absorb protobuf length overhead"),
+                );
+            }
+        }
+        panic!("protobuf fixture cannot reach encoded length {target}");
+    }
+}

--- a/crates/coral-app/src/search/response_safety.rs
+++ b/crates/coral-app/src/search/response_safety.rs
@@ -1,0 +1,190 @@
+//! Public Search-response credential scrubbing.
+//!
+//! Search results can expose observed values, so the response boundary applies
+//! the same obvious-credential suppression used while collecting those values.
+//! This is defense in depth, not PII redaction or a data-loss-prevention boundary.
+
+use crate::search::observed::{
+    DEFAULT_OBSERVED_VALUE_BYTES_LIMIT, is_sensitive_column, sanitize_observed_value,
+};
+use crate::search::result::{FieldValues, SearchResponse};
+
+/// Scrubs credential-like matching-value evidence before it crosses the public boundary.
+///
+/// The caller must apply this once before mapping the domain response to its
+/// public representation so the live and retained responses stay identical.
+pub(crate) fn sanitize_search_response(response: &mut SearchResponse) {
+    for result in &mut response.results {
+        sanitize_matching_values(&mut result.matching_values);
+    }
+}
+
+fn sanitize_matching_values(matching_values: &mut Vec<FieldValues>) {
+    matching_values.retain_mut(|field_values| {
+        if is_sensitive_column(&field_values.field) {
+            return false;
+        }
+
+        let mut sanitized_values = Vec::with_capacity(field_values.values.len());
+        for value in std::mem::take(&mut field_values.values) {
+            let Some(value) = sanitize_observed_value(value, DEFAULT_OBSERVED_VALUE_BYTES_LIMIT)
+            else {
+                continue;
+            };
+            sanitized_values.push(value);
+        }
+        sanitized_values.sort();
+        sanitized_values.dedup();
+        field_values.values = sanitized_values;
+        !field_values.values.is_empty()
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::search::response_safety::{sanitize_matching_values, sanitize_search_response};
+    use crate::search::result::{
+        CatalogSurface, Field, FieldValues, ProviderCoverage, ProviderStatus, SearchProviderKind,
+        SearchProviderState, SearchResponse, SearchResult, SearchSurfaceId, SearchSurfaceKind,
+        SearchTruncation, SurfaceShape,
+    };
+
+    #[test]
+    fn removes_credential_fields_and_values() {
+        let mut matching_values = vec![
+            FieldValues {
+                field: "api_token".to_string(),
+                values: vec!["must-not-escape".to_string()],
+            },
+            FieldValues {
+                field: "details".to_string(),
+                values: vec![
+                    r#"{"name":"Ada","password":"hidden"}"#.to_string(),
+                    "plain-safe-value".to_string(),
+                    "sk-12345678901234567890".to_string(),
+                    "x".repeat(4 * 1024 + 1),
+                ],
+            },
+        ];
+
+        sanitize_matching_values(&mut matching_values);
+
+        assert_eq!(
+            matching_values,
+            [FieldValues {
+                field: "details".to_string(),
+                values: vec![
+                    "plain-safe-value".to_string(),
+                    r#"{"name":"Ada"}"#.to_string()
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn drops_empty_groups_and_deduplicates_values_created_by_scrubbing() {
+        let mut matching_values = vec![
+            FieldValues {
+                field: "empty".to_string(),
+                values: vec!["github_pat_1234567890".to_string()],
+            },
+            FieldValues {
+                field: "callback".to_string(),
+                values: vec![
+                    "https://example.test/?z=last&token=first".to_string(),
+                    "https://example.test/?name=Ada&token=first".to_string(),
+                    "https://example.test/?name=Ada&token=second".to_string(),
+                ],
+            },
+        ];
+
+        sanitize_matching_values(&mut matching_values);
+
+        assert_eq!(
+            matching_values,
+            [FieldValues {
+                field: "callback".to_string(),
+                values: vec![
+                    "https://example.test/?name=Ada".to_string(),
+                    "https://example.test/?z=last".to_string()
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn public_response_scrubbing_preserves_non_value_debugging_context() {
+        let mut response = SearchResponse {
+            results: vec![SearchResult {
+                surface: CatalogSurface {
+                    id: SearchSurfaceId {
+                        catalog_name: Some("catalog".to_string()),
+                        schema_name: "schema".to_string(),
+                        name: "search_function".to_string(),
+                        kind: SearchSurfaceKind::TableFunction,
+                    },
+                    description: "may mention token handling".to_string(),
+                    guide: "pass api_key as configured".to_string(),
+                    shape: SurfaceShape::Function {
+                        arguments: vec![Field {
+                            name: "api_token".to_string(),
+                            data_type: "TEXT".to_string(),
+                            required: true,
+                        }],
+                        returns: vec![Field {
+                            name: "session_count".to_string(),
+                            data_type: "BIGINT".to_string(),
+                            required: false,
+                        }],
+                    },
+                },
+                providers: vec![SearchProviderKind::ObservedValues],
+                matching_values: vec![FieldValues {
+                    field: "details".to_string(),
+                    values: vec![r#"{"name":"Ada","password":"hidden"}"#.to_string()],
+                }],
+                omitted_matching_field_count: 7,
+            }],
+            provider_statuses: vec![ProviderStatus {
+                provider: SearchProviderKind::ObservedValues,
+                state: SearchProviderState::ResultsFound,
+                note: "provider token note".to_string(),
+                coverage: Some(ProviderCoverage::default()),
+            }],
+            truncation: SearchTruncation {
+                truncated: true,
+                returned_count: 1,
+                max_results: 10,
+                note: "result token note".to_string(),
+            },
+        };
+
+        sanitize_search_response(&mut response);
+
+        let result = response.results.first().expect("one result");
+        assert_eq!(
+            result.matching_values,
+            [FieldValues {
+                field: "details".to_string(),
+                values: vec![r#"{"name":"Ada"}"#.to_string()],
+            }]
+        );
+        assert_eq!(result.surface.description, "may mention token handling");
+        assert_eq!(result.surface.guide, "pass api_key as configured");
+        assert_eq!(result.omitted_matching_field_count, 7);
+        assert_eq!(
+            response
+                .provider_statuses
+                .first()
+                .expect("one provider status")
+                .note,
+            "provider token note"
+        );
+        assert_eq!(response.truncation.note, "result token note");
+        let SurfaceShape::Function { arguments, returns } = &result.surface.shape else {
+            panic!("function shape is preserved");
+        };
+        assert_eq!(arguments.first().expect("one argument").name, "api_token");
+        assert_eq!(returns.first().expect("one return").name, "session_count");
+    }
+}

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -1,7 +1,7 @@
 //! Transport-neutral Universal Search request and result models.
 
 use crate::bootstrap::AppError;
-use crate::workspaces::WorkspaceName;
+use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
 
 pub(crate) const DEFAULT_UNIVERSAL_SEARCH_LIMIT: u32 = 10;
 pub(crate) const MAX_UNIVERSAL_SEARCH_LIMIT: u32 = 50;
@@ -79,6 +79,22 @@ pub(crate) struct SearchResponse {
     pub(crate) results: Vec<SearchResult>,
     pub(crate) provider_statuses: Vec<ProviderStatus>,
     pub(crate) truncation: SearchTruncation,
+}
+
+/// One successful Search execution plus the identity of its exact operation
+/// span. The identity stays transport-neutral so the service can map the
+/// response once and decide whether to retain that public representation.
+#[derive(Debug, Clone)]
+pub(crate) struct SearchExecution {
+    pub(crate) response: SearchResponse,
+    pub(crate) identity: Option<SearchExecutionIdentity>,
+    pub(crate) workspace_lifecycle_revision: WorkspaceLifecycleRevision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SearchExecutionIdentity {
+    pub(crate) trace_id: String,
+    pub(crate) span_id: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -43,9 +43,11 @@ use crate::search::maintenance::{
     SearchMaintenanceState, SearchStorageCleanupResult,
 };
 use crate::search::manager::SearchManager;
+use crate::search::response_history::SearchResponseHistory;
+use crate::search::response_safety::sanitize_search_response;
 use crate::search::result::{
-    Field, FieldValues, ProviderCoverage, ProviderStatus, SearchManagerError, SearchProviderKind,
-    SearchProviderState as DomainProviderState, SearchRequest, SearchResponse,
+    Field, FieldValues, ProviderCoverage, ProviderStatus, SearchExecution, SearchManagerError,
+    SearchProviderKind, SearchProviderState as DomainProviderState, SearchRequest, SearchResponse,
     SearchResult as DomainSearchResult, SearchSurfaceId, SurfaceShape,
 };
 use crate::sources::SourceName;
@@ -55,6 +57,7 @@ use crate::transport::{grpc_span, instrument_grpc, request_context, workspace_na
 
 #[derive(Clone)]
 pub(crate) struct SearchService {
+    response_history: Option<SearchResponseHistory>,
     search: SearchManager,
     tasks: TaskManager,
 }
@@ -62,9 +65,15 @@ pub(crate) struct SearchService {
 impl SearchService {
     pub(crate) fn new(search_manager: SearchManager, task_manager: TaskManager) -> Self {
         Self {
+            response_history: None,
             search: search_manager,
             tasks: task_manager,
         }
+    }
+
+    pub(crate) fn with_response_history(mut self, response_history: SearchResponseHistory) -> Self {
+        self.response_history = Some(response_history);
+        self
     }
 }
 
@@ -76,6 +85,7 @@ impl SearchServiceApi for SearchService {
     ) -> Result<Response<ProtoSearchResponse>, Status> {
         let span = grpc_span(&request);
         let search = self.search.clone();
+        let response_history = self.response_history.clone();
         let tasks = self.tasks.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
@@ -89,11 +99,26 @@ impl SearchServiceApi for SearchService {
             );
             let request = SearchRequest::new(workspace_name, &request.query, request.limit)
                 .map_err(search_status)?;
-            let response = search
+            let execution = search
                 .search(&request, &attribution)
                 .await
                 .map_err(search_status)?;
-            Ok(Response::new(search_response_to_proto(response)))
+            let SearchExecution {
+                mut response,
+                identity,
+                workspace_lifecycle_revision,
+            } = execution;
+            sanitize_search_response(&mut response);
+            let response = search_response_to_proto(response);
+            if let Some(response_history) = response_history {
+                response_history.capture(
+                    &request.workspace_name,
+                    workspace_lifecycle_revision,
+                    identity.as_ref(),
+                    &response,
+                );
+            }
+            Ok(Response::new(response))
         }))
         .await
     }

--- a/crates/coral-app/src/state/db/clock.rs
+++ b/crates/coral-app/src/state/db/clock.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "next stack layer computes Search response retention bounds"
-    )
-)]
-
 use std::time::Duration;
 
 use crate::bootstrap::AppError;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -16,7 +16,9 @@ mod trace_search_response_state;
 mod transaction;
 mod workspace_state;
 
-pub(crate) use clock::now_unix_nanos_i64;
+#[cfg(test)]
+pub(crate) use clock::TraceSearchResponseRetentionBounds;
+pub(crate) use clock::{now_unix_nanos_i64, trace_search_response_retention_bounds};
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
@@ -33,4 +35,7 @@ pub(crate) use task_query_state::{TaskQueryRelationWrite, TaskQueryWrite, TaskQu
 #[cfg(test)]
 pub(crate) use task_state::TaskMutationBarrier;
 pub(crate) use task_state::{TaskCreation, TaskCreationResult};
+pub(crate) use trace_search_response_state::{
+    TraceSearchResponseCapture, TraceSearchResponseInsertResult, TraceSearchResponseOutcome,
+};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/trace_search_responses.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_search_responses.rs
@@ -1,8 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(dead_code, reason = "next stack layer wires capture")
-)]
-
 use sea_query::{Condition, Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::state::db::clock::TraceSearchResponseRetentionBounds;
@@ -27,6 +22,10 @@ where
         Self { session }
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "next stack layer wires trace reads")
+    )]
     pub(in crate::state::db) async fn get(
         &mut self,
         workspace_id: &str,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -48,10 +48,6 @@ pub(in crate::state::db) enum TaskQueryRelations {
 }
 
 #[derive(Iden)]
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "next stack layer wires capture")
-)]
 pub(in crate::state::db) enum TraceSearchResponses {
     Table,
     WorkspaceId,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -59,10 +59,6 @@ pub(crate) trait DbRepos: DbSession + Sized {
         TaskQueriesRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "next stack layer wires capture")
-    )]
     fn trace_search_responses(&mut self) -> TraceSearchResponsesRepo<'_, Self> {
         TraceSearchResponsesRepo::new(self)
     }

--- a/crates/coral-app/src/state/db/trace_search_response_state.rs
+++ b/crates/coral-app/src/state/db/trace_search_response_state.rs
@@ -1,10 +1,5 @@
 //! Transactional persistence for workspace-scoped Search response history.
 
-#![cfg_attr(
-    not(test),
-    expect(dead_code, reason = "next stack layer wires capture")
-)]
-
 use std::collections::VecDeque;
 use std::fmt;
 
@@ -185,6 +180,10 @@ impl CoralDb {
             .await
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "next stack layer wires trace reads")
+    )]
     pub(crate) async fn get_trace_search_response(
         &self,
         workspace_id: &str,

--- a/crates/coral-app/src/telemetry/config.rs
+++ b/crates/coral-app/src/telemetry/config.rs
@@ -11,7 +11,7 @@ pub(super) const DEFAULT_TRACE_FILTER: &str = "coral_app=trace,coral_client=trac
 pub(super) const DEFAULT_LOCAL_TRACE_FILTER: &str = "coral_app=trace,coral_client=trace,coral_mcp=trace,coral_engine=trace,coral_engine::datafusion=trace,coral.http.body=trace,coral.mcp.body=trace";
 pub(super) const DEFAULT_LOG_FILTER: &str = "coral_app=info,coral_engine=info";
 const DEFAULT_SERVICE_NAME: &str = "coral";
-const DEFAULT_TRACE_HISTORY_RETENTION_DAYS: u64 = 7;
+const DEFAULT_TRACE_HISTORY_RETENTION_DAYS: u64 = 30;
 const DEFAULT_TRACE_HISTORY_HTTP_BODY_MAX_BYTES: usize = 64 * 1024;
 const HOURS_PER_DAY: u64 = 24;
 const SECONDS_PER_HOUR: u64 = 60 * 60;
@@ -134,6 +134,11 @@ mod tests {
 
         assert_eq!(config, TelemetryConfig::default());
         assert!(config.trace_history.enabled);
+        assert_eq!(config.trace_history.retention_days, 30);
+        assert_eq!(
+            config.trace_history.retention(),
+            Duration::from_hours(30 * 24)
+        );
         assert!(!config.trace_history.record_http_bodies);
         assert_eq!(config.trace_history.http_body_recording_max_bytes(), None);
     }

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -23,6 +23,8 @@ use coral_engine::{
 };
 use rusqlite::OptionalExtension as _;
 use serde_json::json;
+use sqlx::Connection as _;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteConnection};
 use tonic::{Code, Request};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -218,6 +220,39 @@ fn field_names(result: &ProtoSearchResult) -> Vec<&str> {
             .collect(),
         None => Vec::new(),
     }
+}
+
+#[tokio::test]
+async fn search_does_not_wait_for_response_history_database_contention() {
+    let harness = GrpcHarness::new().await;
+    let database_path = harness.config_dir().join("coral.db");
+    let mut blocker =
+        SqliteConnection::connect_with(&SqliteConnectOptions::new().filename(&database_path))
+            .await
+            .expect("open Coral database blocker");
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut blocker)
+        .await
+        .expect("hold Coral database writer");
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        harness.search_client().search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "response history contention".to_string(),
+            limit: 10,
+        })),
+    )
+    .await
+    .expect("Search must not wait for response-history database work")
+    .expect("Search success must not depend on response-history capture")
+    .into_inner();
+    assert!(response.truncation.is_some());
+
+    sqlx::query("COMMIT")
+        .execute(&mut blocker)
+        .await
+        .expect("release Coral database writer");
 }
 
 fn catalog_item_matches(item: &CatalogItem, schema_name: &str, item_name: &str) -> bool {

--- a/crates/coral-app/tests/telemetry_otlp_loopback.rs
+++ b/crates/coral-app/tests/telemetry_otlp_loopback.rs
@@ -20,12 +20,15 @@ use tonic::Request;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request as WiremockRequest, ResponseTemplate};
 
-use coral_api::v1::{ExecuteSqlRequest, SearchRequest};
+use coral_api::v1::{
+    ExecuteSqlRequest, ImportSourceRequest, SearchRequest, import_source_response,
+};
 use coral_app::{ServerBuilder, shutdown_tracing};
 use coral_client::{AppClient, decode_execute_sql_response, default_workspace};
 
 const LOCAL_ONLY_SENTINEL: &str = "LOCAL_ONLY_FUTURE_TOOL_SENTINEL";
 const SEARCH_QUERY_SENTINEL: &str = "LOCAL_ONLY_SEARCH_QUERY_SENTINEL";
+const SEARCH_RESPONSE_SENTINEL: &str = "LOCAL_ONLY_SEARCH_RESPONSE_SENTINEL";
 
 #[tokio::test]
 async fn otlp_export_loopback_covers_traces_logs_and_metrics() {
@@ -118,14 +121,63 @@ async fn emit_test_telemetry(endpoint_uri: &str) {
     let result = decode_execute_sql_response(&response).expect("decode loopback query");
     assert_eq!(result.row_count(), 1);
 
-    app.search_client()
+    let manifest_yaml = serde_json::json!({
+        "name": "telemetry_search_response_fixture",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": "https://example.test",
+        "tables": [{
+            "name": "local_only_search_query_sentinel",
+            "description": SEARCH_RESPONSE_SENTINEL,
+            "request": { "method": "GET", "path": "/sentinel" },
+            "response": {},
+            "pagination": { "mode": "none" },
+            "columns": [{ "name": "id", "type": "Utf8" }]
+        }]
+    })
+    .to_string();
+    let mut import = app
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml,
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect("import Search response sentinel fixture")
+        .into_inner();
+    let imported = import
+        .message()
+        .await
+        .expect("read source import response")
+        .is_some_and(|response| {
+            matches!(
+                response.event,
+                Some(import_source_response::Event::Source(_))
+            )
+        });
+    assert!(imported, "source fixture should finish importing");
+
+    let search_response = app
+        .search_client()
         .search(Request::new(SearchRequest {
             workspace: Some(default_workspace()),
             query: SEARCH_QUERY_SENTINEL.to_string(),
             limit: 0,
         }))
         .await
-        .expect("search empty catalog");
+        .expect("search sentinel catalog entry")
+        .into_inner();
+    assert!(
+        search_response
+            .results
+            .iter()
+            .any(|result| result.description == SEARCH_RESPONSE_SENTINEL),
+        "the Search response must contain the privacy sentinel"
+    );
 
     let query = tracing::info_span!(
         target: "coral_app",
@@ -246,6 +298,10 @@ fn assert_exported_trace_contract(trace_exports: &[ExportTraceServiceRequest], s
         trace_exports,
         SEARCH_QUERY_SENTINEL
     ));
+    assert!(!trace_exports_contain_string(
+        trace_exports,
+        SEARCH_RESPONSE_SENTINEL
+    ));
     assert!(spans.iter().all(|span| {
         span.attributes.iter().all(|attribute| {
             !attribute
@@ -276,6 +332,11 @@ fn assert_exported_log_contract(logs: &[LogRecord]) {
         logs.iter()
             .all(|log| !log_contains_string(log, SEARCH_QUERY_SENTINEL)),
         "OTLP logs must not contain local-only Search text: {logs:?}"
+    );
+    assert!(
+        logs.iter()
+            .all(|log| !log_contains_string(log, SEARCH_RESPONSE_SENTINEL)),
+        "OTLP logs must not contain Search response content: {logs:?}"
     );
 }
 
@@ -372,6 +433,10 @@ fn assert_local_trace_history_contract(local_trace_history: &str) {
             "local trace history should contain {expected}: {local_trace_history}"
         );
     }
+    assert!(
+        !local_trace_history.contains(SEARCH_RESPONSE_SENTINEL),
+        "local span history must not contain retained Search response content"
+    );
 }
 
 fn span_named<'a>(spans: &'a [Span], name: &str) -> &'a Span {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -674,7 +674,8 @@ fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<
 async fn run_server(
     feature_overrides: coral_app::features::FeatureOverrides,
 ) -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_standalone_server(feature_overrides).await?;
+    // Keep the assembled server future out of this command's inline async state.
+    let server = Box::pin(bootstrap::start_standalone_server(feature_overrides)).await?;
     let endpoint = server.endpoint_uri().to_string();
 
     // An endpoint that does not parse back to an address is treated as exposed:


### PR DESCRIPTION
## Summary

- apply the observed-values credential scrubber to matching-value evidence before mapping the public SearchResponse, so Search returns and retains the same scrubbed response
- enqueue retention into a bounded in-memory queue processed by one worker, so Search never waits on CoralDb and capture drops best-effort when the queue is unavailable or saturated
- retain up to 1 MiB per successful response in the operator-configured SQLite or PostgreSQL database, with an explicit oversized marker above that boundary
- prune on startup and opportunistically using the shared 30-day trace-history policy, retry failed pruning, and drain accepted work within a bounded shutdown window
- keep response contents out of spans and OTLP

## Stack goal

The goal of this stack is to bring a clearer Search UI to Query Stream, improving visibility into Search responses and making Search behavior easier to debug from retained trace history.

## Data and retention policy

When trace history is enabled, Coral returns and retains the same Search response after applying the observed-values credential scrubber to matching-value evidence. Search responses are retained for 30 days in the operator-configured CoralDb, including PostgreSQL. This suppresses obvious credentials but is not general PII redaction. Retention is best-effort and does not wait on CoralDb in the Search request path.

Depends on #2129. Next: #2119 exposes the retained outcome through GetTrace.

## Testing

- make rust-checks — 2,582 tests passed, 10 skipped; formatting, Clippy, and rustdoc passed
- cargo test --locked -p coral-app search::response --lib — 14 passed
- cargo test --locked -p coral-app --test grpc search_does_not_wait_for_response_history_database_contention — 1 passed
- make postgres-tests — 8 repository tests and 2 server tests passed
- xtask perf-check — coral.tables mean 0.218 s against a 0.750 s ceiling
- cargo fmt --all -- --check
- git diff --check
