### PR TITLE
feat(reef): allow an opt-in insecure Coral endpoint

### DIFF
--- a/apps/reef/.env.example
+++ b/apps/reef/.env.example
@@ -10,7 +10,7 @@
 # Choose one Reef-to-Coral data-plane topology:
 # 1. HTTPS (recommended for separate hosts or untrusted networks).
 # CORAL_ENDPOINT=https://coral.internal.example.com
-# 2. Explicit loopback HTTP (same host; bare localhost, 127/8, or ::1).
+# 2. Explicit loopback HTTP (same host; bare localhost, 127/8, or bracketed [::1]).
 # CORAL_ENDPOINT=http://127.0.0.1:14555
 # 3. Trusted-network HTTP. This opt-in relaxes only Reef-to-Coral transport.
 # CORAL_ENDPOINT=http://coral.internal:14555

--- a/apps/reef/.env.example
+++ b/apps/reef/.env.example
@@ -6,7 +6,15 @@
 # REEF_SESSION_SECRET=
 # REEF_AUTH_ISSUER=https://coral.example.com
 # REEF_PUBLIC_URL=https://reef.example.com
+
+# Choose one Reef-to-Coral data-plane topology:
+# 1. HTTPS (recommended for separate hosts or untrusted networks).
 # CORAL_ENDPOINT=https://coral.internal.example.com
+# 2. Explicit loopback HTTP (same host; bare localhost, 127/8, or ::1).
+# CORAL_ENDPOINT=http://127.0.0.1:14555
+# 3. Trusted-network HTTP. This opt-in relaxes only Reef-to-Coral transport.
+# CORAL_ENDPOINT=http://coral.internal:14555
+# REEF_ALLOW_INSECURE_CORAL_ENDPOINT=true
 
 # Optional session overrides. The cookie name must be an RFC 6265 token —
 # letters, digits, or !#$%&'*+-.^_`|~ — and a __Host- or __Secure- prefix works

--- a/apps/reef/README.md
+++ b/apps/reef/README.md
@@ -56,12 +56,30 @@ canonicalize to the same URL. Reef derives the OAuth resource
 `https://reef.example.com/auth/callback` from it. Do not configure separate
 client, resource, callback, or scope values.
 
-`CORAL_ENDPOINT` is only the data-plane address. Authenticated Reef calls it
-with native gRPC over HTTP/2 and attaches the server-held bearer token. The
-endpoint must use HTTPS, except for the explicit-loopback local topology below.
-It is not an OAuth resource and does not need to match `REEF_PUBLIC_URL`.
-Reef does not use Coral's MCP HTTP endpoint or protected-resource metadata for
-login or data access.
+`CORAL_ENDPOINT` is only the Reef-to-Coral data-plane address and is required
+whenever authentication is enabled. Reef never derives an authenticated Coral
+destination from the browser request URL, `Host`, or forwarded-host headers.
+Authenticated Reef uses native gRPC over HTTP/2 and attaches the server-held
+bearer token. It does not use Coral's MCP HTTP endpoint or protected-resource
+metadata for login or data access.
+
+Choose one transport topology:
+
+1. Use `CORAL_ENDPOINT=https://coral.internal.example.com` when TLS terminates
+   at Coral or at a trusted proxy directly in front of it.
+2. Use explicit-loopback HTTP, such as `http://127.0.0.1:14555` or bare
+   `http://localhost:14555`, when Reef and Coral share a host. Acceptance of
+   `localhost` trusts that host's name resolution; use a loopback IP when that
+   trust is undesirable. Names such as `coral.localhost` are not treated as
+   explicit loopback.
+3. On a trusted private network without Reef-to-Coral TLS, set an `http://`
+   endpoint and `REEF_ALLOW_INSECURE_CORAL_ENDPOINT=true`. This sends bearer
+   tokens in cleartext on that network and emits a process warning once per
+   Coral origin.
+
+The insecure endpoint flag relaxes only the Reef-to-Coral hop. It does not
+relax `REEF_PUBLIC_URL`, the OAuth issuer, browser-to-Reef transport, audience,
+cookie, or callback validation.
 
 `REEF_SESSION_MAX_AGE_SECONDS` defaults to 3600 and caps how long Reef keeps a
 login, even if Coral issues a longer-lived access token. A shorter token expiry

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -77,29 +77,6 @@ describe('architecture', () => {
     expect(dependencyNames.filter((name) => name.toLowerCase().includes('tailwind'))).toEqual([])
   })
 
-  it('keeps Coral endpoint policy and configuration server-only', () => {
-    const runtimeFiles = filesUnder(
-      appDir,
-      (name) => /\.[cm]?[jt]sx?$/.test(name) && !name.includes('.test.'),
-    )
-    const endpointConfig = ['CORAL_ENDPOINT', 'REEF_ALLOW_INSECURE_CORAL_ENDPOINT']
-    const violations = runtimeFiles.flatMap((file) => {
-      const source = fs.readFileSync(file, 'utf8')
-      const readsEndpointConfig = endpointConfig.some((name) =>
-        new RegExp(`(?:process\\.env|env)\\.${name}\\b`).test(source),
-      )
-      const importsEndpointPolicy = importsFrom(source).some((specifier) =>
-        specifier.endsWith('/coral-endpoint.server'),
-      )
-      return (readsEndpointConfig || importsEndpointPolicy) &&
-        !path.basename(file).includes('.server.')
-        ? [path.relative(appDir, file)]
-        : []
-    })
-
-    expect(violations, 'Coral endpoint policy must remain in server-only modules').toEqual([])
-  })
-
   it('keeps a story in every visual Wax component directory', () => {
     const missingStories = fs
       .readdirSync(waxComponentsDir, { withFileTypes: true })

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -77,6 +77,29 @@ describe('architecture', () => {
     expect(dependencyNames.filter((name) => name.toLowerCase().includes('tailwind'))).toEqual([])
   })
 
+  it('keeps Coral endpoint policy and configuration server-only', () => {
+    const runtimeFiles = filesUnder(
+      appDir,
+      (name) => /\.[cm]?[jt]sx?$/.test(name) && !name.includes('.test.'),
+    )
+    const endpointConfig = ['CORAL_ENDPOINT', 'REEF_ALLOW_INSECURE_CORAL_ENDPOINT']
+    const violations = runtimeFiles.flatMap((file) => {
+      const source = fs.readFileSync(file, 'utf8')
+      const readsEndpointConfig = endpointConfig.some((name) =>
+        new RegExp(`(?:process\\.env|env)\\.${name}\\b`).test(source),
+      )
+      const importsEndpointPolicy = importsFrom(source).some((specifier) =>
+        specifier.endsWith('/coral-endpoint.server'),
+      )
+      return (readsEndpointConfig || importsEndpointPolicy) &&
+        !path.basename(file).includes('.server.')
+        ? [path.relative(appDir, file)]
+        : []
+    })
+
+    expect(violations, 'Coral endpoint policy must remain in server-only modules').toEqual([])
+  })
+
   it('keeps a story in every visual Wax component directory', () => {
     const missingStories = fs
       .readdirSync(waxComponentsDir, { withFileTypes: true })

--- a/apps/reef/app/lib/coral-endpoint.server.test.ts
+++ b/apps/reef/app/lib/coral-endpoint.server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
 import { resolveCoralEndpoint } from './coral-endpoint.server'
 
 const request = new Request('https://attacker.example.test/a/path')
@@ -104,4 +105,20 @@ describe('Coral endpoint policy', () => {
       'CORAL_ENDPOINT must be set in production',
     )
   })
+
+  it.each(['http://[::1]:5173/a/path', 'http://[::ffff:127.0.0.1]:5173/a/path'])(
+    'uses the default Coral endpoint for unauthenticated IPv6 development origin %s',
+    (url) => {
+      expect(
+        resolveCoralEndpoint({
+          authenticated: false,
+          env: { NODE_ENV: 'development' },
+          request: new Request(url),
+        }),
+      ).toEqual({
+        authenticatedCleartextOrigin: null,
+        baseUrl: DEFAULT_DEV_CORAL_ENDPOINT,
+      })
+    },
+  )
 })

--- a/apps/reef/app/lib/coral-endpoint.server.test.ts
+++ b/apps/reef/app/lib/coral-endpoint.server.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCoralEndpoint } from './coral-endpoint.server'
+
+const request = new Request('https://attacker.example.test/a/path')
+
+function resolve(
+  env: NodeJS.ProcessEnv,
+  authenticated = true,
+): ReturnType<typeof resolveCoralEndpoint> {
+  return resolveCoralEndpoint({ authenticated, env, request })
+}
+
+describe('Coral endpoint policy', () => {
+  it('requires an explicit endpoint for authenticated calls in every environment', () => {
+    for (const NODE_ENV of ['development', 'test', 'production']) {
+      expect(() => resolve({ NODE_ENV })).toThrow(
+        'CORAL_ENDPOINT must be set when Coral authentication is enabled',
+      )
+    }
+  })
+
+  it('accepts authenticated HTTPS and ignores an irrelevant opt-in value', () => {
+    expect(
+      resolve({
+        CORAL_ENDPOINT: 'https://coral.example.test/',
+        REEF_ALLOW_INSECURE_CORAL_ENDPOINT: 'garbage',
+      }),
+    ).toEqual({ authenticatedCleartextOrigin: null, baseUrl: 'https://coral.example.test' })
+  })
+
+  it.each([
+    'http://localhost:14555',
+    'http://127.42.0.1:14555',
+    'http://[::1]:14555',
+    'http://[::ffff:127.0.0.1]:14555',
+  ])('accepts authenticated explicit-loopback HTTP: %s', (CORAL_ENDPOINT) => {
+    expect(resolve({ CORAL_ENDPOINT })).toEqual({
+      authenticatedCleartextOrigin: null,
+      baseUrl: CORAL_ENDPOINT,
+    })
+  })
+
+  it.each([' 1 ', ' TrUe '])('accepts normalized cleartext opt-in %j', (optIn) => {
+    expect(
+      resolve({
+        CORAL_ENDPOINT: 'http://coral.internal:14555/rpc/',
+        REEF_ALLOW_INSECURE_CORAL_ENDPOINT: optIn,
+      }),
+    ).toEqual({
+      authenticatedCleartextOrigin: 'http://coral.internal:14555',
+      baseUrl: 'http://coral.internal:14555/rpc',
+    })
+  })
+
+  it.each([undefined, '', '0', ' false '])('rejects cleartext without opt-in %j', (optIn) => {
+    expect(() =>
+      resolve({
+        CORAL_ENDPOINT: 'http://coral.internal:14555',
+        REEF_ALLOW_INSECURE_CORAL_ENDPOINT: optIn,
+      }),
+    ).toThrow('CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP')
+  })
+
+  it('rejects localhost subdomains and validates garbage only on an insecure path', () => {
+    expect(() => resolve({ CORAL_ENDPOINT: 'http://coral.localhost:14555' })).toThrow(
+      'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP',
+    )
+    expect(() =>
+      resolve({
+        CORAL_ENDPOINT: 'http://coral.internal:14555',
+        REEF_ALLOW_INSECURE_CORAL_ENDPOINT: 'yes',
+      }),
+    ).toThrow('REEF_ALLOW_INSECURE_CORAL_ENDPOINT must be set to 1 or true')
+  })
+
+  it.each(['file:///tmp/coral.sock', 'grpc://coral.internal:14555'])(
+    'always rejects non-HTTP endpoint %s',
+    (CORAL_ENDPOINT) => {
+      expect(() => resolve({ CORAL_ENDPOINT, REEF_ALLOW_INSECURE_CORAL_ENDPOINT: 'true' })).toThrow(
+        'CORAL_ENDPOINT must be an absolute HTTP(S) URL',
+      )
+    },
+  )
+
+  it('preserves request-derived development fallback only for unauthenticated calls', () => {
+    expect(resolve({ NODE_ENV: 'development' }, false)).toEqual({
+      authenticatedCleartextOrigin: null,
+      baseUrl: request.url.replace('/a/path', ''),
+    })
+    expect(() => resolve({ NODE_ENV: 'production' }, false)).toThrow(
+      'CORAL_ENDPOINT must be set in production',
+    )
+  })
+})

--- a/apps/reef/app/lib/coral-endpoint.server.test.ts
+++ b/apps/reef/app/lib/coral-endpoint.server.test.ts
@@ -83,6 +83,18 @@ describe('Coral endpoint policy', () => {
     },
   )
 
+  it.each([
+    'https://operator:secret@coral.example.test',
+    'https://coral.example.test/rpc?tenant=analytics',
+    'https://coral.example.test/rpc?',
+    'https://coral.example.test/rpc#method',
+    'https://coral.example.test/rpc#',
+  ])('rejects endpoint URL components that Connect cannot safely compose: %s', (CORAL_ENDPOINT) => {
+    expect(() => resolve({ CORAL_ENDPOINT })).toThrow(
+      'CORAL_ENDPOINT must not include credentials, a query string, or a fragment',
+    )
+  })
+
   it('preserves request-derived development fallback only for unauthenticated calls', () => {
     expect(resolve({ NODE_ENV: 'development' }, false)).toEqual({
       authenticatedCleartextOrigin: null,

--- a/apps/reef/app/lib/coral-endpoint.server.ts
+++ b/apps/reef/app/lib/coral-endpoint.server.ts
@@ -1,0 +1,64 @@
+import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
+import { isExplicitLoopbackUrl } from './loopback.server'
+import { isLocalDevOrigin, trimTrailingSlash } from './utils'
+
+export interface CoralEndpointPolicy {
+  authenticatedCleartextOrigin: string | null
+  baseUrl: string
+}
+
+interface CoralEndpointInput {
+  authenticated: boolean
+  env?: NodeJS.ProcessEnv
+  request: Request
+}
+
+export function resolveCoralEndpoint({
+  authenticated,
+  env = process.env,
+  request,
+}: CoralEndpointInput): CoralEndpointPolicy {
+  const configured = env.CORAL_ENDPOINT?.trim()
+  if (!configured) {
+    if (authenticated)
+      throw new Error('CORAL_ENDPOINT must be set when Coral authentication is enabled')
+    if (env.NODE_ENV === 'production') throw new Error('CORAL_ENDPOINT must be set in production')
+
+    const requestUrl = new URL(request.url)
+    return policy(isLocalDevOrigin(requestUrl) ? DEFAULT_DEV_CORAL_ENDPOINT : requestUrl.origin)
+  }
+
+  return policy(configured, authenticated, env.REEF_ALLOW_INSECURE_CORAL_ENDPOINT)
+}
+
+function policy(
+  configured: string,
+  authenticated = false,
+  allowInsecure: string | undefined = undefined,
+): CoralEndpointPolicy {
+  let endpoint: URL
+  try {
+    endpoint = new URL(configured)
+  } catch {
+    throw new Error('CORAL_ENDPOINT must be an absolute HTTP(S) URL')
+  }
+  if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+    throw new Error('CORAL_ENDPOINT must be an absolute HTTP(S) URL')
+  }
+
+  const baseUrl = trimTrailingSlash(configured)
+  if (!authenticated || endpoint.protocol === 'https:' || isExplicitLoopbackUrl(endpoint)) {
+    return { authenticatedCleartextOrigin: null, baseUrl }
+  }
+
+  const optIn = allowInsecure?.trim().toLowerCase()
+  if (optIn === '1' || optIn === 'true') {
+    return { authenticatedCleartextOrigin: endpoint.origin, baseUrl }
+  }
+  if (optIn && optIn !== '0' && optIn !== 'false') {
+    throw new Error('REEF_ALLOW_INSECURE_CORAL_ENDPOINT must be set to 1 or true')
+  }
+  throw new Error(
+    'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP when Coral authentication is enabled',
+  )
+}

--- a/apps/reef/app/lib/coral-endpoint.server.ts
+++ b/apps/reef/app/lib/coral-endpoint.server.ts
@@ -45,6 +45,14 @@ function policy(
   if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
     throw new Error('CORAL_ENDPOINT must be an absolute HTTP(S) URL')
   }
+  if (
+    endpoint.username ||
+    endpoint.password ||
+    configured.includes('?') ||
+    configured.includes('#')
+  ) {
+    throw new Error('CORAL_ENDPOINT must not include credentials, a query string, or a fragment')
+  }
 
   const baseUrl = trimTrailingSlash(configured)
   if (!authenticated || endpoint.protocol === 'https:' || isExplicitLoopbackUrl(endpoint)) {

--- a/apps/reef/app/lib/coral-endpoint.server.ts
+++ b/apps/reef/app/lib/coral-endpoint.server.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
+import { DEFAULT_DEV_CORAL_ENDPOINT, DEFAULT_DEV_CORAL_PORT } from './constants'
 import { isExplicitLoopbackUrl } from './loopback.server'
-import { isLocalDevOrigin, trimTrailingSlash } from './utils'
+import { trimTrailingSlash } from './utils'
 
 export interface CoralEndpointPolicy {
   authenticatedCleartextOrigin: string | null
@@ -25,7 +25,11 @@ export function resolveCoralEndpoint({
     if (env.NODE_ENV === 'production') throw new Error('CORAL_ENDPOINT must be set in production')
 
     const requestUrl = new URL(request.url)
-    return policy(isLocalDevOrigin(requestUrl) ? DEFAULT_DEV_CORAL_ENDPOINT : requestUrl.origin)
+    return policy(
+      isExplicitLoopbackUrl(requestUrl) && requestUrl.port !== DEFAULT_DEV_CORAL_PORT
+        ? DEFAULT_DEV_CORAL_ENDPOINT
+        : requestUrl.origin,
+    )
   }
 
   return policy(configured, authenticated, env.REEF_ALLOW_INSECURE_CORAL_ENDPOINT)

--- a/apps/reef/app/lib/coral-request.server.test.ts
+++ b/apps/reef/app/lib/coral-request.server.test.ts
@@ -56,6 +56,7 @@ describe('request-scoped Coral transport authentication', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllEnvs()
   })
 
@@ -141,7 +142,6 @@ describe('request-scoped Coral transport authentication', () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('bearer tokens over cleartext HTTP to http://coral.internal:50051'),
     )
-    warn.mockRestore()
   })
 
   // The transport follows the deployment topology, not whether a token reached

--- a/apps/reef/app/lib/coral-request.server.test.ts
+++ b/apps/reef/app/lib/coral-request.server.test.ts
@@ -34,6 +34,9 @@ import {
 } from './coral-request.server'
 
 const request = new Request('http://localhost:5173/workspaces/analytics/sources')
+const attackerRequest = new Request('https://attacker.example.test/workspaces/analytics/sources', {
+  headers: { Host: 'attacker.example.test', 'X-Forwarded-Host': 'attacker.example.test' },
+})
 const clientFactories = [
   catalogClientForRequest,
   functionClientForRequest,
@@ -59,7 +62,7 @@ describe('request-scoped Coral transport authentication', () => {
   it('uses native gRPC and adds the server-held bearer token to every Coral RPC', async () => {
     for (const clientFactory of clientFactories) {
       const transport = clientFactory(
-        request,
+        attackerRequest,
         'coral-access-token',
       ) as unknown as GrpcTransportOptions
       const [interceptor] = transport.interceptors ?? []
@@ -69,6 +72,20 @@ describe('request-scoped Coral transport authentication', () => {
       expect(await authorizationHeader(interceptor)).toBe('Bearer coral-access-token')
     }
     expect(transportMocks.createGrpcTransport).toHaveBeenCalledTimes(clientFactories.length)
+    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
+  })
+
+  it('requires CORAL_ENDPOINT under auth instead of trusting request or forwarded hosts', () => {
+    vi.stubEnv('CORAL_ENDPOINT', '')
+    vi.stubEnv('REEF_AUTH_MODE', 'required')
+    vi.stubEnv('REEF_AUTH_ISSUER', 'https://auth.example.test')
+    vi.stubEnv('REEF_PUBLIC_URL', 'https://reef.example.test')
+    vi.stubEnv('REEF_SESSION_SECRET', '0123456789abcdef0123456789abcdef')
+
+    expect(() => sourceClientForRequest(attackerRequest, 'coral-access-token')).toThrow(
+      'CORAL_ENDPOINT must be set when Coral authentication is enabled',
+    )
+    expect(transportMocks.createGrpcTransport).not.toHaveBeenCalled()
     expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
   })
 
@@ -103,6 +120,28 @@ describe('request-scoped Coral transport authentication', () => {
     expect(transport.baseUrl).toBe(endpoint)
     expect(transportMocks.createGrpcTransport).toHaveBeenCalledOnce()
     expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
+  })
+
+  it('allows opted-in h2c with native bearer transport and warns once per origin', () => {
+    vi.stubEnv('CORAL_ENDPOINT', 'http://coral.internal:50051/rpc')
+    vi.stubEnv('REEF_ALLOW_INSECURE_CORAL_ENDPOINT', ' TrUe ')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    for (const clientFactory of clientFactories) {
+      const transport = clientFactory(
+        request,
+        'coral-access-token',
+      ) as unknown as GrpcTransportOptions
+      expect(transport.baseUrl).toBe('http://coral.internal:50051/rpc')
+    }
+
+    expect(transportMocks.createGrpcTransport).toHaveBeenCalledTimes(clientFactories.length)
+    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('bearer tokens over cleartext HTTP to http://coral.internal:50051'),
+    )
+    warn.mockRestore()
   })
 
   // The transport follows the deployment topology, not whether a token reached

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -17,9 +17,7 @@ import { TraceService } from '@/generated/coral/v1/traces_pb'
 import { WorkspaceService } from '@/generated/coral/v1/workspaces_pb'
 import { expiredSessionRedirect } from '@/auth/response.server'
 
-import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
-import { isExplicitLoopbackUrl } from './loopback.server'
-import { isLocalDevOrigin, trimTrailingSlash } from './utils'
+import { resolveCoralEndpoint } from './coral-endpoint.server'
 
 export function sourceClientForRequest(request: Request, accessToken: string | null) {
   return createClient(SourceService, coralTransportForRequest(request, accessToken))
@@ -45,21 +43,13 @@ export function traceClientForRequest(request: Request, accessToken: string | nu
   return createClient(TraceService, coralTransportForRequest(request, accessToken))
 }
 
-export function coralEndpointForRequest(request: Request): string {
-  const configured = process.env.CORAL_ENDPOINT?.trim()
-  if (configured) return trimTrailingSlash(configured)
-
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('CORAL_ENDPOINT must be set in production')
-  }
-
-  const url = new URL(request.url)
-  if (isLocalDevOrigin(url)) return DEFAULT_DEV_CORAL_ENDPOINT
-  return url.origin
-}
-
 function coralTransportForRequest(request: Request, accessToken: string | null) {
-  const baseUrl = coralEndpointForRequest(request)
+  const authMode = reefAuthConfig().mode
+  const endpoint = resolveCoralEndpoint({
+    authenticated: authMode !== 'disabled' || accessToken !== null,
+    request,
+  })
+  const { baseUrl } = endpoint
   if (!accessToken) {
     // The transport follows the deployment topology, not whether a token
     // happened to be threaded here. `coral ui` — the Desktop sidecar, and the
@@ -71,30 +61,32 @@ function coralTransportForRequest(request: Request, accessToken: string | null) 
     // loader runs, so a null token in `required` mode is a caller that dropped
     // it. Falling through would send anonymous RPCs to a hosted Coral and
     // surface the result as an opaque transport error rather than an auth one.
-    if (reefAuthConfig().mode !== 'disabled') {
+    if (authMode !== 'disabled') {
       throw new Error('Coral authentication is required but this request carried no access token')
     }
 
     return createGrpcWebTransport({ baseUrl })
   }
 
-  const endpoint = new URL(baseUrl)
-  if (
-    endpoint.protocol !== 'https:' &&
-    !(endpoint.protocol === 'http:' && isExplicitLoopbackUrl(endpoint))
-  ) {
-    throw new Error(
-      'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP when Coral authentication is enabled',
-    )
-  }
+  warnAuthenticatedCleartext(endpoint.authenticatedCleartextOrigin)
 
   return redirectUnauthenticatedTransport(
     request,
     createGrpcTransport({
       baseUrl,
       interceptors: [bearerAuthInterceptor(accessToken)],
-      sessionManager: coralSessionManager(endpoint),
+      sessionManager: coralSessionManager(new URL(baseUrl)),
     }),
+  )
+}
+
+const warnedCleartextOrigins = new Set<string>()
+
+function warnAuthenticatedCleartext(origin: string | null): void {
+  if (!origin || warnedCleartextOrigins.has(origin)) return
+  warnedCleartextOrigins.add(origin)
+  console.warn(
+    `REEF_ALLOW_INSECURE_CORAL_ENDPOINT sends Coral bearer tokens over cleartext HTTP to ${origin}; trust the entire Reef-to-Coral network path.`,
   )
 }
 

--- a/apps/reef/app/lib/utils.ts
+++ b/apps/reef/app/lib/utils.ts
@@ -1,15 +1,6 @@
-import { DEFAULT_DEV_CORAL_PORT } from './constants'
-
 export function errorMessage(error: unknown): string {
   if (error instanceof Response) throw error
   return error instanceof Error ? error.message : String(error)
-}
-
-export function isLocalDevOrigin(url: URL): boolean {
-  return (
-    (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
-    url.port !== DEFAULT_DEV_CORAL_PORT
-  )
 }
 
 export function trimTrailingSlash(value: string): string {


### PR DESCRIPTION
## Intent

Make the Coral destination an explicit server-side configuration and reject unsafe authenticated cleartext transport by default.

## What it enables

Authenticated Reef deployments can use HTTPS or shared-namespace loopback safely, while operators may deliberately opt into h2c on a controlled network.

## Usage examples

Set `CORAL_ENDPOINT=https://coral.internal.example.com`. For an operator-controlled cleartext network, also set `REEF_ALLOW_INSECURE_CORAL_ENDPOINT=1`; Reef logs a warning when that transport is first used.
