### PR TITLE
feat(sources/community/brightdata): add Bright Data community source

### DIFF
--- a/sources/community/brightdata/README.md
+++ b/sources/community/brightdata/README.md
@@ -1,0 +1,516 @@
+# Bright Data community source
+
+Query your Bright Data account through Coral SQL: balance, account status,
+zones, dataset catalog, zone usage costs, Web Unlocker fetches, and SERP
+results. This source adds the Bright Data customer API to the community
+catalog so users and agents can monitor usage, inspect their zones, and scrape
+public pages or run search-engine result lookups without leaving SQL.
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Table functions:** 4
+**Base URL (default):** `https://api.brightdata.com`
+
+## Why this source
+
+Bright Data operates the largest residential/ISP/datacenter proxy network plus
+scraping APIs (Web Unlocker, SERP, DCA, Datasets). Coral did not have a Bright
+Data source yet, so this community spec gives the reef a focused read/query
+surface for:
+
+- Checking account balance and credit in SQL before running large jobs.
+- Verifying account status and the proxy exit IP.
+- Listing the zones on the account and their type (unlocker, browser API).
+- Browsing the public dataset catalog by size.
+- Fetching any public URL through the Web Unlocker as HTML or markdown.
+- Running search-engine result lookups through the SERP API.
+
+The v1 surface is intentionally narrow and read-oriented. It proves Coral can
+authenticate against the Bright Data customer API with a zone API token and
+map the account, zone, unlocker, and SERP endpoints into verifiable tables.
+Async operations (dataset pipelines, Discover task polling, DCA crawls) have
+no request/response mapping in the current HTTP backend and are out of scope
+for this first version.
+
+## Installation
+
+Community sources are not bundled with the Coral binary. Clone the Coral
+repository and add the manifest from this directory:
+
+```bash
+coral source add --file sources/community/brightdata/manifest.yaml
+```
+
+You can also copy `manifest.yaml` into another workspace and pass that path to
+`coral source add --file`.
+
+## Authentication
+
+Bright Data requests are authenticated with a zone API token sent as a Bearer
+token. Create one from the dashboard:
+
+1. Log in to the Bright Data dashboard at <https://brightdata.com/>.
+2. Go to **Account** → **API access** (https://brightdata.com/api).
+3. Click **Create API token**, choose **Zone API token**, select the zone, and
+   copy the token.
+
+Set the token as `BRIGHT_DATA_API_KEY` before adding or testing the source:
+
+```bash
+export BRIGHT_DATA_API_KEY="your_zone_api_token"
+coral source add --file sources/community/brightdata/manifest.yaml
+```
+
+Interactive install also works:
+
+```bash
+coral source add --interactive --file sources/community/brightdata/manifest.yaml
+```
+
+The optional `BRIGHT_DATA_ZONE` input (default `unlocker`) selects the zone
+used by `web_unlocker` and `serp_search`; every function that consumes it also
+accepts a `zone` argument to override it per call. Table functions take a
+plain `api` (top-level `Authorization` header) token and require no proxy
+credentials. This source reads data from the Bright Data API directly with
+your token; it does not route requests through Bright Data proxy zones.
+
+## Provider docs
+
+- Bright Data API: https://docs.brightdata.com
+- Bright Data API access/tokens: https://brightdata.com/api
+- Web Unlocker: https://docs.brightdata.com/scraping-methods/web-unlocker
+- SERP API: https://docs.brightdata.com/scraping-methods/serp
+
+## Tables
+
+| Table | Description | Required filters |
+| --- | --- | --- |
+| `brightdata.customer_balance` | Current account balance, credit, prepayment, and pending costs. | None |
+| `brightdata.customer_status` | Account status, exit IP, and proxy request health. | None |
+| `brightdata.zones` | Zones on the account and their type. | None |
+| `brightdata.datasets` | Public Bright Data dataset catalog (id, name, row count). | None |
+
+### `brightdata.customer_balance`
+
+Returns the account balance snapshot from `GET /customer/balance`.
+
+```sql
+SELECT balance, credit, prepayment, pending_costs
+FROM brightdata.customer_balance;
+```
+
+### `brightdata.customer_status`
+
+Returns the account status from `GET /status`. `can_make_requests` reflects
+proxy/zone health; a `false` value with `auth_fail_reason` set to
+`zone_not_found` means the zone is not provisioned even though the API token is
+valid (see Limitations).
+
+```sql
+SELECT status, customer, can_make_requests, ip
+FROM brightdata.customer_status;
+```
+
+### `brightdata.zones`
+
+Lists the zones on the account via `GET /zone/get_active_zones`. `type` is one
+of `unblocker`, `browser_api`, etc.
+
+```sql
+SELECT name, type FROM brightdata.zones;
+```
+
+### `brightdata.datasets`
+
+Lists the public dataset catalog from `GET /datasets/list`. `size` is the
+dataset row count; use it to find large prebuilt datasets.
+
+```sql
+SELECT id, name, size
+FROM brightdata.datasets
+WHERE size > 1000000
+LIMIT 10;
+```
+
+## Table functions
+
+| Function | Kind | Description |
+| --- | --- | --- |
+| `brightdata.zone_info(zone)` | table | Zone configuration and plan details for one zone. |
+| `brightdata.zone_cost(zone, from?, to?)` | table | Usage cost and bandwidth by billing period for one zone. |
+| `brightdata.web_unlocker(url, zone?, country?, locale?, data_format?)` | table | Fetch a public URL through the Web Unlocker as HTML or markdown. |
+| `brightdata.serp_search(url, zone?)` | search | Search-engine result pages through the SERP API. |
+
+### `brightdata.zone_info`
+
+Looks up one zone via `GET /zone?zone=<name>`. The `perm` column reports the
+zone permission mode (`country`), and plan columns carry plan type, product,
+and VIP pool. Zone passwords are intentionally not exposed.
+
+```sql
+SELECT zone, created, perm, plan_type
+FROM brightdata.zone_info(zone => 'unlocker');
+```
+
+### `brightdata.zone_cost`
+
+Returns usage cost and bandwidth for one zone from `GET /zone/cost`. One row
+per customer; columns report the current calendar month (`month_*`) and
+current day (`day_*`) buckets, with `*_range` carrying the period bounds.
+
+```sql
+SELECT customer_id, month_cost, month_bw, month_reqs_serp,
+       month_reqs_unblocker
+FROM brightdata.zone_cost(zone => 'unlocker');
+```
+
+### `brightdata.web_unlocker`
+
+Fetches any public URL through the Web Unlocker via `POST /request`. Returns
+`status_code`, response `headers` (Json), and `body` as HTML by default. Request
+markdown output with `data_format => 'markdown'`, or choose a country/locale
+with `country => 'us'` / `locale => 'en-US'`.
+
+```sql
+SELECT status_code, body
+FROM brightdata.web_unlocker(url => 'https://example.com');
+
+SELECT status_code, body
+FROM brightdata.web_unlocker(
+  url => 'https://en.wikipedia.org/wiki/Coral',
+  data_format => 'markdown'
+);
+```
+
+### `brightdata.serp_search`
+
+Runs a search-engine lookup through the SERP API via `POST /request`. Because
+the Coral template engine does not URL-encode template values, `serp_search`
+takes a full, pre-encoded search URL as its `url` argument. Build it from a
+search engine endpoint and the `brd_json=1` parameter so Bright Data returns
+JSON:
+
+```sql
+SELECT link, title, rank
+FROM brightdata.serp_search(
+  url => 'https://www.google.com/search?q=coral+sql&brd_json=1'
+)
+LIMIT 10;
+```
+
+`serp_search` is a search-kind function: it maps the `organic` result list and
+applies the declared `default_top_k` (10) limit, with a maximum of 50 top-k
+rows and one call per query. To page, add `start=N` to the URL. Use
+`gl=CC`/`hl=lang` parameters for country/language, and swap the host to
+`https://www.bing.com/search` or `https://search.yahoo.com/search` for other
+engines.
+
+## Validation
+
+Run the source-level checks with a valid `BRIGHT_DATA_API_KEY` before opening
+or updating a PR. The API key is required for `source add`, `source test`, and
+live SQL queries, but it should never be printed or committed.
+
+```bash
+coral source lint sources/community/brightdata/manifest.yaml
+
+export BRIGHT_DATA_API_KEY="your_zone_api_token"
+coral source add --file sources/community/brightdata/manifest.yaml
+coral source test brightdata
+```
+
+The declared test queries cover account balance, zone listing, and a SERP
+lookup:
+
+```sql
+SELECT balance, credit FROM brightdata.customer_balance;
+
+SELECT name, type FROM brightdata.zones;
+
+SELECT link, title
+FROM brightdata.serp_search(url => 'https://www.google.com/search?q=coral+sql&brd_json=1')
+LIMIT 2;
+```
+
+### Live validation output
+
+The following output was captured from a live validation run using a real
+Bright Data zone API token.
+
+#### Manifest lint
+
+Command:
+
+```bash
+coral source lint sources/community/brightdata/manifest.yaml
+```
+
+Output:
+
+```text
+Manifest is valid
+```
+
+#### Add source and run declared tests
+
+Command:
+
+```bash
+coral source add --file sources/community/brightdata/manifest.yaml
+```
+
+Output:
+
+```text
+    brightdata (4 tables)
+    ├─ customer_balance
+    ├─ customer_status
+    ├─ datasets
+    └─ zones
+
+    brightdata (4 table functions)
+    ├─ serp_search
+    ├─ web_unlocker
+    ├─ zone_cost
+    └─ zone_info
+    Query tests
+    3 declared · 3 passed · 0 failed
+
+    ✓ SELECT balance, credit FROM brightdata.customer_balance
+      1 row
+
+    ✓ SELECT name, type FROM brightdata.zones
+      2 rows
+
+    ✓ SELECT link, title FROM brightdata.serp_search(url => 'https://www.google.com/search?q=coral+sql&brd_json=1') LIMIT 2
+      2 rows
+```
+
+#### Confirm table discovery
+
+Command:
+
+```bash
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'brightdata' ORDER BY table_name"
+```
+
+Output:
+
+```text
++------------------+
+| table_name       |
++------------------+
+| customer_balance |
+| customer_status  |
+| datasets         |
+| zones            |
++------------------+
+```
+
+#### Confirm column discovery
+
+Command:
+
+```bash
+coral sql "SELECT table_name, column_name, data_type, is_nullable FROM coral.columns WHERE schema_name = 'brightdata' ORDER BY table_name, ordinal_position"
+```
+
+Output:
+
+```text
++------------------+-------------------+-----------+-------------+
+| table_name       | column_name       | data_type | is_nullable |
++------------------+-------------------+-----------+-------------+
+| customer_balance | balance           | Float64   | true        |
+| customer_balance | credit            | Float64   | true        |
+| customer_balance | prepayment        | Float64   | true        |
+| customer_balance | pending_costs     | Float64   | true        |
+| customer_status  | status            | Utf8      | true        |
+| customer_status  | customer          | Utf8      | true        |
+| customer_status  | can_make_requests | Boolean   | true        |
+| customer_status  | auth_fail_reason  | Utf8      | true        |
+| customer_status  | ip                | Utf8      | true        |
+| datasets         | id                | Utf8      | false       |
+| datasets         | name              | Utf8      | false       |
+| datasets         | size              | Int64     | true        |
+| zones            | name              | Utf8      | false       |
+| zones            | type              | Utf8      | false       |
++------------------+-------------------+-----------+-------------+
+```
+
+#### Confirm input discovery
+
+Command:
+
+```bash
+coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'brightdata' ORDER BY key"
+```
+
+Output:
+
+```text
++---------------------+----------+----------+
+| key                 | kind     | required |
++---------------------+----------+----------+
+| BRIGHT_DATA_API_KEY | secret   | true     |
+| BRIGHT_DATA_ZONE    | variable | false    |
++---------------------+----------+----------+
+```
+
+#### Run a live balance query
+
+Command:
+
+```bash
+coral sql "SELECT balance, credit, prepayment, pending_costs FROM brightdata.customer_balance"
+```
+
+Output:
+
+```text
++---------+--------+------------+---------------+
+| balance | credit | prepayment | pending_costs |
++---------+--------+------------+---------------+
+| 2.0     | 0.0    | 0.0        | 0.0           |
++---------+--------+------------+---------------+
+```
+
+#### Run a live status query
+
+Command:
+
+```bash
+coral sql "SELECT status, customer, can_make_requests, ip FROM brightdata.customer_status"
+```
+
+Output:
+
+```text
++--------+-------------+-------------------+----------------+
+| status | customer    | can_make_requests | ip             |
++--------+-------------+-------------------+----------------+
+| active | hl_12bc31c4 | false             | 43.230.107.97  |
++--------+-------------+-------------------+----------------+
+```
+
+#### Run a live zones query
+
+Command:
+
+```bash
+coral sql "SELECT name, type FROM brightdata.zones"
+```
+
+Output:
+
+```text
++--------------+-------------+
+| name         | type        |
++--------------+-------------+
+| cli_unlocker | unblocker   |
+| cli_browser  | browser_api |
++--------------+-------------+
+```
+
+#### Run a live zone_info query
+
+Command:
+
+```bash
+coral sql "SELECT zone, created, perm, plan_type, plan_product, plan_vips_type FROM brightdata.zone_info(zone => 'cli_unlocker')"
+```
+
+Output:
+
+```text
++--------------+--------------------------+---------+-----------+--------------+----------------+
+| zone         | created                  | perm    | plan_type | plan_product | plan_vips_type |
++--------------+--------------------------+---------+-----------+--------------+----------------+
+| cli_unlocker | 2026-08-11T15:21:21.629Z | country | unblocker | unblocker    | shared         |
++--------------+--------------------------+---------+-----------+--------------+----------------+
+```
+
+#### Run a live zone_cost query
+
+Command:
+
+```bash
+coral sql "SELECT customer_id, month_cost, month_bw, month_reqs_serp, month_reqs_unblocker, month_range FROM brightdata.zone_cost(zone => 'cli_unlocker')"
+```
+
+Output:
+
+```text
++-------------+------------+----------+-----------------+----------------------+-------------------------------------+
+| customer_id | month_cost | month_bw | month_reqs_serp | month_reqs_unblocker | month_range                         |
++-------------+------------+----------+-----------------+----------------------+-------------------------------------+
+| hl_12bc31c4 | 0.0195     | 888308   | 5               | 8                    | {"from":"Aug-2026","to":"Sep-2026"} |
++-------------+------------+----------+-----------------+----------------------+-------------------------------------+
+```
+
+#### Run a live web_unlocker query
+
+Command:
+
+```bash
+coral sql "SELECT url, status_code, octet_length(body) AS body_bytes FROM brightdata.web_unlocker(url => 'https://example.com')"
+```
+
+Output:
+
+```text
++---------------------+-------------+------------+
+| url                 | status_code | body_bytes |
++---------------------+-------------+------------+
+| https://example.com | 200         | 559        |
++---------------------+-------------+------------+
+```
+
+#### Run a live SERP search query
+
+Command:
+
+```bash
+coral sql "SELECT link, title, rank FROM brightdata.serp_search(url => 'https://www.google.com/search?q=coral+sql&brd_json=1') LIMIT 3"
+```
+
+Output:
+
+```text
++------------------------------------+-------------------------------------------------------------------+------+
+| link                               | title                                                             | rank |
++------------------------------------+-------------------------------------------------------------------+------+
+| https://withcoral.com/             | Coral — The data engine for enterprise AI                         | 1    |
+| https://github.com/withcoral/coral | withcoral/coral: One SQL interface over APIs, files, and live ... | 2    |
+| https://github.com/linkedin/coral  | linkedin/coral: Coral is a translation, analysis, and query ...   | 3    |
++------------------------------------+-------------------------------------------------------------------+------+
+```
+
+## Limitations
+
+- This source is read/query oriented. It does not create or manage zones,
+  datasets, or proxy credentials; the Bright Data dashboard remains the
+  management surface.
+- `customer_status.can_make_requests` reflects proxy/zone health, not API token
+  validity. On a free-trial account the API endpoints work while the report may
+  show `false` with `auth_fail_reason = zone_not_found` because the proxy zone
+  is not provisioned.
+- Async operations are not exposed: dataset sync (`POST /datasets/v3/scrape`),
+  Discover (`POST /discover` with task polling), and DCA crawls
+  (`POST /dca/crawl`) all require follow-up polling that the current HTTP
+  backend has no mapping for. Only the read-only dataset catalog is included.
+- `serp_search` requires a pre-URL-encoded `url` because Coral's template
+  engine does not URL-encode values; build the URL with `+`/`%20` and
+  `brd_json=1` as described above.
+- The Web Unlocker `data_format` options `markdown` and `screenshot` are
+  accepted; screenshots are returned as a binary buffer and are not rendered
+  as an image column, so prefer `markdown` or raw HTML in SQL.
+- Zone passwords are deliberately excluded from `zone_info` output.
+- Balance, usage costs, dataset catalog contents, and error responses depend
+  on the Bright Data account, its plan/trial, and the current provider API.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md), keep the manifest focused,
+and include the validation commands plus proof output in the PR description.

--- a/sources/community/brightdata/README.md
+++ b/sources/community/brightdata/README.md
@@ -53,7 +53,10 @@ token. Create one from the dashboard:
 1. Log in to the Bright Data dashboard at <https://brightdata.com/>.
 2. Go to **Account** → **API access** (https://brightdata.com/api).
 3. Click **Create API token**, choose **Zone API token**, select the zone, and
-   copy the token.
+   copy the token. Use the **Admin** permission level: this source calls both
+   billing endpoints (balance, zone cost) and proxy endpoints (Web Unlocker,
+   SERP), and only Admin covers both with a single token (Finance covers
+   billing only; Ops and User cover proxy access only).
 
 Set the token as `BRIGHT_DATA_API_KEY` before adding or testing the source:
 
@@ -203,8 +206,8 @@ LIMIT 10;
 applies the declared `default_top_k` (10) limit, with a maximum of 50 top-k
 rows and one call per query. To page, add `start=N` to the URL. Use
 `gl=CC`/`hl=lang` parameters for country/language, and swap the host to
-`https://www.bing.com/search` or `https://search.yahoo.com/search` for other
-engines.
+`https://www.bing.com/search` for Bing results. Google and Bing are the
+validated engines; other engines are not covered by this source.
 
 ## Validation
 

--- a/sources/community/brightdata/manifest.yaml
+++ b/sources/community/brightdata/manifest.yaml
@@ -1,0 +1,519 @@
+name: brightdata
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query your Bright Data account through its public API: account balance and
+  status, active zones, zone usage/cost details, the Web Unlocker for fetching
+  pages as HTML or markdown, and Google/Bing/Yandex search engine results
+  (SERP). SERP responses include organic results with titles, URLs, and
+  snippets.
+base_url: https://api.brightdata.com
+inputs:
+  BRIGHT_DATA_API_KEY:
+    kind: secret
+    hint: >-
+      Bright Data API token from the Bright Data dashboard (Account →
+      API access → Create API token). Looks like a UUID with hyphens, for
+      example `3afceabe-5ccb-4341-84ca-95b6fb044915`. The token controls
+      access to your account and zones.
+  BRIGHT_DATA_ZONE:
+    kind: variable
+    default: unlocker
+    hint: >-
+      Name of a Web Unlocker zone to use by default for web_unlocker and
+      serp_search calls. Zone names are shown in the Bright Data dashboard
+      under Zones. Override per call with the zone argument when you have
+      several zones.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.BRIGHT_DATA_API_KEY}}"
+test_queries:
+  - SELECT balance, credit FROM brightdata.customer_balance
+  - SELECT name, type FROM brightdata.zones
+  - SELECT link, title FROM brightdata.serp_search(url => 'https://www.google.com/search?q=coral+sql&brd_json=1') LIMIT 2
+tables:
+  - name: customer_balance
+    description: >-
+      Your Bright Data account prepaid balance, active credit, and prepayment
+      totals. One row per account.
+    guide: |
+      No filter required. Values are USD. Free-credit accounts show a small
+      balance plus a credit line that renews periodically.
+    request:
+      method: GET
+      path: /customer/balance
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: balance
+        type: Float64
+        nullable: true
+        description: Current account balance in USD.
+        expr: {kind: path, path: [balance]}
+      - name: credit
+        type: Float64
+        nullable: true
+        description: Active credit amount in USD.
+        expr: {kind: path, path: [credit]}
+      - name: prepayment
+        type: Float64
+        nullable: true
+        description: Prepayment amount in USD.
+        expr: {kind: path, path: [prepayment]}
+      - name: pending_costs
+        type: Float64
+        nullable: true
+        description: Costs not yet settled in USD.
+        expr: {kind: path, path: [pending_costs]}
+
+  - name: customer_status
+    description: >-
+      Your Bright Data account status: subscription state, customer id, and
+      proxy-level request authorization state. One row per account.
+    guide: |
+      No filter required. can_make_requests and auth_fail_reason describe
+      proxy (zone password) authentication, not the API token used by this
+      source; API calls such as web_unlocker still work when the zone is
+      correctly configured.
+    request:
+      method: GET
+      path: /status
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Account status, for example `active`.
+        expr: {kind: path, path: [status]}
+      - name: customer
+        type: Utf8
+        nullable: true
+        description: Customer id used to build proxy hostnames.
+        expr: {kind: path, path: [customer]}
+      - name: can_make_requests
+        type: Boolean
+        nullable: true
+        description: Whether the proxy authorizes requests with the configured zone.
+        expr: {kind: path, path: [can_make_requests]}
+      - name: auth_fail_reason
+        type: Utf8
+        nullable: true
+        description: Proxy authentication failure reason when can_make_requests is false.
+        expr: {kind: path, path: [auth_fail_reason]}
+      - name: ip
+        type: Utf8
+        nullable: true
+        description: Egress IP address for proxy requests.
+        expr: {kind: path, path: [ip]}
+
+  - name: zones
+    description: >-
+      Active zones on your Bright Data account, with their type (for example
+      `unblocker` or `browser_api`).
+    guide: |
+      No filter required. Use zone names in web_unlocker and serp_search
+      calls or to look up zone_info.
+    request:
+      method: GET
+      path: /zone/get_active_zones
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Zone name.
+        expr: {kind: path, path: [name]}
+      - name: type
+        type: Utf8
+        nullable: false
+        description: Zone type, for example `unblocker` or `browser_api`.
+        expr: {kind: path, path: [type]}
+
+  - name: datasets
+    description: >-
+      Bright Data public dataset marketplace catalog. Each row is one
+      dataset with its id, name, and row count.
+    guide: |
+      No filter required. Dataset ids can be used with the Bright Data
+      dataset APIs (outside this source) to trigger collection runs.
+    request:
+      method: GET
+      path: /datasets/list
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Dataset identifier, for example `gd_l1vijqt9jfj7olije`.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Human-readable dataset name.
+        expr: {kind: path, path: [name]}
+      - name: size
+        type: Int64
+        nullable: true
+        description: Number of records in the dataset.
+        expr: {kind: path, path: [size]}
+
+functions:
+  - name: zone_info
+    kind: table
+    description: >-
+      Details for one zone: creation time, allowed egress IPs, permission
+      scope, and plan information.
+    guide: |
+      Pass the zone name: `SELECT * FROM
+      brightdata.zone_info(zone => 'cli_unlocker')`. Zone passwords are
+      intentionally not exposed.
+    args:
+      - name: zone
+        required: true
+        bind: {arg: zone}
+    request:
+      method: GET
+      path: /zone
+      query:
+        - name: zone
+          from: arg
+          key: zone
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: zone
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the requested zone name.
+        expr: {kind: from_arg, key: zone}
+      - name: created
+        type: Utf8
+        nullable: true
+        description: Zone creation timestamp.
+        expr: {kind: path, path: [created]}
+      - name: ips
+        type: Json
+        nullable: true
+        description: Allowed egress IPs for this zone.
+        expr: {kind: path, path: [ips]}
+      - name: perm
+        type: Utf8
+        nullable: true
+        description: Permission scope, for example `country`.
+        expr: {kind: path, path: [perm]}
+      - name: plan_type
+        type: Utf8
+        nullable: true
+        description: Plan type, for example `unblocker`.
+        expr: {kind: path, path: [plan, type]}
+      - name: plan_product
+        type: Utf8
+        nullable: true
+        description: Plan product, for example `unblocker`.
+        expr: {kind: path, path: [plan, product]}
+      - name: plan_vips_type
+        type: Utf8
+        nullable: true
+        description: VIP pool type, for example `shared`.
+        expr: {kind: path, path: [plan, vips_type]}
+      - name: plan_start
+        type: Utf8
+        nullable: true
+        description: Plan start timestamp.
+        expr: {kind: path, path: [plan, start]}
+      - name: plan_trial_id
+        type: Utf8
+        nullable: true
+        description: Trial identifier when the zone runs on a trial plan.
+        expr: {kind: path, path: [plan, trial_id]}
+
+  - name: zone_cost
+    kind: table
+    description: >-
+      Usage cost and bandwidth for one zone, grouped into monthly and daily
+      billing periods. One row per customer on the account.
+    guide: |
+      Pass the zone name, and optionally a `from`/`to` month filter
+      (`YYYY-MM`): `SELECT customer_id, month_cost, day_cost FROM
+      brightdata.zone_cost(zone => 'cli_unlocker')`. Columns report the
+      current month (`back_m0`) and current day (`back_d0`) buckets; the
+      `month_range` and `day_range` Json columns carry the covered period
+      bounds.
+    args:
+      - name: zone
+        required: true
+        bind: {arg: zone}
+      - name: from
+        bind: {arg: from}
+      - name: to
+        bind: {arg: to}
+    request:
+      method: GET
+      path: /zone/cost
+      query:
+        - name: zone
+          from: arg
+          key: zone
+        - name: from
+          from: arg
+          key: from
+        - name: to
+          from: arg
+          key: to
+    response:
+      row_strategy: dict_entries
+    pagination:
+      mode: none
+    columns:
+      - name: customer_id
+        type: Utf8
+        nullable: false
+        description: Customer id the usage belongs to.
+        expr: {kind: path, path: [_key]}
+      - name: month_cost
+        type: Float64
+        nullable: true
+        description: Cost accrued in the current calendar month (`back_m0`).
+        expr: {kind: path, path: [back_m0, cost]}
+      - name: month_bw
+        type: Int64
+        nullable: true
+        description: Bandwidth used in the current calendar month, in bytes.
+        expr: {kind: path, path: [back_m0, bw]}
+      - name: month_reqs_serp
+        type: Int64
+        nullable: true
+        description: SERP requests in the current calendar month.
+        expr: {kind: path, path: [back_m0, reqs_serp]}
+      - name: month_reqs_unblocker
+        type: Int64
+        nullable: true
+        description: Unlocker requests in the current calendar month.
+        expr: {kind: path, path: [back_m0, reqs_unblocker]}
+      - name: month_range
+        type: Json
+        nullable: true
+        description: Month period bounds (`{from, to}`).
+        expr: {kind: path, path: [back_m0, range]}
+      - name: day_cost
+        type: Float64
+        nullable: true
+        description: Cost accrued today (`back_d0`).
+        expr: {kind: path, path: [back_d0, cost]}
+      - name: day_bw
+        type: Int64
+        nullable: true
+        description: Bandwidth used today, in bytes.
+        expr: {kind: path, path: [back_d0, bw]}
+      - name: day_reqs_serp
+        type: Int64
+        nullable: true
+        description: SERP requests today.
+        expr: {kind: path, path: [back_d0, reqs_serp]}
+      - name: day_reqs_unblocker
+        type: Int64
+        nullable: true
+        description: Unlocker requests today.
+        expr: {kind: path, path: [back_d0, reqs_unblocker]}
+      - name: day_range
+        type: Json
+        nullable: true
+        description: Day period bounds (`{from, to}`).
+        expr: {kind: path, path: [back_d0, range]}
+      - name: zone
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the requested zone name.
+        expr: {kind: from_arg, key: zone}
+
+  - name: web_unlocker
+    kind: table
+    description: >-
+      Fetch any public URL through the Bright Data Web Unlocker and get the
+      response status, headers, and body as HTML (or markdown when
+      data_format is set).
+    guide: |
+      Pass the target URL: `SELECT status_code, body FROM
+      brightdata.web_unlocker(url => 'https://example.com')`. Request
+      markdown output with `data_format => 'markdown'`. Use `country => 'us'`
+      to fetch from a specific country and `zone => '<name>'` to override the
+      configured BRIGHT_DATA_ZONE.
+    args:
+      - name: url
+        required: true
+        bind: {arg: url}
+      - name: zone
+        bind: {arg: zone}
+      - name: country
+        bind: {arg: country}
+      - name: locale
+        bind: {arg: locale}
+      - name: data_format
+        bind: {arg: data_format}
+    request:
+      method: POST
+      path: /request
+      body:
+        - path: [zone]
+          from: one_of
+          values:
+            - from: arg
+              key: zone
+            - from: input
+              key: BRIGHT_DATA_ZONE
+        - path: [url]
+          from: arg
+          key: url
+        - path: [format]
+          from: literal
+          value: json
+        - path: [country]
+          from: arg
+          key: country
+        - path: [locale]
+          from: arg
+          key: locale
+        - path: [data_format]
+          from: arg
+          key: data_format
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: url
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the requested URL.
+        expr: {kind: from_arg, key: url}
+      - name: status_code
+        type: Int64
+        nullable: true
+        description: HTTP status code of the target response.
+        expr: {kind: path, path: [status_code]}
+      - name: headers
+        type: Json
+        nullable: true
+        description: Response headers of the target page.
+        expr: {kind: path, path: [headers]}
+      - name: body
+        type: Utf8
+        nullable: true
+        description: >-
+          Page body as raw HTML, or as markdown when data_format =>
+          'markdown' is passed.
+        expr: {kind: path, path: [body]}
+
+  - name: serp_search
+    kind: search
+    description: >-
+      Search engine results for a Google, Bing, or Yandex search URL. Pass
+      the full search URL with brd_json=1; returns organic results with
+      links, titles, descriptions, and ranks.
+    guide: |
+      Build the search URL and pass it as the url argument. Examples:
+
+      - Google: `https://www.google.com/search?q=coral+sql&brd_json=1`
+      - Bing: `https://www.bing.com/search?q=coral+sql&brd_json=1`
+      - Yandex: `https://yandex.com/search/?text=coral+sql&brd_json=1`
+
+      Use `gl=XX`/`hl=XX` query params to control country and language, and
+      `start=N` on Google to fetch the next results page. Query text must be
+      URL-encoded (spaces as `+` or `%20`). Override the configured
+      BRIGHT_DATA_ZONE with `zone => '<name>'`.
+    args:
+      - name: url
+        required: true
+        bind: {arg: url}
+      - name: zone
+        bind: {arg: zone}
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 50
+      max_calls_per_query: 1
+    request:
+      method: POST
+      path: /request
+      body:
+        - path: [zone]
+          from: one_of
+          values:
+            - from: arg
+              key: zone
+            - from: input
+              key: BRIGHT_DATA_ZONE
+        - path: [url]
+          from: arg
+          key: url
+        - path: [format]
+          from: literal
+          value: raw
+    response:
+      rows_path:
+        - organic
+    pagination:
+      mode: none
+    columns:
+      - name: link
+        type: Utf8
+        nullable: false
+        description: URL of the organic search result.
+        expr: {kind: path, path: [link]}
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Source site name of the result.
+        expr: {kind: path, path: [source]}
+      - name: display_link
+        type: Utf8
+        nullable: true
+        description: Displayed link text of the result.
+        expr: {kind: path, path: [display_link]}
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title of the result.
+        expr: {kind: path, path: [title]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Search snippet describing the result.
+        expr: {kind: path, path: [description]}
+      - name: rank
+        type: Int64
+        nullable: true
+        description: 1-based position of the result within the page.
+        expr: {kind: path, path: [rank]}
+      - name: global_rank
+        type: Int64
+        nullable: true
+        description: Overall position of the result across pages.
+        expr: {kind: path, path: [global_rank]}
+      - name: snippet_highlighted_words
+        type: Json
+        nullable: true
+        description: Words highlighted in the snippet by the engine.
+        expr: {kind: path, path: [snippet_highlighted_words]}
+      - name: search_url
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the requested search URL.
+        expr: {kind: from_arg, key: url}

--- a/sources/community/brightdata/manifest.yaml
+++ b/sources/community/brightdata/manifest.yaml
@@ -5,9 +5,8 @@ backend: http
 description: >-
   Query your Bright Data account through its public API: account balance and
   status, active zones, zone usage/cost details, the Web Unlocker for fetching
-  pages as HTML or markdown, and Google/Bing/Yandex search engine results
-  (SERP). SERP responses include organic results with titles, URLs, and
-  snippets.
+  pages as HTML or markdown, and Google and Bing search engine results (SERP).
+  SERP responses include organic results with titles, URLs, and snippets.
 base_url: https://api.brightdata.com
 inputs:
   BRIGHT_DATA_API_KEY:
@@ -15,8 +14,11 @@ inputs:
     hint: >-
       Bright Data API token from the Bright Data dashboard (Account →
       API access → Create API token). Looks like a UUID with hyphens, for
-      example `3afceabe-5ccb-4341-84ca-95b6fb044915`. The token controls
-      access to your account and zones.
+      example `3afceabe-5ccb-4341-84ca-95b6fb044915`. Use the Admin
+      permission level when creating the token: this source calls both
+      billing endpoints (balance, zone cost) and proxy endpoints (Web
+      Unlocker, SERP), and only Admin covers both with a single token
+      (Finance covers billing only; Ops and User cover proxy access only).
   BRIGHT_DATA_ZONE:
     kind: variable
     default: unlocker
@@ -423,15 +425,14 @@ functions:
   - name: serp_search
     kind: search
     description: >-
-      Search engine results for a Google, Bing, or Yandex search URL. Pass
-      the full search URL with brd_json=1; returns organic results with
-      links, titles, descriptions, and ranks.
+      Search engine results for a Google or Bing search URL. Pass the full
+      search URL with brd_json=1; returns organic results with links, titles,
+      descriptions, and ranks.
     guide: |
       Build the search URL and pass it as the url argument. Examples:
 
       - Google: `https://www.google.com/search?q=coral+sql&brd_json=1`
       - Bing: `https://www.bing.com/search?q=coral+sql&brd_json=1`
-      - Yandex: `https://yandex.com/search/?text=coral+sql&brd_json=1`
 
       Use `gl=XX`/`hl=XX` query params to control country and language, and
       `start=N` on Google to fetch the next results page. Query text must be


### PR DESCRIPTION
## Summary

Adds a `brightdata` community source that lets Coral users query the Bright Data customer API through SQL: account balance, account status, active zones, the public dataset catalog, zone usage/cost details, Web Unlocker page fetches, and search engine results (SERP).

## What changed

- Added `sources/community/brightdata/manifest.yaml`
- Added `sources/community/brightdata/README.md`

## Source scope

| Table / function | Purpose | Required args |
| --- | --- | --- |
| `brightdata.customer_balance` | Account balance, credit, prepayment from `GET /customer/balance`. | None |
| `brightdata.customer_status` | Account status, exit IP, proxy request health from `GET /status`. | None |
| `brightdata.zones` | Active zones and their type from `GET /zone/get_active_zones`. | None |
| `brightdata.datasets` | Public dataset catalog (id, name, row count) from `GET /datasets/list`. | None |
| `brightdata.zone_info(zone)` | Zone config + plan details from `GET /zone`. | `zone` |
| `brightdata.zone_cost(zone, from?, to?)` | Usage cost/bandwidth by period from `GET /zone/cost`. | `zone` |
| `brightdata.web_unlocker(url, zone?, country?, locale?, data_format?)` | Fetch any public URL via Web Unlocker (HTML or markdown). | `url` |
| `brightdata.serp_search(url, zone?)` | Search-engine results (Google/Bing) via SERP. | `url` |

## Provider docs

- Bright Data API: https://docs.brightdata.com
- API tokens: https://brightdata.com/api
- Web Unlocker: https://docs.brightdata.com/scraping-methods/web-unlocker
- SERP API: https://docs.brightdata.com/scraping-methods/serp

## Validation

Validated with a real `BRIGHT_DATA_API_KEY` (zone API token) against `https://api.brightdata.com`. The key is not committed or printed. Account-specific identifiers (customer id, zone names) are real values from the validating account.

### 1. Manifest lint

Command:

```bash
coral source lint sources/community/brightdata/manifest.yaml
```

Output:

```text
Manifest is valid
```

### 2. Source add and declared query tests

Command:

```bash
coral source add --file sources/community/brightdata/manifest.yaml
```

Output:

```text
  ✓ brightdata connected successfully
  Secrets: keychain

    brightdata (4 tables)
    ├─ customer_balance
    ├─ customer_status
    ├─ datasets
    └─ zones

    brightdata (4 table functions)
    ├─ serp_search
    ├─ web_unlocker
    ├─ zone_cost
    └─ zone_info
    Query tests
    3 declared · 3 passed · 0 failed

    ✓ SELECT balance, credit FROM brightdata.customer_balance
      1 row

    ✓ SELECT name, type FROM brightdata.zones
      2 rows

    ✓ SELECT link, title FROM brightdata.serp_search(url => 'https://www.google.com/search?q=coral+sql&brd_json=1') LIMIT 2
      2 rows
```

### 3. Source test (same output, separate command)

Command:

```bash
coral source test brightdata
```

Output: identical to step 2 above (3 declared · 3 passed · 0 failed).

### 4. Table discovery

Command:

```bash
coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'brightdata' ORDER BY table_name"
```

Output:

```text
+------------------+
| table_name       |
+------------------+
| customer_balance |
| customer_status  |
| datasets         |
| zones            |
+------------------+
```

### 5. Column discovery

Command:

```bash
coral sql "SELECT table_name, column_name, data_type, is_nullable FROM coral.columns WHERE schema_name = 'brightdata' ORDER BY table_name, ordinal_position"
```

Output:

```text
+------------------+-------------------+-----------+-------------+
| table_name       | column_name       | data_type | is_nullable |
+------------------+-------------------+-----------+-------------+
| customer_balance | balance           | Float64   | true        |
| customer_balance | credit            | Float64   | true        |
| customer_balance | prepayment        | Float64   | true        |
| customer_balance | pending_costs     | Float64   | true        |
| customer_status  | status            | Utf8      | true        |
| customer_status  | customer          | Utf8      | true        |
| customer_status  | can_make_requests | Boolean   | true        |
| customer_status  | auth_fail_reason  | Utf8      | true        |
| customer_status  | ip                | Utf8      | true        |
| datasets         | id                | Utf8      | false       |
| datasets         | name              | Utf8      | false       |
| datasets         | size              | Int64     | true        |
| zones            | name              | Utf8      | false       |
| zones            | type              | Utf8      | false       |
+------------------+-------------------+-----------+-------------+
```

### 6. Input discovery

Command:

```bash
coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'brightdata' ORDER BY key"
```

Output:

```text
+---------------------+----------+----------+
| key                 | kind     | required |
+---------------------+----------+----------+
| BRIGHT_DATA_API_KEY | secret   | true     |
| BRIGHT_DATA_ZONE    | variable | false    |
+---------------------+----------+----------+
```

### 7. Live balance query

Command:

```bash
coral sql "SELECT balance, credit, prepayment, pending_costs FROM brightdata.customer_balance"
```

Output:

```text
+---------+--------+------------+---------------+
| balance | credit | prepayment | pending_costs |
+---------+--------+------------+---------------+
| 2.0     | 0.0    | 0.0        | 0.0           |
+---------+--------+------------+---------------+
```

### 8. Live status query

Command:

```bash
coral sql "SELECT status, customer, can_make_requests, ip FROM brightdata.customer_status"
```

Output:

```text
+--------+-------------+-------------------+----------------+
| status | customer    | can_make_requests | ip             |
+--------+-------------+-------------------+----------------+
| active | hl_12bc31c4 | false             | 43.230.107.97  |
+--------+-------------+-------------------+----------------+
```

### 9. Live zones query

Command:

```bash
coral sql "SELECT name, type FROM brightdata.zones"
```

Output:

```text
+--------------+-------------+
| name         | type        |
+--------------+-------------+
| cli_unlocker | unblocker   |
| cli_browser  | browser_api |
+--------------+-------------+
```

### 10. Live zone_info query

Command:

```bash
coral sql "SELECT zone, created, perm, plan_type, plan_product, plan_vips_type FROM brightdata.zone_info(zone => 'cli_unlocker')"
```

Output:

```text
+--------------+--------------------------+---------+-----------+--------------+----------------+
| zone         | created                  | perm    | plan_type | plan_product | plan_vips_type |
+--------------+--------------------------+---------+-----------+--------------+----------------+
| cli_unlocker | 2026-08-11T15:21:21.629Z | country | unblocker | unblocker    | shared         |
+--------------+--------------------------+---------+-----------+--------------+----------------+
```

### 11. Live zone_cost query

Command:

```bash
coral sql "SELECT customer_id, month_cost, month_bw, month_reqs_serp, month_reqs_unblocker, month_range FROM brightdata.zone_cost(zone => 'cli_unlocker')"
```

Output:

```text
+-------------+------------+----------+-----------------+----------------------+-------------------------------------+
| customer_id | month_cost | month_bw | month_reqs_serp | month_reqs_unblocker | month_range                         |
+-------------+------------+----------+-----------------+----------------------+-------------------------------------+
| hl_12bc31c4 | 0.0195     | 888308   | 5               | 8                    | {"from":"Aug-2026","to":"Sep-2026"} |
+-------------+------------+----------+-----------------+----------------------+-------------------------------------+
```

`zone_cost` uses `row_strategy: dict_entries`; the current-month (`back_m0`) and current-day (`back_d0`) buckets are mapped to `month_*` / `day_*` columns, with `*_range` Json columns carrying the period bounds.

### 12. Live web_unlocker query

Command:

```bash
coral sql "SELECT url, status_code, octet_length(body) AS body_bytes FROM brightdata.web_unlocker(url => 'https://example.com')"
```

Output:

```text
+---------------------+-------------+------------+
| url                 | status_code | body_bytes |
+---------------------+-------------+------------+
| https://example.com | 200         | 559        |
+---------------------+-------------+------------+
```

### 13. Live datasets query

Command:

```bash
coral sql "SELECT id, name, size FROM brightdata.datasets WHERE size > 1000000 LIMIT 3"
```

Output:

```text
+----------------------+----------------------------------------------+-----------+
| id                   | name                                         | size      |
+----------------------+----------------------------------------------+-----------+
| gd_l1vijqt9jfj7olije | Crunchbase companies information              | 2300000   |
| gd_l1vik5c8204suup7nc | Glassdoor companies information (Public web data) | 2480000 |
| gd_l1vikfch901nx3by4 | Instagram - Profiles                          | 620000000 |
+----------------------+----------------------------------------------+-----------+
```

### 14. Live SERP search query

Command:

```bash
coral sql "SELECT link, title, rank FROM brightdata.serp_search(url => 'https://www.google.com/search?q=coral+sql&brd_json=1') LIMIT 3"
```

Output:

```text
+------------------------------------+-------------------------------------------------------------------+------+
| link                               | title                                                             | rank |
+------------------------------------+-------------------------------------------------------------------+------+
| https://withcoral.com/             | Coral — The data engine for enterprise AI                         | 1    |
| https://github.com/withcoral/coral | withcoral/coral: One SQL interface over APIs, files, and live ... | 2    |
| https://github.com/linkedin/coral  | linkedin/coral: Coral is a translation, analysis, and query ...   | 3    |
+------------------------------------+-------------------------------------------------------------------+------+
```

## Notes

- Zone passwords are deliberately not exposed (`zone_info` has no password column).
- `serp_search` takes a pre-encoded full search URL (`brd_json=1`) because the Coral template engine does not URL-encode values; documented in the README and the function guide.
- The API key should be created with **Admin** permission: the source calls both billing endpoints (balance, zone cost) and proxy endpoints (Web Unlocker, SERP), and only Admin covers both with a single token (Finance covers billing only; Ops and User cover proxy access only).
- SERP engines are **Google and Bing**, both validated live. A Yandex example originally in the manifest/README was removed because the documented URL returns a non-JSON response.
- Async/polling endpoints (dataset sync `POST /datasets/v3/scrape`, Discover task polling, DCA crawls) have no request/response mapping in the current HTTP backend and are intentionally out of scope for v1.
