### PR TITLE
feat(reef): enforce same-origin OAuth metadata

### DIFF
--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -19,6 +19,15 @@ const metadata = {
   issuer: AUTH_ISSUER,
   token_endpoint: `${AUTH_ISSUER}/token`,
 }
+const untrustedEndpointCases = [
+  ['lookalike host', 'https://coral.example.test.attacker.test/oauth'],
+  ['alternate port', 'https://coral.example.test:444/oauth'],
+  ['scheme change', 'http://coral.example.test/oauth'],
+  ['credentials', 'https://user:password@coral.example.test/oauth'],
+  ['relative URL', '/oauth'],
+  ['malformed URL', 'not a URL'],
+  ['non-HTTP URL', 'ftp://coral.example.test/oauth'],
+] as const
 
 describe('Coral OAuth adapter', () => {
   beforeEach(() => {
@@ -272,51 +281,44 @@ describe('Coral OAuth adapter', () => {
     ).rejects.toThrow('metadata issuer does not match')
   })
 
-  it.each([
-    ['lookalike host', 'https://coral.example.test.attacker.test/oauth'],
-    ['alternate port', 'https://coral.example.test:444/oauth'],
-    ['scheme change', 'http://coral.example.test/oauth'],
-    ['credentials', 'https://user:password@coral.example.test/oauth'],
-    ['relative URL', '/oauth'],
-    ['malformed URL', 'not a URL'],
-    ['non-HTTP URL', 'ftp://coral.example.test/oauth'],
-  ])('rejects an untrusted authorization endpoint using a %s', async (_, endpoint) => {
-    const fetch = mockFetch(jsonResponse({ ...metadata, authorization_endpoint: endpoint }))
+  it.each(untrustedEndpointCases)(
+    'rejects an untrusted authorization endpoint using a %s',
+    async (_, endpoint) => {
+      const fetch = mockFetch(jsonResponse({ ...metadata, authorization_endpoint: endpoint }))
 
-    await expect(
-      startCoralOAuthLogin(new Request('https://reef.example.test/login'), config),
-    ).rejects.toThrow('authorization_endpoint must be an absolute same-origin HTTP(S) URL')
-    expect(fetch).toHaveBeenCalledTimes(1)
-  })
+      await expect(
+        startCoralOAuthLogin(new Request('https://reef.example.test/login'), config),
+      ).rejects.toThrow('authorization_endpoint must be an absolute same-origin HTTP(S) URL')
+      expect(fetch).toHaveBeenCalledTimes(1)
+    },
+  )
 
-  it.each([
-    ['lookalike host', 'https://coral.example.test.attacker.test/oauth'],
-    ['alternate port', 'https://coral.example.test:444/oauth'],
-    ['scheme change', 'http://coral.example.test/oauth'],
-    ['credentials', 'https://user:password@coral.example.test/oauth'],
-    ['relative URL', '/oauth'],
-    ['malformed URL', 'not a URL'],
-    ['non-HTTP URL', 'ftp://coral.example.test/oauth'],
-  ])('rejects an untrusted token endpoint using a %s', async (_, endpoint) => {
-    const fetch = mockFetch(
-      jsonResponse(metadata),
-      jsonResponse({ ...metadata, token_endpoint: endpoint }),
-    )
-    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
-    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
-
-    await expect(
-      completeCoralOAuthLogin(
-        new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
-          headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
-        }),
+  it.each(untrustedEndpointCases)(
+    'rejects an untrusted token endpoint using a %s',
+    async (_, endpoint) => {
+      const fetch = mockFetch(
+        jsonResponse(metadata),
+        jsonResponse({ ...metadata, token_endpoint: endpoint }),
+      )
+      const login = await startCoralOAuthLogin(
+        new Request('https://reef.example.test/login'),
         config,
-      ),
-    ).rejects.toThrow('token_endpoint must be an absolute same-origin HTTP(S) URL')
-    expect(fetch).toHaveBeenCalledTimes(2)
-  })
+      )
+      const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
 
-  it('does not follow a token endpoint redirect off-origin', async () => {
+      await expect(
+        completeCoralOAuthLogin(
+          new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+            headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
+          }),
+          config,
+        ),
+      ).rejects.toThrow('token_endpoint must be an absolute same-origin HTTP(S) URL')
+      expect(fetch).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it('rejects a token endpoint redirect without retaining OAuth state', async () => {
     const attackerEndpoint = 'https://attacker.example/token'
     const metadataEndpoint = `${AUTH_ISSUER}/.well-known/oauth-authorization-server`
     const fetch = vi.fn<typeof globalThis.fetch>()
@@ -324,7 +326,12 @@ describe('Coral OAuth adapter', () => {
       const url = input instanceof Request ? input.url : input.toString()
       if (url === metadataEndpoint) return jsonResponse(metadata)
       if (url === metadata.token_endpoint) {
-        if (init?.redirect === 'error') throw new TypeError('token redirect blocked')
+        if (init?.redirect === 'manual') {
+          return new Response(null, {
+            headers: { location: attackerEndpoint },
+            status: 307,
+          })
+        }
         return fetch(attackerEndpoint, init)
       }
       if (url === attackerEndpoint) {
@@ -337,14 +344,19 @@ describe('Coral OAuth adapter', () => {
     const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
     const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
 
-    await expect(
-      completeCoralOAuthLogin(
-        new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
-          headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
-        }),
-        config,
-      ),
-    ).rejects.toThrow('token redirect blocked')
+    const error = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+        headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
+      }),
+      config,
+    ).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(Response)
+    expect((error as Response).status).toBe(400)
+    await expect((error as Response).text()).resolves.toBe(
+      'Coral OAuth token exchange failed with HTTP 307',
+    )
+    expect((error as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
     expect(fetch.mock.calls.map(([input]) => input.toString())).toEqual([
       metadataEndpoint,
       metadataEndpoint,

--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -259,11 +259,61 @@ describe('Coral OAuth adapter', () => {
   })
 
   it('rejects metadata for a different issuer', async () => {
-    mockFetch(jsonResponse({ ...metadata, issuer: 'https://attacker.example' }))
+    mockFetch(
+      jsonResponse({
+        ...metadata,
+        authorization_endpoint: 'not a URL',
+        issuer: 'https://attacker.example',
+      }),
+    )
 
     await expect(
       startCoralOAuthLogin(new Request('https://reef.example.test/login'), config),
     ).rejects.toThrow('metadata issuer does not match')
+  })
+
+  it.each([
+    ['lookalike host', 'https://coral.example.test.attacker.test/oauth'],
+    ['alternate port', 'https://coral.example.test:444/oauth'],
+    ['scheme change', 'http://coral.example.test/oauth'],
+    ['credentials', 'https://user:password@coral.example.test/oauth'],
+    ['relative URL', '/oauth'],
+    ['malformed URL', 'not a URL'],
+    ['non-HTTP URL', 'ftp://coral.example.test/oauth'],
+  ])('rejects an untrusted authorization endpoint using a %s', async (_, endpoint) => {
+    const fetch = mockFetch(jsonResponse({ ...metadata, authorization_endpoint: endpoint }))
+
+    await expect(
+      startCoralOAuthLogin(new Request('https://reef.example.test/login'), config),
+    ).rejects.toThrow('authorization_endpoint must be an absolute same-origin HTTP(S) URL')
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['lookalike host', 'https://coral.example.test.attacker.test/oauth'],
+    ['alternate port', 'https://coral.example.test:444/oauth'],
+    ['scheme change', 'http://coral.example.test/oauth'],
+    ['credentials', 'https://user:password@coral.example.test/oauth'],
+    ['relative URL', '/oauth'],
+    ['malformed URL', 'not a URL'],
+    ['non-HTTP URL', 'ftp://coral.example.test/oauth'],
+  ])('rejects an untrusted token endpoint using a %s', async (_, endpoint) => {
+    const fetch = mockFetch(
+      jsonResponse(metadata),
+      jsonResponse({ ...metadata, token_endpoint: endpoint }),
+    )
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    await expect(
+      completeCoralOAuthLogin(
+        new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+          headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
+        }),
+        config,
+      ),
+    ).rejects.toThrow('token_endpoint must be an absolute same-origin HTTP(S) URL')
+    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it('requires a positive standards-based token expiry', async () => {

--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -316,6 +316,42 @@ describe('Coral OAuth adapter', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
+  it('does not follow a token endpoint redirect off-origin', async () => {
+    const attackerEndpoint = 'https://attacker.example/token'
+    const metadataEndpoint = `${AUTH_ISSUER}/.well-known/oauth-authorization-server`
+    const fetch = vi.fn<typeof globalThis.fetch>()
+    fetch.mockImplementation(async (input, init) => {
+      const url = input instanceof Request ? input.url : input.toString()
+      if (url === metadataEndpoint) return jsonResponse(metadata)
+      if (url === metadata.token_endpoint) {
+        if (init?.redirect === 'error') throw new TypeError('token redirect blocked')
+        return fetch(attackerEndpoint, init)
+      }
+      if (url === attackerEndpoint) {
+        return jsonResponse({ access_token: 'stolen-token', expires_in: 3600 })
+      }
+      throw new Error(`unexpected fetch to ${url}`)
+    })
+    vi.stubGlobal('fetch', fetch)
+
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    await expect(
+      completeCoralOAuthLogin(
+        new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+          headers: { cookie: cookieHeader(login, oauthCookieName(config)) },
+        }),
+        config,
+      ),
+    ).rejects.toThrow('token redirect blocked')
+    expect(fetch.mock.calls.map(([input]) => input.toString())).toEqual([
+      metadataEndpoint,
+      metadataEndpoint,
+      metadata.token_endpoint,
+    ])
+  })
+
   it('requires a positive standards-based token expiry', async () => {
     mockFetch(
       jsonResponse(metadata),

--- a/apps/reef/app/auth/coral-oauth.server.ts
+++ b/apps/reef/app/auth/coral-oauth.server.ts
@@ -191,6 +191,7 @@ async function exchangeAuthorizationCode(
     body,
     headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
     method: 'POST',
+    redirect: 'error',
   })
   if (!response.ok) {
     throw await tokenExchangeError(response)

--- a/apps/reef/app/auth/coral-oauth.server.ts
+++ b/apps/reef/app/auth/coral-oauth.server.ts
@@ -121,6 +121,15 @@ async function authorizationServerMetadata(
   }
 
   const metadata = (await response.json()) as AuthorizationServerMetadata
+  validateAuthorizationServerMetadata(metadata, config.issuer)
+
+  return metadata
+}
+
+function validateAuthorizationServerMetadata(
+  metadata: AuthorizationServerMetadata,
+  issuer: string,
+): void {
   if (
     typeof metadata.authorization_endpoint !== 'string' ||
     typeof metadata.issuer !== 'string' ||
@@ -128,11 +137,36 @@ async function authorizationServerMetadata(
   ) {
     throw new Error('Coral auth metadata is missing required OAuth endpoints')
   }
-  if (metadata.issuer !== config.issuer) {
+  if (metadata.issuer !== issuer) {
     throw new Error('Coral auth metadata issuer does not match REEF_AUTH_ISSUER')
   }
 
-  return metadata
+  const issuerOrigin = new URL(issuer).origin
+  validateMetadataEndpoint(metadata.authorization_endpoint, 'authorization_endpoint', issuerOrigin)
+  validateMetadataEndpoint(metadata.token_endpoint, 'token_endpoint', issuerOrigin)
+}
+
+function validateMetadataEndpoint(endpoint: string, name: string, issuerOrigin: string): void {
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    throw invalidMetadataEndpoint(name)
+  }
+  if (
+    (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+    url.origin !== issuerOrigin ||
+    url.username ||
+    url.password
+  ) {
+    throw invalidMetadataEndpoint(name)
+  }
+}
+
+function invalidMetadataEndpoint(name: string): Error {
+  return new Error(
+    `Coral auth metadata ${name} must be an absolute same-origin HTTP(S) URL without credentials`,
+  )
 }
 
 async function exchangeAuthorizationCode(

--- a/apps/reef/app/auth/coral-oauth.server.ts
+++ b/apps/reef/app/auth/coral-oauth.server.ts
@@ -191,7 +191,7 @@ async function exchangeAuthorizationCode(
     body,
     headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
     method: 'POST',
-    redirect: 'error',
+    redirect: 'manual',
   })
   if (!response.ok) {
     throw await tokenExchangeError(response)


### PR DESCRIPTION
## Intent

Keep Reef's OAuth client and protected-resource metadata on the validated issuer origin, including token exchange redirects.

## What it enables

Reef can participate in Coral OAuth without trusting attacker-controlled metadata URLs or leaking authorization codes and PKCE verifiers across redirects.

## Usage examples

Configure `REEF_AUTH_MODE=required`, `REEF_AUTH_ISSUER`, `REEF_PUBLIC_URL`, and a session secret. Reef serves its client metadata at `/.well-known/oauth-client` and validates discovered OAuth endpoints against the configured issuer.
