### PR TITLE
feat(reef): add a runtime features settings page

### DIFF
--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -74,13 +74,28 @@ export function Sidebar({
     { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
   ] satisfies NavItem[]
   const settingsPath = routePath('settings')
+  const mcpClientsPath = routePath('settingsMcpClients')
+  const runtimeFeaturesPath = routePath('settingsRuntimeFeatures')
   const isSettingsRoute = Boolean(useMatch({ end: false, path: settingsPath }))
-  // MCP client configuration exists only in the Desktop shell. The section index
-  // redirects to it, so the link stays on the section root and follows wherever
-  // the landing page moves.
-  const settingsNavItems: NavItem[] = desktop
-    ? [{ icon: 'Settings', label: 'MCP Clients', paths: [settingsPath], to: settingsPath }]
+  // MCP client configuration exists only in the Desktop shell. Runtime features
+  // are Coral config, so they are reachable from every build.
+  //
+  // Both address their own page. The section root belongs to the cog in the
+  // workspace menu, whose redirect picks a landing page per build; a link that
+  // names one page cannot borrow it, and `/settings` in `paths` would light both
+  // rows at once.
+  const mcpClientsNavItems: NavItem[] = desktop
+    ? [{ icon: 'Settings', label: 'MCP Clients', paths: [mcpClientsPath], to: mcpClientsPath }]
     : []
+  const settingsNavItems: NavItem[] = [
+    ...mcpClientsNavItems,
+    {
+      icon: 'Flag',
+      label: 'Features',
+      paths: [runtimeFeaturesPath],
+      to: runtimeFeaturesPath,
+    },
+  ]
   const navItems = isSettingsRoute ? settingsNavItems : workspaceNavItems
   const settingsHomeButton = (
     <ButtonContainer ariaLabel="Home" as={Link} size="22" to={routePath('home')} variant="bare">

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -36,6 +36,7 @@ export default [
       route(routePattern('settings'), 'routes/settings.tsx', [
         index('routes/settings/index.ts'),
         route('mcp-clients', 'routes/settings/mcp-clients.tsx'),
+        route('runtime-features', 'routes/settings/runtime-features.tsx'),
       ]),
     ]),
   ]),

--- a/apps/reef/app/routes/settings/index.ts
+++ b/apps/reef/app/routes/settings/index.ts
@@ -1,8 +1,13 @@
 import { redirect } from 'react-router'
 
+import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { routePath } from '@/routing/routemap'
 
-// Settings has one page today, so the section index sends every visitor to it.
+// MCP Clients was the settings landing page before settings gained sub-pages,
+// and it exists only in the Desktop shell. Everywhere else, runtime features are
+// the first page a browser can actually use.
 export function loader() {
-  return redirect(routePath('settingsMcpClients'))
+  return redirect(
+    isCoralDesktopBuild() ? routePath('settingsMcpClients') : routePath('settingsRuntimeFeatures'),
+  )
 }

--- a/apps/reef/app/routes/settings/runtime-features.server.test.ts
+++ b/apps/reef/app/routes/settings/runtime-features.server.test.ts
@@ -1,0 +1,137 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it, vi } from 'vitest'
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+
+const { featureClientForRequest, listFeatures, setFeature } = vi.hoisted(() => ({
+  featureClientForRequest: vi.fn(),
+  listFeatures: vi.fn(),
+  setFeature: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  featureClientForRequest,
+}))
+
+import { FeatureConfiguredState, FeatureStatusSchema } from '@/generated/coral/v1/features_pb'
+
+import { action, loader, toRuntimeFeature } from './runtime-features'
+
+describe('runtime features mapping', () => {
+  it('shows the configured state, not the state the server is running', () => {
+    const feature = create(FeatureStatusSchema, {
+      // Toggled on since this server started, so `enabled` and `active` disagree.
+      active: false,
+      configured: FeatureConfiguredState.ENABLED,
+      defaultEnabled: false,
+      description: 'Enables installing and querying database sources.',
+      enabled: true,
+      key: 'database_sources',
+    })
+
+    expect(toRuntimeFeature(feature)).toEqual({
+      description: 'Enables installing and querying database sources.',
+      enabled: true,
+      key: 'database_sources',
+      label: 'Database sources',
+    })
+  })
+})
+
+describe('runtime features loader', () => {
+  it('flags a restart when config has moved away from what the server booted with', async () => {
+    listFeatures.mockResolvedValue({
+      features: [featureStatus({ active: false, enabled: true, key: 'feedback' })],
+    })
+    featureClientForRequest.mockReturnValue({ listFeatures })
+
+    const result = await loader(authRouteTestArgs(loadRequest(), {}))
+
+    expect(result.restartPending).toBe(true)
+  })
+
+  it('does not ask for a restart while config and the running server agree', async () => {
+    listFeatures.mockResolvedValue({
+      features: [
+        featureStatus({ active: false, enabled: false, key: 'feedback' }),
+        // Enabled before this server started, so it is already running.
+        featureStatus({ active: true, enabled: true, key: 'database_sources' }),
+      ],
+    })
+    featureClientForRequest.mockReturnValue({ listFeatures })
+
+    const result = await loader(authRouteTestArgs(loadRequest(), {}))
+
+    expect(result.restartPending).toBe(false)
+  })
+
+  it('returns a load error as data rather than throwing', async () => {
+    listFeatures.mockRejectedValue(new Error('coral is unreachable'))
+    featureClientForRequest.mockReturnValue({ listFeatures })
+
+    const result = await loader(authRouteTestArgs(loadRequest(), {}))
+
+    expect(result).toEqual({
+      features: [],
+      loadError: 'coral is unreachable',
+      restartPending: false,
+    })
+  })
+})
+
+describe('runtime features action', () => {
+  it('persists the requested override', async () => {
+    setFeature.mockResolvedValue({})
+    featureClientForRequest.mockReturnValue({ setFeature })
+    const request = toggleRequest('feedback', 'true')
+
+    const result = await action(authRouteTestArgs(request, {}))
+
+    expect(featureClientForRequest).toHaveBeenCalledWith(request, 'test-coral-token')
+    expect(setFeature).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, key: 'feedback' }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(result).toEqual({ key: 'feedback', status: 'success' })
+  })
+
+  it('treats any non-true value as a disable', async () => {
+    setFeature.mockResolvedValue({})
+    featureClientForRequest.mockReturnValue({ setFeature })
+
+    await action(authRouteTestArgs(toggleRequest('feedback', 'false'), {}))
+
+    expect(setFeature).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false, key: 'feedback' }),
+      expect.anything(),
+    )
+  })
+
+  it('returns a write error as data rather than throwing', async () => {
+    setFeature.mockRejectedValue(new Error("unknown feature 'nope'"))
+    featureClientForRequest.mockReturnValue({ setFeature })
+
+    const result = await action(authRouteTestArgs(toggleRequest('nope', 'true'), {}))
+
+    expect(result).toEqual({ key: 'nope', message: "unknown feature 'nope'", status: 'error' })
+  })
+})
+
+function featureStatus(overrides: { active: boolean; enabled: boolean; key: string }) {
+  return create(FeatureStatusSchema, {
+    configured: FeatureConfiguredState.DEFAULT,
+    description: 'A runtime feature.',
+    ...overrides,
+  })
+}
+
+function loadRequest() {
+  return new Request('http://reef.test/settings/runtime-features')
+}
+
+function toggleRequest(key: string, enabled: string) {
+  return new Request('http://reef.test/settings/runtime-features', {
+    body: new URLSearchParams({ enabled, key }),
+    method: 'POST',
+  })
+}

--- a/apps/reef/app/routes/settings/runtime-features.tsx
+++ b/apps/reef/app/routes/settings/runtime-features.tsx
@@ -1,0 +1,155 @@
+import { create } from '@bufbuild/protobuf'
+import { useFetcher } from 'react-router'
+
+import type { Route } from './+types/runtime-features'
+
+import { requestAuthContext } from '@/auth/server-context'
+import {
+  RuntimeFeatureRow,
+  RuntimeFeaturesList,
+  type RuntimeFeatureListItem,
+} from '@/components/runtime-features-list'
+import {
+  ListFeaturesRequestSchema,
+  SetFeatureRequestSchema,
+  type FeatureStatus,
+} from '@/generated/coral/v1/features_pb'
+import { isCoralDesktopBuild } from '@/lib/coral-desktop'
+import { featureClientForRequest } from '@/lib/coral-request.server'
+import { errorMessage } from '@/lib/utils'
+import { Banner, Typography } from '@/wax/components'
+
+import * as styles from '@/views/settings/settings.css'
+
+// Coral cannot restart itself, and how you restart it depends on what is running
+// it. The Desktop shell owns its own sidecar; everything else is supervised by
+// whatever started the server.
+const RESTART_MESSAGE = isCoralDesktopBuild()
+  ? 'Coral is running with different settings. Quit and reopen Coral to apply your changes.'
+  : 'Coral is running with different settings. Restart the Coral server to apply your changes.'
+
+export interface RuntimeFeaturesRouteData {
+  features: RuntimeFeatureListItem[]
+  loadError: string | null
+  /** Whether Coral is running with a feature state its config no longer matches. */
+  restartPending: boolean
+}
+
+export type RuntimeFeaturesActionData =
+  | { key: string; message: string; status: 'error' }
+  | { key: string; status: 'success' }
+
+export async function action({
+  context,
+  request,
+}: Route.ActionArgs): Promise<RuntimeFeaturesActionData> {
+  const formData = await request.formData()
+  const keyValue = formData.get('key')
+  const key = typeof keyValue === 'string' ? keyValue : ''
+  if (!key) return { key, message: 'Missing feature key', status: 'error' }
+
+  try {
+    await featureClientForRequest(request, context.get(requestAuthContext).accessToken).setFeature(
+      create(SetFeatureRequestSchema, { enabled: formData.get('enabled') === 'true', key }),
+      { signal: request.signal },
+    )
+    return { key, status: 'success' }
+  } catch (error) {
+    return { key, message: errorMessage(error), status: 'error' }
+  }
+}
+
+export async function loader({
+  context,
+  request,
+}: Route.LoaderArgs): Promise<RuntimeFeaturesRouteData> {
+  try {
+    const response = await featureClientForRequest(
+      request,
+      context.get(requestAuthContext).accessToken,
+    ).listFeatures(create(ListFeaturesRequestSchema, {}), { signal: request.signal })
+    return {
+      features: response.features.map(toRuntimeFeature),
+      loadError: null,
+      // Coral resolves features once, at startup, so a feature whose configured
+      // state has moved away from the state this server booted with is the exact
+      // set that needs a restart. Nothing else has to guess.
+      restartPending: response.features.some((feature) => feature.enabled !== feature.active),
+    }
+  } catch (error) {
+    return { features: [], loadError: errorMessage(error), restartPending: false }
+  }
+}
+
+export default function RuntimeFeaturesRoute({ loaderData }: Route.ComponentProps) {
+  const { features, loadError, restartPending } = loaderData
+
+  return (
+    <section className={styles.section}>
+      <header className={styles.sectionHeader}>
+        <Typography.HeadingLarge as="h1">Features</Typography.HeadingLarge>
+        <Typography.Body variant="secondary">
+          Turn experimental Coral capabilities on or off for this machine. Changes are saved right
+          away and apply the next time Coral starts.
+        </Typography.Body>
+      </header>
+
+      <RuntimeFeaturesList
+        error={loadError ?? undefined}
+        features={features}
+        renderRow={(feature) => <RuntimeFeatureToggleRow feature={feature} />}
+      />
+
+      {/* Below the list, so appearing after a toggle grows into empty page space
+          instead of pushing the switch the reader just used. */}
+      {restartPending && <Banner>{RESTART_MESSAGE}</Banner>}
+    </section>
+  )
+}
+
+// Every row writes through its own fetcher. React Router aborts the request in
+// flight when the same fetcher submits again, so one fetcher for the whole page
+// would drop the first toggle when a reader moves two switches in a row.
+function RuntimeFeatureToggleRow({ feature }: { feature: RuntimeFeatureListItem }) {
+  const fetcher = useFetcher<RuntimeFeaturesActionData>({ key: fetcherKey(feature.key) })
+  // The switch has to move on click, but the value it settles on comes from the
+  // server. Read the in-flight submission so the row does not snap back while
+  // the action and its revalidation are still running. React Router clears the
+  // form data once the fetcher is idle, which returns a failed write to the
+  // value config still holds.
+  const submitted = fetcher.formData
+  const enabled = submitted ? submitted.get('enabled') === 'true' : feature.enabled
+
+  return (
+    <RuntimeFeatureRow
+      error={fetcher.data?.status === 'error' ? fetcher.data.message : undefined}
+      feature={{ ...feature, enabled }}
+      onToggle={(next) =>
+        fetcher.submit({ enabled: String(next), key: feature.key }, { method: 'post' })
+      }
+      pending={fetcher.state !== 'idle'}
+    />
+  )
+}
+
+// Fetcher keys are global to the app, so the feature key alone is not enough to
+// keep this page's writes apart from anyone else's.
+function fetcherKey(featureKey: string): string {
+  return `runtime-feature:${featureKey}`
+}
+
+export function toRuntimeFeature(feature: FeatureStatus): RuntimeFeatureListItem {
+  return {
+    description: feature.description,
+    enabled: feature.enabled,
+    key: feature.key,
+    label: featureLabel(feature.key),
+  }
+}
+
+// Feature keys are the stable config contract; the page shows a readable form of
+// the same key rather than a second name the CLI would not recognize.
+function featureLabel(key: string): string {
+  const words = key.replaceAll('_', ' ')
+  return words.charAt(0).toUpperCase() + words.slice(1)
+}

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -18,6 +18,7 @@ const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
 const WORKSPACE_TRACE_PATH = '/workspaces/:workspaceId/traces/:traceId'
 const SETTINGS_PATH = '/settings'
 const SETTINGS_MCP_CLIENTS_PATH = '/settings/mcp-clients'
+const SETTINGS_RUNTIME_FEATURES_PATH = '/settings/runtime-features'
 
 export const routeDefinitions = {
   home: {
@@ -43,6 +44,10 @@ export const routeDefinitions = {
   settingsMcpClients: {
     path: SETTINGS_MCP_CLIENTS_PATH,
     toPath: () => SETTINGS_MCP_CLIENTS_PATH,
+  },
+  settingsRuntimeFeatures: {
+    path: SETTINGS_RUNTIME_FEATURES_PATH,
+    toPath: () => SETTINGS_RUNTIME_FEATURES_PATH,
   },
   workspaces: {
     path: WORKSPACES_PATH,


### PR DESCRIPTION
## Summary

Adding a new page to settings, which allows users to update Coral's runtime features.

## Test plan

Update a value, check it is correctly written in the config.
Restart Coral, check flag is correctly enabled/disabled

<img width="1282" height="549" alt="image" src="https://github.com/user-attachments/assets/9665bbe7-21a9-48b0-8c97-0b5aa4b24a04" />
