### PR TITLE
feat(reef): serve Reef from a production Node entry

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,6 @@ jobs:
       ui-build: ${{ steps.filter.outputs.ui-build }}
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
-      reef-server-smoke: ${{ steps.filter.outputs.reef-server-smoke }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
@@ -105,9 +104,6 @@ jobs:
               # Reef re-exports the desktop IPC bridge types, so a change there
               # can break the reef type-check.
               - 'apps/desktop/src/shared/types.ts'
-            reef-server-smoke:
-              - '.github/workflows/validate.yml'
-              - 'apps/reef/**'
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'
@@ -482,7 +478,6 @@ jobs:
         run: npm run build --prefix apps/reef
 
       - name: Smoke production Reef server
-        if: ${{ needs.changes.outputs.reef-server-smoke == 'true' }}
         run: npm run test:server --prefix apps/reef
 
   desktop-checks:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -107,13 +107,7 @@ jobs:
               - 'apps/desktop/src/shared/types.ts'
             reef-server-smoke:
               - '.github/workflows/validate.yml'
-              - 'apps/reef/server.js'
-              - 'apps/reef/server.test.mjs'
-              - 'apps/reef/app/entry.server.*'
-              - 'apps/reef/app/lib/runtime-config.server.ts'
-              - 'apps/reef/app/routes.ts'
-              - 'apps/reef/app/routes/**'
-              - 'apps/reef/package*.json'
+              - 'apps/reef/**'
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,6 +39,7 @@ jobs:
       ui-build: ${{ steps.filter.outputs.ui-build }}
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
+      reef-server-smoke: ${{ steps.filter.outputs.reef-server-smoke }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
@@ -104,6 +105,15 @@ jobs:
               # Reef re-exports the desktop IPC bridge types, so a change there
               # can break the reef type-check.
               - 'apps/desktop/src/shared/types.ts'
+            reef-server-smoke:
+              - '.github/workflows/validate.yml'
+              - 'apps/reef/server.js'
+              - 'apps/reef/server.test.mjs'
+              - 'apps/reef/app/entry.server.*'
+              - 'apps/reef/app/lib/runtime-config.server.ts'
+              - 'apps/reef/app/routes.ts'
+              - 'apps/reef/app/routes/**'
+              - 'apps/reef/package*.json'
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'
@@ -476,6 +486,10 @@ jobs:
 
       - name: Build Reef
         run: npm run build --prefix apps/reef
+
+      - name: Smoke production Reef server
+        if: ${{ needs.changes.outputs.reef-server-smoke == 'true' }}
+        run: npm run test:server --prefix apps/reef
 
   desktop-checks:
     name: Desktop checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,9 @@
 - UI changes must pass `npm run check --prefix apps/ui` (oxfmt + oxlint) before submitting.
 - Reef changes must pass `npm run check --prefix apps/reef`,
   `npm run typecheck --prefix apps/reef`, `npm test --prefix apps/reef`, and
-  `npm run build --prefix apps/reef` before submitting.
+  `npm run build --prefix apps/reef`, followed by
+  `npm run test:server --prefix apps/reef`, before submitting. The production
+  server smoke test consumes the build output and runs on every Reef CI job.
 - Desktop changes must pass `npm run check --prefix apps/desktop` and
   `npm test --prefix apps/desktop` before submitting.
 - Keep Reef Vitest coverage Node-only and focused on atomic deterministic

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -97,23 +97,6 @@ describe('architecture', () => {
     expect(server).toContain('pathToFileURL(process.argv[1]).href === import.meta.url')
   })
 
-  it('runs the production server smoke after its build when server inputs change', () => {
-    const validate = fs.readFileSync(
-      path.resolve(reefRoot, '../..', '.github/workflows/validate.yml'),
-      'utf8',
-    )
-    const smokeFilter = validate.match(
-      /            reef-server-smoke:\n(?<paths>(?:              - .*\n)+)/,
-    )?.groups?.paths
-
-    expect(smokeFilter).toBe(
-      "              - '.github/workflows/validate.yml'\n              - 'apps/reef/**'\n",
-    )
-    expect(validate.indexOf('run: npm run build --prefix apps/reef')).toBeLessThan(
-      validate.indexOf('run: npm run test:server --prefix apps/reef'),
-    )
-  })
-
   it('keeps a story in every visual Wax component directory', () => {
     const missingStories = fs
       .readdirSync(waxComponentsDir, { withFileTypes: true })

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -102,16 +102,13 @@ describe('architecture', () => {
       path.resolve(reefRoot, '../..', '.github/workflows/validate.yml'),
       'utf8',
     )
-    for (const input of [
-      'apps/reef/server.js',
-      'apps/reef/app/entry.server.*',
-      'apps/reef/app/lib/runtime-config.server.ts',
-      'apps/reef/app/routes.ts',
-      'apps/reef/app/routes/**',
-      'apps/reef/package*.json',
-    ]) {
-      expect(validate).toContain(`- '${input}'`)
-    }
+    const smokeFilter = validate.match(
+      /            reef-server-smoke:\n(?<paths>(?:              - .*\n)+)/,
+    )?.groups?.paths
+
+    expect(smokeFilter).toBe(
+      "              - '.github/workflows/validate.yml'\n              - 'apps/reef/**'\n",
+    )
     expect(validate.indexOf('run: npm run build --prefix apps/reef')).toBeLessThan(
       validate.indexOf('run: npm run test:server --prefix apps/reef'),
     )

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -77,6 +77,46 @@ describe('architecture', () => {
     expect(dependencyNames.filter((name) => name.toLowerCase().includes('tailwind'))).toEqual([])
   })
 
+  it('keeps the production entry dependency-light and import-safe', () => {
+    const server = fs.readFileSync(path.join(reefRoot, 'server.js'), 'utf8')
+    const allowedImports = new Set([
+      'node:fs',
+      'node:fs/promises',
+      'node:http',
+      'node:path',
+      'node:stream',
+      'node:stream/promises',
+      'node:url',
+      'react-router',
+      './build/server/index.js',
+    ])
+
+    expect(importsFrom(server).filter((specifier) => !allowedImports.has(specifier))).toEqual([])
+    expect(server).not.toMatch(/@react-router\/dev|react-router dev|vite|express/)
+    expect(server).toContain('export async function startServer')
+    expect(server).toContain('pathToFileURL(process.argv[1]).href === import.meta.url')
+  })
+
+  it('runs the production server smoke after its build when server inputs change', () => {
+    const validate = fs.readFileSync(
+      path.resolve(reefRoot, '../..', '.github/workflows/validate.yml'),
+      'utf8',
+    )
+    for (const input of [
+      'apps/reef/server.js',
+      'apps/reef/app/entry.server.*',
+      'apps/reef/app/lib/runtime-config.server.ts',
+      'apps/reef/app/routes.ts',
+      'apps/reef/app/routes/**',
+      'apps/reef/package*.json',
+    ]) {
+      expect(validate).toContain(`- '${input}'`)
+    }
+    expect(validate.indexOf('run: npm run build --prefix apps/reef')).toBeLessThan(
+      validate.indexOf('run: npm run test:server --prefix apps/reef'),
+    )
+  })
+
   it('keeps a story in every visual Wax component directory', () => {
     const missingStories = fs
       .readdirSync(waxComponentsDir, { withFileTypes: true })

--- a/apps/reef/app/lib/runtime-config.server.test.ts
+++ b/apps/reef/app/lib/runtime-config.server.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { assertReefRuntimeConfig } from './runtime-config.server'
+
+const SESSION_SECRET = '0123456789abcdef0123456789abcdef'
+
+function stubRequiredEnv(overrides: NodeJS.ProcessEnv = {}): void {
+  const env = {
+    CORAL_ENDPOINT: 'https://coral.example.test',
+    NODE_ENV: 'production',
+    REEF_AUTH_ISSUER: 'https://auth.example.test',
+    REEF_AUTH_MODE: 'required',
+    REEF_PUBLIC_URL: 'https://reef.example.test',
+    REEF_SESSION_SECRET: SESSION_SECRET,
+    ...overrides,
+  }
+  for (const [name, value] of Object.entries(env)) vi.stubEnv(name, value)
+}
+
+describe('Reef startup configuration', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('accepts complete production auth and Coral configuration', () => {
+    stubRequiredEnv()
+
+    expect(() => assertReefRuntimeConfig()).not.toThrow()
+  })
+
+  it.each([
+    ['REEF_AUTH_MODE', '', 'REEF_AUTH_MODE must be set to disabled or required in production'],
+    ['REEF_PUBLIC_URL', '', 'REEF_PUBLIC_URL must be set when auth is required'],
+    [
+      'REEF_SESSION_SECRET',
+      '',
+      'REEF_SESSION_SECRET must be at least 32 characters when auth is required',
+    ],
+    ['CORAL_ENDPOINT', '', 'CORAL_ENDPOINT must be set when Coral authentication is enabled'],
+  ])('fails deterministically for invalid %s', (name, value, message) => {
+    stubRequiredEnv({ [name]: value })
+
+    expect(() => assertReefRuntimeConfig()).toThrow(message)
+  })
+
+  it('uses the authenticated endpoint policy for insecure Coral URLs', () => {
+    stubRequiredEnv({
+      CORAL_ENDPOINT: 'http://coral.internal:14555',
+      REEF_ALLOW_INSECURE_CORAL_ENDPOINT: 'false',
+    })
+
+    expect(() => assertReefRuntimeConfig()).toThrow(
+      'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP when Coral authentication is enabled',
+    )
+  })
+
+  it('allows disabled auth without parsing the insecure endpoint flag', () => {
+    stubRequiredEnv({
+      CORAL_ENDPOINT: 'http://coral.internal:14555',
+      REEF_ALLOW_INSECURE_CORAL_ENDPOINT: 'not-a-boolean',
+      REEF_AUTH_MODE: 'disabled',
+    })
+
+    expect(() => assertReefRuntimeConfig()).not.toThrow()
+  })
+})

--- a/apps/reef/app/lib/runtime-config.server.ts
+++ b/apps/reef/app/lib/runtime-config.server.ts
@@ -1,0 +1,14 @@
+import { reefAuthConfig } from '@/auth/config.server'
+
+import { resolveCoralEndpoint } from './coral-endpoint.server'
+
+const STARTUP_REQUEST = new Request('http://127.0.0.1')
+
+/** Fail startup before Reef accepts traffic when production configuration is invalid. */
+export function assertReefRuntimeConfig(): void {
+  const auth = reefAuthConfig()
+  resolveCoralEndpoint({
+    authenticated: auth.mode === 'required',
+    request: STARTUP_REQUEST,
+  })
+}

--- a/apps/reef/app/routes.test.ts
+++ b/apps/reef/app/routes.test.ts
@@ -5,6 +5,7 @@ import routes from './routes'
 
 const protectedBoundaryFile = 'routes/_protected.tsx'
 const publicRouteFiles = new Set([
+  'routes/healthz.ts',
   'routes/oauth-client-metadata.ts',
   'routes/login.tsx',
   'routes/auth.callback.tsx',

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -3,8 +3,9 @@ import { type RouteConfig, index, layout, route } from '@react-router/dev/routes
 import { routePattern } from './routing/routemap'
 
 export default [
-  // Public auth resources: Coral needs CIMD before authorization, and the
-  // browser needs login/callback/logout outside the session boundary.
+  // Public resources: health probes must not cross the session boundary; Coral
+  // needs CIMD before authorization; and the browser needs auth routes outside it.
+  route('healthz', 'routes/healthz.ts'),
   route('.well-known/oauth-client', 'routes/oauth-client-metadata.ts'),
   route(routePattern('login'), 'routes/login.tsx'),
   route('auth/callback', 'routes/auth.callback.tsx'),

--- a/apps/reef/app/routes/healthz.server.test.ts
+++ b/apps/reef/app/routes/healthz.server.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { loader } from './healthz'
+
+describe('health check route', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns 200 without contacting Coral or an auth provider', async () => {
+    vi.stubEnv('CORAL_ENDPOINT', 'http://unreachable.invalid')
+    vi.stubEnv('REEF_AUTH_ISSUER', 'https://unreachable.invalid')
+    const fetch = vi.fn(() => Promise.reject(new Error('outbound access is unavailable')))
+    vi.stubGlobal('fetch', fetch)
+
+    const response = loader({
+      request: new Request('http://reef.test/healthz'),
+    } as never)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('application/json')
+    await expect(response.json()).resolves.toEqual({ status: 'ok' })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/reef/app/routes/healthz.server.test.ts
+++ b/apps/reef/app/routes/healthz.server.test.ts
@@ -2,25 +2,55 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { loader } from './healthz'
 
+const SESSION_SECRET = '0123456789abcdef0123456789abcdef'
+
+function stubRequiredEnv(overrides: NodeJS.ProcessEnv = {}): void {
+  const env = {
+    CORAL_ENDPOINT: 'https://unreachable.invalid',
+    NODE_ENV: 'production',
+    REEF_AUTH_ISSUER: 'https://unreachable.invalid',
+    REEF_AUTH_MODE: 'required',
+    REEF_PUBLIC_URL: 'https://reef.example.test',
+    REEF_SESSION_SECRET: SESSION_SECRET,
+    ...overrides,
+  }
+  for (const [name, value] of Object.entries(env)) vi.stubEnv(name, value)
+}
+
 describe('health check route', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
     vi.unstubAllGlobals()
   })
 
-  it('returns 200 without contacting Coral or an auth provider', async () => {
-    vi.stubEnv('CORAL_ENDPOINT', 'http://unreachable.invalid')
-    vi.stubEnv('REEF_AUTH_ISSUER', 'https://unreachable.invalid')
+  it('returns 200 for valid config without contacting Coral or an auth provider', async () => {
+    stubRequiredEnv()
     const fetch = vi.fn(() => Promise.reject(new Error('outbound access is unavailable')))
     vi.stubGlobal('fetch', fetch)
 
-    const response = loader({
-      request: new Request('http://reef.test/healthz'),
-    } as never)
+    const response = runLoader()
 
     expect(response.status).toBe(200)
     expect(response.headers.get('Content-Type')).toContain('application/json')
     await expect(response.json()).resolves.toEqual({ status: 'ok' })
     expect(fetch).not.toHaveBeenCalled()
   })
+
+  it('throws synchronously for invalid required-auth config', () => {
+    stubRequiredEnv({ REEF_PUBLIC_URL: '' })
+
+    expect(() => runLoader()).toThrow('REEF_PUBLIC_URL must be set when auth is required')
+  })
+
+  it('throws synchronously for an insecure authenticated Coral endpoint', () => {
+    stubRequiredEnv({ CORAL_ENDPOINT: 'http://coral.internal:14555' })
+
+    expect(() => runLoader()).toThrow(
+      'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP when Coral authentication is enabled',
+    )
+  })
 })
+
+function runLoader(): Response {
+  return loader({ request: new Request('http://reef.test/healthz') } as never)
+}

--- a/apps/reef/app/routes/healthz.ts
+++ b/apps/reef/app/routes/healthz.ts
@@ -1,0 +1,5 @@
+import type { Route } from './+types/healthz'
+
+export function loader({ request: _request }: Route.LoaderArgs): Response {
+  return Response.json({ status: 'ok' })
+}

--- a/apps/reef/app/routes/healthz.ts
+++ b/apps/reef/app/routes/healthz.ts
@@ -1,5 +1,8 @@
 import type { Route } from './+types/healthz'
 
+import { assertReefRuntimeConfig } from '@/lib/runtime-config.server'
+
 export function loader({ request: _request }: Route.LoaderArgs): Response {
+  assertReefRuntimeConfig()
   return Response.json({ status: 'ok' })
 }

--- a/apps/reef/package.json
+++ b/apps/reef/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "build": "npm run proto:gen && react-router build",
     "dev": "npm run proto:gen && react-router dev",
+    "start": "node server.js",
     "proto:gen": "buf generate --template buf.gen.yaml",
     "typecheck": "npm run proto:gen && react-router typegen && tsc",
     "test": "npm run proto:gen && vitest run",
+    "test:server": "node --test server.test.mjs",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",

--- a/apps/reef/server.js
+++ b/apps/reef/server.js
@@ -1,0 +1,187 @@
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { extname, resolve, sep } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { Readable } from 'node:stream'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { createRequestHandler, RouterContextProvider } from 'react-router'
+
+const CLIENT_ROOT = resolve(fileURLToPath(new URL('./build/client/', import.meta.url)))
+const CONTENT_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+class StartupFailure extends Error {
+  constructor(stage, cause) {
+    super(`${stage}: ${cause instanceof Error ? cause.message : String(cause)}`, { cause })
+  }
+}
+
+export async function probeRuntimeConfig(handler) {
+  let response
+  try {
+    response = await handler(new Request('http://127.0.0.1/healthz'), new RouterContextProvider())
+  } catch (cause) {
+    throw new StartupFailure('runtime configuration', cause)
+  }
+  if (!response.ok) {
+    throw new StartupFailure(
+      'runtime configuration',
+      new Error(`health probe returned HTTP ${response.status}`),
+    )
+  }
+}
+
+export async function startServer({
+  handler,
+  server,
+  env = process.env,
+  host = env.HOST?.trim() || '0.0.0.0',
+  port = env.PORT ? Number(env.PORT) : 3000,
+  listen = listenServer,
+}) {
+  if (env.REEF_AUTH_MODE?.trim().toLowerCase() === 'disabled') {
+    console.warn('WARNING: Reef authentication is disabled; all clients have full local access.')
+  }
+  await probeRuntimeConfig(handler)
+  await listen(server, port, host)
+  return server
+}
+
+async function listenServer(server, port, host) {
+  try {
+    await new Promise((resolveListen, reject) => {
+      const onError = (error) => reject(error)
+      server.once('error', onError)
+      server.listen(port, host, () => {
+        server.off('error', onError)
+        resolveListen()
+      })
+    })
+  } catch (cause) {
+    throw new StartupFailure('HTTP listener', cause)
+  }
+}
+
+async function serveStatic(request, response) {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return false
+
+  let pathname
+  try {
+    pathname = decodeURIComponent(new URL(request.url ?? '/', 'http://localhost').pathname)
+  } catch {
+    return false
+  }
+  const file = resolve(CLIENT_ROOT, `.${pathname}`)
+  if (!file.startsWith(`${CLIENT_ROOT}${sep}`)) return false
+
+  let metadata
+  try {
+    metadata = await stat(file)
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return false
+    throw error
+  }
+  if (!metadata.isFile()) return false
+
+  response.setHeader(
+    'Cache-Control',
+    pathname.startsWith('/assets/') ? 'public, max-age=31536000, immutable' : 'no-cache',
+  )
+  response.setHeader('Content-Length', metadata.size)
+  response.setHeader('Content-Type', CONTENT_TYPES[extname(file)] ?? 'application/octet-stream')
+  if (request.method === 'HEAD') response.end()
+  else await pipeline(createReadStream(file), response)
+  return true
+}
+
+function toWebRequest(request) {
+  const headers = new Headers()
+  for (const [name, value] of Object.entries(request.headers)) {
+    for (const item of Array.isArray(value) ? value : [value]) {
+      if (item !== undefined) headers.append(name, item)
+    }
+  }
+  const init = { headers, method: request.method }
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = Readable.toWeb(request)
+    init.duplex = 'half'
+  }
+  return new Request(
+    new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`),
+    init,
+  )
+}
+
+async function sendWebResponse(request, response, webResponse) {
+  response.statusCode = webResponse.status
+  for (const [name, value] of webResponse.headers) {
+    if (name !== 'set-cookie') response.setHeader(name, value)
+  }
+  const cookies = webResponse.headers.getSetCookie()
+  if (cookies.length) response.setHeader('Set-Cookie', cookies)
+  if (!webResponse.body || request.method === 'HEAD') {
+    await webResponse.body?.cancel()
+    response.end()
+  } else {
+    await pipeline(Readable.fromWeb(webResponse.body), response)
+  }
+}
+
+async function handleNodeRequest(request, response, handler) {
+  try {
+    if (await serveStatic(request, response)) return
+    const webResponse = await handler(toWebRequest(request), new RouterContextProvider())
+    await sendWebResponse(request, response, webResponse)
+  } catch (error) {
+    console.error('Reef request failed:', error)
+    if (response.headersSent) response.destroy()
+    else response.writeHead(500).end('Internal Server Error')
+  }
+}
+
+function installShutdown(server) {
+  let closing = false
+  const shutdown = () => {
+    if (closing) return
+    closing = true
+    server.close((error) => {
+      if (error) {
+        console.error('Reef shutdown failed:', error)
+        process.exitCode = 1
+      }
+    })
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+}
+
+async function main() {
+  process.env.NODE_ENV = 'production'
+  const build = await import('./build/server/index.js')
+  const handler = createRequestHandler(build, 'production')
+  const server = createServer((request, response) => {
+    void handleNodeRequest(request, response, handler)
+  })
+  installShutdown(server)
+  await startServer({ handler, server })
+  const address = server.address()
+  const host = typeof address === 'object' && address ? address.address : process.env.HOST
+  const port = typeof address === 'object' && address ? address.port : process.env.PORT
+  console.log(`Reef listening on http://${host}:${port}`)
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(`Reef startup failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exitCode = 1
+  })
+}

--- a/apps/reef/server.js
+++ b/apps/reef/server.js
@@ -45,7 +45,7 @@ export async function startServer({
   server,
   env = process.env,
   host = env.HOST?.trim() || '0.0.0.0',
-  port = env.PORT ? Number(env.PORT) : 3000,
+  port = Number(env.PORT?.trim() || 3000),
   listen = listenServer,
   installShutdown = installShutdownHandlers,
 }) {

--- a/apps/reef/server.js
+++ b/apps/reef/server.js
@@ -1,7 +1,7 @@
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { createServer } from 'node:http'
-import { extname, resolve, sep } from 'node:path'
+import { extname, relative, resolve, sep } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -47,12 +47,14 @@ export async function startServer({
   host = env.HOST?.trim() || '0.0.0.0',
   port = env.PORT ? Number(env.PORT) : 3000,
   listen = listenServer,
+  installShutdown = installShutdownHandlers,
 }) {
   if (env.REEF_AUTH_MODE?.trim().toLowerCase() === 'disabled') {
     console.warn('WARNING: Reef authentication is disabled; all clients have full local access.')
   }
   await probeRuntimeConfig(handler)
   await listen(server, port, host)
+  installShutdown(server)
   return server
 }
 
@@ -92,9 +94,10 @@ async function serveStatic(request, response) {
   }
   if (!metadata.isFile()) return false
 
+  const clientPath = relative(CLIENT_ROOT, file)
   response.setHeader(
     'Cache-Control',
-    pathname.startsWith('/assets/') ? 'public, max-age=31536000, immutable' : 'no-cache',
+    clientPath.split(sep)[0] === 'assets' ? 'public, max-age=31536000, immutable' : 'no-cache',
   )
   response.setHeader('Content-Length', metadata.size)
   response.setHeader('Content-Type', CONTENT_TYPES[extname(file)] ?? 'application/octet-stream')
@@ -103,22 +106,37 @@ async function serveStatic(request, response) {
   return true
 }
 
-function toWebRequest(request) {
+export function createWebRequest(request, response) {
+  const controller = new AbortController()
+  const abort = () => controller.abort()
+  const abortIncompleteRequest = () => !request.complete && abort()
+  const abortIncompleteResponse = () => !response.writableEnded && abort()
+  request.once('aborted', abort)
+  request.once('close', abortIncompleteRequest)
+  response.once('close', abortIncompleteResponse)
+
   const headers = new Headers()
   for (const [name, value] of Object.entries(request.headers)) {
     for (const item of Array.isArray(value) ? value : [value]) {
       if (item !== undefined) headers.append(name, item)
     }
   }
-  const init = { headers, method: request.method }
+  const init = { headers, method: request.method, signal: controller.signal }
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     init.body = Readable.toWeb(request)
     init.duplex = 'half'
   }
-  return new Request(
-    new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`),
-    init,
-  )
+  return {
+    request: new Request(
+      new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`),
+      init,
+    ),
+    release() {
+      request.off('aborted', abort)
+      request.off('close', abortIncompleteRequest)
+      response.off('close', abortIncompleteResponse)
+    },
+  }
 }
 
 async function sendWebResponse(request, response, webResponse) {
@@ -137,18 +155,22 @@ async function sendWebResponse(request, response, webResponse) {
 }
 
 async function handleNodeRequest(request, response, handler) {
+  let bridge
   try {
     if (await serveStatic(request, response)) return
-    const webResponse = await handler(toWebRequest(request), new RouterContextProvider())
+    bridge = createWebRequest(request, response)
+    const webResponse = await handler(bridge.request, new RouterContextProvider())
     await sendWebResponse(request, response, webResponse)
   } catch (error) {
     console.error('Reef request failed:', error)
     if (response.headersSent) response.destroy()
     else response.writeHead(500).end('Internal Server Error')
+  } finally {
+    bridge?.release()
   }
 }
 
-function installShutdown(server) {
+function installShutdownHandlers(server) {
   let closing = false
   const shutdown = () => {
     if (closing) return
@@ -171,7 +193,6 @@ async function main() {
   const server = createServer((request, response) => {
     void handleNodeRequest(request, response, handler)
   })
-  installShutdown(server)
   await startServer({ handler, server })
   const address = server.address()
   const host = typeof address === 'object' && address ? address.address : process.env.HOST

--- a/apps/reef/server.test.mjs
+++ b/apps/reef/server.test.mjs
@@ -1,10 +1,21 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { readdir } from 'node:fs/promises'
+import { access, readdir } from 'node:fs/promises'
 import { EventEmitter, once } from 'node:events'
 import { test } from 'node:test'
 
 import { createWebRequest, startServer } from './server.js'
+
+try {
+  await Promise.all([
+    access(new URL('./build/server/index.js', import.meta.url)),
+    access(new URL('./build/client/assets/', import.meta.url)),
+  ])
+} catch {
+  throw new Error(
+    'Reef production build artifacts are missing; run `npm run build` before `npm run test:server`.',
+  )
+}
 
 const REQUIRED_ENV = {
   CORAL_ENDPOINT: 'http://127.0.0.1:9',
@@ -48,6 +59,22 @@ test('probes valid runtime config immediately before listen with a fresh context
   assert.deepEqual(events, ['probe', 'listen:0.0.0.0:3000', 'shutdown'])
   assert.equal(contexts.length, 1)
   assert.match(warnings[0], /authentication is disabled/)
+})
+
+test('treats a blank PORT as unset', async () => {
+  let configuredPort
+
+  await startServer({
+    env: { PORT: '   ', REEF_AUTH_MODE: 'required' },
+    handler: async () => new Response(null, { status: 204 }),
+    installShutdown: () => undefined,
+    listen: async (_server, port) => {
+      configuredPort = port
+    },
+    server: {},
+  })
+
+  assert.equal(configuredPort, 3000)
 })
 
 test('aborts Fetch requests only for actual Node client disconnects', () => {
@@ -155,22 +182,40 @@ test('production entry names fatal runtime config and exits without listening', 
   assert.match(error, /Reef startup failed: runtime configuration: health probe returned HTTP 500/)
 })
 
+test('stops waiting for a listening port when the child exits', async () => {
+  const child = spawn(process.execPath, ['-e', 'process.exit(2)'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  await assert.rejects(listeningPort(child), /server exited before listening \(2\)/)
+})
+
 function listeningPort(child) {
   return new Promise((resolve, reject) => {
     let output = ''
-    const timeout = setTimeout(
-      () => reject(new Error('server did not listen within 10 seconds')),
-      10_000,
-    )
-    child.stdout.setEncoding('utf8').on('data', (chunk) => {
+    const cleanup = () => {
+      clearTimeout(timeout)
+      child.stdout.off('data', onData)
+      child.off('exit', onExit)
+    }
+    const onData = (chunk) => {
       output += chunk
       const match = output.match(/Reef listening on http:\/\/127\.0\.0\.1:(\d+)/)
       if (match) {
-        clearTimeout(timeout)
+        cleanup()
         resolve(Number(match[1]))
       }
-    })
-    child.once('exit', (code) => reject(new Error(`server exited before listening (${code})`)))
+    }
+    const onExit = (code) => {
+      cleanup()
+      reject(new Error(`server exited before listening (${code})`))
+    }
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error('server did not listen within 10 seconds'))
+    }, 10_000)
+    child.stdout.setEncoding('utf8').on('data', onData)
+    child.once('exit', onExit)
   })
 }
 

--- a/apps/reef/server.test.mjs
+++ b/apps/reef/server.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
 import { readdir } from 'node:fs/promises'
-import { once } from 'node:events'
+import { EventEmitter, once } from 'node:events'
 import { test } from 'node:test'
 
-import { startServer } from './server.js'
+import { createWebRequest, startServer } from './server.js'
 
 const REQUIRED_ENV = {
   CORAL_ENDPOINT: 'http://127.0.0.1:9',
@@ -29,18 +29,52 @@ test('probes valid runtime config immediately before listen with a fresh context
     return new Response(null, { status: 204 })
   }
   const listen = async (_server, port, host) => events.push(`listen:${host}:${port}`)
+  const installShutdown = () => events.push('shutdown')
 
   const originalWarn = console.warn
   console.warn = (message) => warnings.push(message)
   try {
-    await startServer({ env: { REEF_AUTH_MODE: 'disabled' }, handler, listen, server: {} })
+    await startServer({
+      env: { REEF_AUTH_MODE: 'disabled' },
+      handler,
+      installShutdown,
+      listen,
+      server: {},
+    })
   } finally {
     console.warn = originalWarn
   }
 
-  assert.deepEqual(events, ['probe', 'listen:0.0.0.0:3000'])
+  assert.deepEqual(events, ['probe', 'listen:0.0.0.0:3000', 'shutdown'])
   assert.equal(contexts.length, 1)
   assert.match(warnings[0], /authentication is disabled/)
+})
+
+test('aborts Fetch requests only for actual Node client disconnects', () => {
+  const nodeRequest = Object.assign(new EventEmitter(), {
+    complete: false,
+    headers: { host: 'reef.test' },
+    method: 'GET',
+    url: '/',
+  })
+  const nodeResponse = Object.assign(new EventEmitter(), { writableEnded: false })
+  const aborted = createWebRequest(nodeRequest, nodeResponse)
+  nodeRequest.emit('aborted')
+  assert.equal(aborted.request.signal.aborted, true)
+  aborted.release()
+
+  const disconnected = createWebRequest(nodeRequest, nodeResponse)
+  nodeResponse.emit('close')
+  assert.equal(disconnected.request.signal.aborted, true)
+  disconnected.release()
+
+  nodeRequest.complete = true
+  nodeResponse.writableEnded = true
+  const completed = createWebRequest(nodeRequest, nodeResponse)
+  nodeRequest.emit('close')
+  nodeResponse.emit('close')
+  assert.equal(completed.request.signal.aborted, false)
+  completed.release()
 })
 
 test('does not listen when the runtime probe throws or returns non-2xx', async () => {
@@ -88,6 +122,9 @@ test('production entry serves static files, delegates SSR, and shuts down cleanl
     const favicon = await fetch(`${origin}/favicon.svg`)
     assert.equal(favicon.status, 200)
     assert.equal(favicon.headers.get('cache-control'), 'no-cache')
+    const traversal = await fetch(`${origin}/assets%2f..%2ffavicon.svg`)
+    assert.equal(traversal.status, 200)
+    assert.equal(traversal.headers.get('cache-control'), 'no-cache')
 
     const [asset] = await readdir(new URL('./build/client/assets/', import.meta.url))
     const immutable = await fetch(`${origin}/assets/${asset}`)

--- a/apps/reef/server.test.mjs
+++ b/apps/reef/server.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { readdir } from 'node:fs/promises'
+import { once } from 'node:events'
+import { test } from 'node:test'
+
+import { startServer } from './server.js'
+
+const REQUIRED_ENV = {
+  CORAL_ENDPOINT: 'http://127.0.0.1:9',
+  HOST: '127.0.0.1',
+  NODE_ENV: 'production',
+  PORT: '0',
+  REEF_AUTH_ISSUER: 'http://127.0.0.1:9',
+  REEF_AUTH_MODE: 'required',
+  REEF_PUBLIC_URL: 'http://127.0.0.1:3000',
+  REEF_SESSION_SECRET: '0123456789abcdef0123456789abcdef',
+}
+const CHILD_ENV = { ...process.env, ...REQUIRED_ENV }
+delete CHILD_ENV.FORCE_COLOR
+
+test('probes valid runtime config immediately before listen with a fresh context', async () => {
+  const events = []
+  const contexts = []
+  const warnings = []
+  const handler = async (_request, context) => {
+    events.push('probe')
+    contexts.push(context)
+    return new Response(null, { status: 204 })
+  }
+  const listen = async (_server, port, host) => events.push(`listen:${host}:${port}`)
+
+  const originalWarn = console.warn
+  console.warn = (message) => warnings.push(message)
+  try {
+    await startServer({ env: { REEF_AUTH_MODE: 'disabled' }, handler, listen, server: {} })
+  } finally {
+    console.warn = originalWarn
+  }
+
+  assert.deepEqual(events, ['probe', 'listen:0.0.0.0:3000'])
+  assert.equal(contexts.length, 1)
+  assert.match(warnings[0], /authentication is disabled/)
+})
+
+test('does not listen when the runtime probe throws or returns non-2xx', async () => {
+  for (const handler of [
+    async () => {
+      throw new Error('missing setting')
+    },
+    async () => new Response(null, { status: 503 }),
+  ]) {
+    let listened = false
+    await assert.rejects(
+      startServer({
+        handler,
+        listen: async () => {
+          listened = true
+        },
+        server: {},
+      }),
+      /runtime configuration: (missing setting|health probe returned HTTP 503)/,
+    )
+    assert.equal(listened, false)
+  }
+})
+
+test('production entry serves static files, delegates SSR, and shuts down cleanly', async () => {
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: import.meta.dirname,
+    env: CHILD_ENV,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let stderr = ''
+  child.stderr.setEncoding('utf8').on('data', (chunk) => (stderr += chunk))
+
+  try {
+    const port = await listeningPort(child)
+    const origin = `http://127.0.0.1:${port}`
+    const health = await fetch(`${origin}/healthz`)
+    assert.equal(health.status, 200)
+    assert.deepEqual(await health.json(), { status: 'ok' })
+
+    const root = await fetch(origin, { redirect: 'manual' })
+    assert.equal(root.status, 302)
+    assert.match(root.headers.get('location') ?? '', /^\/login/)
+
+    const favicon = await fetch(`${origin}/favicon.svg`)
+    assert.equal(favicon.status, 200)
+    assert.equal(favicon.headers.get('cache-control'), 'no-cache')
+
+    const [asset] = await readdir(new URL('./build/client/assets/', import.meta.url))
+    const immutable = await fetch(`${origin}/assets/${asset}`)
+    assert.equal(immutable.status, 200)
+    assert.equal(immutable.headers.get('cache-control'), 'public, max-age=31536000, immutable')
+  } finally {
+    const [code, signal] = await stopChild(child)
+    assert.equal(stderr, '')
+    assert.equal(signal, null)
+    assert.equal(code, 0)
+  }
+})
+
+test('production entry names fatal runtime config and exits without listening', async () => {
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: import.meta.dirname,
+    env: { ...CHILD_ENV, REEF_PUBLIC_URL: '' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const stdout = streamText(child.stdout)
+  const stderr = streamText(child.stderr)
+  const [code] = await once(child, 'exit')
+
+  assert.notEqual(code, 0)
+  assert.doesNotMatch(await stdout, /Reef listening/)
+  const error = await stderr
+  assert.match(error, /REEF_PUBLIC_URL must be set when auth is required/)
+  assert.match(error, /Reef startup failed: runtime configuration: health probe returned HTTP 500/)
+})
+
+function listeningPort(child) {
+  return new Promise((resolve, reject) => {
+    let output = ''
+    const timeout = setTimeout(
+      () => reject(new Error('server did not listen within 10 seconds')),
+      10_000,
+    )
+    child.stdout.setEncoding('utf8').on('data', (chunk) => {
+      output += chunk
+      const match = output.match(/Reef listening on http:\/\/127\.0\.0\.1:(\d+)/)
+      if (match) {
+        clearTimeout(timeout)
+        resolve(Number(match[1]))
+      }
+    })
+    child.once('exit', (code) => reject(new Error(`server exited before listening (${code})`)))
+  })
+}
+
+async function streamText(stream) {
+  stream.setEncoding('utf8')
+  let output = ''
+  for await (const chunk of stream) output += chunk
+  return output
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return [child.exitCode, child.signalCode]
+  }
+  child.kill('SIGTERM')
+  return once(child, 'exit')
+}


### PR DESCRIPTION
## Intent

Provide a production Node entrypoint that serves Reef's SSR build and rejects invalid runtime configuration before accepting traffic.

## What it enables

Operators get static asset serving, graceful shutdown, disconnect cancellation, `/healthz`, and a production boot probe through the real React Router handler.

## Usage examples

Build Reef with `npm run build --prefix apps/reef`, set the required runtime variables, and run `node apps/reef/server.js`. Probe `GET /healthz` for process liveness.
