### PR TITLE
refactor(engine): target runtime components at source catalogs

### DIFF
--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -145,8 +145,8 @@ root.
   not reimplement table matching, column filtering, pagination, or
   missing-table context.
 - `sources/runtime_package.rs` owns app-level conversion from installed source
-  state and materialized artifacts into the generic runtime components accepted
-  by `coral-engine`.
+  state and materialized artifacts into the generic runtime components and
+  explicit SQL catalog target accepted by `coral-engine`.
 - For all service calls, keep protobuf request/response types confined to the
   service edge. Convert request data into small app-local command, query, or
   binding structs before calling managers; do not pass `coral_api::v1`

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -197,6 +197,7 @@ impl McpQueryTableUsage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpQueryTableFunctionUsage {
     source: String,
+    catalog: Option<String>,
     schema: String,
     function: String,
 }
@@ -206,6 +207,12 @@ impl McpQueryTableFunctionUsage {
     #[must_use]
     pub fn source_name(&self) -> &str {
         &self.source
+    }
+
+    /// SQL catalog name used in the query, when explicitly qualified.
+    #[must_use]
+    pub fn catalog_name(&self) -> Option<&str> {
+        self.catalog.as_deref()
     }
 
     /// SQL schema name used in the query.
@@ -223,6 +230,7 @@ impl McpQueryTableFunctionUsage {
     fn from_trace(usage: TraceQueryTableFunctionUsage) -> Self {
         Self {
             source: usage.source,
+            catalog: usage.catalog,
             schema: usage.schema,
             function: usage.function,
         }
@@ -435,6 +443,7 @@ mod tests {
             table_functions: (0..table_function_count)
                 .map(|index| McpQueryTableFunctionUsage {
                     source: table_source.to_string(),
+                    catalog: None,
                     schema: "schema".to_string(),
                     function: format!("function_{index}"),
                 })

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeSet, HashSet};
 
-use coral_engine::{CoralSqlFunctionDefinition, QuerySource, RuntimeSourceComponent};
+use coral_engine::{
+    CoralSqlFunctionDefinition, QuerySource, RuntimeCatalogTarget, RuntimeSourceComponent,
+};
 
 use crate::bootstrap::AppError;
 
@@ -30,6 +32,9 @@ pub(crate) fn source_sql_publish_targets_for_schemas(
 ) -> SqlPublishTargets {
     let mut targets = HashSet::new();
     for source in selected_sources {
+        if !matches!(source.catalog_target(), RuntimeCatalogTarget::Default) {
+            continue;
+        }
         for component in source.components() {
             if schemas.contains(component.source_name()) {
                 record_source_component_sql_targets(component, &mut targets);
@@ -54,6 +59,9 @@ pub(crate) fn unchecked_source_publish_schemas(
 fn source_sql_publish_targets(selected_sources: &[QuerySource]) -> SqlPublishTargets {
     let mut targets = HashSet::new();
     for source in selected_sources {
+        if !matches!(source.catalog_target(), RuntimeCatalogTarget::Default) {
+            continue;
+        }
         for component in source.components() {
             record_source_component_sql_targets(component, &mut targets);
         }
@@ -166,6 +174,7 @@ tables:
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
+                catalog_target: RuntimeCatalogTarget::Default,
                 components: primary
                     .components()
                     .iter()
@@ -177,6 +186,25 @@ tables:
             BTreeMap::new(),
         )
         .expect("multi-schema source")
+    }
+
+    fn named_catalog_source() -> QuerySource {
+        let component = http_source("issues", "review_queue");
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "github_v4".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                identity_requirements: None,
+                catalog_target: RuntimeCatalogTarget::Source,
+                components: component.components().to_vec(),
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("named catalog source")
     }
 
     fn runtime_function() -> CoralSqlFunctionDefinition {
@@ -201,6 +229,13 @@ tables:
         let targets = initial_sql_publish_targets(&[functions_source()]);
 
         assert!(targets.contains(&SqlPublishTarget::new("functions", "review_queue")));
+    }
+
+    #[test]
+    fn named_catalog_relations_do_not_reserve_default_catalog_udf_targets() {
+        let targets = initial_sql_publish_targets(&[named_catalog_source()]);
+
+        assert!(!targets.contains(&SqlPublishTarget::new("issues", "review_queue")));
     }
 
     #[test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1159,7 +1159,11 @@ fn task_query_relations(provenance: &QueryExecutionProvenance) -> Vec<TaskQueryR
             )
         })
         .chain(provenance.table_functions().iter().map(|function| {
-            TaskQueryRelation::table_function(function.schema_name(), function.function_name())
+            TaskQueryRelation::table_function(
+                function.catalog_name(),
+                function.schema_name(),
+                function.function_name(),
+            )
         }))
         .collect()
 }
@@ -1193,7 +1197,8 @@ fn required_query_guides(
     }
     for usage in resources.table_functions() {
         if let Some(function) = catalog.table_functions.iter().find(|function| {
-            function.schema_name == usage.schema_name()
+            function.catalog_name.as_deref() == usage.catalog_name()
+                && function.schema_name == usage.schema_name()
                 && function.function_name == usage.function_name()
         }) && function.require_guide_read
         {
@@ -1418,6 +1423,7 @@ fn record_query_provenance(span: &tracing::Span, provenance: &QueryExecutionProv
             .map(|function| {
                 json!({
                     "source_name": function.source_name(),
+                    "catalog_name": function.catalog_name(),
                     "schema_name": function.schema_name(),
                     "function_name": function.function_name(),
                 })
@@ -1905,6 +1911,7 @@ mod tests {
             )],
             vec![QueryTableFunctionUsage::new(
                 "github",
+                Some("github"),
                 "github",
                 "search_runs",
             )],
@@ -1944,7 +1951,7 @@ mod tests {
                 crate::state::db::TaskQueryRelationRecord {
                     query_id: query.id.clone(),
                     relation_kind: "table_function".to_string(),
-                    catalog_name: None,
+                    catalog_name: Some("github".to_string()),
                     schema_name: "github".to_string(),
                     relation_name: "search_runs".to_string(),
                 },
@@ -2104,6 +2111,7 @@ mod tests {
             ],
             vec![QueryTableFunctionUsage::new(
                 "github",
+                None,
                 "github",
                 "search_issues",
             )],
@@ -2139,7 +2147,7 @@ mod tests {
                 crate::telemetry::QUERY_TRACE_TABLE_FUNCTIONS_ATTR
             ),
             Some(
-                r#"[{"source_name":"github","schema_name":"github","function_name":"search_issues"}]"#
+                r#"[{"source_name":"github","catalog_name":null,"schema_name":"github","function_name":"search_issues"}]"#
                     .to_string()
             )
         );

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -291,8 +291,8 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use coral_engine::{
-        QuerySource, RuntimeSourceComponent, RuntimeSourcePackage, SourceObservationSurfaceKind,
-        SourceScanObservation,
+        QuerySource, RuntimeCatalogTarget, RuntimeSourceComponent, RuntimeSourcePackage,
+        SourceObservationSurfaceKind, SourceScanObservation,
     };
     use coral_spec::{DO_NOT_INDEX_COLUMN_METADATA_KEY, parse_source_manifest_yaml};
     use serde_json::json;
@@ -702,6 +702,7 @@ tables:
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
+                catalog_target: RuntimeCatalogTarget::Default,
                 components: vec![
                     http_component("github_v4_rest"),
                     http_component("github_v4_mcp"),
@@ -722,6 +723,7 @@ tables:
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
+                catalog_target: RuntimeCatalogTarget::Default,
                 components: vec![http_component(source_name)],
             },
             BTreeMap::new(),

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -394,6 +394,8 @@ mod tests {
 
         publisher.publish_source_scan(SourceScanObservation {
             source_name: "github",
+            catalog_name: None,
+            schema_name: "github",
             surface_kind: SourceObservationSurfaceKind::Table,
             surface_name: "issues",
             batch: &batch,
@@ -441,6 +443,8 @@ mod tests {
 
         publisher.publish_source_scan(SourceScanObservation {
             source_name: "github",
+            catalog_name: None,
+            schema_name: "github",
             surface_kind: SourceObservationSurfaceKind::Table,
             surface_name: "issues",
             batch: &batch,
@@ -476,6 +480,8 @@ mod tests {
         for source_name in ["github_v4_rest", "github_v4_mcp", "github_mcp_v4"] {
             publisher.publish_source_scan(SourceScanObservation {
                 source_name,
+                catalog_name: None,
+                schema_name: source_name,
                 surface_kind: SourceObservationSurfaceKind::Table,
                 surface_name: "list_issues",
                 batch: &batch,
@@ -529,6 +535,8 @@ mod tests {
         for source_name in ["github_v4", "github_mcp_v4"] {
             publisher.publish_source_scan(SourceScanObservation {
                 source_name,
+                catalog_name: None,
+                schema_name: source_name,
                 surface_kind: SourceObservationSurfaceKind::Table,
                 surface_name: "list_issues",
                 batch: &batch,
@@ -580,6 +588,8 @@ mod tests {
 
         publisher.publish_source_scan(SourceScanObservation {
             source_name: "github",
+            catalog_name: None,
+            schema_name: "github",
             surface_kind: SourceObservationSurfaceKind::Table,
             surface_name: "issues",
             batch: &batch,

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -2,7 +2,9 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use coral_engine::{QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use coral_engine::{
+    QuerySource, RuntimeCatalogTarget, RuntimeSourceComponent, RuntimeSourcePackage,
+};
 use coral_spec::backends::database::DatabaseSourceManifest;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::backends::mcp::{
@@ -153,6 +155,17 @@ pub(crate) fn query_source_from_installed_manifest(
             &source.variables,
             component.as_ref(),
         )?;
+        let catalog_target = if matches!(
+            component.as_ref(),
+            Some(RuntimeSourceComponent::Database(_))
+        ) {
+            RuntimeCatalogTarget::Source
+        } else {
+            // Static DSL v4 placement changes only when canonical projection
+            // schemas are materialized; until then preserve the existing
+            // default-catalog runtime contract.
+            RuntimeCatalogTarget::Default
+        };
         let query_source = QuerySource::from_runtime_components(
             RuntimeSourcePackage {
                 source_name: source_spec.schema_name().to_string(),
@@ -161,6 +174,7 @@ pub(crate) fn query_source_from_installed_manifest(
                 declared_inputs: source_spec.declared_inputs().to_vec(),
                 test_queries: source_spec.test_queries().to_vec(),
                 identity_requirements: None,
+                catalog_target,
                 components: component.into_iter().collect(),
             },
             source.variables.clone(),

--- a/crates/coral-app/src/task/activity.rs
+++ b/crates/coral-app/src/task/activity.rs
@@ -63,10 +63,14 @@ impl<'a> TaskQueryRelation<'a> {
         }
     }
 
-    pub(crate) const fn table_function(schema_name: &'a str, relation_name: &'a str) -> Self {
+    pub(crate) const fn table_function(
+        catalog_name: Option<&'a str>,
+        schema_name: &'a str,
+        relation_name: &'a str,
+    ) -> Self {
         Self {
             kind: TaskQueryRelationKind::TableFunction,
-            catalog_name: None,
+            catalog_name,
             schema_name,
             relation_name,
         }

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -529,6 +529,9 @@ pub(crate) struct TraceQueryTableUsage {
 pub(crate) struct TraceQueryTableFunctionUsage {
     #[serde(rename = "source_name")]
     pub(crate) source: String,
+    /// Absent on spans recorded before function provenance carried the catalog.
+    #[serde(rename = "catalog_name", default)]
+    pub(crate) catalog: Option<String>,
     #[serde(rename = "schema_name")]
     pub(crate) schema: String,
     #[serde(rename = "function_name")]

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -10,7 +10,8 @@ use std::fs;
 
 use coral_client::local::ServerBuilder;
 use coral_engine::{
-    CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
+    CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeCatalogTarget, RuntimeSourceComponent,
+    RuntimeSourcePackage,
 };
 use coral_spec::{
     DatabaseConnectionSpec, DatabaseSourceManifest, ParsedTemplate, PostgresConnectionSpec,
@@ -146,6 +147,7 @@ fn postgres_source(database_url: &str) -> QuerySource {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Source,
             components: vec![RuntimeSourceComponent::Database(manifest)],
         },
         BTreeMap::new(),

--- a/crates/coral-engine/AGENTS.md
+++ b/crates/coral-engine/AGENTS.md
@@ -30,9 +30,10 @@ registration, and query execution.
   validated source-spec types and backend-specific spec structs from there.
 - Runtime code should work with compiled sources and generic metadata, not app
   policy or transport concerns.
-- Runtime components are the app-to-engine package boundary. Do not add a
-  backend that reaches back into DSL v4 materialization or authored-manifest
-  types when `coral-app` can assemble existing backend-ready component specs.
+- Runtime components plus their explicit catalog target are the app-to-engine
+  package boundary. `coral-app` decides SQL catalog placement; backends compile
+  existing backend-ready component specs and must not infer placement from DSL
+  version or reach back into v4 materialization and authored-manifest types.
 - Installed-function inputs are executable Coral SQL definitions. Do not add
   placeholder variants for languages that `DataFusion` cannot execute.
 - Reuse database connection pools only through an explicit

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -178,7 +178,7 @@ pub(crate) struct BackendSchemaRegistration {
 pub(crate) struct BackendCatalogRegistration {
     pub(crate) catalog: Arc<dyn CatalogProvider>,
     pub(crate) source: RegisteredSource,
-    pub(crate) column_fetcher: Arc<dyn DatabaseColumnFetcher>,
+    pub(crate) column_fetcher: Option<Arc<dyn DatabaseColumnFetcher>>,
 }
 
 /// Row-set restriction for one lazy database column-metadata fetch.

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -8,6 +8,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
 
+use crate::RuntimeCatalogTarget;
 use crate::backends::{
     BackendCatalogRegistration, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredInput, RegisteredSource,
@@ -16,15 +17,18 @@ use crate::backends::{
 
 struct CompositeCompiledSource {
     source_name: String,
+    catalog_target: RuntimeCatalogTarget,
     components: Vec<Box<dyn CompiledBackendSource>>,
 }
 
 pub(crate) fn compile_source(
     source_name: String,
+    catalog_target: RuntimeCatalogTarget,
     components: Vec<Box<dyn CompiledBackendSource>>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(CompositeCompiledSource {
         source_name,
+        catalog_target,
         components,
     })
 }
@@ -32,7 +36,10 @@ pub(crate) fn compile_source(
 #[async_trait]
 impl CompiledBackendSource for CompositeCompiledSource {
     fn qualified_name(&self) -> SourceQualifiedName {
-        SourceQualifiedName::Schema(self.source_name.clone())
+        match &self.catalog_target {
+            RuntimeCatalogTarget::Default => SourceQualifiedName::Schema(self.source_name.clone()),
+            RuntimeCatalogTarget::Source => SourceQualifiedName::Catalog(self.source_name.clone()),
+        }
     }
 
     fn source_name(&self) -> &str {
@@ -60,21 +67,25 @@ impl CompiledBackendSource for CompositeCompiledSource {
             for schema in registration.schemas {
                 let schema_name = schema.source.qualified_name.name().to_string();
                 let target = schemas
-                    .entry(schema_name.clone())
+                    .entry(schema_name.to_ascii_lowercase())
                     .or_insert_with(|| CompositeSchemaRegistration::new(schema_name.clone()));
                 for (name, table) in schema.tables {
-                    if target.tables.insert(name.clone(), table).is_some() {
+                    if !target.relation_keys.insert(name.to_ascii_lowercase()) {
                         return Err(DataFusionError::Execution(format!(
-                            "source '{}' schema '{schema_name}' registered duplicate table '{name}'",
+                            "source '{}' schema '{schema_name}' registered duplicate relation '{name}'",
                             self.source_name
                         )));
                     }
+                    target.tables.insert(name, table);
                 }
                 for function in schema.source.table_functions {
                     let function_name = function.function_name.clone();
-                    if !target.function_keys.insert(function_name.clone()) {
+                    if !target
+                        .relation_keys
+                        .insert(function_name.to_ascii_lowercase())
+                    {
                         return Err(DataFusionError::Execution(format!(
-                            "source '{}' schema '{schema_name}' registered duplicate table function '{function_name}'",
+                            "source '{}' schema '{schema_name}' registered duplicate relation '{function_name}'",
                             self.source_name
                         )));
                     }
@@ -102,7 +113,7 @@ impl CompiledBackendSource for CompositeCompiledSource {
 struct CompositeSchemaRegistration {
     schema_name: String,
     tables: HashMap<String, Arc<dyn TableProvider>>,
-    function_keys: BTreeSet<String>,
+    relation_keys: BTreeSet<String>,
     registered_tables: Vec<RegisteredTable>,
     registered_functions: Vec<RegisteredTableFunction>,
     inputs: Vec<RegisteredInput>,
@@ -114,7 +125,7 @@ impl CompositeSchemaRegistration {
         Self {
             schema_name,
             tables: HashMap::new(),
-            function_keys: BTreeSet::new(),
+            relation_keys: BTreeSet::new(),
             registered_tables: Vec::new(),
             registered_functions: Vec::new(),
             inputs: Vec::new(),

--- a/crates/coral-engine/src/backends/database/source.rs
+++ b/crates/coral-engine/src/backends/database/source.rs
@@ -146,7 +146,7 @@ impl CompiledBackendSource for CompiledDatabaseSource {
             catalogs: vec![BackendCatalogRegistration {
                 catalog: database_catalog.provider,
                 source,
-                column_fetcher: database_catalog.column_fetcher,
+                column_fetcher: Some(database_catalog.column_fetcher),
             }],
         })
     }
@@ -448,8 +448,9 @@ mod tests {
     };
     use crate::backends::shared::template::RenderContext;
     use crate::{
-        CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
-        SourceDecorator, SourceDecoratorError, SourceFailurePolicy, SourceTables,
+        CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeCatalogTarget, RuntimeSourceComponent,
+        RuntimeSourcePackage, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
+        SourceTables,
     };
 
     struct AbortOnSourceFailureDecorator;
@@ -540,6 +541,7 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
+                catalog_target: RuntimeCatalogTarget::Source,
                 components: vec![RuntimeSourceComponent::Database(database)],
             },
             BTreeMap::new(),

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -35,6 +35,8 @@ struct FunctionCallContext<'a> {
 /// table function.
 struct HttpSourceFunctionState {
     backend: HttpSourceClient,
+    source_name: String,
+    catalog_name: Option<String>,
     source_schema: String,
     function_name: String,
     target: Arc<HttpFetchTarget>,
@@ -61,6 +63,8 @@ impl fmt::Debug for HttpSourceTableFunction {
 impl HttpSourceTableFunction {
     pub(crate) fn new(
         backend: HttpSourceClient,
+        source_name: String,
+        catalog_name: Option<String>,
         source_schema: String,
         function: SourceTableFunctionSpec,
         source_observation_publishers: SourceObservationPublishers,
@@ -72,6 +76,8 @@ impl HttpSourceTableFunction {
             spec: Arc::new(function),
             state: Arc::new(HttpSourceFunctionState {
                 backend,
+                source_name,
+                catalog_name,
                 source_schema,
                 function_name,
                 target: Arc::new(target),
@@ -144,6 +150,8 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         http_json_exec(HttpJsonExecRequest {
             backend: self.state.backend.clone(),
+            source_name: &self.state.source_name,
+            catalog_name: self.state.catalog_name.as_deref(),
             source_schema: &self.state.source_schema,
             target: (*self.state.target).clone(),
             schema: self.state.schema.clone(),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -132,6 +132,7 @@ impl CompiledBackendSource for HttpCompiledSource {
         for table in &self.manifest.tables {
             let provider: Arc<dyn TableProvider> = Arc::new(HttpSourceTableProvider::new(
                 backend.clone(),
+                self.source_input_resolution.source_name().to_string(),
                 self.manifest.common.name.clone(),
                 table.clone(),
                 Arc::clone(&self.source_observation_publishers),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -20,8 +20,8 @@ use crate::backends::{
     required_filter_names, validate_lookup_key_filter_backend_support,
 };
 use crate::{
-    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, SourceInputResolutionContext,
-    SourceInputResolver,
+    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, RuntimeCatalogTarget,
+    SourceInputResolutionContext, SourceInputResolver,
 };
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
@@ -52,6 +52,7 @@ pub(crate) use provider::HttpSourceTableProvider;
 struct HttpCompiledSource {
     manifest: HttpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
+    catalog_name: Option<String>,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<opentelemetry::Context>,
@@ -68,6 +69,11 @@ pub(crate) fn compile_manifest(
     Box::new(HttpCompiledSource {
         manifest: manifest.clone(),
         source_input_resolution: SourceInputResolutionContext::from_query_source(request.source),
+        catalog_name: matches!(
+            request.source.catalog_target(),
+            RuntimeCatalogTarget::Source
+        )
+        .then(|| request.source.source_name().to_string()),
         request_authenticators: request.request_authenticators.clone(),
         body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
         trace_context: request.runtime_context.trace_context.clone(),
@@ -133,6 +139,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             let provider: Arc<dyn TableProvider> = Arc::new(HttpSourceTableProvider::new(
                 backend.clone(),
                 self.source_input_resolution.source_name().to_string(),
+                self.catalog_name.clone(),
                 self.manifest.common.name.clone(),
                 table.clone(),
                 Arc::clone(&self.source_observation_publishers),
@@ -145,6 +152,8 @@ impl CompiledBackendSource for HttpCompiledSource {
             let factory: Arc<dyn SourceFunctionProviderFactory> =
                 Arc::new(function::HttpSourceTableFunction::new(
                     backend.clone(),
+                    self.source_input_resolution.source_name().to_string(),
+                    self.catalog_name.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
                     Arc::clone(&self.source_observation_publishers),

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -30,6 +30,7 @@ use coral_spec::backends::http::HttpTableSpec;
 /// Table provider that exposes one manifest-defined HTTP table to `DataFusion`.
 pub(crate) struct HttpSourceTableProvider {
     backend: HttpSourceClient,
+    source_name: String,
     source_schema: String,
     table: Arc<HttpTableSpec>,
     target: HttpFetchTarget,
@@ -40,6 +41,7 @@ pub(crate) struct HttpSourceTableProvider {
 impl std::fmt::Debug for HttpSourceTableProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HttpSourceTableProvider")
+            .field("source_name", &self.source_name)
             .field("source_schema", &self.source_schema)
             .field("table", &self.table.name())
             .finish_non_exhaustive()
@@ -55,6 +57,7 @@ impl HttpSourceTableProvider {
     /// is invalid.
     pub(crate) fn new(
         backend: HttpSourceClient,
+        source_name: String,
         source_schema: String,
         table: HttpTableSpec,
         source_observation_publishers: SourceObservationPublishers,
@@ -63,12 +66,17 @@ impl HttpSourceTableProvider {
         let target = HttpFetchTarget::from_resolved_table_request(&table, table.request.clone());
         Ok(Self {
             backend,
+            source_name,
             source_schema,
             table: Arc::new(table),
             target,
             schema,
             source_observation_publishers,
         })
+    }
+
+    pub(crate) fn source_name(&self) -> &str {
+        &self.source_name
     }
 
     pub(crate) fn source_schema(&self) -> &str {

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -24,13 +24,16 @@ use crate::backends::shared::filter_expr::{
 };
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
 use crate::backends::shared::mapping::{convert_items, filter_items_by_column_values};
-use crate::backends::shared::source_observation::SourceObservationPublishers;
+use crate::backends::shared::source_observation::{
+    SourceObservationIdentity, SourceObservationPublishers,
+};
 use coral_spec::backends::http::HttpTableSpec;
 
 /// Table provider that exposes one manifest-defined HTTP table to `DataFusion`.
 pub(crate) struct HttpSourceTableProvider {
     backend: HttpSourceClient,
     source_name: String,
+    catalog_name: Option<String>,
     source_schema: String,
     table: Arc<HttpTableSpec>,
     target: HttpFetchTarget,
@@ -58,6 +61,7 @@ impl HttpSourceTableProvider {
     pub(crate) fn new(
         backend: HttpSourceClient,
         source_name: String,
+        catalog_name: Option<String>,
         source_schema: String,
         table: HttpTableSpec,
         source_observation_publishers: SourceObservationPublishers,
@@ -67,6 +71,7 @@ impl HttpSourceTableProvider {
         Ok(Self {
             backend,
             source_name,
+            catalog_name,
             source_schema,
             table: Arc::new(table),
             target,
@@ -108,6 +113,8 @@ struct HttpFetchPlan {
 
 pub(crate) struct HttpJsonExecRequest<'a> {
     pub(crate) backend: HttpSourceClient,
+    pub(crate) source_name: &'a str,
+    pub(crate) catalog_name: Option<&'a str>,
     pub(crate) source_schema: &'a str,
     pub(crate) target: HttpFetchTarget,
     pub(crate) schema: SchemaRef,
@@ -161,9 +168,15 @@ fn merge_filter_values(
     values
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "HTTP execution assembly keeps filtering, conversion, and observation paths aligned."
+)]
 pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn ExecutionPlan>> {
     let HttpJsonExecRequest {
         backend,
+        source_name,
+        catalog_name,
         source_schema,
         target,
         schema,
@@ -254,6 +267,12 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         projection.cloned(),
     )?
     .with_source_observation_converter(
+        SourceObservationIdentity::new(
+            source_name,
+            catalog_name.map(ToString::to_string),
+            source_schema,
+            target.name(),
+        ),
         surface_kind,
         source_observation_publishers,
         observation_converter,
@@ -347,6 +366,8 @@ impl TableProvider for HttpSourceTableProvider {
 
         http_json_exec(HttpJsonExecRequest {
             backend: self.backend.clone(),
+            source_name: &self.source_name,
+            catalog_name: self.catalog_name.as_deref(),
             source_schema: &self.source_schema,
             target,
             schema: self.schema.clone(),

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -18,7 +18,9 @@ use crate::SourceObservationSurfaceKind;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
-use crate::backends::shared::source_observation::SourceObservationPublishers;
+use crate::backends::shared::source_observation::{
+    SourceObservationIdentity, SourceObservationPublishers,
+};
 use crate::backends::{BoundSourceFunctionArg, SourceFunctionProviderFactory};
 
 #[derive(Clone)]
@@ -29,6 +31,8 @@ pub(super) struct McpSourceTableFunction {
 
 struct McpFunctionState {
     backend: McpSourceClient,
+    source_name: String,
+    catalog_name: Option<String>,
     source_schema: String,
     function_name: String,
     tool_name: String,
@@ -64,6 +68,8 @@ impl std::fmt::Debug for McpFunctionState {
 impl McpSourceTableFunction {
     pub(super) fn new(
         backend: McpSourceClient,
+        source_name: String,
+        catalog_name: Option<String>,
         source_schema: String,
         function: McpTableFunctionSpec,
         source_observation_publishers: SourceObservationPublishers,
@@ -80,6 +86,8 @@ impl McpSourceTableFunction {
             spec: Arc::new(function),
             state: Arc::new(McpFunctionState {
                 backend,
+                source_name,
+                catalog_name,
                 source_schema,
                 function_name,
                 tool_name,
@@ -188,6 +196,12 @@ impl TableProvider for McpFunctionCallTableProvider {
             projection.cloned(),
         )?
         .with_source_observation(
+            SourceObservationIdentity::new(
+                &self.state.source_name,
+                self.state.catalog_name.clone(),
+                &self.state.source_schema,
+                &self.state.function_name,
+            ),
             SourceObservationSurfaceKind::Function,
             Arc::clone(&self.state.source_observation_publishers),
         );

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -38,13 +38,15 @@ use crate::backends::{
 };
 use crate::runtime::error::datafusion_to_core;
 use crate::{
-    CoreError, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+    CoreError, RuntimeCatalogTarget, SourceInputResolutionContext, SourceInputResolver,
+    SourceInputResolverError,
 };
 
 #[derive(Clone)]
 struct McpCompiledSource {
     manifest: McpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
+    catalog_name: Option<String>,
     source_inputs: Arc<McpSourceInputs>,
     caller: McpSourceClient,
     source_observation_publishers: SourceObservationPublishers,
@@ -127,6 +129,11 @@ pub(crate) fn compile_manifest(
     compile_source_with_caller(
         manifest.clone(),
         source_input_resolution,
+        matches!(
+            request.source.catalog_target(),
+            RuntimeCatalogTarget::Source
+        )
+        .then(|| request.source.source_name().to_string()),
         source_inputs,
         caller,
         source_observation_publishers(request.source_observation_publishers),
@@ -163,6 +170,7 @@ pub async fn discover_tool_catalog(
 fn compile_source_with_caller(
     manifest: McpSourceManifest,
     source_input_resolution: SourceInputResolutionContext,
+    catalog_name: Option<String>,
     source_inputs: Arc<McpSourceInputs>,
     caller: Arc<dyn McpToolCaller>,
     source_observation_publishers: SourceObservationPublishers,
@@ -170,6 +178,7 @@ fn compile_source_with_caller(
     Box::new(McpCompiledSource {
         manifest,
         source_input_resolution,
+        catalog_name,
         source_inputs,
         caller: McpSourceClient::new(caller),
         source_observation_publishers,
@@ -209,6 +218,8 @@ impl CompiledBackendSource for McpCompiledSource {
             let factory: Arc<dyn SourceFunctionProviderFactory> =
                 Arc::new(McpSourceTableFunction::new(
                     self.caller.clone(),
+                    self.source_input_resolution.source_name().to_string(),
+                    self.catalog_name.clone(),
                     self.manifest.common.name.clone(),
                     function.clone(),
                     Arc::clone(&self.source_observation_publishers),
@@ -225,6 +236,8 @@ impl CompiledBackendSource for McpCompiledSource {
         for table in &self.manifest.tables {
             let provider: Arc<dyn TableProvider> = Arc::new(McpTableProvider::new(
                 self.caller.clone(),
+                self.source_input_resolution.source_name().to_string(),
+                self.catalog_name.clone(),
                 self.manifest.common.name.clone(),
                 Arc::clone(&self.source_inputs),
                 table.clone(),

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -21,10 +21,14 @@ use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{classify_filter_pushdown, extract_filter_values};
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
-use crate::backends::shared::source_observation::SourceObservationPublishers;
+use crate::backends::shared::source_observation::{
+    SourceObservationIdentity, SourceObservationPublishers,
+};
 
 pub(super) struct McpTableProvider {
     backend: McpSourceClient,
+    source_name: String,
+    catalog_name: Option<String>,
     source_schema: String,
     source_inputs: Arc<McpSourceInputs>,
     table: Arc<McpTableSpec>,
@@ -45,6 +49,8 @@ impl std::fmt::Debug for McpTableProvider {
 impl McpTableProvider {
     pub(super) fn new(
         backend: McpSourceClient,
+        source_name: String,
+        catalog_name: Option<String>,
         source_schema: String,
         source_inputs: Arc<McpSourceInputs>,
         table: McpTableSpec,
@@ -53,6 +59,8 @@ impl McpTableProvider {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
         Ok(Self {
             backend,
+            source_name,
+            catalog_name,
             source_schema,
             source_inputs,
             table: Arc::new(table),
@@ -172,6 +180,12 @@ impl TableProvider for McpTableProvider {
             projection.cloned(),
         )?
         .with_source_observation(
+            SourceObservationIdentity::new(
+                &self.source_name,
+                self.catalog_name.clone(),
+                &self.source_schema,
+                self.table.name(),
+            ),
             SourceObservationSurfaceKind::Table,
             Arc::clone(&self.source_observation_publishers),
         );

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -561,12 +561,7 @@ async fn missing_required_function_arg_fails_planning() {
 
 fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    let source_functions = SourceFunctionRegistry::new(
-        registration
-            .active_sources
-            .iter()
-            .flat_map(|source| source.table_functions.iter()),
-    );
+    let source_functions = SourceFunctionRegistry::new(&registration.active_sources);
     source_functions
         .install(ctx)
         .expect("source function planner should register");
@@ -582,12 +577,7 @@ fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<Compile
         catalog::CatalogColumnFetchFailures::default(),
     )
     .expect("catalog should register");
-    let source_functions = SourceFunctionRegistry::new(
-        registration
-            .active_sources
-            .iter()
-            .flat_map(|source| source.table_functions.iter()),
-    );
+    let source_functions = SourceFunctionRegistry::new(&registration.active_sources);
     source_functions
         .install(ctx)
         .expect("source function planner should register");

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -340,6 +340,7 @@ fn compile_sources_with_mcp_manifest(
     let compiled = compile_source_with_caller(
         mcp_manifest,
         source_input_resolution,
+        None,
         source_inputs,
         caller,
         source_observation_publishers(&[]),
@@ -403,6 +404,7 @@ fn compile_sources_with_inputs_and_observation_publishers(
     let compiled = compile_source_with_caller(
         mcp_manifest,
         source_input_resolution,
+        None,
         source_inputs,
         caller,
         source_observation_publishers(publishers),

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -104,12 +104,9 @@ pub(crate) fn compile_query_source(
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     source_observation_publishers: &[Arc<dyn SourceObservationPublisher>],
     request_identity_http_authenticators: &HashMap<String, BoundRequestIdentityHttpAuthenticator>,
-) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
+) -> Result<Option<Box<dyn CompiledBackendSource>>, CoreError> {
     if source.components().is_empty() {
-        return Err(CoreError::FailedPrecondition(format!(
-            "source '{}' has no runtime components",
-            source.source_name()
-        )));
+        return Ok(None);
     }
     let request = BackendCompileRequest {
         source,
@@ -127,10 +124,11 @@ pub(crate) fn compile_query_source(
         .iter()
         .map(|component| compile_component(component, &request))
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(composite::compile_source(
+    Ok(Some(composite::compile_source(
         source.source_name().to_string(),
+        source.catalog_target().clone(),
         compiled_components,
-    ))
+    )))
 }
 
 fn compile_component(

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -20,7 +20,8 @@ use serde_json::Value;
 
 use crate::SourceObservationSurfaceKind;
 use crate::backends::shared::source_observation::{
-    SourceObservationConfig, SourceObservationPublishers, publish_source_scan_batch,
+    SourceObservationConfig, SourceObservationIdentity, SourceObservationPublishers,
+    publish_source_scan_batch,
 };
 
 /// Fetches raw JSON rows for one logical table scan.
@@ -37,8 +38,6 @@ pub(crate) type Fetcher = Arc<dyn RowFetcher>;
 pub(crate) type Converter = Arc<dyn Fn(&[Value]) -> Result<RecordBatch> + Send + Sync>;
 
 fn observe_source_scan_batch(
-    source_name: String,
-    surface_name: String,
     observation: SourceObservationConfig,
     observation_converter: Converter,
     output_converter: Converter,
@@ -47,17 +46,14 @@ fn observe_source_scan_batch(
         let output_batch = output_converter(items)?;
         match observation_converter(items) {
             Ok(observation_batch) => {
-                publish_source_scan_batch(
-                    &source_name,
-                    &surface_name,
-                    &observation,
-                    &observation_batch,
-                );
+                publish_source_scan_batch(&observation, &observation_batch);
             }
             Err(error) => {
                 tracing::debug!(
-                    source = source_name,
-                    surface = surface_name,
+                    source = observation.identity.source_name,
+                    catalog = observation.identity.catalog_name,
+                    schema = observation.identity.schema_name,
+                    surface = observation.identity.surface_name,
                     error = %error,
                     "failed to convert source-scan observation batch; dropping observation"
                 );
@@ -68,14 +64,12 @@ fn observe_source_scan_batch(
 }
 
 fn observe_output_batch(
-    source_name: String,
-    surface_name: String,
     observation: SourceObservationConfig,
     output_converter: Converter,
 ) -> Converter {
     Arc::new(move |items| {
         let output_batch = output_converter(items)?;
-        publish_source_scan_batch(&source_name, &surface_name, &observation, &output_batch);
+        publish_source_scan_batch(&observation, &output_batch);
         Ok(output_batch)
     })
 }
@@ -147,18 +141,15 @@ impl JsonExec {
     #[must_use]
     pub(crate) fn with_source_observation(
         mut self,
+        identity: SourceObservationIdentity,
         surface_kind: SourceObservationSurfaceKind,
         publishers: SourceObservationPublishers,
     ) -> Self {
-        let Some(observation) = SourceObservationConfig::new(surface_kind, publishers) else {
+        let Some(observation) = SourceObservationConfig::new(identity, surface_kind, publishers)
+        else {
             return self;
         };
-        self.converter = observe_output_batch(
-            self.source_name.clone(),
-            self.table_name.clone(),
-            observation,
-            self.converter.clone(),
-        );
+        self.converter = observe_output_batch(observation, self.converter.clone());
         self
     }
 
@@ -170,20 +161,17 @@ impl JsonExec {
     #[must_use]
     pub(crate) fn with_source_observation_converter(
         mut self,
+        identity: SourceObservationIdentity,
         surface_kind: SourceObservationSurfaceKind,
         publishers: SourceObservationPublishers,
         observation_converter: Converter,
     ) -> Self {
-        let Some(observation) = SourceObservationConfig::new(surface_kind, publishers) else {
+        let Some(observation) = SourceObservationConfig::new(identity, surface_kind, publishers)
+        else {
             return self;
         };
-        self.converter = observe_source_scan_batch(
-            self.source_name.clone(),
-            self.table_name.clone(),
-            observation,
-            observation_converter,
-            self.converter.clone(),
-        );
+        self.converter =
+            observe_source_scan_batch(observation, observation_converter, self.converter.clone());
         self
     }
 }
@@ -313,7 +301,8 @@ mod tests {
 
     use super::{ChunkState, Converter, Fetcher, JsonExec, RowFetcher, next_projected_batch};
     use crate::backends::shared::source_observation::{
-        source_observation_publishers, test_support::RecordingSourceObservationPublisher,
+        SourceObservationIdentity, source_observation_publishers,
+        test_support::RecordingSourceObservationPublisher,
     };
     use crate::{SourceObservationPublisher, SourceObservationSurfaceKind};
 
@@ -429,6 +418,7 @@ mod tests {
         )
         .expect("exec should build")
         .with_source_observation(
+            SourceObservationIdentity::new("demo", None, "demo", "items"),
             SourceObservationSurfaceKind::Table,
             source_observation_publishers(&[
                 publisher.clone() as Arc<dyn SourceObservationPublisher>
@@ -485,6 +475,7 @@ mod tests {
         )
         .expect("exec should build")
         .with_source_observation(
+            SourceObservationIdentity::new("demo", None, "demo", "items"),
             SourceObservationSurfaceKind::Table,
             source_observation_publishers(&[
                 publisher.clone() as Arc<dyn SourceObservationPublisher>
@@ -534,6 +525,7 @@ mod tests {
         )
         .expect("exec should build")
         .with_source_observation_converter(
+            SourceObservationIdentity::new("demo", None, "demo", "items"),
             SourceObservationSurfaceKind::Table,
             source_observation_publishers(&[
                 publisher.clone() as Arc<dyn SourceObservationPublisher>
@@ -575,6 +567,7 @@ mod tests {
         )
         .expect("exec should build")
         .with_source_observation_converter(
+            SourceObservationIdentity::new("demo", None, "demo", "items"),
             SourceObservationSurfaceKind::Table,
             source_observation_publishers(&[
                 publisher.clone() as Arc<dyn SourceObservationPublisher>

--- a/crates/coral-engine/src/backends/shared/source_observation.rs
+++ b/crates/coral-engine/src/backends/shared/source_observation.rs
@@ -8,18 +8,49 @@ use crate::{SourceObservationPublisher, SourceObservationSurfaceKind, SourceScan
 
 pub(crate) type SourceObservationPublishers = Arc<[Arc<dyn SourceObservationPublisher>]>;
 
+#[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "explicit name suffixes distinguish each SQL and ownership coordinate"
+)]
+pub(crate) struct SourceObservationIdentity {
+    pub(crate) source_name: String,
+    pub(crate) catalog_name: Option<String>,
+    pub(crate) schema_name: String,
+    pub(crate) surface_name: String,
+}
+
+impl SourceObservationIdentity {
+    pub(crate) fn new(
+        source_name: impl Into<String>,
+        catalog_name: Option<String>,
+        schema_name: impl Into<String>,
+        surface_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            source_name: source_name.into(),
+            catalog_name,
+            schema_name: schema_name.into(),
+            surface_name: surface_name.into(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct SourceObservationConfig {
+    pub(crate) identity: SourceObservationIdentity,
     pub(crate) surface_kind: SourceObservationSurfaceKind,
     pub(crate) publishers: SourceObservationPublishers,
 }
 
 impl SourceObservationConfig {
     pub(crate) fn new(
+        identity: SourceObservationIdentity,
         surface_kind: SourceObservationSurfaceKind,
         publishers: SourceObservationPublishers,
     ) -> Option<Self> {
         (!publishers.is_empty()).then_some(Self {
+            identity,
             surface_kind,
             publishers,
         })
@@ -38,15 +69,16 @@ pub(crate) fn source_observation_publishers(
 /// backpressure, dropping, and shutdown drainage belong in the app-side
 /// publisher implementation that owns the corresponding lifecycle.
 pub(crate) fn publish_source_scan_batch(
-    source_name: &str,
-    surface_name: &str,
     observation: &SourceObservationConfig,
     batch: &RecordBatch,
 ) {
+    let identity = &observation.identity;
     let event = SourceScanObservation {
-        source_name,
+        source_name: &identity.source_name,
+        catalog_name: identity.catalog_name.as_deref(),
+        schema_name: &identity.schema_name,
         surface_kind: observation.surface_kind,
-        surface_name,
+        surface_name: &identity.surface_name,
         batch,
     };
     for publisher in observation.publishers.iter() {
@@ -56,8 +88,10 @@ pub(crate) fn publish_source_scan_batch(
         .is_err()
         {
             tracing::warn!(
-                source = source_name,
-                surface = surface_name,
+                source = identity.source_name,
+                catalog = identity.catalog_name,
+                schema = identity.schema_name,
+                surface = identity.surface_name,
                 "source observation publisher panicked; dropping source-scan observation"
             );
         }
@@ -79,6 +113,8 @@ pub(crate) mod test_support {
 
     pub(crate) struct RecordedSourceObservation {
         pub(crate) source_name: String,
+        pub(crate) catalog_name: Option<String>,
+        pub(crate) schema_name: String,
         pub(crate) surface_kind: SourceObservationSurfaceKind,
         pub(crate) surface_name: String,
         pub(crate) column_names: Vec<String>,
@@ -96,6 +132,8 @@ pub(crate) mod test_support {
         fn clone(&self) -> Self {
             Self {
                 source_name: self.source_name.clone(),
+                catalog_name: self.catalog_name.clone(),
+                schema_name: self.schema_name.clone(),
                 surface_kind: self.surface_kind,
                 surface_name: self.surface_name.clone(),
                 column_names: self.column_names.clone(),
@@ -112,6 +150,8 @@ pub(crate) mod test_support {
                 .expect("observations lock")
                 .push(RecordedSourceObservation {
                     source_name: observation.source_name.to_string(),
+                    catalog_name: observation.catalog_name.map(ToString::to_string),
+                    schema_name: observation.schema_name.to_string(),
                     surface_kind: observation.surface_kind,
                     surface_name: observation.surface_name.to_string(),
                     column_names: observation

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -93,11 +93,15 @@ pub enum SourceObservationSurfaceKind {
 /// One typed source-scan batch observed during shared source execution.
 #[derive(Debug, Clone, Copy)]
 pub struct SourceScanObservation<'a> {
-    /// Source/schema name.
+    /// Installed source that owns the scanned relation.
     pub source_name: &'a str,
+    /// SQL catalog used by a three-part relation, when present.
+    pub catalog_name: Option<&'a str>,
+    /// SQL schema containing the scanned relation.
+    pub schema_name: &'a str,
     /// Kind of source surface.
     pub surface_kind: SourceObservationSurfaceKind,
-    /// Table or function name within the source.
+    /// Table or function name within the SQL schema.
     pub surface_name: &'a str,
     /// Typed, table-shaped batch. Consumers that need to retain data must clone
     /// or enqueue it themselves.

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -541,13 +541,13 @@ pub trait SourceDecorator: Send + Sync {
     /// Stable decorator name used in diagnostics.
     fn name(&self) -> &'static str;
 
-    /// Whether this decorator supports sources registered as `SQL` catalogs.
+    /// Whether this decorator supports provider-discovered catalog sources.
     ///
-    /// Catalog-backed sources expose table providers lazily, so
-    /// [`SourceDecorator::decorate_source`] is not called for them. Decorators
-    /// should return `true` only when their guarantees remain intact without
-    /// decorating those table providers, such as when they only observe
-    /// registration lifecycle events.
+    /// Discovered database catalogs expose table providers lazily, so
+    /// [`SourceDecorator::decorate_source`] is not called for them. Static
+    /// source-named catalogs remain enumerable and are decorated normally.
+    /// Decorators should return `true` only when their guarantees remain intact
+    /// without decorating discovered providers.
     fn supports_catalog_sources(&self) -> bool {
         false
     }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -16,7 +16,8 @@ pub use query::{
     QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue,
     QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    ResolvedQueryResources, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
+    ResolvedQueryResources, RuntimeCatalogTarget, RuntimeSourceComponent, RuntimeSourcePackage,
+    SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 pub use udfs::{

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -61,7 +61,7 @@ pub struct RuntimeSourcePackage {
 /// SQL catalog placement for one app-assembled runtime package.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeCatalogTarget {
-    /// Publish static component schemas into DataFusion's default catalog.
+    /// Publish static component schemas into `DataFusion`'s default catalog.
     Default,
     /// Publish static component schemas together under the installed source name.
     Source,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -31,6 +31,7 @@ pub struct QuerySource {
     declared_inputs: Vec<ManifestInputSpec>,
     test_queries: Vec<String>,
     identity_requirements: Option<IdentityRequirements>,
+    catalog_target: RuntimeCatalogTarget,
     components: Vec<RuntimeSourceComponent>,
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
@@ -51,8 +52,19 @@ pub struct RuntimeSourcePackage {
     pub test_queries: Vec<String>,
     /// Source-level request identity requirements, when declared.
     pub identity_requirements: Option<IdentityRequirements>,
+    /// SQL catalog that receives the source's static runtime components.
+    pub catalog_target: RuntimeCatalogTarget,
     /// Backend-ready runtime components that make up the logical source.
     pub components: Vec<RuntimeSourceComponent>,
+}
+
+/// SQL catalog placement for one app-assembled runtime package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeCatalogTarget {
+    /// Publish static component schemas into DataFusion's default catalog.
+    Default,
+    /// Publish static component schemas together under the installed source name.
+    Source,
 }
 
 /// One backend-ready component inside an app-assembled query source package.
@@ -77,6 +89,7 @@ impl fmt::Debug for QuerySource {
             .field("description", &self.description)
             .field("declared_inputs", &self.declared_inputs)
             .field("test_queries", &self.test_queries)
+            .field("catalog_target", &self.catalog_target)
             .field("components", &self.components)
             .field("variables", &self.variables)
             .field("secret_count", &self.secrets.len())
@@ -146,6 +159,7 @@ impl QuerySource {
             declared_inputs: source_spec.declared_inputs().to_vec(),
             test_queries: source_spec.test_queries().to_vec(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components,
             variables,
             secrets,
@@ -167,6 +181,7 @@ impl QuerySource {
                 "runtime source package source_name must not be empty".to_string(),
             ));
         }
+        validate_runtime_catalog_target(&package)?;
         for component in &package.components {
             let schema_name = component.source_name();
             if schema_name.trim().is_empty() {
@@ -184,6 +199,7 @@ impl QuerySource {
             declared_inputs: package.declared_inputs,
             test_queries: package.test_queries,
             identity_requirements: package.identity_requirements,
+            catalog_target: package.catalog_target,
             components: package.components,
             variables,
             secrets,
@@ -234,19 +250,24 @@ impl QuerySource {
         })
     }
 
+    /// Returns the SQL catalog placement for this source's static components.
     #[must_use]
+    pub fn catalog_target(&self) -> &RuntimeCatalogTarget {
+        &self.catalog_target
+    }
+
     /// Returns backend-ready runtime components supplied by the app.
+    #[must_use]
     pub fn components(&self) -> &[RuntimeSourceComponent] {
         &self.components
     }
 
     #[must_use]
-    /// Returns the SQL schema names published by this source's two-part
-    /// components. Database components publish catalogs instead; see
-    /// [`Self::catalog_names`]. A source with no components claims its source
-    /// name as a schema. Schema and catalog names of all selected sources
-    /// share one flat namespace.
+    /// Returns the top-level SQL schema names claimed by a default-catalog source.
     pub fn schema_names(&self) -> Vec<&str> {
+        if matches!(self.catalog_target, RuntimeCatalogTarget::Source) {
+            return Vec::new();
+        }
         let mut names = Vec::new();
         for component in &self.components {
             if matches!(component, RuntimeSourceComponent::Database(_)) {
@@ -264,10 +285,11 @@ impl QuerySource {
     }
 
     #[must_use]
-    /// Returns the SQL catalog names published by this source's database
-    /// components. Tables of these components resolve as
-    /// `catalog.schema.table`, with schemas discovered at registration time.
+    /// Returns the top-level SQL catalog names claimed by this source.
     pub fn catalog_names(&self) -> Vec<&str> {
+        if matches!(self.catalog_target, RuntimeCatalogTarget::Source) {
+            return vec![self.source_name()];
+        }
         let mut names = Vec::new();
         for component in &self.components {
             let RuntimeSourceComponent::Database(manifest) = component else {
@@ -306,6 +328,42 @@ impl RuntimeSourceComponent {
             Self::Mcp(manifest) => &manifest.common.name,
         }
     }
+}
+
+fn validate_runtime_catalog_target(package: &RuntimeSourcePackage) -> Result<(), crate::CoreError> {
+    let database_components = package
+        .components
+        .iter()
+        .filter_map(|component| match component {
+            RuntimeSourceComponent::Database(manifest) => Some(manifest),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if !database_components.is_empty() && package.components.len() != 1 {
+        return Err(crate::CoreError::InvalidInput(format!(
+            "runtime source package '{}' mixes a discovered database catalog with static components",
+            package.source_name
+        )));
+    }
+
+    if matches!(package.catalog_target, RuntimeCatalogTarget::Default) {
+        if let Some(database) = database_components.first() {
+            return Err(crate::CoreError::InvalidInput(format!(
+                "database component '{}' requires the source-named catalog target",
+                database.common.name
+            )));
+        }
+        return Ok(());
+    }
+    if let Some(database) = database_components.first()
+        && database.common.name != package.source_name
+    {
+        return Err(crate::CoreError::InvalidInput(format!(
+            "runtime source package '{}' uses its source-named catalog, but its database component owns catalog '{}'",
+            package.source_name, database.common.name
+        )));
+    }
+    Ok(())
 }
 
 fn validate_runtime_source_identity_requirements(
@@ -1224,6 +1282,7 @@ impl QueryTableUsage {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct QueryTableFunctionUsage {
     source: String,
+    catalog: Option<String>,
     schema: String,
     function: String,
 }
@@ -1233,11 +1292,13 @@ impl QueryTableFunctionUsage {
     /// Builds one source-scoped table function usage entry.
     pub fn new(
         source_name: impl Into<String>,
+        catalog_name: Option<&str>,
         schema_name: impl Into<String>,
         function_name: impl Into<String>,
     ) -> Self {
         Self {
             source: source_name.into(),
+            catalog: catalog_name.map(ToString::to_string),
             schema: schema_name.into(),
             function: function_name.into(),
         }
@@ -1249,8 +1310,14 @@ impl QueryTableFunctionUsage {
         &self.source
     }
 
+    /// Returns the SQL catalog for this function, or `None` for two-part calls.
     #[must_use]
+    pub fn catalog_name(&self) -> Option<&str> {
+        self.catalog.as_deref()
+    }
+
     /// Returns the SQL schema name for this table function.
+    #[must_use]
     pub fn schema_name(&self) -> &str {
         &self.schema
     }
@@ -1271,7 +1338,9 @@ mod tests {
     use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
     use serde_json::json;
 
-    use super::{MemorySize, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+    use super::{
+        MemorySize, QuerySource, RuntimeCatalogTarget, RuntimeSourceComponent, RuntimeSourcePackage,
+    };
 
     #[test]
     fn memory_size_parses_binary_units() {
@@ -1310,6 +1379,7 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: Some(identity_requirements()),
+                catalog_target: RuntimeCatalogTarget::Default,
                 components: vec![RuntimeSourceComponent::Http(http_manifest())],
             },
             BTreeMap::new(),
@@ -1339,6 +1409,7 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: Some(requirements.clone()),
+                catalog_target: RuntimeCatalogTarget::Source,
                 components: vec![RuntimeSourceComponent::Http(manifest)],
             },
             BTreeMap::new(),

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -450,6 +450,25 @@ fn table_not_found_hint(
         .collect();
 
     if tables_in_schema.is_empty() {
+        // A former two-part v4 reference can name the correct inner schema and
+        // relation while omitting its source catalog. Suggest the unique
+        // canonical three-part identity instead of reporting that inner schema
+        // as globally unregistered.
+        let mut catalog_matches = known_tables.iter().filter(|info| {
+            info.catalog_name.is_some()
+                && eq_folded(schema, &[info.schema_name.as_str()])
+                && info.table_name.eq_ignore_ascii_case(table)
+        });
+        if let Some(hit) = catalog_matches.next()
+            && catalog_matches.next().is_none()
+        {
+            return Some(did_you_mean_hint(&format_schema_relation(
+                hit.catalog_name.as_deref(),
+                &hit.schema_name,
+                &hit.table_name,
+            )));
+        }
+
         // `known_tables` only contains successfully-registered sources, so an
         // empty schema here could mean either "not installed" or "configured
         // but failed to register". Keep the hint transport-neutral — point

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -87,8 +87,8 @@ pub use contracts::{
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
     QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
     QueryTestFailure, QueryTestResult, QueryTestSuccess, ResolvedQueryResources,
-    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
-    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    RuntimeCatalogTarget, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
+    StatusCode, StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
     TableFunctionResultColumnInfo, TableInfo,
 };
 pub use runtime::normalize_catalog_name;

--- a/crates/coral-engine/src/runtime/dependent_join/exec.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/exec.rs
@@ -21,7 +21,7 @@ use futures::{StreamExt, stream};
 use crate::SourceObservationSurfaceKind;
 use crate::backends::http::HttpSourceClient;
 use crate::backends::shared::source_observation::{
-    SourceObservationConfig, SourceObservationPublishers,
+    SourceObservationConfig, SourceObservationIdentity, SourceObservationPublishers,
 };
 use crate::runtime::dependent_join::bindings::BindingProjector;
 use crate::runtime::dependent_join::driver::run_binding_phase;
@@ -35,6 +35,7 @@ pub(crate) struct DependentJoinExec {
     resolver: Arc<dyn ExecutionPlan>,
     dependent: HttpSourceClient,
     dependent_source_schema: String,
+    source_observation_identity: SourceObservationIdentity,
     table: Arc<HttpTableSpec>,
     binding_keys: Arc<[BindingKey]>,
     literal_filters: Arc<BTreeMap<String, String>>,
@@ -57,6 +58,7 @@ pub(crate) struct DependentJoinExecConfig {
     pub(crate) resolver: Arc<dyn ExecutionPlan>,
     pub(crate) dependent: HttpSourceClient,
     pub(crate) dependent_source_schema: String,
+    pub(crate) source_observation_identity: SourceObservationIdentity,
     pub(crate) table: Arc<HttpTableSpec>,
     pub(crate) binding_keys: Arc<[BindingKey]>,
     pub(crate) literal_filters: Arc<BTreeMap<String, String>>,
@@ -84,6 +86,7 @@ impl DependentJoinExec {
             resolver: config.resolver,
             dependent: config.dependent,
             dependent_source_schema: config.dependent_source_schema,
+            source_observation_identity: config.source_observation_identity,
             table: config.table,
             binding_keys: config.binding_keys,
             literal_filters: config.literal_filters,
@@ -110,6 +113,7 @@ impl DependentJoinExec {
             resolver,
             dependent: self.dependent.clone(),
             dependent_source_schema: self.dependent_source_schema.clone(),
+            source_observation_identity: self.source_observation_identity.clone(),
             table: Arc::clone(&self.table),
             binding_keys: Arc::clone(&self.binding_keys),
             literal_filters: Arc::clone(&self.literal_filters),
@@ -286,6 +290,7 @@ impl ExecutionPlan for DependentJoinExec {
             .partition_count();
         let dependent = self.dependent.clone();
         let dependent_source_schema = self.dependent_source_schema.clone();
+        let source_observation_identity = self.source_observation_identity.clone();
         let table = Arc::clone(&self.table);
         let binding_keys = Arc::clone(&self.binding_keys);
         let dependent_projection = Arc::clone(&self.dependent_projection);
@@ -339,6 +344,7 @@ impl ExecutionPlan for DependentJoinExec {
                 max_concurrency,
                 max_rows_per_binding,
                 page_hint,
+                source_observation_identity,
                 source_observation_publishers,
                 metrics,
                 output_schema,
@@ -385,6 +391,7 @@ async fn execute_dependent_join(
     max_concurrency: usize,
     max_rows_per_binding: usize,
     page_hint: Option<usize>,
+    source_observation_identity: SourceObservationIdentity,
     source_observation_publishers: SourceObservationPublishers,
     metrics: DependentJoinMetrics,
     output_schema: SchemaRef,
@@ -416,6 +423,7 @@ async fn execute_dependent_join(
 
     let output_memory = state.memory().new_empty();
     let source_observation = SourceObservationConfig::new(
+        source_observation_identity,
         SourceObservationSurfaceKind::Table,
         source_observation_publishers,
     );

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -650,7 +650,7 @@ fn peel_dependent_side(plan: &LogicalPlan) -> PeelOutcome {
             };
 
             PeelOutcome::Match(PeeledDependentScan {
-                source_name: provider.source_schema().to_string(),
+                source_name: provider.source_name().to_string(),
                 table_ref: scan.table_name.clone(),
                 table_schema: scan.projected_schema.clone(),
                 table: Arc::clone(provider.table_spec()),

--- a/crates/coral-engine/src/runtime/dependent_join/output.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/output.rs
@@ -62,12 +62,7 @@ pub(crate) fn build_joined_batches(
             rows,
         )?;
         if let Some(source_observation) = config.source_observation {
-            publish_source_scan_batch(
-                config.dependent_source_schema,
-                config.dependent_table.name(),
-                source_observation,
-                &dependent_batch,
-            );
+            publish_source_scan_batch(source_observation, &dependent_batch);
         }
         // The rewrite replaced the Join node, so nothing downstream re-applies
         // the ON condition. APIs can resolve keyed lookups loosely (rename

--- a/crates/coral-engine/src/runtime/dependent_join/planner.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/planner.rs
@@ -8,7 +8,9 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 
 use crate::backends::http::HttpSourceTableProvider;
-use crate::backends::shared::source_observation::SourceObservationPublishers;
+use crate::backends::shared::source_observation::{
+    SourceObservationIdentity, SourceObservationPublishers,
+};
 use crate::runtime::dependent_join::exec::{DependentJoinExec, DependentJoinExecConfig};
 use crate::runtime::dependent_join::logical::DependentJoinNode;
 
@@ -38,6 +40,7 @@ impl ExtensionPlanner for DependentJoinExtensionPlanner {
             resolver: Arc::clone(resolver),
             dependent: provider.client,
             dependent_source_schema: provider.source_schema,
+            source_observation_identity: provider.source_observation_identity,
             table: provider.table,
             binding_keys: Arc::from(node.binding_keys.clone()),
             literal_filters: Arc::new(node.literal_filters.clone()),
@@ -61,6 +64,7 @@ impl ExtensionPlanner for DependentJoinExtensionPlanner {
 struct ResolvedHttpDependent {
     client: crate::backends::http::HttpSourceClient,
     source_schema: String,
+    source_observation_identity: SourceObservationIdentity,
     table: Arc<coral_spec::backends::http::HttpTableSpec>,
     source_observation_publishers: SourceObservationPublishers,
 }
@@ -108,6 +112,13 @@ async fn resolve_http_provider(
     Ok(ResolvedHttpDependent {
         client: provider.client().clone(),
         source_schema: provider.source_schema().to_string(),
+        source_observation_identity: SourceObservationIdentity::new(
+            provider.source_name(),
+            crate::runtime::normalize_catalog_name(Some(&table_ref.catalog))
+                .map(ToString::to_string),
+            table_ref.schema.as_ref(),
+            table_ref.table.as_ref(),
+        ),
         table: Arc::clone(provider.table_spec()),
         source_observation_publishers: Arc::clone(provider.source_observation_publishers()),
     })

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -345,12 +345,7 @@ async fn build_registered_runtime(
         config.source_decorators,
     )
     .await?;
-    let source_functions = SourceFunctionRegistry::new(
-        registration
-            .active_sources
-            .iter()
-            .flat_map(|source| source.table_functions.iter()),
-    );
+    let source_functions = SourceFunctionRegistry::new(&registration.active_sources);
     let source_function_names = source_functions.names();
     let udf_table_functions = published_table_functions(config.udfs, &source_function_names)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
@@ -427,20 +422,40 @@ fn validate_catalog_surface_namespace(
     tables: &[TableInfo],
     table_functions: &[TableFunctionInfo],
 ) -> Result<(), CoreError> {
-    let two_part_tables = tables
+    let table_names = tables
         .iter()
-        .filter(|table| table.catalog_name.is_none())
-        .map(|table| ScopedTableFunctionName::from_parts(&table.schema_name, &table.table_name))
+        .map(|table| {
+            ScopedTableFunctionName::from_catalog_parts(
+                table
+                    .catalog_name
+                    .as_deref()
+                    .unwrap_or(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
+                &table.schema_name,
+                &table.table_name,
+            )
+        })
         .collect::<HashSet<_>>();
     if let Some(function) = table_functions.iter().find(|function| {
-        two_part_tables.contains(&ScopedTableFunctionName::from_parts(
+        table_names.contains(&ScopedTableFunctionName::from_catalog_parts(
+            function
+                .catalog_name
+                .as_deref()
+                .unwrap_or(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
             &function.schema_name,
             &function.function_name,
         ))
     }) {
+        let name = function.catalog_name.as_ref().map_or_else(
+            || format!("{}.{}", function.schema_name, function.function_name),
+            |catalog| {
+                format!(
+                    "{catalog}.{}.{}",
+                    function.schema_name, function.function_name
+                )
+            },
+        );
         return Err(CoreError::FailedPrecondition(format!(
-            "catalog surface '{}.{}' is registered as both a table and a table function",
-            function.schema_name, function.function_name
+            "catalog surface '{name}' is registered as both a table and a table function"
         )));
     }
     Ok(())
@@ -531,7 +546,7 @@ async fn register_runtime_sources(
             &extension_hooks.source_observation_publishers,
             request_identity_http_authenticators,
         ) {
-            Ok(compiled) => {
+            Ok(Some(compiled)) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
                     CompiledQuerySource {
                         source: source.clone(),
@@ -539,6 +554,7 @@ async fn register_runtime_sources(
                     },
                 ));
             }
+            Ok(None) => {}
             Err(error) => source_candidates.push(SourceRegistrationCandidate::CompileFailed {
                 source: source.clone(),
                 error,
@@ -969,6 +985,7 @@ impl QueryRuntimeAdapter {
             return self.tables.clone();
         }
         match self.table_metadata_for_error_context(&filters).await {
+            Ok(tables) if tables.is_empty() => self.tables.clone(),
             Ok(tables) => tables,
             Err(error) => {
                 tracing::debug!(
@@ -1036,7 +1053,10 @@ impl QueryRuntimeAdapter {
         sources.extend(
             table_functions
                 .iter()
-                .filter(|usage| self.name_to_source.contains_key(usage.schema_name()))
+                .filter(|usage| {
+                    self.name_to_source
+                        .contains_key(usage.catalog_name().unwrap_or(usage.schema_name()))
+                })
                 .map(|usage| usage.source_name().to_string()),
         );
 
@@ -1114,8 +1134,11 @@ impl QueryRuntimeAdapter {
         let Some((schema_name, function_name)) = relation_parts(table_reference) else {
             return false;
         };
+        let catalog_name = normalize_catalog_name(table_reference.catalog());
         if self.table_functions.iter().any(|function| {
-            function.schema_name == schema_name && function.function_name == function_name
+            function.catalog_name.as_deref() == catalog_name
+                && function.schema_name == schema_name
+                && function.function_name == function_name
         }) {
             return self.record_table_function_usage(table_reference, table_functions);
         }
@@ -1130,8 +1153,10 @@ impl QueryRuntimeAdapter {
         let Some((schema_name, function_name)) = relation_parts(table_reference) else {
             return false;
         };
+        let catalog_name = normalize_catalog_name(table_reference.catalog());
         table_functions.insert(QueryTableFunctionUsage::new(
-            self.source_name_for(schema_name),
+            self.source_name_for(catalog_name.unwrap_or(schema_name)),
+            catalog_name,
             schema_name,
             function_name,
         ));

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 use tracing::{Instrument as _, info_span};
@@ -13,7 +14,7 @@ use crate::backends::{
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
-use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
+use crate::{CoreError, QuerySource, RuntimeCatalogTarget, SourceDecorator, SourceFailurePolicy};
 
 /// Source SQL names the runtime owns. Mirrored by `RESERVED_SOURCE_SCHEMA_NAMES`
 /// in `coral-spec`, which rejects the same names during manifest validation so a
@@ -139,6 +140,7 @@ async fn register_sources_inner(
                     &registration_context,
                     &mut seen_schemas,
                     &mut seen_catalogs,
+                    query_source,
                     compiled_source.as_ref(),
                 )
                 .await
@@ -243,13 +245,25 @@ async fn register_source(
     registration_context: &BackendRegistrationContext,
     seen_schemas: &mut std::collections::HashSet<String>,
     seen_catalogs: &mut std::collections::HashSet<String>,
+    query_source: &QuerySource,
     source: &dyn CompiledBackendSource,
 ) -> DataFusionResult<BackendRegistration> {
     source.validate_runtime_capabilities()?;
 
     let registration = source.register(ctx, registration_context).await?;
-    claim_registration_schemas(&registration, seen_schemas)?;
-    claim_registration_catalogs(&registration, seen_catalogs)?;
+    match query_source.catalog_target() {
+        RuntimeCatalogTarget::Default => {
+            claim_registration_schemas(&registration, seen_schemas)?;
+            claim_registration_catalogs(&registration, seen_catalogs)?;
+        }
+        RuntimeCatalogTarget::Source => {
+            claim_named_catalog_registration(
+                &registration,
+                query_source.source_name(),
+                seen_catalogs,
+            )?;
+        }
+    }
 
     Ok(registration)
 }
@@ -272,6 +286,36 @@ fn claim_registration_schemas(
         }
     }
     seen_schemas.extend(registration_schemas);
+    Ok(())
+}
+
+fn claim_named_catalog_registration(
+    registration: &BackendRegistration,
+    catalog_name: &str,
+    seen_catalogs: &mut std::collections::HashSet<String>,
+) -> DataFusionResult<()> {
+    check_reserved_schema(catalog_name)?;
+    if seen_catalogs.contains(catalog_name) {
+        return Err(DataFusionError::Execution(format!(
+            "duplicate source catalog '{catalog_name}'"
+        )));
+    }
+    if !registration.schemas.is_empty() && !registration.catalogs.is_empty() {
+        return Err(DataFusionError::Execution(format!(
+            "source catalog '{catalog_name}' mixes static schemas with a discovered catalog"
+        )));
+    }
+    if registration.catalogs.len() > 1
+        || registration
+            .catalogs
+            .iter()
+            .any(|catalog| catalog.source.qualified_name.name() != catalog_name)
+    {
+        return Err(DataFusionError::Execution(format!(
+            "runtime package target '{catalog_name}' does not match its discovered catalog registration"
+        )));
+    }
+    seen_catalogs.insert(catalog_name.to_string());
     Ok(())
 }
 
@@ -305,6 +349,19 @@ fn register_backend_registration(
     registration: BackendRegistration,
     result: &mut SourceRegistrationResult,
 ) -> std::result::Result<(), CoreError> {
+    if matches!(query_source.catalog_target(), RuntimeCatalogTarget::Source)
+        && registration.catalogs.is_empty()
+    {
+        return register_named_static_catalog(
+            ctx,
+            source_decorators,
+            query_source,
+            query_source.source_name(),
+            registration.schemas,
+            result,
+        );
+    }
+
     // Source decorators wrap table providers at registration time, but catalog
     // registrations expose providers lazily through the catalog itself.
     // Decorators must explicitly allow that their table-decoration hook is
@@ -376,22 +433,71 @@ fn register_backend_registration(
         result.active_sources.push(registered_source);
     }
     for (catalog_name, _registered_catalog, registered_source, column_fetcher) in catalog_staged {
-        result.column_fetchers.push(CatalogColumnFetcher {
-            catalog_name,
-            relation_names: registered_source
-                .tables
-                .iter()
-                .filter_map(|table| {
-                    table
-                        .schema_name
-                        .as_ref()
-                        .map(|schema_name| (schema_name.clone(), table.table_name.clone()))
-                })
-                .collect(),
-            fetcher: column_fetcher,
-        });
+        if let Some(fetcher) = column_fetcher {
+            result.column_fetchers.push(CatalogColumnFetcher {
+                catalog_name,
+                relation_names: registered_source
+                    .tables
+                    .iter()
+                    .filter_map(|table| {
+                        table
+                            .schema_name
+                            .as_ref()
+                            .map(|schema_name| (schema_name.clone(), table.table_name.clone()))
+                    })
+                    .collect(),
+                fetcher,
+            });
+        }
         result.active_sources.push(registered_source);
     }
+    Ok(())
+}
+
+fn register_named_static_catalog(
+    ctx: &SessionContext,
+    source_decorators: &mut [Box<dyn SourceDecorator>],
+    query_source: &QuerySource,
+    catalog_name: &str,
+    schemas: Vec<BackendSchemaRegistration>,
+    result: &mut SourceRegistrationResult,
+) -> Result<(), CoreError> {
+    let provider: Arc<dyn CatalogProvider> = Arc::new(MemoryCatalogProvider::new());
+    let mut tables = Vec::new();
+    let mut table_functions = Vec::new();
+    let mut inputs = Vec::new();
+    let mut input_keys = std::collections::HashSet::new();
+
+    for schema in schemas {
+        let BackendSchemaRegistration {
+            tables: schema_tables,
+            source,
+        } = schema;
+        let schema_name = source.qualified_name.name().to_string();
+        let decorated = decorate_source_tables(source_decorators, query_source, schema_tables)?;
+        provider
+            .register_schema(&schema_name, Arc::new(StaticSchemaProvider::new(decorated)))
+            .map_err(|error| datafusion_to_core(&error, &[]))?;
+
+        tables.extend(source.tables.into_iter().map(|mut table| {
+            table.schema_name = Some(schema_name.clone());
+            table
+        }));
+        table_functions.extend(source.table_functions);
+        for input in source.inputs {
+            if input_keys.insert(input.key.clone()) {
+                inputs.push(input);
+            }
+        }
+    }
+
+    ctx.register_catalog(catalog_name, provider);
+    result.active_sources.push(RegisteredSource {
+        qualified_name: crate::backends::SourceQualifiedName::Catalog(catalog_name.to_string()),
+        tables,
+        table_functions,
+        inputs,
+    });
     Ok(())
 }
 
@@ -500,7 +606,7 @@ fn source_decorator_error(name: &str, error: &crate::SourceDecoratorError) -> Co
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::{CoreError, QuerySource, RuntimeSourcePackage};
+    use crate::{CoreError, QuerySource, RuntimeCatalogTarget, RuntimeSourcePackage};
 
     use super::{check_reserved_schema, validate_selected_source_names};
 
@@ -566,6 +672,7 @@ mod tests {
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
                 identity_requirements: None,
+                catalog_target: RuntimeCatalogTarget::Default,
                 components: Vec::new(),
             },
             BTreeMap::new(),

--- a/crates/coral-engine/src/runtime/scoped_table_functions.rs
+++ b/crates/coral-engine/src/runtime/scoped_table_functions.rs
@@ -32,29 +32,31 @@ pub(crate) trait ScopedTableFunctionSignature {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct ScopedTableFunctionName {
+    pub(crate) catalog: String,
     pub(crate) schema: String,
     pub(crate) function: String,
 }
 
 impl ScopedTableFunctionName {
     pub(crate) fn from_parts(schema: &str, function: &str) -> Self {
+        Self::from_catalog_parts(crate::runtime::DATAFUSION_DEFAULT_CATALOG, schema, function)
+    }
+
+    pub(crate) fn from_catalog_parts(catalog: &str, schema: &str, function: &str) -> Self {
         Self {
+            catalog: normalize_runtime_identifier(catalog),
             schema: normalize_runtime_identifier(schema),
             function: normalize_runtime_identifier(function),
         }
     }
 
-    pub(crate) fn from_manifest(function: &RegisteredTableFunction) -> Self {
+    pub(crate) fn from_manifest(catalog: Option<&str>, function: &RegisteredTableFunction) -> Self {
         Self {
+            catalog: catalog
+                .unwrap_or(crate::runtime::DATAFUSION_DEFAULT_CATALOG)
+                .to_string(),
             schema: function.schema_name.clone(),
             function: function.function_name.clone(),
-        }
-    }
-
-    fn from_sql(schema: Ident, function: Ident, context: &dyn RelationPlannerContext) -> Self {
-        Self {
-            schema: context.normalize_ident(schema),
-            function: context.normalize_ident(function),
         }
     }
 }
@@ -83,16 +85,32 @@ impl ScopedTableFunctionCall {
             return None;
         };
 
-        // Coral function surfaces are exactly `schema.function(...)`. Longer
-        // names belong to DataFusion's normal relation/function planner.
-        let [schema, function] = name.0.as_slice() else {
-            return None;
+        let (lookup_key, display_name) = match name.0.as_slice() {
+            [schema, function] => {
+                let schema = schema.as_ident()?.clone();
+                let function = function.as_ident()?.clone();
+                let display_name = qualified_name(&schema.value, &function.value);
+                let lookup_key = ScopedTableFunctionName {
+                    catalog: crate::runtime::DATAFUSION_DEFAULT_CATALOG.to_string(),
+                    schema: context.normalize_ident(schema),
+                    function: context.normalize_ident(function),
+                };
+                (lookup_key, display_name)
+            }
+            [catalog, schema, function] => {
+                let catalog = catalog.as_ident()?.clone();
+                let schema = schema.as_ident()?.clone();
+                let function = function.as_ident()?.clone();
+                let display_name = format!("{}.{}.{}", catalog.value, schema.value, function.value);
+                let lookup_key = ScopedTableFunctionName {
+                    catalog: context.normalize_ident(catalog),
+                    schema: context.normalize_ident(schema),
+                    function: context.normalize_ident(function),
+                };
+                (lookup_key, display_name)
+            }
+            _ => return None,
         };
-
-        let schema = schema.as_ident()?.clone();
-        let function = function.as_ident()?.clone();
-        let display_name = qualified_name(&schema.value, &function.value);
-        let lookup_key = ScopedTableFunctionName::from_sql(schema, function, context);
 
         Some(Self {
             lookup_key,
@@ -123,12 +141,15 @@ pub(crate) fn qualified_name(schema: &str, function: &str) -> String {
 }
 
 pub(crate) fn available_functions_hint<'a>(
+    catalog: &str,
     schema: &str,
     functions: impl IntoIterator<Item = (&'a ScopedTableFunctionName, &'a str)>,
 ) -> String {
     let mut names: Vec<&str> = functions
         .into_iter()
-        .filter_map(|(key, display_name)| (key.schema == schema).then_some(display_name))
+        .filter_map(|(key, display_name)| {
+            (key.catalog == catalog && key.schema == schema).then_some(display_name)
+        })
         .collect();
     names.sort_unstable();
 

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -35,7 +35,7 @@ use datafusion::prelude::SessionContext;
 use crate::backends::shared::filter_expr::literal_to_string;
 use crate::backends::shared::scalar::timestamp_to_rfc3339;
 use crate::backends::{
-    BoundSourceFunctionArg, BoundSourceFunctionValue, RegisteredTableFunction,
+    BoundSourceFunctionArg, BoundSourceFunctionValue, RegisteredSource, RegisteredTableFunction,
     RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
 };
 use crate::runtime::literal_scalar_value;
@@ -54,25 +54,29 @@ const SOURCE_FUNCTION_ANALYZER_RULE_NAME: &str = "coral_source_functions";
 #[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
     functions: HashMap<ScopedTableFunctionName, SourceFunction>,
-    source_schemas: HashSet<String>,
+    source_qualifiers: HashSet<(String, String)>,
 }
 
 impl SourceFunctionRegistry {
-    pub(crate) fn new<'a>(
-        functions: impl IntoIterator<Item = &'a RegisteredTableFunction>,
-    ) -> Self {
-        let mut source_schemas = HashSet::new();
+    pub(crate) fn new(sources: &[RegisteredSource]) -> Self {
+        let mut source_qualifiers = HashSet::new();
         let mut functions_by_name = HashMap::new();
 
-        for function in functions {
-            let lookup_key = ScopedTableFunctionName::from_manifest(function);
-            source_schemas.insert(lookup_key.schema.clone());
-            functions_by_name.insert(lookup_key, SourceFunction::from_registered(function));
+        for source in sources {
+            let catalog = source.qualified_name.catalog_name();
+            for function in &source.table_functions {
+                let lookup_key = ScopedTableFunctionName::from_manifest(catalog, function);
+                source_qualifiers.insert((lookup_key.catalog.clone(), lookup_key.schema.clone()));
+                functions_by_name.insert(
+                    lookup_key.clone(),
+                    SourceFunction::from_registered(function, catalog),
+                );
+            }
         }
 
         Self {
             functions: functions_by_name,
-            source_schemas,
+            source_qualifiers,
         }
     }
 
@@ -124,16 +128,41 @@ impl SourceFunctionRegistry {
         self.functions.get(&call.lookup_key)
     }
 
-    fn owns_schema(&self, call: &ScopedTableFunctionCall) -> bool {
-        self.source_schemas.contains(&call.lookup_key.schema)
+    fn owns_qualifier(&self, call: &ScopedTableFunctionCall) -> bool {
+        self.source_qualifiers.contains(&(
+            call.lookup_key.catalog.clone(),
+            call.lookup_key.schema.clone(),
+        ))
     }
 
-    fn available_functions_hint(&self, schema: &str) -> String {
+    fn available_functions_hint(&self, catalog: &str, schema: &str) -> String {
         available_functions_hint(
+            catalog,
             schema,
             self.functions
                 .iter()
                 .map(|(key, function)| (key, function.display_name.as_str())),
+        )
+    }
+
+    fn canonical_catalog_hint(&self, call: &ScopedTableFunctionCall) -> String {
+        if call.lookup_key.catalog != crate::runtime::DATAFUSION_DEFAULT_CATALOG {
+            return String::new();
+        }
+        let mut matches = self.functions.iter().filter(|(key, _)| {
+            key.catalog != crate::runtime::DATAFUSION_DEFAULT_CATALOG
+                && key.schema == call.lookup_key.schema
+                && key.function == call.lookup_key.function
+        });
+        let Some((_, function)) = matches.next() else {
+            return String::new();
+        };
+        if matches.next().is_some() {
+            return String::new();
+        }
+        format!(
+            "; use the canonical function name {}",
+            function.display_name
         )
     }
 }
@@ -149,8 +178,13 @@ impl RelationPlanner for SourceFunctionRegistry {
         };
 
         let Some(function) = self.find(&call) else {
-            if self.owns_schema(&call) {
-                let hint = self.available_functions_hint(&call.lookup_key.schema);
+            let canonical_hint = self.canonical_catalog_hint(&call);
+            if !canonical_hint.is_empty() {
+                return Err(call.unknown_function_error("source table function", &canonical_hint));
+            }
+            if self.owns_qualifier(&call) {
+                let hint = self
+                    .available_functions_hint(&call.lookup_key.catalog, &call.lookup_key.schema);
                 return Err(call.unknown_function_error("source table function", &hint));
             }
             return Ok(original_relation(relation));
@@ -189,18 +223,36 @@ struct SourceFunction {
 }
 
 impl SourceFunction {
-    fn from_registered(function: &RegisteredTableFunction) -> Self {
+    fn from_registered(function: &RegisteredTableFunction, catalog: Option<&str>) -> Self {
         let arguments = function
             .arguments
             .iter()
             .map(SourceFunctionArgument::from_registered)
             .collect::<Vec<_>>();
+        let (display_name, table_reference) = if let Some(catalog) = catalog {
+            (
+                format!(
+                    "{catalog}.{}.{}",
+                    function.schema_name, function.function_name
+                ),
+                TableReference::full(
+                    catalog.to_string(),
+                    function.schema_name.clone(),
+                    function.function_name.clone(),
+                ),
+            )
+        } else {
+            (
+                qualified_name(&function.schema_name, &function.function_name),
+                TableReference::partial(
+                    function.schema_name.clone(),
+                    function.function_name.clone(),
+                ),
+            )
+        };
         Self {
-            display_name: qualified_name(&function.schema_name, &function.function_name),
-            table_reference: TableReference::partial(
-                function.schema_name.clone(),
-                function.function_name.clone(),
-            ),
+            display_name,
+            table_reference,
             arguments,
             factory: Arc::clone(&function.factory),
         }

--- a/crates/coral-engine/src/runtime/udf_calls.rs
+++ b/crates/coral-engine/src/runtime/udf_calls.rs
@@ -54,6 +54,7 @@ impl UdfCallRegistry {
     ) -> Result<Self> {
         let source_function_schemas = source_functions
             .iter()
+            .filter(|function| function.catalog == crate::runtime::DATAFUSION_DEFAULT_CATALOG)
             .map(|function| function.schema.clone())
             .collect();
         let mut registry = Self {
@@ -107,7 +108,8 @@ impl UdfCallRegistry {
     }
 
     fn owns_udf_only_schema(&self, call: &ScopedTableFunctionCall) -> bool {
-        self.udf_schemas.contains(&call.lookup_key.schema)
+        call.lookup_key.catalog == crate::runtime::DATAFUSION_DEFAULT_CATALOG
+            && self.udf_schemas.contains(&call.lookup_key.schema)
             && !self
                 .source_function_schemas
                 .contains(&call.lookup_key.schema)
@@ -115,6 +117,7 @@ impl UdfCallRegistry {
 
     fn available_functions_hint(&self, schema: &str) -> String {
         available_functions_hint(
+            crate::runtime::DATAFUSION_DEFAULT_CATALOG,
             schema,
             self.functions
                 .iter()

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -7,17 +7,44 @@ use coral_engine::{
     BoundRequestIdentityHttpAuthenticator, CoralQuery, QueryRuntimeConfig, QuerySource,
     RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
     RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
-    RuntimeSourceComponent, RuntimeSourcePackage, SelectedRequestIdentity,
+    RuntimeCatalogTarget, RuntimeSourceComponent, RuntimeSourcePackage, SelectedRequestIdentity,
 };
-use coral_spec::parse_source_manifest_yaml;
 use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
 use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
+use coral_spec::{parse_source_manifest_value, parse_source_manifest_yaml};
 use reqwest::header::{HeaderName, HeaderValue};
 use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{execution_to_rows, test_runtime};
+
+#[tokio::test]
+async fn source_without_runtime_components_registers_nothing() {
+    let source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "empty_v4".to_string(),
+            authored_version: None,
+            description: String::new(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Source,
+            components: Vec::new(),
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("empty runtime package");
+
+    let catalog = CoralQuery::list_catalog(&[source], test_runtime(), None, None)
+        .await
+        .expect("empty source should not fail runtime registration");
+
+    assert!(catalog.tables.iter().all(|table| {
+        table.catalog_name.as_deref() != Some("empty_v4") && table.schema_name != "empty_v4"
+    }));
+}
 
 #[tokio::test]
 async fn multi_component_source_executes_across_component_tables() {
@@ -47,6 +74,7 @@ async fn multi_component_source_executes_across_component_tables() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components: vec![
                 RuntimeSourceComponent::Http(issues),
                 RuntimeSourceComponent::Http(pulls),
@@ -77,6 +105,72 @@ async fn multi_component_source_executes_across_component_tables() {
 }
 
 #[tokio::test]
+async fn named_static_catalog_invokes_catalog_qualified_function() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{"title": "Flaky cleanup"}]
+        })))
+        .mount(&server)
+        .await;
+    let source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "github_v4".to_string(),
+            authored_version: None,
+            description: String::new(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Source,
+            components: vec![RuntimeSourceComponent::Http(http_function_component(
+                &server.uri(),
+                "issues",
+            ))],
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("runtime package");
+
+    let legacy_error = CoralQuery::execute_sql(
+        &[source.clone()],
+        test_runtime(),
+        "SELECT title FROM issues.search_issues(q => 'flaky')",
+    )
+    .await
+    .expect_err("the former two-part function name must not resolve");
+    assert!(
+        legacy_error
+            .to_string()
+            .contains("use the canonical function name github_v4.issues.search_issues"),
+        "unexpected error: {legacy_error}"
+    );
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM github_v4.issues.search_issues(q => 'flaky')",
+    )
+    .await
+    .expect("catalog-qualified function query");
+
+    assert_eq!(
+        execution_to_rows(&execution),
+        vec![json!({"title": "Flaky cleanup"})]
+    );
+    let usage = execution
+        .provenance()
+        .table_functions()
+        .first()
+        .expect("function provenance");
+    assert_eq!(usage.source_name(), "github_v4");
+    assert_eq!(usage.catalog_name(), Some("github_v4"));
+    assert_eq!(usage.schema_name(), "issues");
+    assert_eq!(usage.function_name(), "search_issues");
+}
+
+#[tokio::test]
 async fn composite_source_rejects_unsupported_lookup_key_component_backend() {
     let source = QuerySource::from_runtime_components(
         RuntimeSourcePackage {
@@ -86,6 +180,7 @@ async fn composite_source_rejects_unsupported_lookup_key_component_backend() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components: vec![RuntimeSourceComponent::File(
                 file_component_with_lookup_key_filter(),
             )],
@@ -108,7 +203,7 @@ async fn composite_source_rejects_unsupported_lookup_key_component_backend() {
 }
 
 #[tokio::test]
-async fn multi_component_source_can_register_multiple_schemas() {
+async fn named_static_catalog_executes_across_component_schemas() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/issues"))
@@ -129,12 +224,13 @@ async fn multi_component_source_can_register_multiple_schemas() {
     let pulls = http_component(&server.uri(), "github_mcp", "pulls", "/pulls");
     let source = QuerySource::from_runtime_components(
         RuntimeSourcePackage {
-            source_name: "github".to_string(),
+            source_name: "github_v4".to_string(),
             authored_version: None,
             description: "Composite GitHub runtime package".to_string(),
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Source,
             components: vec![
                 RuntimeSourceComponent::Http(issues),
                 RuntimeSourceComponent::Http(pulls),
@@ -145,11 +241,25 @@ async fn multi_component_source_can_register_multiple_schemas() {
     )
     .expect("runtime package");
 
+    let legacy_error = CoralQuery::execute_sql(
+        &[source.clone()],
+        test_runtime(),
+        "SELECT id FROM github_rest.issues",
+    )
+    .await
+    .expect_err("the former two-part table name must not resolve");
+    assert!(
+        legacy_error
+            .to_string()
+            .contains("github_v4.github_rest.issues"),
+        "unexpected error: {legacy_error}"
+    );
+
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
             test_runtime(),
-            "SELECT 'issue' AS kind, id, title FROM github_rest.issues UNION ALL SELECT 'pull' AS kind, id, title FROM github_mcp.pulls ORDER BY kind",
+            "SELECT 'issue' AS kind, id, title FROM github_v4.github_rest.issues UNION ALL SELECT 'pull' AS kind, id, title FROM github_v4.github_mcp.pulls ORDER BY kind",
         )
         .await
         .expect("query should execute"),
@@ -165,6 +275,44 @@ async fn multi_component_source_can_register_multiple_schemas() {
 }
 
 #[tokio::test]
+async fn named_catalog_rejects_case_insensitive_relation_collisions() {
+    let source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "github_v4".to_string(),
+            authored_version: None,
+            description: String::new(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Source,
+            components: vec![
+                RuntimeSourceComponent::Http(http_component(
+                    "https://example.com",
+                    "issues",
+                    "Events",
+                    "/events",
+                )),
+                RuntimeSourceComponent::Http(http_component(
+                    "https://example.com",
+                    "ISSUES",
+                    "events",
+                    "/other-events",
+                )),
+            ],
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("runtime package");
+
+    let error = CoralQuery::validate_source(&source, test_runtime(), &[])
+        .await
+        .expect_err("case-insensitive duplicate relation");
+
+    assert!(error.to_string().contains("duplicate relation"), "{error}");
+}
+
+#[tokio::test]
 async fn selected_sources_reject_runtime_schema_collisions() {
     let server = MockServer::start().await;
     let first = QuerySource::from_runtime_components(
@@ -175,6 +323,7 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components: vec![RuntimeSourceComponent::Http(http_component(
                 &server.uri(),
                 "github_v4_rest",
@@ -194,6 +343,7 @@ async fn selected_sources_reject_runtime_schema_collisions() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components: vec![RuntimeSourceComponent::Http(http_component(
                 &server.uri(),
                 "github_v4_rest",
@@ -231,6 +381,7 @@ async fn validate_source_reports_only_component_schemas_for_multi_schema_source(
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components: vec![
                 RuntimeSourceComponent::Http(issues),
                 RuntimeSourceComponent::Http(pulls),
@@ -444,6 +595,43 @@ tables:
     manifest.as_http().expect("http manifest").clone()
 }
 
+fn http_function_component(
+    base_url: &str,
+    schema_name: &str,
+) -> coral_spec::backends::http::HttpSourceManifest {
+    let manifest = parse_source_manifest_value(json!({
+        "name": schema_name,
+        "version": "1.0.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "functions": [{
+            "name": "search_issues",
+            "kind": "search",
+            "description": "Search issues",
+            "search_limits": {
+                "default_top_k": 10,
+                "max_top_k": 100,
+                "max_calls_per_query": 1
+            },
+            "args": [{
+                "name": "q",
+                "required": true,
+                "bind": { "arg": "q" }
+            }],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/issues",
+                "query": [{ "name": "q", "from": "arg", "key": "q" }]
+            },
+            "response": { "rows_path": ["items"] },
+            "columns": [{ "name": "title", "type": "Utf8" }]
+        }]
+    }))
+    .expect("function manifest");
+    manifest.as_http().expect("HTTP manifest").clone()
+}
+
 fn identity_http_component() -> coral_spec::backends::http::HttpSourceManifest {
     let mut manifest = http_component(
         "https://api.example.com",
@@ -472,6 +660,7 @@ fn identity_runtime_source_with_components(
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: Some(identity_requirements()),
+            catalog_target: RuntimeCatalogTarget::Default,
             components: components
                 .into_iter()
                 .map(RuntimeSourceComponent::Http)

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -134,7 +134,7 @@ async fn named_static_catalog_invokes_catalog_qualified_function() {
     .expect("runtime package");
 
     let legacy_error = CoralQuery::execute_sql(
-        &[source.clone()],
+        std::slice::from_ref(&source),
         test_runtime(),
         "SELECT title FROM issues.search_issues(q => 'flaky')",
     )
@@ -242,7 +242,7 @@ async fn named_static_catalog_executes_across_component_schemas() {
     .expect("runtime package");
 
     let legacy_error = CoralQuery::execute_sql(
-        &[source.clone()],
+        std::slice::from_ref(&source),
         test_runtime(),
         "SELECT id FROM github_rest.issues",
     )

--- a/crates/coral-engine/tests/engine/dependent_join_execution_tests.rs
+++ b/crates/coral-engine/tests/engine/dependent_join_execution_tests.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use coral_engine::{
     CoralQuery, CoreError, DependentJoinConfig, DependentJoinSourceConfig, MemorySize,
-    QueryRuntimeConfig, QuerySource, StatusCode,
+    QueryRuntimeConfig, QuerySource, RuntimeCatalogTarget, RuntimeSourcePackage, StatusCode,
 };
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use serde_json::{Value, json};
@@ -1683,6 +1683,64 @@ async fn dependent_join_source_config_disables_rewrite_for_source() {
         SELECT i.title AS issue_title, pr.state AS pr_state
         FROM issues.items AS i
         JOIN github.pull_requests AS pr
+          ON pr.owner = i.github_owner
+         AND pr.repo = i.github_repo
+         AND pr.number = i.github_pr_number
+        ORDER BY i.title
+        ",
+    )
+    .await
+    .expect("explain should succeed");
+
+    let explain = execution_text(&execution);
+    assert!(!explain.contains("DependentJoinExec"), "{explain}");
+}
+
+#[tokio::test]
+async fn dependent_join_source_config_uses_installed_owner_for_named_catalog() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "issues.jsonl",
+        &[issue_row("First", "withcoral", "coral", 123)],
+    );
+    let component = build_source(source_named(
+        github_broad_query_manifest("http://127.0.0.1:9"),
+        "api",
+    ));
+    let named_source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "github_v4".to_string(),
+            authored_version: None,
+            description: String::new(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Source,
+            components: component.components().to_vec(),
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("named catalog source");
+
+    let execution = CoralQuery::execute_sql(
+        &[build_source(issues_manifest(temp.path())), named_source],
+        runtime_with_dependent_join(DependentJoinConfig {
+            per_source: BTreeMap::from([(
+                "github_v4".to_string(),
+                DependentJoinSourceConfig {
+                    enabled: Some(false),
+                    ..DependentJoinSourceConfig::default()
+                },
+            )]),
+            ..DependentJoinConfig::default()
+        }),
+        "
+        EXPLAIN
+        SELECT i.title AS issue_title, pr.state AS pr_state
+        FROM issues.items AS i
+        JOIN github_v4.api.pull_requests AS pr
           ON pr.owner = i.github_owner
          AND pr.repo = i.github_repo
          AND pr.number = i.github_pr_number

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -10,7 +10,8 @@ use coral_engine::{
     CoralSqlFunctionInferenceDefinition, CoralSqlFunctionSignature, CoralSqlResultColumn,
     CoralSqlTableFunctionPublish, CoreError, EngineExtensions, QueryExecutionProvenance,
     QueryParameterValue, QueryParameters, QueryResultObserver, QueryResultObserverError,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage, StatusCode,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeCatalogTarget,
+    RuntimeSourcePackage, StatusCode,
 };
 use coral_spec::ManifestDataType;
 use serde_json::{Value, json};
@@ -529,6 +530,7 @@ async fn infer_udf_signature_maps_component_schema_to_canonical_source_name() {
             declared_inputs: Vec::new(),
             test_queries: Vec::new(),
             identity_requirements: None,
+            catalog_target: RuntimeCatalogTarget::Default,
             components: component_source.components().to_vec(),
         },
         BTreeMap::new(),


### PR DESCRIPTION
## Summary

- Preserve `RuntimeSourceComponent` as the app-to-engine compilation and registration boundary.
- Add an explicit `RuntimeCatalogTarget` so static components can publish either to the default catalog or the installed source catalog.
- Assemble source-targeted schemas with the existing composite compiler and `MemoryCatalogProvider`, without introducing backend relation wrappers or a new runtime catalog algebra.
- Resolve source-scoped table functions by catalog, schema, and function while retaining DSL v3 two-part behavior.
- Carry installed-source ownership separately from catalog/schema identity through provenance, dependent joins, telemetry, and source-scan observations.

## Contributor guidance

Updates app and engine guidance to document runtime components plus explicit catalog placement as the package boundary. This replaces the previous runtime-catalog direction.

## Validation

- `cargo check -p coral-engine -p coral-app --all-features --all-targets`
- `cargo clippy -p coral-engine -p coral-app --all-features --all-targets -- -D warnings`
- Focused engine composite, table-function, database, dependent-join, and source-observation tests
- Focused app validation, provenance, activity, telemetry, bootstrap, and observed-value tests