### PR TITLE
feat(reef): add a runtime features list component

### DIFF
--- a/apps/reef/app/components/runtime-features-list/index.ts
+++ b/apps/reef/app/components/runtime-features-list/index.ts
@@ -1,0 +1,7 @@
+export {
+  RuntimeFeatureRow,
+  RuntimeFeaturesList,
+  type RuntimeFeatureListItem,
+  type RuntimeFeatureRowProps,
+  type RuntimeFeaturesListProps,
+} from './runtime-features-list'

--- a/apps/reef/app/components/runtime-features-list/runtime-features-list.css.ts
+++ b/apps/reef/app/components/runtime-features-list/runtime-features-list.css.ts
@@ -1,0 +1,42 @@
+import { style } from '@vanilla-extract/css'
+
+import { theme } from '@/wax/theme/theme.css'
+
+export const statusCell = style({
+  paddingBlock: '24px',
+  paddingInline: '12px',
+  textAlign: 'center',
+})
+
+export const tableContainer = style({
+  background: theme.surface.card,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '10px',
+  overflow: 'hidden',
+})
+
+export const table = style({
+  tableLayout: 'fixed',
+})
+
+// `table-layout: fixed` takes column widths from the first row, so this must
+// also go on the header cell.
+export const enabledColumn = style({
+  verticalAlign: 'top',
+  width: '96px',
+})
+
+// Wax table cells are built for short single-line values: they clamp to 250px
+// and ellipsize rather than wrap. A feature carries a sentence of prose, so this
+// cell opts out of all three.
+export const featureCell = style({
+  maxWidth: 'none',
+  overflow: 'visible',
+  whiteSpace: 'normal',
+})
+
+export const feature = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2px',
+})

--- a/apps/reef/app/components/runtime-features-list/runtime-features-list.stories.tsx
+++ b/apps/reef/app/components/runtime-features-list/runtime-features-list.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { fn } from 'storybook/test'
+
+import { RuntimeFeatureRow, RuntimeFeaturesList } from './runtime-features-list'
+
+const meta = {
+  args: {
+    features: [
+      {
+        description: 'Enables installing and querying database sources. Off by default.',
+        enabled: false,
+        key: 'database_sources',
+        label: 'Database sources',
+      },
+      {
+        description: 'Exposes the MCP feedback tool when enabled.',
+        enabled: true,
+        key: 'feedback',
+        label: 'Feedback',
+      },
+      {
+        description:
+          'Enables collecting, indexing, retrieving, and maintaining values observed during earlier queries. Off by default.',
+        enabled: false,
+        key: 'observed_values_search',
+        label: 'Observed values search',
+      },
+    ],
+    renderRow: (feature) => <RuntimeFeatureRow feature={feature} onToggle={fn()} />,
+  },
+  component: RuntimeFeaturesList,
+  parameters: { layout: 'padded' },
+  render: (args) => (
+    <div style={{ maxWidth: 960 }}>
+      <RuntimeFeaturesList {...args} />
+    </div>
+  ),
+  tags: ['autodocs'],
+  title: 'Components/RuntimeFeaturesList',
+} satisfies Meta<typeof RuntimeFeaturesList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Pending: Story = {
+  args: {
+    renderRow: (feature) => (
+      <RuntimeFeatureRow feature={feature} onToggle={fn()} pending={feature.key === 'feedback'} />
+    ),
+  },
+}
+
+export const WriteError: Story = {
+  args: {
+    renderRow: (feature) => (
+      <RuntimeFeatureRow
+        error={feature.key === 'feedback' ? "Unknown feature 'feedback'." : undefined}
+        feature={feature}
+        onToggle={fn()}
+      />
+    ),
+  },
+}
+
+export const Empty: Story = {
+  args: { features: [] },
+}
+
+export const Error: Story = {
+  args: { error: 'Unable to read runtime features.', features: [] },
+}

--- a/apps/reef/app/components/runtime-features-list/runtime-features-list.tsx
+++ b/apps/reef/app/components/runtime-features-list/runtime-features-list.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react'
+import { Fragment } from 'react'
+
+import { Inputs, Table, Typography } from '@/wax/components'
+
+import * as styles from './runtime-features-list.css'
+
+export interface RuntimeFeatureListItem {
+  readonly description: string
+  /** Stable `[features]` key in `config.toml`. */
+  readonly key: string
+  /** Resolved state from config. This is what the next Coral start uses. */
+  readonly enabled: boolean
+  /** Human-readable feature name derived from the key. */
+  readonly label: string
+}
+
+export interface RuntimeFeatureRowProps {
+  /** Why the last write for this feature failed, if it did. */
+  readonly error?: string
+  readonly feature: RuntimeFeatureListItem
+  readonly onToggle: (enabled: boolean) => void
+  readonly pending?: boolean
+}
+
+export interface RuntimeFeaturesListProps {
+  readonly error?: string
+  readonly features: ReadonlyArray<RuntimeFeatureListItem>
+  /** Renders one row. Each row writes on its own, so the caller owns the row. */
+  readonly renderRow: (feature: RuntimeFeatureListItem) => ReactNode
+}
+
+export function RuntimeFeaturesList({ error, features, renderRow }: RuntimeFeaturesListProps) {
+  const status = error ? (
+    <Typography.BodySmall role="alert" variant="error">
+      {error}
+    </Typography.BodySmall>
+  ) : features.length === 0 ? (
+    <Typography.BodySmall variant="tertiary">
+      This Coral build has no runtime features.
+    </Typography.BodySmall>
+  ) : null
+
+  return (
+    <div className={styles.tableContainer}>
+      <Table.Wrapper>
+        <Table.Root className={styles.table}>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell>Feature</Table.HeaderCell>
+              {/* The switch column shows no label: the switch already reads as on
+                  or off. The name stays for screen readers. */}
+              <Table.HeaderCell
+                align="right"
+                ariaLabel="Enabled"
+                className={styles.enabledColumn}
+              />
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            {status ? (
+              <Table.Row>
+                <td className={styles.statusCell} colSpan={2}>
+                  {status}
+                </td>
+              </Table.Row>
+            ) : (
+              features.map((feature) => <Fragment key={feature.key}>{renderRow(feature)}</Fragment>)
+            )}
+          </Table.Body>
+        </Table.Root>
+      </Table.Wrapper>
+    </div>
+  )
+}
+
+export function RuntimeFeatureRow({
+  error,
+  feature,
+  onToggle,
+  pending = false,
+}: RuntimeFeatureRowProps) {
+  return (
+    <Table.Row>
+      <Table.Cell className={styles.featureCell}>
+        <div className={styles.feature}>
+          <Typography.BodyStrong variant="primary">{feature.label}</Typography.BodyStrong>
+          <Typography.BodySmall variant="secondary">{feature.description}</Typography.BodySmall>
+          {/* Beside the switch that failed, so a reader never has to work out
+              which of several rows an error belongs to. */}
+          {error && (
+            <Typography.BodySmall role="alert" variant="error">
+              {error}
+            </Typography.BodySmall>
+          )}
+        </div>
+      </Table.Cell>
+      <Table.Cell align="right" className={styles.enabledColumn}>
+        <Inputs.Switch
+          aria-label={feature.label}
+          checked={feature.enabled}
+          disabled={pending}
+          onCheckedChange={onToggle}
+        />
+      </Table.Cell>
+    </Table.Row>
+  )
+}


### PR DESCRIPTION
## Summary

Adding a presentation component for Coral "Runtime features" (kinda like our own feature flags)

## Test plan

<img width="992" height="280" alt="image" src="https://github.com/user-attachments/assets/11157ff1-00b7-4373-9ba6-25ba397d9851" />
