### PR TITLE
feat(app): export process memory telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,11 +1368,13 @@ dependencies = [
  "fs2",
  "jsonwebtoken",
  "keyring-core",
+ "memory-stats",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-proto",
  "opentelemetry_sdk",
+ "page_size",
  "prost",
  "regex",
  "reqwest 0.13.4",
@@ -4357,6 +4359,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4874,6 +4886,16 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,14 @@ keyring-core = { version = "1.0.0", default-features = false }
 apple-native-keyring-store = { version = "1.0.0", default-features = false, features = ["keychain"] }
 windows-native-keyring-store = { version = "1.0.0", default-features = false }
 zbus-secret-service-keyring-store = { version = "1.0.0", default-features = false, features = ["rt-tokio-crypto-rust"] }
+memory-stats = { version = "=1.2.0", default-features = false }
 object_store = { version = "0.13.2", features = ["aws"] }
 opentelemetry = "0.31.0"
 opentelemetry-appender-tracing = "0.31.0"
 opentelemetry-otlp = "0.31.0"
 opentelemetry-proto = { version = "0.31.0", default-features = false, features = ["gen-tonic-messages", "logs", "trace"] }
 opentelemetry_sdk = "0.31.0"
+page_size = "=0.6.0"
 parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "form", "http2", "json", "query", "rustls", "system-proxy"] }

--- a/apps/docs/guides/observe-with-opentelemetry.mdx
+++ b/apps/docs/guides/observe-with-opentelemetry.mdx
@@ -130,13 +130,33 @@ Tracing events are bridged into OTLP logs via `opentelemetry-appender-tracing`. 
 
 ### Metrics
 
-Three query instruments are exported on a 5-second periodic reader:
+Metrics are exported on a 5-second periodic reader. Counters and histograms record completed operations; observable gauges are sampled when the exporter collects them.
 
-| Metric                   | Kind      | Unit        | Attributes                                      | Description                                            |
-| ------------------------ | --------- | ----------- | ----------------------------------------------- | ------------------------------------------------------ |
-| `coral.query.count`      | Counter   | `{queries}` | `status=ok\|error`, `operation=execute_sql\|explain_sql` | Total SQL execution and explain operations requested.  |
-| `coral.query.duration`   | Histogram | `s`         | `status=ok\|error`, `operation=execute_sql\|explain_sql` | SQL execution and explain latency in seconds.          |
-| `coral.query.rows`       | Histogram | `{rows}`    | `status=ok`, `operation=execute_sql`            | Rows returned per successful SQL execution.            |
+| Metric                                                       | Kind                 | Unit        | Attributes                                                   | Description                                                |
+| ------------------------------------------------------------ | -------------------- | ----------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| `coral.query.count`                                          | Counter              | `{queries}` | `status=ok\|error`, `operation=execute_sql\|explain_sql\|list_tables\|list_catalog\|describe_table` | Completed query operations.                                |
+| `coral.query.duration`                                       | Histogram            | `s`         | `status=ok\|error`, `operation=execute_sql\|explain_sql\|list_tables\|list_catalog\|describe_table` | Query-operation latency in seconds.                        |
+| `coral.query.rows`                                           | Histogram            | `{rows}`    | `status=ok`, `operation=execute_sql\|list_tables\|list_catalog` | Rows returned per successful row-producing operation.      |
+| `coral.query.active`                                         | Observable gauge     | `{queries}` | none                                                         | Current query operations in flight; zero is reported when idle. |
+| `coral.process.memory.resident`                              | Observable gauge     | `By`        | none                                                         | Current resident memory of the Coral process.               |
+| `coral.query.memory.datafusion_reserved_peak`                | Histogram            | `By`        | `status=ok\|error`, `operation=execute_sql`                  | Peak DataFusion reservation for one top-level execution.    |
+| `coral.query.result.arrow.estimated_occupied_memory`         | Histogram            | `By`        | `status=ok`, `operation=execute_sql`                          | Estimated occupied memory of a successful Arrow result.     |
+| `coral.query.result.ipc.encoded_size`                        | Histogram            | `By`        | `status=ok`, `operation=execute_sql`                          | Exact encoded size of a successful Arrow IPC result.        |
+
+#### Interpret memory metrics separately
+
+These memory signals cover different scopes and are not additive. None of them can attribute a change in the process's resident memory to an individual query.
+
+- `coral.process.memory.resident` is a point-in-time process measurement. On Linux it is the resident set size read from `/proc/self/statm`; on macOS it is the Mach resident size; on Windows it is the process working set. Resident memory includes shared pages, so values are neither comparable across platforms nor a measure of the process's private memory. If a sample is unavailable—because the platform is unsupported, a read or parse fails, or a collection is already in progress—Coral skips that data point rather than repeating a stale value. A genuine zero is still reported.
+- `coral.query.memory.datafusion_reserved_peak` is the highest number of bytes reserved through DataFusion's memory pool during one top-level SQL execution, including primary and fallback attempts. It excludes unreserved decoding, HTTP or MCP bodies, result buffers after reservation release, Arrow IPC output, shared pools, allocator retention, and general runtime state.
+- `coral.query.result.arrow.estimated_occupied_memory` estimates the occupied memory of the successful Arrow result. Shared or sliced buffers can be counted more than once, so this is not an exact allocation measurement.
+- `coral.query.result.ipc.encoded_size` is the exact serialized payload length after Arrow IPC encoding finishes successfully. It measures output size, not live memory, and is omitted when encoding fails or the size cannot be represented in the metric.
+
+The process-residency and active-query gauges use the same exporter cadence, but independent callbacks collect them. Treat nearby points as context, not an atomic snapshot, and do not derive per-query memory cost by comparing the two.
+
+Reservation peaks are emitted for successful queries and for handled failures or cancellations after all tracked reservations are released. `status=error` combines handled errors and cancellations; no error-code attribute is exported. If a reservation leaks or the process terminates, no observation is recorded. The successful Arrow and IPC histograms use only `status=ok`. All three byte-valued query histograms use explicit byte boundaries at 4 KiB, 16 KiB, 64 KiB, 256 KiB, 1 MiB, 4 MiB, 16 MiB, 64 MiB, 256 MiB, 1 GiB, 4 GiB, and 16 GiB, plus an overflow bucket.
+
+These byte-valued query metrics contain no SQL, query IDs, trace IDs, task IDs, workspace names, users, sources, or tables. Span attributes on query traces can support approximate correlation with these metrics by time window when your backend and privacy policy allow it, but Coral does not emit exemplars or direct metric-to-trace links. `coral.query` spans can contain raw SQL whether they descend from a `coral.cli` root span, a `coral.mcp.*` server span, or another entry point, so review trace access and retention separately.
 
 ## Distributed tracing
 

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -65,11 +65,14 @@ coral-telemetry.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store.workspace = true
+memory-stats.workspace = true
 
 [target.'cfg(windows)'.dependencies]
+memory-stats.workspace = true
 windows-native-keyring-store.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+page_size.workspace = true
 zbus-secret-service-keyring-store.workspace = true
 
 [dev-dependencies]

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -8,6 +8,8 @@ use coral_engine::QueryMemoryOutcome;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter, ObservableGauge};
 
+use super::process::{ProcessMemoryReader, SystemProcessMemoryReader};
+
 const QUERY_MEMORY_BUCKETS: [f64; 12] = [
     4_096.0,
     16_384.0,
@@ -31,6 +33,7 @@ pub(crate) struct Metrics {
     rows: Histogram<u64>,
     active_queries: Arc<AtomicU64>,
     _active_query_gauge: ObservableGauge<u64>,
+    _process_memory_gauge: ObservableGauge<u64>,
     datafusion_reserved_peak: Histogram<u64>,
     arrow_estimated_occupied_memory: Histogram<u64>,
     ipc_encoded_size: Histogram<u64>,
@@ -109,7 +112,7 @@ fn query_memory_attributes(outcome: QueryMemoryOutcome) -> [KeyValue; 2] {
 
 static METRICS: RwLock<Option<Metrics>> = RwLock::new(None);
 
-fn build_metrics(meter: &Meter) -> Metrics {
+fn build_metrics(meter: &Meter, process_memory: Arc<dyn ProcessMemoryReader>) -> Metrics {
     let active_queries = Arc::new(AtomicU64::new(0));
     let active_query_count = Arc::clone(&active_queries);
 
@@ -138,6 +141,16 @@ fn build_metrics(meter: &Meter) -> Metrics {
                 observer.observe(active_query_count.load(Ordering::Relaxed), &[]);
             })
             .build(),
+        _process_memory_gauge: meter
+            .u64_observable_gauge("coral.process.memory.resident")
+            .with_unit("By")
+            .with_description("Current process resident memory")
+            .with_callback(move |observer| {
+                if let Some(bytes) = process_memory.resident_bytes() {
+                    observer.observe(bytes, &[]);
+                }
+            })
+            .build(),
         datafusion_reserved_peak: meter
             .u64_histogram("coral.query.memory.datafusion_reserved_peak")
             .with_unit("By")
@@ -160,10 +173,14 @@ fn build_metrics(meter: &Meter) -> Metrics {
 }
 
 pub(crate) fn init(meter: &Meter) {
+    init_with_process_memory_reader(meter, Arc::new(SystemProcessMemoryReader::new()));
+}
+
+fn init_with_process_memory_reader(meter: &Meter, process_memory: Arc<dyn ProcessMemoryReader>) {
     let mut metrics = METRICS
         .write()
         .expect("metrics lock poisoned during initialization");
-    *metrics = Some(build_metrics(meter));
+    *metrics = Some(build_metrics(meter, process_memory));
 }
 
 pub(crate) fn init_global() {
@@ -190,7 +207,10 @@ pub(crate) fn metrics() -> Metrics {
         .expect("metrics lock poisoned during initialization");
     if metrics.is_none() {
         let meter = opentelemetry::global::meter("coral");
-        *metrics = Some(build_metrics(&meter));
+        *metrics = Some(build_metrics(
+            &meter,
+            Arc::new(SystemProcessMemoryReader::new()),
+        ));
     }
 
     metrics
@@ -200,9 +220,12 @@ pub(crate) fn metrics() -> Metrics {
 
 #[cfg(test)]
 pub(crate) mod test_support {
+    use std::sync::Arc;
+
     use opentelemetry::metrics::MeterProvider as _;
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
 
+    use super::super::process::{ProcessMemoryReader, SystemProcessMemoryReader};
     use super::METRICS;
 
     std::thread_local! {
@@ -216,9 +239,9 @@ pub(crate) mod test_support {
         TEST_METRICS.with(|metrics| metrics.borrow().clone())
     }
 
-    fn install_provider(provider: SdkMeterProvider) {
+    fn install_provider(provider: SdkMeterProvider, process_memory: Arc<dyn ProcessMemoryReader>) {
         let meter = provider.meter("coral");
-        let metrics = super::build_metrics(&meter);
+        let metrics = super::build_metrics(&meter, process_memory);
         TEST_METRICS.with(|slot| {
             *slot.borrow_mut() = Some(metrics);
         });
@@ -228,11 +251,19 @@ pub(crate) mod test_support {
     }
 
     pub(crate) fn install_metrics_exporter() -> InMemoryMetricExporter {
+        install_metrics_exporter_with_process_memory_reader(Arc::new(
+            SystemProcessMemoryReader::new(),
+        ))
+    }
+
+    pub(crate) fn install_metrics_exporter_with_process_memory_reader(
+        process_memory: Arc<dyn ProcessMemoryReader>,
+    ) -> InMemoryMetricExporter {
         let exporter = InMemoryMetricExporter::default();
         let provider = SdkMeterProvider::builder()
             .with_reader(PeriodicReader::builder(exporter.clone()).build())
             .build();
-        install_provider(provider);
+        install_provider(provider, process_memory);
         exporter
     }
 
@@ -261,11 +292,33 @@ pub(crate) mod test_support {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
     use coral_engine::QueryMemoryOutcome;
     use opentelemetry::{KeyValue, Value};
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
 
     use super::{QUERY_MEMORY_BUCKETS, metrics};
+    use crate::telemetry::process::ProcessMemoryReader;
+
+    struct SequenceProcessMemoryReader {
+        samples: Mutex<VecDeque<Option<u64>>>,
+    }
+
+    impl SequenceProcessMemoryReader {
+        fn new(samples: impl IntoIterator<Item = Option<u64>>) -> Self {
+            Self {
+                samples: Mutex::new(samples.into_iter().collect()),
+            }
+        }
+    }
+
+    impl ProcessMemoryReader for SequenceProcessMemoryReader {
+        fn resident_bytes(&self) -> Option<u64> {
+            self.samples.try_lock().ok()?.pop_front().flatten()
+        }
+    }
 
     fn find_metric<'a>(
         metrics: &'a [ResourceMetrics],
@@ -288,6 +341,103 @@ mod tests {
     struct ExpectedMetricPoint<'a> {
         attributes: &'a [(&'a str, &'a str)],
         value: u64,
+    }
+
+    #[test]
+    fn process_memory_exports_fresh_bytes_alongside_active_query_count() {
+        super::test_support::reset_metrics();
+        let reader = Arc::new(SequenceProcessMemoryReader::new([Some(42)]));
+        let exporter =
+            super::test_support::install_metrics_exporter_with_process_memory_reader(reader);
+
+        super::test_support::flush_metrics();
+        let finished = exporter.get_finished_metrics().expect("finished metrics");
+        let collection = finished.last().expect("latest metric collection");
+
+        assert_gauge_point(
+            collection,
+            "coral.process.memory.resident",
+            "By",
+            "Current process resident memory",
+            42,
+        );
+        assert_gauge_point(
+            collection,
+            "coral.query.active",
+            "{queries}",
+            "Current query operations in flight",
+            0,
+        );
+    }
+
+    #[test]
+    fn process_memory_failure_after_success_omits_without_stale_replay() {
+        super::test_support::reset_metrics();
+        let reader = Arc::new(SequenceProcessMemoryReader::new([Some(42), None]));
+        let exporter =
+            super::test_support::install_metrics_exporter_with_process_memory_reader(reader);
+
+        super::test_support::flush_metrics();
+        let first = exporter.get_finished_metrics().expect("finished metrics");
+        assert_gauge_point(
+            first.last().expect("first metric collection"),
+            "coral.process.memory.resident",
+            "By",
+            "Current process resident memory",
+            42,
+        );
+
+        super::test_support::flush_metrics();
+        let finished = exporter.get_finished_metrics().expect("finished metrics");
+        let collection = finished.last().expect("latest metric collection");
+        assert_gauge_omitted(collection, "coral.process.memory.resident");
+        assert_gauge_point(
+            collection,
+            "coral.query.active",
+            "{queries}",
+            "Current query operations in flight",
+            0,
+        );
+    }
+
+    #[test]
+    fn process_memory_lock_contention_omits_only_process_observation() {
+        super::test_support::reset_metrics();
+        let reader = Arc::new(SequenceProcessMemoryReader::new([Some(42)]));
+        let exporter = super::test_support::install_metrics_exporter_with_process_memory_reader(
+            reader.clone(),
+        );
+        let _guard = reader.samples.lock().expect("reader lock");
+
+        super::test_support::flush_metrics();
+        let finished = exporter.get_finished_metrics().expect("finished metrics");
+        let collection = finished.last().expect("latest metric collection");
+        assert_gauge_omitted(collection, "coral.process.memory.resident");
+        assert_gauge_point(
+            collection,
+            "coral.query.active",
+            "{queries}",
+            "Current query operations in flight",
+            0,
+        );
+    }
+
+    #[test]
+    fn process_memory_preserves_measured_zero() {
+        super::test_support::reset_metrics();
+        let reader = Arc::new(SequenceProcessMemoryReader::new([Some(0)]));
+        let exporter =
+            super::test_support::install_metrics_exporter_with_process_memory_reader(reader);
+
+        super::test_support::flush_metrics();
+        let finished = exporter.get_finished_metrics().expect("finished metrics");
+        assert_gauge_point(
+            finished.last().expect("latest metric collection"),
+            "coral.process.memory.resident",
+            "By",
+            "Current process resident memory",
+            0,
+        );
     }
 
     #[test]
@@ -421,6 +571,47 @@ mod tests {
         let point = points.first().expect("active query gauge point");
         assert!(point.attributes().next().is_none());
         assert_eq!(point.value(), expected);
+    }
+
+    fn find_metric_in_collection<'a>(
+        metrics: &'a ResourceMetrics,
+        name: &str,
+    ) -> Option<&'a opentelemetry_sdk::metrics::data::Metric> {
+        metrics
+            .scope_metrics()
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == name)
+    }
+
+    fn assert_gauge_point(
+        metrics: &ResourceMetrics,
+        name: &str,
+        unit: &str,
+        description: &str,
+        expected: u64,
+    ) {
+        let metric = find_metric_in_collection(metrics, name)
+            .unwrap_or_else(|| panic!("metric {name} missing"));
+        assert_eq!(metric.unit(), unit);
+        assert_eq!(metric.description(), description);
+        let AggregatedMetrics::U64(MetricData::Gauge(gauge)) = metric.data() else {
+            panic!("metric {name} should be a u64 gauge");
+        };
+        let points = gauge.data_points().collect::<Vec<_>>();
+        assert_eq!(points.len(), 1, "metric {name} point count");
+        let point = points.first().expect("gauge point");
+        assert!(point.attributes().next().is_none());
+        assert_eq!(point.value(), expected);
+    }
+
+    fn assert_gauge_omitted(metrics: &ResourceMetrics, name: &str) {
+        let has_points = find_metric_in_collection(metrics, name).is_some_and(|metric| {
+            let AggregatedMetrics::U64(MetricData::Gauge(gauge)) = metric.data() else {
+                panic!("metric {name} should be a u64 gauge");
+            };
+            gauge.data_points().next().is_some()
+        });
+        assert!(!has_points, "metric {name} should omit its observation");
     }
 
     fn assert_query_memory_histogram(

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -30,6 +30,7 @@ pub mod config;
 mod local_store;
 mod manager;
 pub mod metrics;
+pub(crate) mod process;
 pub(crate) mod service;
 
 use crate::bootstrap::AppError;

--- a/crates/coral-app/src/telemetry/process.rs
+++ b/crates/coral-app/src/telemetry/process.rs
@@ -1,0 +1,203 @@
+//! Current-process memory observation.
+
+use std::sync::Mutex;
+
+pub(crate) trait ProcessMemoryReader: Send + Sync {
+    fn resident_bytes(&self) -> Option<u64>;
+}
+
+pub(crate) struct SystemProcessMemoryReader {
+    sampler: Mutex<Option<Box<dyn ResidentMemorySampler>>>,
+}
+
+impl SystemProcessMemoryReader {
+    pub(crate) fn new() -> Self {
+        Self::with_sampler(platform_sampler())
+    }
+
+    fn with_sampler(sampler: Option<Box<dyn ResidentMemorySampler>>) -> Self {
+        Self {
+            sampler: Mutex::new(sampler),
+        }
+    }
+}
+
+impl Default for SystemProcessMemoryReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProcessMemoryReader for SystemProcessMemoryReader {
+    fn resident_bytes(&self) -> Option<u64> {
+        self.sampler.try_lock().ok()?.as_mut()?.sample().ok()
+    }
+}
+
+#[derive(Debug)]
+struct SampleUnavailable;
+
+trait ResidentMemorySampler: Send {
+    fn sample(&mut self) -> Result<u64, SampleUnavailable>;
+}
+
+#[cfg(target_os = "linux")]
+fn platform_sampler() -> Option<Box<dyn ResidentMemorySampler>> {
+    LinuxResidentMemorySampler::new()
+        .map(|sampler| Box::new(sampler) as Box<dyn ResidentMemorySampler>)
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxResidentMemorySampler {
+    statm: std::fs::File,
+    page_size: u64,
+    buffer: String,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxResidentMemorySampler {
+    fn new() -> Option<Self> {
+        let page_size = u64::try_from(page_size::get())
+            .ok()
+            .filter(|size| *size > 0)?;
+        Some(Self {
+            statm: std::fs::File::open("/proc/self/statm").ok()?,
+            page_size,
+            buffer: String::new(),
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl ResidentMemorySampler for LinuxResidentMemorySampler {
+    fn sample(&mut self) -> Result<u64, SampleUnavailable> {
+        use std::io::{Read, Seek};
+
+        self.statm.rewind().map_err(|_| SampleUnavailable)?;
+        self.buffer.clear();
+        self.statm
+            .read_to_string(&mut self.buffer)
+            .map_err(|_| SampleUnavailable)?;
+        parse_linux_statm(&self.buffer, self.page_size)
+    }
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_linux_statm(input: &str, page_size: u64) -> Result<u64, SampleUnavailable> {
+    let mut fields = input.split_ascii_whitespace();
+    fields.next().ok_or(SampleUnavailable)?;
+    let resident_pages = fields
+        .next()
+        .ok_or(SampleUnavailable)?
+        .parse::<u64>()
+        .ok()
+        .ok_or(SampleUnavailable)?;
+    resident_pages
+        .checked_mul(page_size)
+        .ok_or(SampleUnavailable)
+}
+
+#[cfg(any(target_os = "macos", windows))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "keep one constructor shape across platform cfg variants"
+)]
+fn platform_sampler() -> Option<Box<dyn ResidentMemorySampler>> {
+    Some(Box::new(NativeResidentMemorySampler))
+}
+
+#[cfg(any(target_os = "macos", windows))]
+struct NativeResidentMemorySampler;
+
+#[cfg(any(target_os = "macos", windows))]
+impl ResidentMemorySampler for NativeResidentMemorySampler {
+    fn sample(&mut self) -> Result<u64, SampleUnavailable> {
+        let memory = memory_stats::memory_stats().ok_or(SampleUnavailable)?;
+        u64::try_from(memory.physical_mem)
+            .ok()
+            .ok_or(SampleUnavailable)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+fn platform_sampler() -> Option<Box<dyn ResidentMemorySampler>> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use super::{
+        ProcessMemoryReader, ResidentMemorySampler, SampleUnavailable, SystemProcessMemoryReader,
+    };
+
+    struct SequenceSampler {
+        samples: VecDeque<Result<u64, SampleUnavailable>>,
+    }
+
+    impl ResidentMemorySampler for SequenceSampler {
+        fn sample(&mut self) -> Result<u64, SampleUnavailable> {
+            self.samples.pop_front().unwrap_or(Err(SampleUnavailable))
+        }
+    }
+
+    fn sequence_reader(
+        samples: impl IntoIterator<Item = Result<u64, SampleUnavailable>>,
+    ) -> SystemProcessMemoryReader {
+        SystemProcessMemoryReader::with_sampler(Some(Box::new(SequenceSampler {
+            samples: samples.into_iter().collect(),
+        })))
+    }
+
+    #[test]
+    fn success_followed_by_failure_omits_instead_of_replaying() {
+        let reader = sequence_reader([Ok(42), Err(SampleUnavailable)]);
+
+        assert_eq!(reader.resident_bytes(), Some(42));
+        assert_eq!(reader.resident_bytes(), None);
+    }
+
+    #[test]
+    fn successful_zero_sample_is_preserved() {
+        let reader = sequence_reader([Ok(0)]);
+
+        assert_eq!(reader.resident_bytes(), Some(0));
+    }
+
+    #[test]
+    fn lock_contention_omits_process_memory() {
+        let reader = SystemProcessMemoryReader::new();
+        let _guard = reader.sampler.lock().expect("sampler lock should succeed");
+
+        assert_eq!(reader.resident_bytes(), None);
+    }
+
+    #[test]
+    fn unavailable_sampler_supports_shared_reader_injection() {
+        let reader: Arc<dyn ProcessMemoryReader> =
+            Arc::new(SystemProcessMemoryReader::with_sampler(None));
+
+        assert_eq!(reader.resident_bytes(), None);
+    }
+
+    #[test]
+    fn current_process_reader_returns_a_fresh_value() {
+        let reader = SystemProcessMemoryReader::new();
+
+        assert!(reader.resident_bytes().is_some());
+    }
+
+    #[test]
+    fn linux_statm_parser_preserves_zero_and_rejects_invalid_samples() {
+        assert_eq!(
+            super::parse_linux_statm("10 0 3", 4_096).expect("zero is a valid sample"),
+            0
+        );
+        super::parse_linux_statm("10", 4_096).expect_err("missing resident field must fail");
+        super::parse_linux_statm("10 invalid", 4_096)
+            .expect_err("invalid resident field must fail");
+        super::parse_linux_statm("10 2", u64::MAX).expect_err("resident byte overflow must fail");
+    }
+}


### PR DESCRIPTION
This stack adds OpenTelemetry metrics for Coral's active queries, query results, and memory use without attaching SQL or identity data to the new metrics.

This final layer adds process-level context for the query measurements and documents how to interpret the complete set of signals.

## Intent

Export the current Coral process's resident memory and document the scope, limits, and privacy properties of every new query and process memory metric.

## What it enables

The attribute-free `coral.process.memory.resident` gauge samples Linux `statm` resident pages, macOS physical resident memory, or the Windows working set. Unsupported platforms, failed reads, and overlapping collection attempts omit that data point rather than repeating a stale value; a genuine zero is still exported.

The OpenTelemetry guide now lists all query metrics, corrects the operation coverage of the existing count, duration, and row metrics, and explains platform differences, measurement exclusions, failure behavior, and why the memory signals must not be added together.

## Usage examples

Collect `coral.process.memory.resident` through the existing OTLP pipeline and view it beside `coral.query.active` for nearby context. The two gauges are sampled independently, so do not treat them as an atomic snapshot or divide resident memory by the active-query count to estimate per-query memory.
