### PR TITLE
feat(app): export Arrow IPC encoded size

### DIFF
--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -1,6 +1,7 @@
 //! Implements the gRPC `QueryService`.
 
 use std::collections::HashSet;
+use std::io::Write;
 
 use arrow::datatypes::SchemaRef;
 use arrow::ipc::writer::StreamWriter;
@@ -10,7 +11,9 @@ use coral_api::v1::{
     ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, QueryGuide,
     QueryGuideReadContext, QueryGuideRequired, QueryPlan as QueryPlanProto,
 };
+use opentelemetry::trace::Status as OtelStatus;
 use tonic::{Request, Response, Status};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::core_status;
 use crate::query::QueryAttribution;
@@ -145,13 +148,265 @@ fn encode_arrow_ipc_stream(
     schema: &SchemaRef,
     batches: &[RecordBatch],
 ) -> Result<Vec<u8>, arrow::error::ArrowError> {
-    let mut bytes = Vec::new();
-    {
-        let mut writer = StreamWriter::try_new(&mut bytes, schema)?;
-        for batch in batches {
-            writer.write(batch)?;
-        }
-        writer.finish()?;
+    observe_arrow_ipc_encoding(|| serialize_arrow_ipc_stream(Vec::new(), schema, batches))
+}
+
+fn serialize_arrow_ipc_stream<W: Write>(
+    sink: W,
+    schema: &SchemaRef,
+    batches: &[RecordBatch],
+) -> Result<W, arrow::error::ArrowError> {
+    let mut writer = StreamWriter::try_new(sink, schema)?;
+    for batch in batches {
+        writer.write(batch)?;
     }
-    Ok(bytes)
+    writer.finish()?;
+    writer.into_inner()
+}
+
+fn observe_arrow_ipc_encoding(
+    encode: impl FnOnce() -> Result<Vec<u8>, arrow::error::ArrowError>,
+) -> Result<Vec<u8>, arrow::error::ArrowError> {
+    observe_arrow_ipc_encoding_with_size(encode, |len| u64::try_from(len).ok())
+}
+
+fn observe_arrow_ipc_encoding_with_size(
+    encode: impl FnOnce() -> Result<Vec<u8>, arrow::error::ArrowError>,
+    encoded_size: impl FnOnce(usize) -> Option<u64>,
+) -> Result<Vec<u8>, arrow::error::ArrowError> {
+    let span = tracing::info_span!(
+        "coral.query.result.ipc",
+        encoded_size_bytes = tracing::field::Empty,
+    );
+    let _entered = span.enter();
+    match encode() {
+        Ok(bytes) => {
+            if let Some(encoded_size) = encoded_size(bytes.len()) {
+                if let Ok(span_size) = i64::try_from(encoded_size) {
+                    span.record("encoded_size_bytes", span_size);
+                }
+                crate::telemetry::metrics::metrics()
+                    .record_query_result_ipc_encoded_size(encoded_size);
+            }
+            span.set_status(OtelStatus::Ok);
+            Ok(bytes)
+        }
+        Err(error) => {
+            coral_telemetry::record_failure(
+                &span,
+                "arrow.ipc.encoding",
+                "Arrow IPC encoding failed",
+            );
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::sync::Arc;
+
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    use super::{
+        encode_arrow_ipc_stream, observe_arrow_ipc_encoding, observe_arrow_ipc_encoding_with_size,
+        serialize_arrow_ipc_stream,
+    };
+
+    #[derive(Default)]
+    struct FinishFailWriter(Vec<u8>);
+
+    impl Write for FinishFailWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.write(bytes)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("forced finish failure"))
+        }
+    }
+
+    #[test]
+    fn ipc_success_records_exact_returned_length_as_grpc_sibling_after_query() {
+        crate::telemetry::metrics::test_support::reset_metrics();
+        let metric_exporter = crate::telemetry::metrics::test_support::install_metrics_exporter();
+        let span_exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter.clone())
+            .build();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("ipc-result-test")));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .expect("test batch");
+        let grpc = tracing::info_span!("grpc.request");
+        let bytes = {
+            let _grpc_entered = grpc.enter();
+            let query = tracing::info_span!("coral.query");
+            {
+                let _query_entered = query.enter();
+            }
+            drop(query);
+            encode_arrow_ipc_stream(&schema, &[batch]).expect("IPC encoding succeeds")
+        };
+        drop(grpc);
+
+        crate::telemetry::metrics::test_support::flush_metrics();
+        let finished = metric_exporter
+            .get_finished_metrics()
+            .expect("finished metrics");
+        let metric =
+            find_metric(&finished, "coral.query.result.ipc.encoded_size").expect("IPC size metric");
+        let AggregatedMetrics::U64(MetricData::Histogram(histogram)) = metric.data() else {
+            panic!("IPC size should be a u64 histogram");
+        };
+        let points = histogram.data_points().collect::<Vec<_>>();
+        assert_eq!(points.len(), 1);
+        let point = points.first().expect("single IPC metric point");
+        assert_eq!(
+            point.sum(),
+            u64::try_from(bytes.len()).expect("payload length")
+        );
+
+        provider.force_flush().expect("flush spans");
+        let spans = span_exporter.get_finished_spans().expect("finished spans");
+        let grpc = find_span(&spans, "grpc.request");
+        let query = find_span(&spans, "coral.query");
+        let ipc = find_span(&spans, "coral.query.result.ipc");
+        assert_eq!(query.parent_span_id, grpc.span_context.span_id());
+        assert_eq!(ipc.parent_span_id, grpc.span_context.span_id());
+        assert!(ipc.start_time >= query.end_time);
+        assert_eq!(ipc.status, OtelStatus::Ok);
+        assert_eq!(
+            span_i64(ipc, "encoded_size_bytes"),
+            Some(i64::try_from(bytes.len()).expect("payload length"))
+        );
+        for forbidden in ["sql", "workspace", "task.id", "source", "table", "user"] {
+            assert!(!has_span_attribute(ipc, forbidden));
+        }
+    }
+
+    #[test]
+    fn ipc_encoding_failure_sets_error_and_omits_size_metric() {
+        crate::telemetry::metrics::test_support::reset_metrics();
+        let metric_exporter = crate::telemetry::metrics::test_support::install_metrics_exporter();
+        let span_exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter.clone())
+            .build();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("ipc-failure-test")));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let stream_schema = Arc::new(Schema::empty());
+        assert!(
+            observe_arrow_ipc_encoding(|| {
+                serialize_arrow_ipc_stream(FinishFailWriter::default(), &stream_schema, &[])
+                    .map(|_| Vec::new())
+            })
+            .is_err(),
+            "forced flush failure should make StreamWriter::finish fail"
+        );
+
+        crate::telemetry::metrics::test_support::flush_metrics();
+        let finished = metric_exporter
+            .get_finished_metrics()
+            .expect("finished metrics");
+        assert!(
+            find_metric(&finished, "coral.query.result.ipc.encoded_size").is_none(),
+            "failed IPC encoding must omit the histogram"
+        );
+
+        provider.force_flush().expect("flush spans");
+        let spans = span_exporter.get_finished_spans().expect("finished spans");
+        let ipc = find_span(&spans, "coral.query.result.ipc");
+        assert!(matches!(ipc.status, OtelStatus::Error { .. }));
+        assert!(span_i64(ipc, "encoded_size_bytes").is_none());
+    }
+
+    #[test]
+    fn ipc_size_conversion_failure_omits_numeric_telemetry() {
+        crate::telemetry::metrics::test_support::reset_metrics();
+        let metric_exporter = crate::telemetry::metrics::test_support::install_metrics_exporter();
+        let span_exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter.clone())
+            .build();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("ipc-size-test")));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let bytes = observe_arrow_ipc_encoding_with_size(|| Ok(vec![1, 2, 3]), |_| None)
+            .expect("encoding still succeeds when its size cannot be represented");
+        assert_eq!(bytes, vec![1, 2, 3]);
+
+        crate::telemetry::metrics::test_support::flush_metrics();
+        let finished = metric_exporter
+            .get_finished_metrics()
+            .expect("finished metrics");
+        assert!(
+            find_metric(&finished, "coral.query.result.ipc.encoded_size").is_none(),
+            "unrepresentable IPC size must omit the histogram"
+        );
+
+        provider.force_flush().expect("flush spans");
+        let spans = span_exporter.get_finished_spans().expect("finished spans");
+        let ipc = find_span(&spans, "coral.query.result.ipc");
+        assert_eq!(ipc.status, OtelStatus::Ok);
+        assert!(span_i64(ipc, "encoded_size_bytes").is_none());
+    }
+
+    fn find_metric<'a>(
+        metrics: &'a [ResourceMetrics],
+        name: &str,
+    ) -> Option<&'a opentelemetry_sdk::metrics::data::Metric> {
+        metrics
+            .iter()
+            .rev()
+            .flat_map(ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == name)
+    }
+
+    fn find_span<'a>(
+        spans: &'a [opentelemetry_sdk::trace::SpanData],
+        name: &str,
+    ) -> &'a opentelemetry_sdk::trace::SpanData {
+        spans
+            .iter()
+            .find(|span| span.name == name)
+            .unwrap_or_else(|| panic!("span {name} missing"))
+    }
+
+    fn span_i64(span: &opentelemetry_sdk::trace::SpanData, name: &str) -> Option<i64> {
+        span.attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == name)
+            .and_then(|attribute| match attribute.value {
+                opentelemetry::Value::I64(value) => Some(value),
+                _ => None,
+            })
+    }
+
+    fn has_span_attribute(span: &opentelemetry_sdk::trace::SpanData, name: &str) -> bool {
+        span.attributes
+            .iter()
+            .any(|attribute| attribute.key.as_str() == name)
+    }
 }

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -33,6 +33,7 @@ pub(crate) struct Metrics {
     _active_query_gauge: ObservableGauge<u64>,
     datafusion_reserved_peak: Histogram<u64>,
     arrow_estimated_occupied_memory: Histogram<u64>,
+    ipc_encoded_size: Histogram<u64>,
 }
 
 impl Metrics {
@@ -77,6 +78,11 @@ impl Metrics {
             return;
         };
         self.arrow_estimated_occupied_memory
+            .record(bytes, &query_memory_attributes(QueryMemoryOutcome::Success));
+    }
+
+    pub(crate) fn record_query_result_ipc_encoded_size(&self, bytes: u64) {
+        self.ipc_encoded_size
             .record(bytes, &query_memory_attributes(QueryMemoryOutcome::Success));
     }
 }
@@ -142,6 +148,12 @@ fn build_metrics(meter: &Meter) -> Metrics {
             .u64_histogram("coral.query.result.arrow.estimated_occupied_memory")
             .with_unit("By")
             .with_description("Estimated Arrow occupied memory per query result")
+            .with_boundaries(QUERY_MEMORY_BUCKETS.to_vec())
+            .build(),
+        ipc_encoded_size: meter
+            .u64_histogram("coral.query.result.ipc.encoded_size")
+            .with_unit("By")
+            .with_description("Exact serialized Arrow IPC payload size per query result")
             .with_boundaries(QUERY_MEMORY_BUCKETS.to_vec())
             .build(),
     }
@@ -359,6 +371,35 @@ mod tests {
             &[ExpectedMetricPoint {
                 attributes: &[("operation", "execute_sql"), ("status", "ok")],
                 value: 0,
+            }],
+        );
+    }
+
+    #[test]
+    fn query_result_ipc_exports_explicit_buckets_and_bounded_attributes() {
+        super::test_support::reset_metrics();
+        let exporter = super::test_support::install_metrics_exporter();
+        let metrics = metrics();
+
+        metrics.record_query_result_ipc_encoded_size(4_096);
+
+        super::test_support::flush_metrics();
+        let finished = exporter.get_finished_metrics().expect("finished metrics");
+        assert_query_memory_histogram(
+            &finished,
+            "coral.query.result.ipc.encoded_size",
+            "Exact serialized Arrow IPC payload size per query result",
+            &[ExpectedMetricPoint {
+                attributes: &[("operation", "execute_sql"), ("status", "ok")],
+                value: 1,
+            }],
+        );
+        assert_u64_histogram_points(
+            &finished,
+            "coral.query.result.ipc.encoded_size",
+            &[ExpectedMetricPoint {
+                attributes: &[("operation", "execute_sql"), ("status", "ok")],
+                value: 4_096,
             }],
         );
     }


### PR DESCRIPTION
This stack adds OpenTelemetry metrics for Coral's active queries, query results, and memory use without attaching SQL or identity data to the new metrics.

The previous PR measures in-memory Arrow results. This PR adds the corresponding serialized-output measurement at the gRPC response boundary.

## Intent

Measure the exact byte length of successfully encoded Arrow IPC query responses.

## What it enables

Successful encoding now records `coral.query.result.ipc.encoded_size` and an `encoded_size_bytes` field on the `coral.query.result.ipc` span. Encoding failures mark the span as failed and emit no size metric; an unrepresentable payload length is also omitted instead of being truncated.

## Usage examples

Collect `coral.query.result.ipc.encoded_size` through the existing OTLP pipeline. Treat it as a separate output-size signal alongside `coral.query.result.arrow.estimated_occupied_memory`: it measures serialized bytes, not live memory, and is not an additive component of the Arrow estimate.
