### PR TITLE
feat(app): serve runtime features over gRPC

### DIFF
--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -10,6 +10,7 @@ import { createGrpcWebTransport } from '@connectrpc/connect-web'
 
 import { reefAuthConfig } from '@/auth/config.server'
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
+import { FeatureService } from '@/generated/coral/v1/features_pb'
 import { FunctionService } from '@/generated/coral/v1/functions_pb'
 import { QueryService } from '@/generated/coral/v1/query_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
@@ -31,6 +32,10 @@ export function workspaceClientForRequest(request: Request, accessToken: string 
 
 export function catalogClientForRequest(request: Request, accessToken: string | null) {
   return createClient(CatalogService, coralTransportForRequest(request, accessToken))
+}
+
+export function featureClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(FeatureService, coralTransportForRequest(request, accessToken))
 }
 
 export function functionClientForRequest(request: Request, accessToken: string | null) {

--- a/apps/reef/buf.gen.yaml
+++ b/apps/reef/buf.gen.yaml
@@ -10,6 +10,7 @@ inputs:
     paths:
       - ../../crates/coral-api/proto/coral/v1/resources.proto
       - ../../crates/coral-api/proto/coral/v1/catalog.proto
+      - ../../crates/coral-api/proto/coral/v1/features.proto
       - ../../crates/coral-api/proto/coral/v1/functions.proto
       - ../../crates/coral-api/proto/coral/v1/query.proto
       - ../../crates/coral-api/proto/coral/v1/sources.proto

--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -23,6 +23,7 @@ fn main() {
                 "proto/coral/v1/workspaces.proto",
                 "proto/coral/v1/task.proto",
                 "proto/coral/v1/feedback.proto",
+                "proto/coral/v1/features.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
                 "proto/coral/v1/search.proto",

--- a/crates/coral-api/proto/coral/v1/features.proto
+++ b/crates/coral-api/proto/coral/v1/features.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package coral.v1;
+
+// How a runtime feature is configured in Coral's local config.
+enum FeatureConfiguredState {
+  // The configured state was not recorded.
+  FEATURE_CONFIGURED_STATE_UNSPECIFIED = 0;
+  // No override exists, so the feature uses its built-in default.
+  FEATURE_CONFIGURED_STATE_DEFAULT = 1;
+  // The local config explicitly enables the feature.
+  FEATURE_CONFIGURED_STATE_ENABLED = 2;
+  // The local config explicitly disables the feature.
+  FEATURE_CONFIGURED_STATE_DISABLED = 3;
+  // The local config carries a known feature key with a non-boolean value.
+  FEATURE_CONFIGURED_STATE_INVALID_VALUE = 4;
+  // The local config uses an unsupported `[features]` container shape.
+  FEATURE_CONFIGURED_STATE_INVALID_CONTAINER = 5;
+}
+
+// One runtime feature and its configured, resolved, and running state.
+message FeatureStatus {
+  // Stable key used under `[features]` in `config.toml`.
+  string key = 1;
+  // Short human-readable description of what the feature does.
+  string description = 2;
+  // Enabled state used when no override exists.
+  bool default_enabled = 3;
+  // Current local config state.
+  FeatureConfiguredState configured = 4;
+  // State local config resolves to, ignoring anything this process was launched
+  // with. Config is what callers write, so this is what they read back.
+  bool enabled = 5;
+  // State this running server booted with, including any `--enable-*` or
+  // `--disable-*` launch flag. Runtime features are read once at startup, so
+  // `enabled` and `active` differ until Coral restarts.
+  bool active = 6;
+}
+
+// Lists runtime features recognized by this Coral binary.
+message ListFeaturesRequest {}
+
+// Returns every recognized runtime feature, ordered by key.
+message ListFeaturesResponse {
+  // Recognized runtime features.
+  repeated FeatureStatus features = 1;
+}
+
+// Persists a local override for one runtime feature.
+message SetFeatureRequest {
+  // Stable feature key to override.
+  string key = 1;
+  // Override value to persist.
+  bool enabled = 2;
+}
+
+// Returns the feature state after the override is persisted.
+message SetFeatureResponse {
+  // Updated runtime feature.
+  FeatureStatus feature = 1;
+}
+
+// Runtime feature inspection and configuration APIs.
+service FeatureService {
+  // Lists runtime features with their configured, resolved, and running state.
+  rpc ListFeatures(ListFeaturesRequest) returns (ListFeaturesResponse);
+  // Persists a local override for one runtime feature. The change takes effect
+  // the next time Coral starts.
+  rpc SetFeature(SetFeatureRequest) returns (SetFeatureResponse);
+}

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -14,6 +14,7 @@ use axum::body::Body as AxumBody;
 use axum::extract::Request as AxumRequest;
 use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
+use coral_api::v1::feature_service_server::FeatureServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::function_service_server::FunctionServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
@@ -47,7 +48,8 @@ use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
-use crate::features::{Feature, FeatureOverrides, FeatureStore};
+use crate::features::service::FeatureService;
+use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
@@ -391,8 +393,8 @@ impl ServerBuilder {
         let principal_provider = self.config.principal_provider.clone();
         let grpc_listener = self.config.grpc_listener.clone();
         layout.ensure()?;
-        let features = FeatureStore::from_layout(layout.clone())
-            .load_with_overrides(&self.config.feature_overrides)?;
+        let feature_store = FeatureStore::from_layout(layout.clone());
+        let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
         let coral_db = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store, &layout).await?;
@@ -473,6 +475,8 @@ impl ServerBuilder {
                 search_observations,
                 feedback: feedback_manager,
                 task: task_manager,
+                feature_store,
+                active_features: features,
             },
             trace_components,
             principal_provider,
@@ -685,19 +689,18 @@ struct ServerDependencies {
     search_observations: Option<SearchObservationHandle>,
     feedback: FeedbackManager,
     task: TaskManager,
+    feature_store: FeatureStore,
+    // The resolution `start` performed, carried forward so the feature service
+    // can report what this server is running rather than only what config says.
+    active_features: Features,
 }
 
-async fn start_server(
+/// Builds the gRPC routes for every application service, and returns the query
+/// manager the health service reads readiness from.
+fn application_routes(
     dependencies: ServerDependencies,
-    trace_components: TraceServerComponents,
-    principal_provider: Arc<dyn PrincipalProvider>,
-    mode: ServerMode,
-    grpc_listener: Option<Arc<std::net::TcpListener>>,
-) -> Result<RunningServer, AppError> {
-    let TraceServerComponents {
-        service: trace_service,
-        local_trace_store_dir,
-    } = trace_components;
+    trace_service: Option<TraceService>,
+) -> (Routes, QueryManager) {
     let ServerDependencies {
         source,
         workspace,
@@ -706,6 +709,8 @@ async fn start_server(
         search_observations,
         feedback,
         task,
+        feature_store,
+        active_features,
     } = dependencies;
     let (source, query) = match search_observations.as_ref() {
         Some(search_observations) => (
@@ -720,10 +725,11 @@ async fn start_server(
     let catalog_service = CatalogService::new(query.clone(), task.clone());
     let function_service = FunctionService::new(query.clone());
     let query_service = QueryService::new(query, task.clone());
-    let search_service = SearchService::new(search.clone(), task.clone());
+    let search_service = SearchService::new(search, task.clone());
     let feedback_service = FeedbackService::new(feedback, task.clone());
+    let feature_service = FeatureService::new(feature_store, active_features);
     let task_service = TaskService::new(task);
-    let mut application_routes = Routes::default()
+    let mut routes = Routes::default()
         .add_service(
             SourceServiceServer::new(source_service)
                 .max_encoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE),
@@ -734,6 +740,7 @@ async fn start_server(
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(FeedbackServiceServer::new(feedback_service))
+        .add_service(FeatureServiceServer::new(feature_service))
         .add_service(FunctionServiceServer::new(function_service))
         .add_service(TaskServiceServer::new(task_service))
         .add_service(
@@ -745,11 +752,29 @@ async fn start_server(
                 .max_encoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE),
         );
     if let Some(trace_service) = trace_service {
-        application_routes = application_routes.add_service(
+        routes = routes.add_service(
             TraceServiceServer::new(trace_service)
                 .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE),
         );
     }
+    (routes, health_queries)
+}
+
+async fn start_server(
+    dependencies: ServerDependencies,
+    trace_components: TraceServerComponents,
+    principal_provider: Arc<dyn PrincipalProvider>,
+    mode: ServerMode,
+    grpc_listener: Option<Arc<std::net::TcpListener>>,
+) -> Result<RunningServer, AppError> {
+    let TraceServerComponents {
+        service: trace_service,
+        local_trace_store_dir,
+    } = trace_components;
+    // `RunningServer` owns both for shutdown; the routes only borrow them.
+    let search = dependencies.search.clone();
+    let search_observations = dependencies.search_observations.clone();
+    let (application_routes, health_queries) = application_routes(dependencies, trace_service);
     let routes = Routes::from(
         application_routes
             .into_axum_router()
@@ -1037,7 +1062,7 @@ mod tests {
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
     use crate::credentials::{CredentialManager, CredentialStore};
-    use crate::features::{Feature, FeatureOverrides};
+    use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
@@ -1774,6 +1799,8 @@ backend = "unsupported"
                 search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
+                feature_store: FeatureStore::from_layout(layout.clone()),
+                active_features: Features::default(),
             },
             TraceServerComponents {
                 service: Some(trace_service),
@@ -2226,6 +2253,8 @@ tables:
                 search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
+                feature_store: FeatureStore::from_layout(layout.clone()),
+                active_features: Features::default(),
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
@@ -2355,6 +2384,8 @@ tables:
                 search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
+                feature_store: FeatureStore::from_layout(layout.clone()),
+                active_features: Features::default(),
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
@@ -2484,6 +2515,8 @@ tables:
                 search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
+                feature_store: FeatureStore::from_layout(layout.clone()),
+                active_features: Features::default(),
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),

--- a/crates/coral-app/src/features/mod.rs
+++ b/crates/coral-app/src/features/mod.rs
@@ -1,5 +1,7 @@
 //! Runtime feature registry and effective feature resolution.
 
+pub(crate) mod service;
+
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -249,6 +251,19 @@ impl FeatureStore {
         let mut features = Features::from_raw_overrides(&raw);
         features.apply_overrides(overrides);
         Ok(features)
+    }
+
+    /// Lists every known feature as local config alone resolves it.
+    ///
+    /// Process-local overrides are deliberately not applied. A launch flag
+    /// belongs to one process, so it describes what a server is running rather
+    /// than what its config says, and callers that write config read this back.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
+    pub fn statuses(&self) -> Result<Vec<FeatureStatus>, AppError> {
+        self.statuses_with_overrides(&FeatureOverrides::default())
     }
 
     /// Lists every known feature, applying process-local overrides to effective state.

--- a/crates/coral-app/src/features/service.rs
+++ b/crates/coral-app/src/features/service.rs
@@ -1,0 +1,277 @@
+//! Implements the gRPC `FeatureService` for runtime feature inspection and
+//! configuration.
+
+use coral_api::v1::feature_service_server::FeatureService as FeatureServiceApi;
+use coral_api::v1::{
+    FeatureConfiguredState as ProtoFeatureConfiguredState, FeatureStatus as ProtoFeatureStatus,
+    ListFeaturesRequest, ListFeaturesResponse, SetFeatureRequest, SetFeatureResponse,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::features::{FeatureConfiguredState, FeatureStatus, FeatureStore, Features};
+use crate::transport::{grpc_span, instrument_grpc};
+
+/// Serves the runtime feature registry over gRPC.
+///
+/// Runtime features are read once, when the server starts, so this service
+/// reports two different truths, each from one source: `enabled` from local
+/// config, read on every call, and `active` from the state this server actually
+/// booted with, launch flags included.
+#[derive(Clone)]
+pub(crate) struct FeatureService {
+    store: FeatureStore,
+    active: Features,
+}
+
+impl FeatureService {
+    pub(crate) fn new(store: FeatureStore, active: Features) -> Self {
+        Self { store, active }
+    }
+
+    fn status_to_proto(&self, status: &FeatureStatus) -> ProtoFeatureStatus {
+        ProtoFeatureStatus {
+            key: status.key.to_string(),
+            description: status.description.to_string(),
+            default_enabled: status.default_enabled,
+            configured: configured_state_to_proto(status.configured).into(),
+            enabled: status.enabled,
+            active: self.active.enabled(status.feature),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl FeatureServiceApi for FeatureService {
+    async fn list_features(
+        &self,
+        request: Request<ListFeaturesRequest>,
+    ) -> Result<Response<ListFeaturesResponse>, Status> {
+        let span = grpc_span(&request);
+        instrument_grpc(span, async move {
+            let features = self
+                .store
+                .statuses()
+                .map_err(app_status)?
+                .iter()
+                .map(|status| self.status_to_proto(status))
+                .collect();
+            Ok(Response::new(ListFeaturesResponse { features }))
+        })
+        .await
+    }
+
+    async fn set_feature(
+        &self,
+        request: Request<SetFeatureRequest>,
+    ) -> Result<Response<SetFeatureResponse>, Status> {
+        let span = grpc_span(&request);
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            if request.enabled {
+                self.store.enable(&request.key).map_err(app_status)?;
+            } else {
+                self.store.disable(&request.key).map_err(app_status)?;
+            }
+            let statuses = self.store.statuses().map_err(app_status)?;
+            let status = statuses
+                .iter()
+                .find(|status| status.key == request.key)
+                .ok_or_else(|| {
+                    Status::internal("persisted feature is missing from the registry")
+                })?;
+            Ok(Response::new(SetFeatureResponse {
+                feature: Some(self.status_to_proto(status)),
+            }))
+        })
+        .await
+    }
+}
+
+fn configured_state_to_proto(state: FeatureConfiguredState) -> ProtoFeatureConfiguredState {
+    match state {
+        FeatureConfiguredState::Default => ProtoFeatureConfiguredState::Default,
+        FeatureConfiguredState::Enabled => ProtoFeatureConfiguredState::Enabled,
+        FeatureConfiguredState::Disabled => ProtoFeatureConfiguredState::Disabled,
+        FeatureConfiguredState::InvalidValue => ProtoFeatureConfiguredState::InvalidValue,
+        FeatureConfiguredState::InvalidContainer => ProtoFeatureConfiguredState::InvalidContainer,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+    use tonic::Code;
+
+    use super::*;
+    use crate::features::{Feature, FeatureOverrides};
+
+    fn service_for(config_dir: &std::path::Path, active: Features) -> FeatureService {
+        let store = FeatureStore::discover(Some(config_dir.to_path_buf())).expect("feature store");
+        FeatureService::new(store, active)
+    }
+
+    #[tokio::test]
+    async fn list_features_reports_every_registry_entry() {
+        let temp = TempDir::new().expect("temp dir");
+
+        let response = service_for(&temp.path().join("config"), Features::default())
+            .list_features(Request::new(ListFeaturesRequest {}))
+            .await
+            .expect("list features")
+            .into_inner();
+
+        let keys = response
+            .features
+            .iter()
+            .map(|feature| feature.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            keys,
+            vec!["database_sources", "feedback", "observed_values_search"]
+        );
+        assert!(response.features.iter().all(|feature| {
+            !feature.enabled
+                && !feature.active
+                && feature.configured == i32::from(ProtoFeatureConfiguredState::Default)
+        }));
+    }
+
+    #[tokio::test]
+    async fn set_feature_persists_the_override_and_reports_the_pending_restart() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("config");
+        // A server that booted before the override still runs with the feature off.
+        let service = service_for(&config_dir, Features::default());
+
+        let response = service
+            .set_feature(Request::new(SetFeatureRequest {
+                key: "feedback".to_string(),
+                enabled: true,
+            }))
+            .await
+            .expect("set feature")
+            .into_inner();
+
+        let feature = response.feature.expect("feature");
+        assert!(feature.enabled);
+        assert!(!feature.active);
+        assert_eq!(
+            feature.configured,
+            i32::from(ProtoFeatureConfiguredState::Enabled)
+        );
+        let config = std::fs::read_to_string(config_dir.join("config.toml")).expect("config file");
+        assert!(config.contains("[features]"));
+        assert!(config.contains("feedback = true"));
+    }
+
+    #[tokio::test]
+    async fn list_features_reports_the_running_state_separately_from_config() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        // Config says on; this server booted with it off.
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[features]\nobserved_values_search = true\n",
+        )
+        .expect("write config");
+
+        let response = service_for(&config_dir, Features::default())
+            .list_features(Request::new(ListFeaturesRequest {}))
+            .await
+            .expect("list features")
+            .into_inner();
+
+        let feature = response
+            .features
+            .iter()
+            .find(|feature| feature.key == "observed_values_search")
+            .expect("observed values search status");
+        assert!(feature.enabled);
+        assert!(!feature.active);
+    }
+
+    #[tokio::test]
+    async fn list_features_reports_active_state_from_the_boot_snapshot() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[features]\nfeedback = true\n",
+        )
+        .expect("write config");
+        let store = FeatureStore::discover(Some(config_dir.clone())).expect("feature store");
+        let active = store
+            .load_with_overrides(&FeatureOverrides::default())
+            .expect("boot features");
+        assert!(active.enabled(Feature::Feedback));
+
+        let response = FeatureService::new(store, active)
+            .list_features(Request::new(ListFeaturesRequest {}))
+            .await
+            .expect("list features")
+            .into_inner();
+
+        let feature = response
+            .features
+            .iter()
+            .find(|feature| feature.key == "feedback")
+            .expect("feedback status");
+        assert!(feature.enabled);
+        assert!(feature.active);
+    }
+
+    #[tokio::test]
+    async fn list_features_ignores_launch_flags_when_resolving_config() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[features]\nfeedback = true\n",
+        )
+        .expect("write config");
+        let store = FeatureStore::discover(Some(config_dir)).expect("feature store");
+        // This server booted with `--disable-feedback`, so it runs with the
+        // feature off while config says on.
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::Feedback, false);
+        let active = store
+            .load_with_overrides(&overrides)
+            .expect("boot features");
+        assert!(!active.enabled(Feature::Feedback));
+
+        let response = FeatureService::new(store, active)
+            .list_features(Request::new(ListFeaturesRequest {}))
+            .await
+            .expect("list features")
+            .into_inner();
+
+        // `enabled` reports config, which a restart without the flag applies.
+        let feature = response
+            .features
+            .iter()
+            .find(|feature| feature.key == "feedback")
+            .expect("feedback status");
+        assert!(feature.enabled);
+        assert!(!feature.active);
+    }
+
+    #[tokio::test]
+    async fn set_feature_rejects_an_unknown_key() {
+        let temp = TempDir::new().expect("temp dir");
+
+        let status = service_for(&temp.path().join("config"), Features::default())
+            .set_feature(Request::new(SetFeatureRequest {
+                key: "nope".to_string(),
+                enabled: true,
+            }))
+            .await
+            .expect_err("unknown feature");
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+        assert!(status.message().contains("unknown feature 'nope'"));
+    }
+}

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -449,7 +449,9 @@ pub(crate) fn set_raw_feature_override(
         doc.insert("features", toml_edit::table());
     }
     let Some(feature_table) = doc.get_mut("features").and_then(Item::as_table_mut) else {
-        return Err(AppError::InvalidInput(
+        // The caller named a valid feature; the file on disk is what blocks the
+        // write, so this is server state rather than bad input.
+        return Err(AppError::FailedPrecondition(
             "unsupported [features] config; expected a table".to_string(),
         ));
     };

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -7,6 +7,8 @@
 
 #[path = "grpc/catalog_discovery_tests.rs"]
 mod catalog_discovery_tests;
+#[path = "grpc/feature_service_tests.rs"]
+mod feature_service_tests;
 #[path = "grpc/function_lifecycle_tests.rs"]
 mod function_lifecycle_tests;
 #[path = "grpc/harness.rs"]

--- a/crates/coral-app/tests/grpc/feature_service_tests.rs
+++ b/crates/coral-app/tests/grpc/feature_service_tests.rs
@@ -1,0 +1,110 @@
+use coral_api::v1::feature_service_client::FeatureServiceClient;
+use coral_api::v1::{
+    FeatureConfiguredState, ListFeaturesRequest, ListFeaturesResponse, SetFeatureRequest,
+};
+use coral_client::local::{RunningServer, ServerBuilder};
+use tempfile::TempDir;
+use tonic::Code;
+use tonic::transport::Channel;
+
+async fn feature_client(server: &RunningServer) -> FeatureServiceClient<Channel> {
+    let channel = Channel::from_shared(server.endpoint_uri().to_string())
+        .expect("valid endpoint")
+        .connect()
+        .await
+        .expect("connect feature client");
+    FeatureServiceClient::new(channel)
+}
+
+async fn list_features(server: &RunningServer) -> ListFeaturesResponse {
+    feature_client(server)
+        .await
+        .list_features(ListFeaturesRequest {})
+        .await
+        .expect("list features")
+        .into_inner()
+}
+
+/// The value of the service is that it reports two different truths at once, and
+/// only a real server restart proves the difference is real: `enabled` follows
+/// `config.toml` immediately, `active` does not move until Coral starts again.
+#[tokio::test]
+async fn grpc_feature_override_applies_to_the_next_server_start() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server");
+
+    let before = list_features(&server).await;
+    let feedback = before
+        .features
+        .iter()
+        .find(|feature| feature.key == "feedback")
+        .expect("feedback feature");
+    assert!(!feedback.enabled);
+    assert!(!feedback.active);
+    assert_eq!(
+        feedback.configured,
+        i32::from(FeatureConfiguredState::Default)
+    );
+
+    let updated = feature_client(&server)
+        .await
+        .set_feature(SetFeatureRequest {
+            key: "feedback".to_string(),
+            enabled: true,
+        })
+        .await
+        .expect("set feature")
+        .into_inner()
+        .feature
+        .expect("updated feature");
+    assert!(updated.enabled);
+    assert!(!updated.active);
+
+    server.shutdown().await.expect("shutdown server");
+    let restarted = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("restart server");
+
+    let after = list_features(&restarted).await;
+    let feedback = after
+        .features
+        .iter()
+        .find(|feature| feature.key == "feedback")
+        .expect("feedback feature");
+    assert!(feedback.enabled);
+    assert!(feedback.active);
+    assert_eq!(
+        feedback.configured,
+        i32::from(FeatureConfiguredState::Enabled)
+    );
+    restarted.shutdown().await.expect("shutdown restarted");
+}
+
+#[tokio::test]
+async fn grpc_set_feature_rejects_an_unknown_key() {
+    let temp = TempDir::new().expect("temp dir");
+    let server = ServerBuilder::new()
+        .with_config_dir(temp.path().join("coral-config"))
+        .start()
+        .await
+        .expect("start server");
+
+    let status = feature_client(&server)
+        .await
+        .set_feature(SetFeatureRequest {
+            key: "nope".to_string(),
+            enabled: true,
+        })
+        .await
+        .expect_err("unknown feature");
+
+    assert_eq!(status.code(), Code::InvalidArgument);
+    server.shutdown().await.expect("shutdown server");
+}


### PR DESCRIPTION
## Summary

Coral cli has a `feature` API that allows users to change Coral's runtime feature. 
This PR exposes that functionality to the UI via gRPC.

## Test plan

From a future PR: call the action via the UI, check the Coral instance's config is updated correctly.