### PR TITLE
refactor(reef): make settings a multi-page section

### DIFF
--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -75,6 +75,9 @@ export function Sidebar({
   ] satisfies NavItem[]
   const settingsPath = routePath('settings')
   const isSettingsRoute = Boolean(useMatch({ end: false, path: settingsPath }))
+  // MCP client configuration exists only in the Desktop shell. The section index
+  // redirects to it, so the link stays on the section root and follows wherever
+  // the landing page moves.
   const settingsNavItems: NavItem[] = desktop
     ? [{ icon: 'Settings', label: 'MCP Clients', paths: [settingsPath], to: settingsPath }]
     : []

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -33,7 +33,10 @@ export default [
       route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
         route(':traceId', 'routes/trace-detail.tsx'),
       ]),
-      route(routePattern('settings'), 'routes/settings.tsx'),
+      route(routePattern('settings'), 'routes/settings.tsx', [
+        index('routes/settings/index.ts'),
+        route('mcp-clients', 'routes/settings/mcp-clients.tsx'),
+      ]),
     ]),
   ]),
 ] satisfies RouteConfig

--- a/apps/reef/app/routes/settings-loader.ts
+++ b/apps/reef/app/routes/settings-loader.ts
@@ -1,4 +1,4 @@
-import type { Route } from './+types/settings'
+import type { Route } from './settings/+types/mcp-clients'
 
 import {
   coralDesktopApi,

--- a/apps/reef/app/routes/settings.tsx
+++ b/apps/reef/app/routes/settings.tsx
@@ -1,31 +1,13 @@
-import type { Route } from './+types/settings'
-import { useFetcher, useRouteLoaderData } from 'react-router'
-import type { loader as appShellLoader } from './app-shell'
+import { Outlet } from 'react-router'
 
-import { isCoralDesktopBuild } from '@/lib/coral-desktop'
-import { Settings, SettingsHydrateFallback } from '@/views/settings/settings'
+import * as styles from '@/views/settings/settings.css'
 
-export { clientAction, clientLoader, loader } from './settings-loader'
-
-export default function SettingsRoute({ loaderData }: Route.ComponentProps) {
-  if (loaderData.runtime !== 'desktop') return null
-
-  const fetcher = useFetcher()
-  const workspaces = useRouteLoaderData<typeof appShellLoader>('routes/app-shell')?.workspaces ?? []
-  const pendingClientId = fetcher.formData?.get('clientId')
-
+export default function SettingsRoute() {
   return (
-    <Settings
-      loaderData={loaderData}
-      pendingClientIds={typeof pendingClientId === 'string' ? [pendingClientId] : []}
-      workspaces={workspaces}
-      onWorkspaceChange={(clientId, workspace) => {
-        fetcher.submit({ clientId, workspace: workspace ?? '' }, { method: 'post' })
-      }}
-    />
+    <main className={styles.page}>
+      <div className={styles.container}>
+        <Outlet />
+      </div>
+    </main>
   )
-}
-
-export function HydrateFallback() {
-  return isCoralDesktopBuild() ? <SettingsHydrateFallback /> : null
 }

--- a/apps/reef/app/routes/settings/index.ts
+++ b/apps/reef/app/routes/settings/index.ts
@@ -1,0 +1,8 @@
+import { redirect } from 'react-router'
+
+import { routePath } from '@/routing/routemap'
+
+// Settings has one page today, so the section index sends every visitor to it.
+export function loader() {
+  return redirect(routePath('settingsMcpClients'))
+}

--- a/apps/reef/app/routes/settings/mcp-clients.tsx
+++ b/apps/reef/app/routes/settings/mcp-clients.tsx
@@ -1,0 +1,33 @@
+import type { Route } from './+types/mcp-clients'
+import { useFetcher, useRouteLoaderData } from 'react-router'
+import type { loader as appShellLoader } from '../app-shell'
+
+import { isCoralDesktopBuild } from '@/lib/coral-desktop'
+import { Settings, SettingsHydrateFallback } from '@/views/settings/settings'
+
+export { clientAction, clientLoader, loader } from '../settings-loader'
+
+export default function SettingsMcpClientsRoute({ loaderData }: Route.ComponentProps) {
+  // Only the Desktop shell can read or write MCP client configuration, so a
+  // browser reaching this URL directly gets nothing rather than an empty table.
+  if (loaderData.runtime !== 'desktop') return null
+
+  const fetcher = useFetcher()
+  const workspaces = useRouteLoaderData<typeof appShellLoader>('routes/app-shell')?.workspaces ?? []
+  const pendingClientId = fetcher.formData?.get('clientId')
+
+  return (
+    <Settings
+      loaderData={loaderData}
+      pendingClientIds={typeof pendingClientId === 'string' ? [pendingClientId] : []}
+      workspaces={workspaces}
+      onWorkspaceChange={(clientId, workspace) => {
+        fetcher.submit({ clientId, workspace: workspace ?? '' }, { method: 'post' })
+      }}
+    />
+  )
+}
+
+export function HydrateFallback() {
+  return isCoralDesktopBuild() ? <SettingsHydrateFallback /> : null
+}

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -17,6 +17,7 @@ const WORKSPACE_SOURCE_PATH = '/workspaces/:workspaceId/sources/:sourceName'
 const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
 const WORKSPACE_TRACE_PATH = '/workspaces/:workspaceId/traces/:traceId'
 const SETTINGS_PATH = '/settings'
+const SETTINGS_MCP_CLIENTS_PATH = '/settings/mcp-clients'
 
 export const routeDefinitions = {
   home: {
@@ -38,6 +39,10 @@ export const routeDefinitions = {
   settings: {
     path: SETTINGS_PATH,
     toPath: () => SETTINGS_PATH,
+  },
+  settingsMcpClients: {
+    path: SETTINGS_MCP_CLIENTS_PATH,
+    toPath: () => SETTINGS_MCP_CLIENTS_PATH,
   },
   workspaces: {
     path: WORKSPACES_PATH,

--- a/apps/reef/app/views/settings/settings.tsx
+++ b/apps/reef/app/views/settings/settings.tsx
@@ -16,50 +16,42 @@ export function Settings({
   readonly workspaces: ReadonlyArray<{ name: string }>
 }) {
   return (
-    <main className={styles.page}>
-      <div className={styles.container}>
-        <section className={styles.section}>
-          <header className={styles.sectionHeader}>
-            <Typography.HeadingLarge as="h1">MCP Clients</Typography.HeadingLarge>
-            <Typography.Body variant="secondary">
-              Choose the Coral workspace each MCP client can access.{' '}
-              <Button.ExternalLink
-                href="https://withcoral.com/docs/guides/use-coral-over-mcp"
-                size="small"
-              >
-                Learn more
-              </Button.ExternalLink>
-            </Typography.Body>
-          </header>
+    <section className={styles.section}>
+      <header className={styles.sectionHeader}>
+        <Typography.HeadingLarge as="h1">MCP Clients</Typography.HeadingLarge>
+        <Typography.Body variant="secondary">
+          Choose the Coral workspace each MCP client can access.{' '}
+          <Button.ExternalLink
+            href="https://withcoral.com/docs/guides/use-coral-over-mcp"
+            size="small"
+          >
+            Learn more
+          </Button.ExternalLink>
+        </Typography.Body>
+      </header>
 
-          <Banner>
-            This page shows only global MCP configurations. Project-specific and other connections
-            will not appear here.
-          </Banner>
+      <Banner>
+        This page shows only global MCP configurations. Project-specific and other connections will
+        not appear here.
+      </Banner>
 
-          <McpClientsList
-            clients={loaderData.mcpClients.clients}
-            error={loaderData.mcpClients.error}
-            onWorkspaceChange={onWorkspaceChange}
-            pendingClientIds={pendingClientIds}
-            workspaces={workspaces}
-          />
-        </section>
-      </div>
-    </main>
+      <McpClientsList
+        clients={loaderData.mcpClients.clients}
+        error={loaderData.mcpClients.error}
+        onWorkspaceChange={onWorkspaceChange}
+        pendingClientIds={pendingClientIds}
+        workspaces={workspaces}
+      />
+    </section>
   )
 }
 
 export function SettingsHydrateFallback() {
   return (
-    <main className={styles.page}>
-      <div className={styles.container}>
-        <section className={styles.section}>
-          <Typography.BodySmall role="status" variant="tertiary">
-            Loading MCP clients…
-          </Typography.BodySmall>
-        </section>
-      </div>
-    </main>
+    <section className={styles.section}>
+      <Typography.BodySmall role="status" variant="tertiary">
+        Loading MCP clients…
+      </Typography.BodySmall>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary

Will soon add another page to our settings, refactoring to allow that transition

## Test plan

Load desktop app, Settings > MCP still works

<img width="1276" height="846" alt="image" src="https://github.com/user-attachments/assets/9a9e5fd1-41e3-4b29-a57b-2a8cc7f7c78e" />
