### PR TITLE
ci(reef): publish and coordinate Reef release images

### DIFF
--- a/.github/workflows/docker-aliases.yml
+++ b/.github/workflows/docker-aliases.yml
@@ -1,0 +1,78 @@
+name: Coordinate Docker aliases
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      coral-digest:
+        required: true
+        type: string
+      reef-digest:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+concurrency:
+  # Alias publication is one cross-repository state transition at a time.
+  group: coordinated-docker-aliases
+  queue: max
+
+jobs:
+  aliases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TAG: ${{ inputs.tag }}
+      CORAL_DIGEST: ${{ inputs.coral-digest }}
+      REEF_DIGEST: ${{ inputs.reef-digest }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          cache-binary: false
+
+      - name: Advance and verify coordinated aliases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          line="${version%.*}"
+          # The release remains a prerelease until both aliases verify.
+          draft="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+          test "$draft" = false
+
+          stable="$(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-pre-releases --exclude-drafts --limit 1000 \
+            --json tagName --jq '.[].tagName')"
+          candidates="$(printf '%s\n%s\n' "$stable" "$TAG" | grep -v '^$' | sort -u)"
+          newest="$(printf '%s\n' "$candidates" | sort -V | tail -1)"
+          newest_line="$(printf '%s\n' "$candidates" | grep -E "^v${line//./\\.}\." | sort -V | tail -1)"
+
+          aliases=()
+          [ "$TAG" != "$newest_line" ] || aliases+=("$line")
+          [ "$TAG" != "$newest" ] || aliases+=(latest)
+          for alias in "${aliases[@]}"; do
+            # A partial failure is deliberately a failed release workflow. A
+            # retry is idempotent and converges both aliases before completion.
+            docker buildx imagetools create --tag "ghcr.io/withcoral/coral:${alias}" \
+              "ghcr.io/withcoral/coral@${CORAL_DIGEST}"
+            docker buildx imagetools create --tag "ghcr.io/withcoral/reef:${alias}" \
+              "ghcr.io/withcoral/reef@${REEF_DIGEST}"
+            coral_actual="$(docker buildx imagetools inspect "ghcr.io/withcoral/coral:${alias}" --format '{{.Manifest.Digest}}')"
+            reef_actual="$(docker buildx imagetools inspect "ghcr.io/withcoral/reef:${alias}" --format '{{.Manifest.Digest}}')"
+            test "$coral_actual" = "$CORAL_DIGEST"
+            test "$reef_actual" = "$REEF_DIGEST"
+          done

--- a/.github/workflows/docker-aliases.yml
+++ b/.github/workflows/docker-aliases.yml
@@ -11,6 +11,10 @@ on:
       reef-digest:
         required: true
         type: string
+    outputs:
+      make-latest:
+        description: Whether this tag is the newest eligible stable release.
+        value: ${{ jobs.aliases.outputs.make-latest }}
 
 permissions:
   contents: read
@@ -29,6 +33,8 @@ jobs:
       TAG: ${{ inputs.tag }}
       CORAL_DIGEST: ${{ inputs.coral-digest }}
       REEF_DIGEST: ${{ inputs.reef-digest }}
+    outputs:
+      make-latest: ${{ steps.advance.outputs.make-latest }}
     steps:
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -43,6 +49,7 @@ jobs:
           cache-binary: false
 
       - name: Advance and verify coordinated aliases
+        id: advance
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -62,8 +69,13 @@ jobs:
           newest_line="$(printf '%s\n' "$candidates" | grep -E "^v${line//./\\.}\." | sort -V | tail -1)"
 
           aliases=()
+          make_latest=false
           [ "$TAG" != "$newest_line" ] || aliases+=("$line")
-          [ "$TAG" != "$newest" ] || aliases+=(latest)
+          if [ "$TAG" = "$newest" ]; then
+            aliases+=(latest)
+            make_latest=true
+          fi
+          echo "make-latest=${make_latest}" >> "$GITHUB_OUTPUT"
           for alias in "${aliases[@]}"; do
             # A partial failure is deliberately a failed release workflow. A
             # retry is idempotent and converges both aliases before completion.

--- a/.github/workflows/docker-aliases.yml
+++ b/.github/workflows/docker-aliases.yml
@@ -31,7 +31,7 @@ jobs:
       packages: write
     env:
       TAG: ${{ inputs.tag }}
-      CORAL_DIGEST: ${{ inputs.coral-digest }}
+      PUBLISHED_CORAL_DIGEST: ${{ inputs.coral-digest }}
       REEF_DIGEST: ${{ inputs.reef-digest }}
     outputs:
       make-latest: ${{ steps.advance.outputs.make-latest }}
@@ -57,6 +57,18 @@ jobs:
           set -euo pipefail
           version="${TAG#v}"
           line="${version%.*}"
+          coral_version_ref="ghcr.io/withcoral/coral:${version}"
+          if ! coral_digest="$(docker buildx imagetools inspect "$coral_version_ref" --format '{{.Manifest.Digest}}')"; then
+            echo "Failed to resolve current exact Coral image ${coral_version_ref}." >&2
+            exit 1
+          fi
+          if [[ ! "$coral_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "${coral_version_ref} resolved to invalid digest '${coral_digest}'." >&2
+            exit 1
+          fi
+          if [ "$coral_digest" != "$PUBLISHED_CORAL_DIGEST" ]; then
+            echo "Using current ${coral_version_ref} at ${coral_digest}; release publication produced ${PUBLISHED_CORAL_DIGEST}."
+          fi
           # The release remains a prerelease until both aliases verify.
           draft="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
           test "$draft" = false
@@ -80,11 +92,11 @@ jobs:
             # A partial failure is deliberately a failed release workflow. A
             # retry is idempotent and converges both aliases before completion.
             docker buildx imagetools create --tag "ghcr.io/withcoral/coral:${alias}" \
-              "ghcr.io/withcoral/coral@${CORAL_DIGEST}"
+              "ghcr.io/withcoral/coral@${coral_digest}"
             docker buildx imagetools create --tag "ghcr.io/withcoral/reef:${alias}" \
               "ghcr.io/withcoral/reef@${REEF_DIGEST}"
             coral_actual="$(docker buildx imagetools inspect "ghcr.io/withcoral/coral:${alias}" --format '{{.Manifest.Digest}}')"
             reef_actual="$(docker buildx imagetools inspect "ghcr.io/withcoral/reef:${alias}" --format '{{.Manifest.Digest}}')"
-            test "$coral_actual" = "$CORAL_DIGEST"
+            test "$coral_actual" = "$coral_digest"
             test "$reef_actual" = "$REEF_DIGEST"
           done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,9 +6,14 @@ on:
         description: Published release tag to package, e.g. v1.2.3.
         required: true
         type: string
+      defer-aliases:
+        description: Defer moving aliases to the paired release coordinator.
+        required: false
+        type: boolean
+        default: false
     outputs:
       digest:
-        description: Published Coral version digest.
+        description: Digest the published Coral version tag resolves to.
         value: ${{ jobs.publish-image.outputs.digest }}
   workflow_dispatch:
     inputs:
@@ -21,9 +26,8 @@ on:
 permissions:
   contents: read
 concurrency:
-  # Serialize rebuilds of the same mutable version tag. Moving aliases are
-  # coordinated across Coral and Reef by docker-aliases.yml.
-  group: docker-publish-${{ inputs.tag }}
+  # Direct CVE rebuilds and the paired release's alias coordination mutate the same tags.
+  group: coordinated-docker-aliases
   queue: max
 
 env:
@@ -57,7 +61,11 @@ jobs:
             exit 1
           fi
 
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          version="${TAG#v}"
+          {
+            echo "version=${version}"
+            echo "major-minor=${version%.*}"
+          } >> "$GITHUB_OUTPUT"
 
       # The Dockerfile and entrypoint come from the ref this workflow runs on:
       # the release tag under workflow_call, and whatever ref the CVE rebuild
@@ -141,6 +149,43 @@ jobs:
           test -n "$digest"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
+      - name: Read release prerelease flag
+        if: ${{ inputs.defer-aliases != true }}
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          prerelease="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease)"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve the newest stable tags
+        if: ${{ inputs.defer-aliases != true }}
+        id: newest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
+        run: |
+          set -euo pipefail
+          # One listing, ranked by version rather than by GitHub's own ordering
+          # (which is by commit date, not by semver). "$TAG" joins the candidate
+          # set either way: the release path may not list it yet, and the CVE
+          # rebuild path already does, so both compare against the same set.
+          stable="$(gh release list --repo "$GITHUB_REPOSITORY" \
+            --exclude-pre-releases --exclude-drafts --limit 1000 \
+            --json tagName --jq '.[].tagName')"
+          candidates="$(printf '%s\n%s\n' "$stable" "$TAG" | grep -v '^$' | sort -u)"
+          newest="$(printf '%s\n' "$candidates" | sort -V | tail -1)"
+          # Dots are literal so the 1.2 line never absorbs 1.20.x.
+          line="$(printf '%s\n' "$candidates" | grep -E "^v${MAJOR_MINOR//./\\.}\." | sort -V | tail -1)"
+          echo "newest candidate is '${newest}'; newest in the ${MAJOR_MINOR} line is '${line}'; this run packages '${TAG}'"
+          {
+            echo "tag=${newest}"
+            echo "line-tag=${line}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Prepare smoke helper
         shell: bash
         run: |
@@ -219,16 +264,33 @@ jobs:
           docker logs coral-smoke-seed 2>&1 | grep -F 'CORAL_SEED_CONFIG ignored'
 
       # Moving aliases are applied to Coral and Reef together by the release
-      # coordinator after both immutable images have passed their own gates.
+      # coordinator. A direct CVE rebuild updates Coral's eligible aliases here.
       - name: Tag the validated manifest
         id: manifest
         shell: bash
         env:
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          DEFER_ALIASES: ${{ inputs.defer-aliases }}
+          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
+          NEWEST_LINE_TAG: ${{ steps.newest.outputs.line-tag }}
+          NEWEST_TAG: ${{ steps.newest.outputs.tag }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
-          docker buildx imagetools create --tag "${IMAGE}:${VERSION}" "${IMAGE}@${BUILD_DIGEST}"
+          # The exact version tag always publishes. During a direct CVE rebuild,
+          # moving tags never move backwards or point at a prerelease: rebuilding
+          # a superseded release republishes only its own exact version tag.
+          tags=(--tag "${IMAGE}:${VERSION}")
+          if [ "$DEFER_ALIASES" != true ]; then
+            if [ "$PRERELEASE" = false ] && [ "$NEWEST_LINE_TAG" = "$TAG" ]; then
+              tags+=(--tag "${IMAGE}:${MAJOR_MINOR}")
+            fi
+            if [ "$PRERELEASE" = false ] && [ "$NEWEST_TAG" = "$TAG" ]; then
+              tags+=(--tag "${IMAGE}:latest")
+            fi
+          fi
+          docker buildx imagetools create "${tags[@]}" "${IMAGE}@${BUILD_DIGEST}"
           # Tagging republishes the index, so re-read the digest the tags resolve to.
           digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
           test -n "$digest"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -208,26 +208,36 @@ jobs:
           tag_digest() {
             local tag="$1"
             local matches
-            matches="$(gh api --paginate \
+            if ! matches="$(gh api --paginate \
               "/orgs/withcoral/packages/container/coral/versions?per_page=100" \
-              --jq ".[] | select(any(.metadata.container.tags[]; . == \"${tag}\")) | .name")"
+              --jq ".[] | select(any(.metadata.container.tags[]; . == \"${tag}\")) | .name")"; then
+              echo "Failed to resolve ${IMAGE}:${tag} through the package API." >&2
+              return 2
+            fi
             if [ -n "$matches" ]; then
-              test "$(printf '%s\n' "$matches" | wc -l)" -eq 1
+              if [ "$(printf '%s\n' "$matches" | wc -l)" -ne 1 ]; then
+                echo "${IMAGE}:${tag} resolved to multiple package digests." >&2
+                return 2
+              fi
               if [[ ! "$matches" =~ ^sha256:[0-9a-f]{64}$ ]]; then
                 echo "${IMAGE}:${tag} resolved to invalid digest '${matches}'." >&2
-                exit 1
+                return 2
               fi
             fi
             printf '%s' "$matches"
           }
 
-          version_digest="$(tag_digest "$VERSION")"
+          if ! version_digest="$(tag_digest "$VERSION")"; then
+            exit 1
+          fi
           can_move_alias() {
             local alias="$1"
             local eligible="$2"
             local alias_digest
             [ "$eligible" = true ] || return 1
-            alias_digest="$(tag_digest "$alias")"
+            if ! alias_digest="$(tag_digest "$alias")"; then
+              return 2
+            fi
             if [ -z "$alias_digest" ] || { [ -n "$version_digest" ] && [ "$alias_digest" = "$version_digest" ]; }; then
               return 0
             fi
@@ -248,9 +258,15 @@ jobs:
           move_latest=false
           if can_move_alias "$MAJOR_MINOR" "$line_eligible"; then
             move_line=true
+          else
+            status=$?
+            [ "$status" -eq 1 ] || exit "$status"
           fi
           if can_move_alias latest "$latest_eligible"; then
             move_latest=true
+          else
+            status=$?
+            [ "$status" -eq 1 ] || exit "$status"
           fi
           {
             echo "move-line=${move_line}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,9 +21,9 @@ on:
 permissions:
   contents: read
 concurrency:
-  # Moving tags (latest and X.Y) are shared mutable state across releases, so
-  # every publish must finish before the next one evaluates and applies them.
-  group: docker-publish
+  # Serialize rebuilds of the same mutable version tag. Moving aliases are
+  # coordinated across Coral and Reef by docker-aliases.yml.
+  group: docker-publish-${{ inputs.tag }}
   queue: max
 
 env:
@@ -57,11 +57,7 @@ jobs:
             exit 1
           fi
 
-          version="${TAG#v}"
-          {
-            echo "version=${version}"
-            echo "major-minor=${version%.*}"
-          } >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       # The Dockerfile and entrypoint come from the ref this workflow runs on:
       # the release tag under workflow_call, and whatever ref the CVE rebuild

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,8 +26,9 @@ on:
 permissions:
   contents: read
 concurrency:
-  # Direct CVE rebuilds and the paired release's alias coordination mutate the same tags.
-  group: coordinated-docker-aliases
+  # Direct CVE rebuilds share the coordinator lock because they may move X.Y
+  # and latest. Deferred release builds get a run-local group instead.
+  group: ${{ inputs.defer-aliases == true && format('docker-publish-deferred-{0}', github.run_id) || 'coordinated-docker-aliases' }}
   queue: max
 
 env:
@@ -40,6 +41,11 @@ env:
 jobs:
   publish-image:
     name: Build, publish, and smoke the linux/amd64 image
+    # Serialize exact-version writes even when a direct rebuild overlaps a
+    # deferred release build for the same tag.
+    concurrency:
+      group: docker-publish-${{ inputs.tag }}
+      queue: max
     # GitHub-hosted, like release.yml's Linux build matrix: the smoke battery
     # runs real containers against the pushed digest on a stock Docker daemon.
     runs-on: ubuntu-latest
@@ -186,6 +192,71 @@ jobs:
             echo "line-tag=${line}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Snapshot direct rebuild alias ownership
+        if: ${{ inputs.defer-aliases != true }}
+        id: aliases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
+          NEWEST_LINE_TAG: ${{ steps.newest.outputs.line-tag }}
+          NEWEST_TAG: ${{ steps.newest.outputs.tag }}
+          PRERELEASE: ${{ steps.release.outputs.prerelease }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag_digest() {
+            local tag="$1"
+            local matches
+            matches="$(gh api --paginate \
+              "/orgs/withcoral/packages/container/coral/versions?per_page=100" \
+              --jq ".[] | select(any(.metadata.container.tags[]; . == \"${tag}\")) | .name")"
+            if [ -n "$matches" ]; then
+              test "$(printf '%s\n' "$matches" | wc -l)" -eq 1
+              if [[ ! "$matches" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "${IMAGE}:${tag} resolved to invalid digest '${matches}'." >&2
+                exit 1
+              fi
+            fi
+            printf '%s' "$matches"
+          }
+
+          version_digest="$(tag_digest "$VERSION")"
+          can_move_alias() {
+            local alias="$1"
+            local eligible="$2"
+            local alias_digest
+            [ "$eligible" = true ] || return 1
+            alias_digest="$(tag_digest "$alias")"
+            if [ -z "$alias_digest" ] || { [ -n "$version_digest" ] && [ "$alias_digest" = "$version_digest" ]; }; then
+              return 0
+            fi
+            echo "Leaving ${IMAGE}:${alias} at ${alias_digest}; it does not belong to ${IMAGE}:${VERSION}${version_digest:+ at ${version_digest}}." >&2
+            return 1
+          }
+
+          line_eligible=false
+          latest_eligible=false
+          if [ "$PRERELEASE" = false ] && [ "$NEWEST_LINE_TAG" = "$TAG" ]; then
+            line_eligible=true
+          fi
+          if [ "$PRERELEASE" = false ] && [ "$NEWEST_TAG" = "$TAG" ]; then
+            latest_eligible=true
+          fi
+
+          move_line=false
+          move_latest=false
+          if can_move_alias "$MAJOR_MINOR" "$line_eligible"; then
+            move_line=true
+          fi
+          if can_move_alias latest "$latest_eligible"; then
+            move_latest=true
+          fi
+          {
+            echo "move-line=${move_line}"
+            echo "move-latest=${move_latest}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Prepare smoke helper
         shell: bash
         run: |
@@ -263,8 +334,21 @@ jobs:
           "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
           docker logs coral-smoke-seed 2>&1 | grep -F 'CORAL_SEED_CONFIG ignored'
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the staged manifest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
       # Moving aliases are applied to Coral and Reef together by the release
-      # coordinator. A direct CVE rebuild updates Coral's eligible aliases here.
+      # coordinator. A direct CVE rebuild moves an alias only when it is absent
+      # or still resolves to the rebuilt exact version, so it cannot roll back
+      # a coordinated pair.
       - name: Tag the validated manifest
         id: manifest
         shell: bash
@@ -272,37 +356,26 @@ jobs:
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
           DEFER_ALIASES: ${{ inputs.defer-aliases }}
           MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
-          NEWEST_LINE_TAG: ${{ steps.newest.outputs.line-tag }}
-          NEWEST_TAG: ${{ steps.newest.outputs.tag }}
-          PRERELEASE: ${{ steps.release.outputs.prerelease }}
+          MOVE_LATEST: ${{ steps.aliases.outputs.move-latest }}
+          MOVE_LINE: ${{ steps.aliases.outputs.move-line }}
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
           # The exact version tag always publishes. During a direct CVE rebuild,
-          # moving tags never move backwards or point at a prerelease: rebuilding
-          # a superseded release republishes only its own exact version tag.
+          # moving tags never move backwards or point at a prerelease: a release
+          # superseded in its own X.Y line republishes only its exact version tag.
           tags=(--tag "${IMAGE}:${VERSION}")
           if [ "$DEFER_ALIASES" != true ]; then
-            if [ "$PRERELEASE" = false ] && [ "$NEWEST_LINE_TAG" = "$TAG" ]; then
+            if [ "$MOVE_LINE" = true ]; then
               tags+=(--tag "${IMAGE}:${MAJOR_MINOR}")
             fi
-            if [ "$PRERELEASE" = false ] && [ "$NEWEST_TAG" = "$TAG" ]; then
+            if [ "$MOVE_LATEST" = true ]; then
               tags+=(--tag "${IMAGE}:latest")
             fi
           fi
           docker buildx imagetools create "${tags[@]}" "${IMAGE}@${BUILD_DIGEST}"
-          # Tagging republishes the index, so re-read the digest the tags resolve to.
+          # A one-source create preserves the signed index; verify the exact tag
+          # still resolves to that digest after publishing all selected tags.
           digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
-          test -n "$digest"
+          test "$digest" = "$BUILD_DIGEST"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign the published manifest
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
-        run: |
-          set -euo pipefail
-          cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,10 @@ on:
         description: Published release tag to package, e.g. v1.2.3.
         required: true
         type: string
+    outputs:
+      digest:
+        description: Published Coral version digest.
+        value: ${{ jobs.publish-image.outputs.digest }}
   workflow_dispatch:
     inputs:
       tag:
@@ -39,6 +43,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    outputs:
+      digest: ${{ steps.manifest.outputs.digest }}
     steps:
       - name: Validate tag
         id: tag
@@ -139,41 +145,6 @@ jobs:
           test -n "$digest"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
-      - name: Read release prerelease flag
-        id: release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          prerelease="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
-          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve the newest stable tags
-        id: newest
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
-        run: |
-          set -euo pipefail
-          # One listing, ranked by version rather than by GitHub's own ordering
-          # (which is by commit date, not by semver). "$TAG" joins the candidate
-          # set either way: the release path may not list it yet, and the CVE
-          # rebuild path already does, so both compare against the same set.
-          stable="$(gh release list --repo "$GITHUB_REPOSITORY" \
-            --exclude-pre-releases --exclude-drafts --limit 1000 \
-            --json tagName --jq '.[].tagName')"
-          candidates="$(printf '%s\n%s\n' "$stable" "$TAG" | grep -v '^$' | sort -u)"
-          newest="$(printf '%s\n' "$candidates" | sort -V | tail -1)"
-          # Dots are literal so the 1.2 line never absorbs 1.20.x.
-          line="$(printf '%s\n' "$candidates" | grep -E "^v${MAJOR_MINOR//./\\.}\." | sort -V | tail -1)"
-          echo "newest stable release is '${newest}'; newest in the ${MAJOR_MINOR} line is '${line}'; this run packages '${TAG}'"
-          {
-            echo "tag=${newest}"
-            echo "line-tag=${line}"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Prepare smoke helper
         shell: bash
         run: |
@@ -251,32 +222,17 @@ jobs:
           "$RUNNER_TEMP/wait-healthy.sh" coral-smoke-seed
           docker logs coral-smoke-seed 2>&1 | grep -F 'CORAL_SEED_CONFIG ignored'
 
-      # The digest is deliberately untagged until every smoke check passes, so
-      # a broken rebuild cannot move an existing release, line, or latest tag.
+      # Moving aliases are applied to Coral and Reef together by the release
+      # coordinator after both immutable images have passed their own gates.
       - name: Tag the validated manifest
         id: manifest
         shell: bash
         env:
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
           VERSION: ${{ steps.tag.outputs.version }}
-          MAJOR_MINOR: ${{ steps.tag.outputs.major-minor }}
-          PRERELEASE: ${{ steps.release.outputs.prerelease }}
-          NEWEST_TAG: ${{ steps.newest.outputs.tag }}
-          NEWEST_LINE_TAG: ${{ steps.newest.outputs.line-tag }}
         run: |
           set -euo pipefail
-          # The exact version tag always publishes. The moving tags never move
-          # backwards and never point at a prerelease: a CVE rebuild of a
-          # superseded release re-publishes its own version tag, but leaves
-          # `X.Y` and `latest` on whichever release is newest by semver.
-          tags=(--tag "${IMAGE}:${VERSION}")
-          if [ "$PRERELEASE" = "false" ] && [ "$NEWEST_LINE_TAG" = "$TAG" ]; then
-            tags+=(--tag "${IMAGE}:${MAJOR_MINOR}")
-          fi
-          if [ "$PRERELEASE" = "false" ] && [ "$NEWEST_TAG" = "$TAG" ]; then
-            tags+=(--tag "${IMAGE}:latest")
-          fi
-          docker buildx imagetools create "${tags[@]}" "${IMAGE}@${BUILD_DIGEST}"
+          docker buildx imagetools create --tag "${IMAGE}:${VERSION}" "${IMAGE}@${BUILD_DIGEST}"
           # Tagging republishes the index, so re-read the digest the tags resolve to.
           digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
           test -n "$digest"

--- a/.github/workflows/reef-docker-publish.yml
+++ b/.github/workflows/reef-docker-publish.yml
@@ -167,7 +167,9 @@ jobs:
         shell: bash
         env:
           DIGEST: ${{ steps.candidate.outputs.digest }}
-          EXPECTED_IDENTITY: ${{ github.server_url }}/${{ github.workflow_ref }}
+          # The certificate embeds job_workflow_ref: this workflow's own path
+          # at the run's ref. github.workflow_ref names release.yml instead.
+          EXPECTED_IDENTITY: ${{ github.server_url }}/${{ github.repository }}/.github/workflows/reef-docker-publish.yml@${{ github.ref }}
         run: |
           set -euo pipefail
           cosign verify \

--- a/.github/workflows/reef-docker-publish.yml
+++ b/.github/workflows/reef-docker-publish.yml
@@ -23,6 +23,10 @@ on:
 
 permissions:
   contents: read
+concurrency:
+  # Serialize compare-and-set publication for one immutable release tag.
+  group: reef-docker-publish-${{ inputs.tag }}
+  queue: max
 
 env:
   IMAGE: ghcr.io/withcoral/reef
@@ -40,7 +44,7 @@ jobs:
     outputs:
       image: ghcr.io/withcoral/reef
       version: ${{ steps.tag.outputs.version }}
-      digest: ${{ steps.manifest.outputs.digest }}
+      digest: ${{ steps.publish.outputs.digest }}
     steps:
       - name: Validate release inputs
         id: tag
@@ -102,25 +106,10 @@ jobs:
           test -n "$digest"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
-      - name: Publish immutable version tag
-        id: manifest
+      - name: Verify staged image metadata
         shell: bash
         env:
-          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
-          VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          set -euo pipefail
-          docker buildx imagetools create \
-            --tag "${IMAGE}:${VERSION}" \
-            "${IMAGE}@${BUILD_DIGEST}"
-          digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
-          test -n "$digest"
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify published version metadata
-        shell: bash
-        env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
+          DIGEST: ${{ steps.build.outputs.digest }}
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
@@ -131,8 +120,38 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Sign the published manifest
+      - name: Sign the staged manifest
         shell: bash
         env:
-          DIGEST: ${{ steps.manifest.outputs.digest }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Publish immutable version tag
+        id: publish
+        shell: bash
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          version_ref="${IMAGE}:${VERSION}"
+          existing_digest="$(gh api --paginate \
+            "/orgs/withcoral/packages/container/reef/versions?per_page=100" \
+            --jq ".[] | select(any(.metadata.container.tags[]; . == \"${VERSION}\")) | .name")"
+          if [ -n "$existing_digest" ]; then
+            test "$(printf '%s\n' "$existing_digest" | wc -l)" -eq 1
+            if [ "$existing_digest" != "$BUILD_DIGEST" ]; then
+              echo "${version_ref} already points to ${existing_digest}; refusing to replace it with ${BUILD_DIGEST}." >&2
+              exit 1
+            fi
+            echo "${version_ref} already points to the verified digest."
+          else
+            docker buildx imagetools create --tag "$version_ref" "${IMAGE}@${BUILD_DIGEST}"
+          fi
+          published_digest="$(docker buildx imagetools inspect "$version_ref" --format '{{.Manifest.Digest}}')"
+          if [ "$published_digest" != "$BUILD_DIGEST" ]; then
+            echo "${version_ref} resolved to ${published_digest}, expected ${BUILD_DIGEST}." >&2
+            exit 1
+          fi
+          echo "digest=${published_digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reef-docker-publish.yml
+++ b/.github/workflows/reef-docker-publish.yml
@@ -86,7 +86,45 @@ jobs:
         with:
           cache-binary: false
 
+      - name: Resolve existing immutable version
+        id: existing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          version_ref="${IMAGE}:${VERSION}"
+          digest=""
+          error_file="$RUNNER_TEMP/reef-package-versions-error.txt"
+          if matches="$(gh api --paginate \
+            "/orgs/withcoral/packages/container/reef/versions?per_page=100" \
+            --jq ".[] | select(any(.metadata.container.tags[]; . == \"${VERSION}\")) | .name" \
+            2>"$error_file")"; then
+            if [ -n "$matches" ]; then
+              test "$(printf '%s\n' "$matches" | wc -l)" -eq 1
+              digest="$matches"
+              resolved="$(docker buildx imagetools inspect "$version_ref" --format '{{.Manifest.Digest}}')"
+              if [ "$resolved" != "$digest" ]; then
+                echo "${version_ref} resolved to ${resolved}, but the package API reported ${digest}." >&2
+                exit 1
+              fi
+              echo "Reusing existing immutable ${version_ref} at ${digest}."
+            fi
+          elif grep -Fq '(HTTP 404)' "$error_file"; then
+            echo "Reef package lookup returned HTTP 404; treating ${version_ref} as unpublished."
+          else
+            cat "$error_file" >&2
+            exit 1
+          fi
+          if [ -n "$digest" ] && [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "${version_ref} resolved to invalid digest '${digest}'." >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push image by digest
+        if: steps.existing.outputs.digest == ''
         id: build
         shell: bash
         env:
@@ -106,10 +144,41 @@ jobs:
           test -n "$digest"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve candidate digest
+        id: candidate
+        shell: bash
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
+        run: |
+          set -euo pipefail
+          digest="${EXISTING_DIGEST:-$BUILD_DIGEST}"
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Reef candidate digest is missing or invalid: '${digest}'." >&2
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Verify existing manifest signature
+        if: steps.existing.outputs.digest != ''
+        shell: bash
+        env:
+          DIGEST: ${{ steps.candidate.outputs.digest }}
+          EXPECTED_IDENTITY: ${{ github.server_url }}/${{ github.workflow_ref }}
+        run: |
+          set -euo pipefail
+          cosign verify \
+            --certificate-identity "$EXPECTED_IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${IMAGE}@${DIGEST}" >/dev/null
+
       - name: Verify staged image metadata
         shell: bash
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST: ${{ steps.candidate.outputs.digest }}
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
@@ -117,41 +186,56 @@ jobs:
           test "$(docker image inspect "${IMAGE}@${DIGEST}" --format '{{index .Config.Labels "org.opencontainers.image.version"}}')" = "$VERSION"
           test "$(docker image inspect "${IMAGE}@${DIGEST}" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$RELEASE_COMMIT_SHA"
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign the staged manifest
+      - name: Smoke staged Reef image
         shell: bash
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST: ${{ steps.candidate.outputs.digest }}
+        run: |
+          set -euo pipefail
+          container=reef-release-smoke
+          cleanup() {
+            docker rm -f "$container" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT HUP INT TERM
+          docker run -d --platform linux/amd64 --read-only --name "$container" \
+            -e CORAL_ENDPOINT=http://127.0.0.1:14555 \
+            -e REEF_AUTH_MODE=disabled \
+            "${IMAGE}@${DIGEST}" >/dev/null
+          for _ in $(seq 1 30); do
+            status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container")"
+            if [ "$status" = healthy ]; then
+              test "$(docker exec "$container" node -e 'process.stdout.write(`${process.getuid()}:${process.getgid()}`)')" = 1000:1000
+              exit 0
+            fi
+            [ "$status" != exited ] || break
+            sleep 1
+          done
+          docker logs "$container" >&2 || true
+          exit 1
+
+      - name: Sign the staged manifest
+        if: steps.existing.outputs.digest == ''
+        shell: bash
+        env:
+          DIGEST: ${{ steps.candidate.outputs.digest }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
       - name: Publish immutable version tag
         id: publish
         shell: bash
         env:
-          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
-          GH_TOKEN: ${{ github.token }}
+          DIGEST: ${{ steps.candidate.outputs.digest }}
+          EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
           set -euo pipefail
           version_ref="${IMAGE}:${VERSION}"
-          existing_digest="$(gh api --paginate \
-            "/orgs/withcoral/packages/container/reef/versions?per_page=100" \
-            --jq ".[] | select(any(.metadata.container.tags[]; . == \"${VERSION}\")) | .name")"
-          if [ -n "$existing_digest" ]; then
-            test "$(printf '%s\n' "$existing_digest" | wc -l)" -eq 1
-            if [ "$existing_digest" != "$BUILD_DIGEST" ]; then
-              echo "${version_ref} already points to ${existing_digest}; refusing to replace it with ${BUILD_DIGEST}." >&2
-              exit 1
-            fi
-            echo "${version_ref} already points to the verified digest."
-          else
-            docker buildx imagetools create --tag "$version_ref" "${IMAGE}@${BUILD_DIGEST}"
+          if [ -z "$EXISTING_DIGEST" ]; then
+            docker buildx imagetools create --tag "$version_ref" "${IMAGE}@${DIGEST}"
           fi
           published_digest="$(docker buildx imagetools inspect "$version_ref" --format '{{.Manifest.Digest}}')"
-          if [ "$published_digest" != "$BUILD_DIGEST" ]; then
-            echo "${version_ref} resolved to ${published_digest}, expected ${BUILD_DIGEST}." >&2
+          if [ "$published_digest" != "$DIGEST" ]; then
+            echo "${version_ref} resolved to ${published_digest}, expected ${DIGEST}." >&2
             exit 1
           fi
           echo "digest=${published_digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reef-docker-publish.yml
+++ b/.github/workflows/reef-docker-publish.yml
@@ -1,0 +1,138 @@
+name: Publish Reef Docker image
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Published release tag to build, e.g. v1.2.3.
+        required: true
+        type: string
+      commit-sha:
+        description: Verified commit referenced by the release tag.
+        required: true
+        type: string
+    outputs:
+      image:
+        description: Reef image repository.
+        value: ${{ jobs.publish-image.outputs.image }}
+      version:
+        description: Published immutable version without the v prefix.
+        value: ${{ jobs.publish-image.outputs.version }}
+      digest:
+        description: Verified digest of the immutable version tag.
+        value: ${{ jobs.publish-image.outputs.digest }}
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: ghcr.io/withcoral/reef
+  TAG: ${{ inputs.tag }}
+  RELEASE_COMMIT_SHA: ${{ inputs.commit-sha }}
+
+jobs:
+  publish-image:
+    name: Build, verify, and publish the linux/amd64 image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      image: ghcr.io/withcoral/reef
+      version: ${{ steps.tag.outputs.version }}
+      digest: ${{ steps.manifest.outputs.digest }}
+    steps:
+      - name: Validate release inputs
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Reef publish tag must look like vX.Y.Z, got '${TAG}'." >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Reef publish commit must be a full Git SHA." >&2
+            exit 1
+          fi
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release tag source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT_SHA"
+          test "$(git rev-parse "${TAG}^{commit}")" = "$RELEASE_COMMIT_SHA"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          cache-binary: false
+
+      - name: Build and push image by digest
+        id: build
+        shell: bash
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx build \
+            --platform linux/amd64 \
+            --provenance=true \
+            --file docker/Dockerfile.reef \
+            --build-arg "REEF_VERSION=${VERSION}" \
+            --build-arg "REEF_REVISION=${RELEASE_COMMIT_SHA}" \
+            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file "$RUNNER_TEMP/reef-build-metadata.json" \
+            .
+          digest="$(jq -r '."containerimage.digest" // ""' "$RUNNER_TEMP/reef-build-metadata.json")"
+          test -n "$digest"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish immutable version tag
+        id: manifest
+        shell: bash
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${VERSION}" \
+            "${IMAGE}@${BUILD_DIGEST}"
+          digest="$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')"
+          test -n "$digest"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify published version metadata
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 "${IMAGE}@${DIGEST}"
+          test "$(docker image inspect "${IMAGE}@${DIGEST}" --format '{{index .Config.Labels "org.opencontainers.image.version"}}')" = "$VERSION"
+          test "$(docker image inspect "${IMAGE}@${DIGEST}" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$RELEASE_COMMIT_SHA"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the published manifest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,6 +545,7 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag: ${{ needs.validate-release-ref.outputs.tag-name }}
+      defer-aliases: true
 
   publish-reef-docker:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -577,9 +577,12 @@ jobs:
     needs:
       - validate-release-ref
       - coordinate-docker-aliases
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      promoted: ${{ steps.promote.outputs.promoted }}
     steps:
       - name: Create GitHub App token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -603,30 +606,36 @@ jobs:
           promoted=false
           if [ "$was_prerelease" = true ]; then
             release_id="$(printf '%s' "$release" | jq -r .id)"
-            release="$(gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
-              -F prerelease=false -f "make_latest=${MAKE_LATEST}")"
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -F prerelease=false -f "make_latest=${MAKE_LATEST}" >/dev/null
             promoted=true
           fi
-          {
-            echo "promoted=${promoted}"
-            echo "name=$(printf '%s' "$release" | jq -r '.name // ""')"
-            echo "url=$(printf '%s' "$release" | jq -r .html_url)"
-            echo "body<<__BODY__"
-            printf '%s' "$release" | jq -r '.body // ""'
-            echo "__BODY__"
-          } >> "$GITHUB_OUTPUT"
+          echo "promoted=${promoted}" >> "$GITHUB_OUTPUT"
 
+  # Keep delivery separate so a failed webhook can be retried without
+  # re-running the already-completed promotion job.
+  notify-release:
+    needs:
+      - validate-release-ref
+      - promote-release
+    if: needs.promote-release.outputs.promoted == 'true'
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
       - name: Post promoted release to Discord
-        if: steps.promote.outputs.promoted == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
-          RELEASE_NAME: ${{ steps.promote.outputs.name }}
-          RELEASE_BODY: ${{ steps.promote.outputs.body }}
-          RELEASE_URL: ${{ steps.promote.outputs.url }}
         run: |
-          body="${RELEASE_BODY:0:3500}"
-          title="🪸 ${RELEASE_NAME:-$TAG_NAME}"
-          jq -n --arg title "${title:0:253}" --arg desc "$body" --arg url "$RELEASE_URL" \
+          set -euo pipefail
+          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}")"
+          name="$(printf '%s' "$release" | jq -r '.name // ""')"
+          url="$(printf '%s' "$release" | jq -r .html_url)"
+          body="$(printf '%s' "$release" | jq -r '.body // ""')"
+          title="🪸 ${name:-$TAG_NAME}"
+          jq -n --arg title "${title:0:253}" --arg desc "${body:0:3500}" --arg url "$url" \
             '{embeds:[{title:$title,description:$desc,url:$url,color:16744272,footer:{text:"Fresh from the reef"}}]}' |
             curl -sf -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,26 +495,6 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --clobber
 
-      - name: Read GitHub release
-        id: promote-release
-        env:
-          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}")"
-          release_id="$(printf '%s' "$release_json" | jq -r '.id')"
-          was_prerelease="$(printf '%s' "$release_json" | jq -r '.prerelease')"
-
-          {
-            echo "was_prerelease=${was_prerelease}"
-            echo "tag_name=$(printf '%s' "$release_json" | jq -r '.tag_name')"
-            echo "release_name=$(printf '%s' "$release_json" | jq -r '.name // ""')"
-            echo "release_url=$(printf '%s' "$release_json" | jq -r '.html_url')"
-            echo "body<<__RELEASE_BODY__"
-            printf '%s' "$release_json" | jq -r '.body // ""'
-            echo "__RELEASE_BODY__"
-          } >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.validate-release-ref.outputs.commit-sha }}
@@ -552,8 +532,8 @@ jobs:
               client_payload: { version },
             });
 
-  # Additive by design: a failure here leaves the image missing until a manual
-  # `docker-publish` dispatch, and never blocks or rewinds a published release.
+  # Both immutable images and their paired aliases are release gates. The
+  # GitHub release remains a prerelease until all three jobs succeed.
   publish-docker:
     needs:
       - validate-release-ref
@@ -614,13 +594,21 @@ jobs:
         id: promote
         env:
           GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
+          MAKE_LATEST: ${{ needs.coordinate-docker-aliases.outputs.make-latest }}
           TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
         run: |
           set -euo pipefail
-          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .id)"
-          release="$(gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
-            -F prerelease=false -F make_latest=true)"
+          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}")"
+          was_prerelease="$(printf '%s' "$release" | jq -r .prerelease)"
+          promoted=false
+          if [ "$was_prerelease" = true ]; then
+            release_id="$(printf '%s' "$release" | jq -r .id)"
+            release="$(gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -F prerelease=false -f "make_latest=${MAKE_LATEST}")"
+            promoted=true
+          fi
           {
+            echo "promoted=${promoted}"
             echo "name=$(printf '%s' "$release" | jq -r '.name // ""')"
             echo "url=$(printf '%s' "$release" | jq -r .html_url)"
             echo "body<<__BODY__"
@@ -629,6 +617,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post promoted release to Discord
+        if: steps.promote.outputs.promoted == 'true'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
           TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,3 +608,16 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       tag: ${{ needs.validate-release-ref.outputs.tag-name }}
+
+  publish-reef-docker:
+    needs:
+      - validate-release-ref
+      - publish-version
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/reef-docker-publish.yml
+    with:
+      tag: ${{ needs.validate-release-ref.outputs.tag-name }}
+      commit-sha: ${{ needs.validate-release-ref.outputs.commit-sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,7 +495,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --clobber
 
-      - name: Promote GitHub release
+      - name: Read GitHub release
         id: promote-release
         env:
           GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
@@ -504,14 +504,6 @@ jobs:
           release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}")"
           release_id="$(printf '%s' "$release_json" | jq -r '.id')"
           was_prerelease="$(printf '%s' "$release_json" | jq -r '.prerelease')"
-
-          if [ "$was_prerelease" = "true" ]; then
-            release_json="$(gh api \
-              --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
-              -F prerelease=false \
-              -F make_latest=true)"
-          fi
 
           {
             echo "was_prerelease=${was_prerelease}"
@@ -560,41 +552,6 @@ jobs:
               client_payload: { version },
             });
 
-      - name: Post promoted release to Discord
-        if: steps.promote-release.outputs.was_prerelease == 'true'
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
-          TAG_NAME: ${{ steps.promote-release.outputs.tag_name }}
-          RELEASE_NAME: ${{ steps.promote-release.outputs.release_name }}
-          RELEASE_BODY: ${{ steps.promote-release.outputs.body }}
-          RELEASE_URL: ${{ steps.promote-release.outputs.release_url }}
-        run: |
-          MAX_LEN=3500
-          BODY="$RELEASE_BODY"
-          if [ ${#BODY} -gt $MAX_LEN ]; then
-            BODY="${BODY:0:$MAX_LEN}..."
-          fi
-
-          TITLE_MAX_LEN=256
-          TITLE="🪸 ${RELEASE_NAME:-$TAG_NAME}"
-          if [ ${#TITLE} -gt $TITLE_MAX_LEN ]; then
-            TITLE="${TITLE:0:$((TITLE_MAX_LEN - 3))}..."
-          fi
-
-          jq -n \
-            --arg title "$TITLE" \
-            --arg desc "$BODY" \
-            --arg url "$RELEASE_URL" \
-            '{
-              embeds: [{
-                title: $title,
-                description: $desc,
-                url: $url,
-                color: 16744272,
-                footer: { text: "Fresh from the reef" }
-              }]
-            }' | curl -sf -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-
   # Additive by design: a failure here leaves the image missing until a manual
   # `docker-publish` dispatch, and never blocks or rewinds a published release.
   publish-docker:
@@ -621,3 +578,66 @@ jobs:
     with:
       tag: ${{ needs.validate-release-ref.outputs.tag-name }}
       commit-sha: ${{ needs.validate-release-ref.outputs.commit-sha }}
+
+  coordinate-docker-aliases:
+    needs:
+      - validate-release-ref
+      - publish-docker
+      - publish-reef-docker
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-aliases.yml
+    with:
+      tag: ${{ needs.validate-release-ref.outputs.tag-name }}
+      coral-digest: ${{ needs.publish-docker.outputs.digest }}
+      reef-digest: ${{ needs.publish-reef-docker.outputs.digest }}
+
+  promote-release:
+    needs:
+      - validate-release-ref
+      - coordinate-docker-aliases
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: github-app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          repositories: coral
+
+      - name: Mark the coordinated release complete
+        id: promote
+        env:
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
+          TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
+        run: |
+          set -euo pipefail
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .id)"
+          release="$(gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+            -F prerelease=false -F make_latest=true)"
+          {
+            echo "name=$(printf '%s' "$release" | jq -r '.name // ""')"
+            echo "url=$(printf '%s' "$release" | jq -r .html_url)"
+            echo "body<<__BODY__"
+            printf '%s' "$release" | jq -r '.body // ""'
+            echo "__BODY__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post promoted release to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
+          TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
+          RELEASE_NAME: ${{ steps.promote.outputs.name }}
+          RELEASE_BODY: ${{ steps.promote.outputs.body }}
+          RELEASE_URL: ${{ steps.promote.outputs.url }}
+        run: |
+          body="${RELEASE_BODY:0:3500}"
+          title="🪸 ${RELEASE_NAME:-$TAG_NAME}"
+          jq -n --arg title "${title:0:253}" --arg desc "$body" --arg url "$RELEASE_URL" \
+            '{embeds:[{title:$title,description:$desc,url:$url,color:16744272,footer:{text:"Fresh from the reef"}}]}' |
+            curl -sf -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -107,6 +107,7 @@ jobs:
               - 'apps/desktop/src/shared/types.ts'
             reef-image:
               - '.github/workflows/validate.yml'
+              - '.github/workflows/reef-docker-publish.yml'
               - '.dockerignore'
               - 'Makefile'
               - 'Cargo.toml'
@@ -122,6 +123,7 @@ jobs:
               - 'docker/entrypoint-reef.sh'
               - 'docker/reef-smoke.sh'
               - 'docker/reef-image.test.mjs'
+              - 'docker/reef-publish.test.mjs'
               - 'apps/reef/**'
               - 'apps/desktop/src/shared/types.ts'
               - 'crates/coral-api/proto/**'
@@ -519,7 +521,7 @@ jobs:
           cache-binary: false
 
       - name: Check Reef image contract
-        run: node --test docker/reef-image.test.mjs
+        run: node --test docker/reef-image.test.mjs docker/reef-publish.test.mjs
 
       - name: Build and smoke linux/amd64 Coral and Reef images
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -107,8 +107,10 @@ jobs:
               - 'apps/desktop/src/shared/types.ts'
             reef-image:
               - '.github/workflows/validate.yml'
-              - '.github/workflows/reef-docker-publish.yml'
               - '.github/workflows/docker-aliases.yml'
+              - '.github/workflows/docker-publish.yml'
+              - '.github/workflows/reef-docker-publish.yml'
+              - '.github/workflows/release.yml'
               - '.dockerignore'
               - 'Makefile'
               - 'Cargo.toml'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -108,6 +108,7 @@ jobs:
             reef-image:
               - '.github/workflows/validate.yml'
               - '.github/workflows/reef-docker-publish.yml'
+              - '.github/workflows/docker-aliases.yml'
               - '.dockerignore'
               - 'Makefile'
               - 'Cargo.toml'

--- a/docker/Dockerfile.reef
+++ b/docker/Dockerfile.reef
@@ -17,8 +17,13 @@ COPY apps/reef/package.json apps/reef/package-lock.json ./
 RUN npm ci --omit=dev
 
 FROM node:24.15.0-trixie-slim
+ARG REEF_VERSION
+ARG REEF_REVISION
 WORKDIR /app
 ENV NODE_ENV=production PORT=3000
+LABEL org.opencontainers.image.source="https://github.com/withcoral/coral" \
+      org.opencontainers.image.version="$REEF_VERSION" \
+      org.opencontainers.image.revision="$REEF_REVISION"
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /src/apps/reef/build ./build
 COPY --from=build /src/apps/reef/package.json ./package.json

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const read = (path) => readFile(new URL(path, import.meta.url), 'utf8')
+
+test('Reef publication is immutable and release-source pinned', async () => {
+  const workflow = await read('../.github/workflows/reef-docker-publish.yml')
+
+  assert.match(workflow, /IMAGE: ghcr\.io\/withcoral\/reef/)
+  assert.match(workflow, /ref: \$\{\{ env\.TAG \}\}/)
+  assert.match(workflow, /git rev-parse HEAD/)
+  assert.match(workflow, /--platform linux\/amd64/)
+  assert.match(workflow, /--provenance=true/)
+  assert.match(workflow, /--tag "\$\{IMAGE\}:\$\{VERSION\}"/)
+  assert.doesNotMatch(workflow, /\$\{IMAGE\}:(?:latest|\$\{MAJOR_MINOR\})/)
+})
+
+test('publication exposes verified version and digest metadata', async () => {
+  const [workflow, dockerfile] = await Promise.all([
+    read('../.github/workflows/reef-docker-publish.yml'),
+    read('./Dockerfile.reef'),
+  ])
+
+  assert.match(workflow, /digest: \$\{\{ steps\.manifest\.outputs\.digest \}\}/)
+  assert.match(workflow, /org\.opencontainers\.image\.version/)
+  assert.match(workflow, /org\.opencontainers\.image\.revision/)
+  assert.match(workflow, /docker buildx imagetools inspect/)
+  assert.match(dockerfile, /org\.opencontainers\.image\.version="\$REEF_VERSION"/)
+  assert.match(dockerfile, /org\.opencontainers\.image\.revision="\$REEF_REVISION"/)
+})
+
+test('release waits for completed artifacts before publishing Reef', async () => {
+  const workflow = await read('../.github/workflows/release.yml')
+
+  assert.match(workflow, /publish-reef-docker:\n(?:.|\n)*- publish-version/)
+  assert.match(workflow, /uses: \.\/\.github\/workflows\/reef-docker-publish\.yml/)
+  assert.match(workflow, /commit-sha: \$\{\{ needs\.validate-release-ref\.outputs\.commit-sha \}\}/)
+})

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -30,24 +30,38 @@ test('publication verifies and signs the digest before exposing its version tag'
   assert.match(dockerfile, /org\.opencontainers\.image\.revision="\$REEF_REVISION"/)
 
   const verify = workflow.indexOf('- name: Verify staged image metadata')
+  const smoke = workflow.indexOf('- name: Smoke staged Reef image')
   const sign = workflow.indexOf('- name: Sign the staged manifest')
   const publish = workflow.indexOf('- name: Publish immutable version tag')
-  assert.ok(verify < sign && sign < publish)
+  assert.ok(verify < smoke && smoke < sign && sign < publish)
+  assert.match(workflow.slice(smoke, sign), /"\$\{IMAGE\}@\$\{DIGEST\}"/)
+  assert.match(workflow.slice(smoke, sign), /State\.Health\.Status/)
+  assert.match(workflow.slice(smoke, sign), /process\.getuid\(\).*process\.getgid\(\)/)
+  assert.match(workflow.slice(smoke, sign), /= 1000:1000/)
   assert.doesNotMatch(workflow.slice(0, publish), /--tag "?\$\{IMAGE\}:\$\{VERSION\}/)
 })
 
-test('immutable version publication handles absent, same, and different digests', async () => {
+test('Reef reruns reuse the signed immutable version digest without rebuilding it', async () => {
   const workflow = await read('../.github/workflows/reef-docker-publish.yml')
+  const resolve = workflow.slice(
+    workflow.indexOf('- name: Resolve existing immutable version'),
+    workflow.indexOf('- name: Build and push image by digest'),
+  )
   const publish = workflow.slice(workflow.indexOf('- name: Publish immutable version tag'))
 
   assert.match(workflow, /group: reef-docker-publish-\$\{\{ inputs\.tag \}\}/)
-  assert.match(publish, /existing_digest="\$\(gh api --paginate/)
-  assert.match(publish, /if \[ -n "\$existing_digest" \]/)
-  assert.match(publish, /existing_digest" != "\$BUILD_DIGEST"/)
-  assert.match(publish, /refusing to replace it/)
-  assert.match(publish, /already points to the verified digest/)
+  assert.match(resolve, /matches="\$\(gh api --paginate/)
+  assert.match(resolve, /test "\$\(printf '%s\\n' "\$matches" \| wc -l\)" -eq 1/)
+  assert.match(resolve, /resolved" != "\$digest"/)
+  assert.match(resolve, /elif grep -Fq '\(HTTP 404\)'/)
+  assert.match(resolve, /cat "\$error_file" >&2\n\s+exit 1/)
+  assert.match(workflow, /if: steps\.existing\.outputs\.digest == ''\n\s+id: build/)
+  assert.match(workflow, /if: steps\.existing\.outputs\.digest != ''[\s\S]*cosign verify/)
+  assert.match(workflow, /EXPECTED_IDENTITY: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.workflow_ref \}\}/)
+  assert.match(workflow, /digest="\$\{EXISTING_DIGEST:-\$BUILD_DIGEST\}"/)
+  assert.match(publish, /if \[ -z "\$EXISTING_DIGEST" \]/)
   assert.match(publish, /imagetools create --tag "\$version_ref"/)
-  assert.match(publish, /published_digest" != "\$BUILD_DIGEST"/)
+  assert.match(publish, /published_digest" != "\$DIGEST"/)
 })
 
 test('release waits for completed artifacts before publishing Reef', async () => {
@@ -58,16 +72,23 @@ test('release waits for completed artifacts before publishing Reef', async () =>
   assert.match(workflow, /commit-sha: \$\{\{ needs\.validate-release-ref\.outputs\.commit-sha \}\}/)
 })
 
-test('moving aliases have one coordinator after both immutable publishers', async () => {
+test('release aliases stay paired while direct Coral CVE rebuilds advance eligible aliases', async () => {
   const [release, coral, aliases] = await Promise.all([
     read('../.github/workflows/release.yml'),
     read('../.github/workflows/docker-publish.yml'),
     read('../.github/workflows/docker-aliases.yml'),
   ])
 
-  assert.doesNotMatch(coral, /\$\{IMAGE\}:(?:latest|\$\{MAJOR_MINOR\})/)
-  assert.doesNotMatch(coral, /major-minor=/)
-  assert.match(coral, /group: docker-publish-\$\{\{ inputs\.tag \}\}/)
+  assert.match(coral, /defer-aliases:/)
+  assert.match(coral, /group: coordinated-docker-aliases/)
+  assert.match(coral, /major-minor=\$\{version%\.\*\}/)
+  assert.match(coral, /if: \$\{\{ inputs\.defer-aliases != true \}\}/)
+  assert.match(coral, /if \[ "\$DEFER_ALIASES" != true \]; then/)
+  assert.match(coral, /\[ "\$PRERELEASE" = false \] && \[ "\$NEWEST_LINE_TAG" = "\$TAG" \]/)
+  assert.match(coral, /\[ "\$PRERELEASE" = false \] && \[ "\$NEWEST_TAG" = "\$TAG" \]/)
+  assert.match(coral, /tags\+=\(--tag "\$\{IMAGE\}:\$\{MAJOR_MINOR\}"\)/)
+  assert.match(coral, /tags\+=\(--tag "\$\{IMAGE\}:latest"\)/)
+  assert.match(release, /publish-docker:[\s\S]*defer-aliases: true/)
   assert.match(
     release,
     /coordinate-docker-aliases:\n(?:.|\n)*- publish-docker\n(?:.|\n)*- publish-reef-docker/,

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -57,7 +57,11 @@ test('Reef reruns reuse the signed immutable version digest without rebuilding i
   assert.match(resolve, /cat "\$error_file" >&2\n\s+exit 1/)
   assert.match(workflow, /if: steps\.existing\.outputs\.digest == ''\n\s+id: build/)
   assert.match(workflow, /if: steps\.existing\.outputs\.digest != ''[\s\S]*cosign verify/)
-  assert.match(workflow, /EXPECTED_IDENTITY: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.workflow_ref \}\}/)
+  assert.match(
+    workflow,
+    /EXPECTED_IDENTITY: \$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}\/\.github\/workflows\/reef-docker-publish\.yml@\$\{\{ github\.ref \}\}/,
+  )
+  assert.doesNotMatch(workflow, /EXPECTED_IDENTITY: .*github\.workflow_ref/)
   assert.match(workflow, /digest="\$\{EXISTING_DIGEST:-\$BUILD_DIGEST\}"/)
   assert.match(publish, /if \[ -z "\$EXISTING_DIGEST" \]/)
   assert.match(publish, /imagetools create --tag "\$version_ref"/)
@@ -80,12 +84,24 @@ test('release aliases stay paired while direct Coral CVE rebuilds advance eligib
   ])
 
   assert.match(coral, /defer-aliases:/)
-  assert.match(coral, /group: coordinated-docker-aliases/)
+  assert.match(coral, /format\('docker-publish-deferred-\{0\}', github\.run_id\)/)
+  assert.match(coral, /\|\| 'coordinated-docker-aliases'/)
+  assert.match(coral, /group: docker-publish-\$\{\{ inputs\.tag \}\}/)
   assert.match(coral, /major-minor=\$\{version%\.\*\}/)
   assert.match(coral, /if: \$\{\{ inputs\.defer-aliases != true \}\}/)
+  assert.match(coral, /- name: Snapshot direct rebuild alias ownership/)
+  assert.match(coral, /version_digest="\$\(tag_digest "\$VERSION"\)"/)
+  assert.match(
+    coral,
+    /\[ -z "\$alias_digest" \] \|\| \{ \[ -n "\$version_digest" \] && \[ "\$alias_digest" = "\$version_digest" \]; \}/,
+  )
   assert.match(coral, /if \[ "\$DEFER_ALIASES" != true \]; then/)
   assert.match(coral, /\[ "\$PRERELEASE" = false \] && \[ "\$NEWEST_LINE_TAG" = "\$TAG" \]/)
   assert.match(coral, /\[ "\$PRERELEASE" = false \] && \[ "\$NEWEST_TAG" = "\$TAG" \]/)
+  assert.match(coral, /echo "move-line=\$\{move_line\}"/)
+  assert.match(coral, /echo "move-latest=\$\{move_latest\}"/)
+  assert.match(coral, /if \[ "\$MOVE_LINE" = true \]; then/)
+  assert.match(coral, /if \[ "\$MOVE_LATEST" = true \]; then/)
   assert.match(coral, /tags\+=\(--tag "\$\{IMAGE\}:\$\{MAJOR_MINOR\}"\)/)
   assert.match(coral, /tags\+=\(--tag "\$\{IMAGE\}:latest"\)/)
   assert.match(release, /publish-docker:[\s\S]*defer-aliases: true/)
@@ -101,6 +117,18 @@ test('release aliases stay paired while direct Coral CVE rebuilds advance eligib
   assert.match(aliases, /if \[ "\$TAG" = "\$newest" \]; then\n\s+aliases\+=\(latest\)/)
   assert.match(aliases, /make_latest=true/)
   assert.match(aliases, /echo "make-latest=\$\{make_latest\}"/)
+})
+
+test('Coral signs the staged digest before exposing the exact version or moving tags', async () => {
+  const workflow = await read('../.github/workflows/docker-publish.yml')
+  const sign = workflow.indexOf('- name: Sign the staged manifest')
+  const publish = workflow.indexOf('- name: Tag the validated manifest')
+
+  assert.ok(sign >= 0 && sign < publish)
+  assert.match(workflow.slice(sign, publish), /DIGEST: \$\{\{ steps\.build\.outputs\.digest \}\}/)
+  assert.match(workflow.slice(sign, publish), /cosign sign --yes "\$\{IMAGE\}@\$\{DIGEST\}"/)
+  assert.doesNotMatch(workflow.slice(0, sign), /imagetools create/)
+  assert.match(workflow.slice(publish), /test "\$digest" = "\$BUILD_DIGEST"/)
 })
 
 test('alias publication converges absent, same, mismatch, and partial-failure states', async () => {

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -90,7 +90,13 @@ test('release aliases stay paired while direct Coral CVE rebuilds advance eligib
   assert.match(coral, /major-minor=\$\{version%\.\*\}/)
   assert.match(coral, /if: \$\{\{ inputs\.defer-aliases != true \}\}/)
   assert.match(coral, /- name: Snapshot direct rebuild alias ownership/)
-  assert.match(coral, /version_digest="\$\(tag_digest "\$VERSION"\)"/)
+  assert.match(coral, /if ! matches="\$\(gh api --paginate/)
+  assert.match(coral, /if ! version_digest="\$\(tag_digest "\$VERSION"\)"; then\n\s+exit 1/)
+  assert.match(
+    coral,
+    /if ! alias_digest="\$\(tag_digest "\$alias"\)"; then\n\s+return 2/,
+  )
+  assert.match(coral, /\[ "\$status" -eq 1 \] \|\| exit "\$status"/)
   assert.match(
     coral,
     /\[ -z "\$alias_digest" \] \|\| \{ \[ -n "\$version_digest" \] && \[ "\$alias_digest" = "\$version_digest" \]; \}/,
@@ -131,8 +137,9 @@ test('Coral signs the staged digest before exposing the exact version or moving 
   assert.match(workflow.slice(publish), /test "\$digest" = "\$BUILD_DIGEST"/)
 })
 
-test('alias publication converges absent, same, mismatch, and partial-failure states', async () => {
+test('alias publication adopts the current exact-version Coral digest and converges after partial failures', async () => {
   const workflow = await read('../.github/workflows/docker-aliases.yml')
+  const resolveCoral = workflow.indexOf('if ! coral_digest="$(docker buildx imagetools inspect')
   const operations = [
     ['write-coral', workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/coral:${alias}"')],
     ['write-reef', workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/reef:${alias}"')],
@@ -149,10 +156,17 @@ test('alias publication converges absent, same, mismatch, and partial-failure st
       ['read-reef', true],
     ],
   )
-  assert.match(workflow, /test "\$coral_actual" = "\$CORAL_DIGEST"/)
+  assert.ok(resolveCoral >= 0 && resolveCoral < operations[0][1])
+  assert.match(workflow, /PUBLISHED_CORAL_DIGEST: \$\{\{ inputs\.coral-digest \}\}/)
+  assert.match(workflow, /if \[ "\$coral_digest" != "\$PUBLISHED_CORAL_DIGEST" \]; then/)
+  assert.match(workflow, /"ghcr\.io\/withcoral\/coral@\$\{coral_digest\}"/)
+  assert.doesNotMatch(workflow, /"ghcr\.io\/withcoral\/coral@\$\{PUBLISHED_CORAL_DIGEST\}"/)
+  assert.match(workflow, /test "\$coral_actual" = "\$coral_digest"/)
   assert.match(workflow, /test "\$reef_actual" = "\$REEF_DIGEST"/)
 
-  const expected = { coral: 'coral-new', reef: 'reef-new' }
+  const releaseProducedCoral = 'coral-d1'
+  const expected = { coral: 'coral-d2-current-exact-tag', reef: 'reef-new' }
+  assert.notEqual(expected.coral, releaseProducedCoral)
   const run = (initial, failAfter = Number.POSITIVE_INFINITY) => {
     const state = { ...initial }
     for (const [index, [operation]] of operations.entries()) {

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -12,22 +12,42 @@ test('Reef publication is immutable and release-source pinned', async () => {
   assert.match(workflow, /git rev-parse HEAD/)
   assert.match(workflow, /--platform linux\/amd64/)
   assert.match(workflow, /--provenance=true/)
-  assert.match(workflow, /--tag "\$\{IMAGE\}:\$\{VERSION\}"/)
+  assert.match(workflow, /push-by-digest=true/)
   assert.doesNotMatch(workflow, /\$\{IMAGE\}:(?:latest|\$\{MAJOR_MINOR\})/)
 })
 
-test('publication exposes verified version and digest metadata', async () => {
+test('publication verifies and signs the digest before exposing its version tag', async () => {
   const [workflow, dockerfile] = await Promise.all([
     read('../.github/workflows/reef-docker-publish.yml'),
     read('./Dockerfile.reef'),
   ])
 
-  assert.match(workflow, /digest: \$\{\{ steps\.manifest\.outputs\.digest \}\}/)
+  assert.match(workflow, /digest: \$\{\{ steps\.publish\.outputs\.digest \}\}/)
   assert.match(workflow, /org\.opencontainers\.image\.version/)
   assert.match(workflow, /org\.opencontainers\.image\.revision/)
   assert.match(workflow, /docker buildx imagetools inspect/)
   assert.match(dockerfile, /org\.opencontainers\.image\.version="\$REEF_VERSION"/)
   assert.match(dockerfile, /org\.opencontainers\.image\.revision="\$REEF_REVISION"/)
+
+  const verify = workflow.indexOf('- name: Verify staged image metadata')
+  const sign = workflow.indexOf('- name: Sign the staged manifest')
+  const publish = workflow.indexOf('- name: Publish immutable version tag')
+  assert.ok(verify < sign && sign < publish)
+  assert.doesNotMatch(workflow.slice(0, publish), /--tag "?\$\{IMAGE\}:\$\{VERSION\}/)
+})
+
+test('immutable version publication handles absent, same, and different digests', async () => {
+  const workflow = await read('../.github/workflows/reef-docker-publish.yml')
+  const publish = workflow.slice(workflow.indexOf('- name: Publish immutable version tag'))
+
+  assert.match(workflow, /group: reef-docker-publish-\$\{\{ inputs\.tag \}\}/)
+  assert.match(publish, /existing_digest="\$\(gh api --paginate/)
+  assert.match(publish, /if \[ -n "\$existing_digest" \]/)
+  assert.match(publish, /existing_digest" != "\$BUILD_DIGEST"/)
+  assert.match(publish, /refusing to replace it/)
+  assert.match(publish, /already points to the verified digest/)
+  assert.match(publish, /imagetools create --tag "\$version_ref"/)
+  assert.match(publish, /published_digest" != "\$BUILD_DIGEST"/)
 })
 
 test('release waits for completed artifacts before publishing Reef', async () => {

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -75,18 +75,46 @@ test('moving aliases have one coordinator after both immutable publishers', asyn
 
 test('alias publication converges absent, same, mismatch, and partial-failure states', async () => {
   const workflow = await read('../.github/workflows/docker-aliases.yml')
-  const coralWrite = workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/coral:${alias}"')
-  const reefWrite = workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/reef:${alias}"')
-  const coralRead = workflow.indexOf('coral_actual="$(docker buildx imagetools inspect')
-  const reefRead = workflow.indexOf('reef_actual="$(docker buildx imagetools inspect')
+  const operations = [
+    ['write-coral', workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/coral:${alias}"')],
+    ['write-reef', workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/reef:${alias}"')],
+    ['read-coral', workflow.indexOf('coral_actual="$(docker buildx imagetools inspect')],
+    ['read-reef', workflow.indexOf('reef_actual="$(docker buildx imagetools inspect')],
+  ].sort((left, right) => left[1] - right[1])
 
-  // create is an idempotent upsert: absent, same, and mismatched aliases all converge.
-  assert.ok(coralWrite >= 0 && coralWrite < reefWrite)
-  assert.ok(reefWrite < coralRead && coralRead < reefRead)
+  assert.deepEqual(
+    operations.map(([name, offset]) => [name, offset >= 0]),
+    [
+      ['write-coral', true],
+      ['write-reef', true],
+      ['read-coral', true],
+      ['read-reef', true],
+    ],
+  )
   assert.match(workflow, /test "\$coral_actual" = "\$CORAL_DIGEST"/)
   assert.match(workflow, /test "\$reef_actual" = "\$REEF_DIGEST"/)
-  assert.match(workflow, /set -euo pipefail/)
-  assert.match(workflow, /retry is idempotent and converges both aliases before completion/)
+
+  const expected = { coral: 'coral-new', reef: 'reef-new' }
+  const run = (initial, failAfter = Number.POSITIVE_INFINITY) => {
+    const state = { ...initial }
+    for (const [index, [operation]] of operations.entries()) {
+      if (index === failAfter) throw Object.assign(new Error('injected failure'), { state })
+      if (operation === 'write-coral') state.coral = expected.coral
+      if (operation === 'write-reef') state.reef = expected.reef
+      if (operation === 'read-coral') assert.equal(state.coral, expected.coral)
+      if (operation === 'read-reef') assert.equal(state.reef, expected.reef)
+    }
+    return state
+  }
+
+  for (const initial of [{}, expected, { coral: 'old', reef: 'old' }]) {
+    assert.deepEqual(run(initial), expected)
+  }
+  for (let failAfter = 0; failAfter < operations.length; failAfter += 1) {
+    let partial
+    assert.throws(() => run({}, failAfter), (error) => ((partial = error.state), true))
+    assert.deepEqual(run(partial), expected)
+  }
 })
 
 test('GitHub release promotion is the final coordinated commit point', async () => {

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -66,11 +66,20 @@ test('moving aliases have one coordinator after both immutable publishers', asyn
   ])
 
   assert.doesNotMatch(coral, /\$\{IMAGE\}:(?:latest|\$\{MAJOR_MINOR\})/)
-  assert.match(release, /coordinate-docker-aliases:\n(?:.|\n)*- publish-docker\n(?:.|\n)*- publish-reef-docker/)
+  assert.doesNotMatch(coral, /major-minor=/)
+  assert.match(coral, /group: docker-publish-\$\{\{ inputs\.tag \}\}/)
+  assert.match(
+    release,
+    /coordinate-docker-aliases:\n(?:.|\n)*- publish-docker\n(?:.|\n)*- publish-reef-docker/,
+  )
   assert.match(aliases, /group: coordinated-docker-aliases/)
+  assert.match(aliases, /value: \$\{\{ jobs\.aliases\.outputs\.make-latest \}\}/)
+  assert.match(aliases, /make-latest: \$\{\{ steps\.advance\.outputs\.make-latest \}\}/)
   assert.match(aliases, /test "\$draft" = false/)
   assert.match(aliases, /\[ "\$TAG" != "\$newest_line" \] \|\| aliases\+=\("\$line"\)/)
-  assert.match(aliases, /\[ "\$TAG" != "\$newest" \] \|\| aliases\+=\(latest\)/)
+  assert.match(aliases, /if \[ "\$TAG" = "\$newest" \]; then\n\s+aliases\+=\(latest\)/)
+  assert.match(aliases, /make_latest=true/)
+  assert.match(aliases, /echo "make-latest=\$\{make_latest\}"/)
 })
 
 test('alias publication converges absent, same, mismatch, and partial-failure states', async () => {
@@ -112,7 +121,10 @@ test('alias publication converges absent, same, mismatch, and partial-failure st
   }
   for (let failAfter = 0; failAfter < operations.length; failAfter += 1) {
     let partial
-    assert.throws(() => run({}, failAfter), (error) => ((partial = error.state), true))
+    assert.throws(
+      () => run({}, failAfter),
+      (error) => ((partial = error.state), true),
+    )
     assert.deepEqual(run(partial), expected)
   }
 })
@@ -124,6 +136,31 @@ test('GitHub release promotion is the final coordinated commit point', async () 
 
   assert.ok(coordinate >= 0 && coordinate < promote)
   assert.match(release.slice(promote), /- coordinate-docker-aliases/)
-  assert.match(release.slice(promote), /-F prerelease=false -F make_latest=true/)
+  assert.match(
+    release.slice(promote),
+    /MAKE_LATEST: \$\{\{ needs\.coordinate-docker-aliases\.outputs\.make-latest \}\}/,
+  )
+  assert.match(release.slice(promote), /if \[ "\$was_prerelease" = true \]/)
+  assert.match(release.slice(promote), /-F prerelease=false -f "make_latest=\$\{MAKE_LATEST\}"/)
+  assert.match(release.slice(promote), /if: steps\.promote\.outputs\.promoted == 'true'/)
+  assert.doesNotMatch(release.slice(0, coordinate), /releases\/tags\/\$\{TAG_NAME\}/)
   assert.doesNotMatch(release.slice(0, coordinate), /-F prerelease=false/)
+})
+
+test('validation watches every workflow consumed by the release contract', async () => {
+  const validate = await read('../.github/workflows/validate.yml')
+  const reefImagePaths = validate.slice(
+    validate.indexOf('            reef-image:\n'),
+    validate.indexOf('            desktop-checks:\n'),
+  )
+
+  for (const workflow of [
+    'docker-aliases.yml',
+    'docker-publish.yml',
+    'reef-docker-publish.yml',
+    'release.yml',
+  ]) {
+    assert.match(reefImagePaths, new RegExp(`\\.github/workflows/${workflow.replace('.', '\\.')}`))
+  }
+  assert.match(reefImagePaths, /docker\/reef-publish\.test\.mjs/)
 })

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -129,20 +129,36 @@ test('alias publication converges absent, same, mismatch, and partial-failure st
   }
 })
 
-test('GitHub release promotion is the final coordinated commit point', async () => {
+test('release promotion is coordinated and notification is independently retryable', async () => {
   const release = await read('../.github/workflows/release.yml')
   const coordinate = release.indexOf('coordinate-docker-aliases:')
   const promote = release.indexOf('promote-release:', coordinate)
+  const notify = release.indexOf('notify-release:', promote)
 
-  assert.ok(coordinate >= 0 && coordinate < promote)
-  assert.match(release.slice(promote), /- coordinate-docker-aliases/)
+  assert.ok(coordinate >= 0 && coordinate < promote && promote < notify)
+  assert.match(release.slice(promote, notify), /- coordinate-docker-aliases/)
+  assert.match(release.slice(promote, notify), /environment: release/)
   assert.match(
-    release.slice(promote),
+    release.slice(promote, notify),
+    /outputs:\n\s+promoted: \$\{\{ steps\.promote\.outputs\.promoted \}\}/,
+  )
+  assert.match(
+    release.slice(promote, notify),
     /MAKE_LATEST: \$\{\{ needs\.coordinate-docker-aliases\.outputs\.make-latest \}\}/,
   )
-  assert.match(release.slice(promote), /if \[ "\$was_prerelease" = true \]/)
-  assert.match(release.slice(promote), /-F prerelease=false -f "make_latest=\$\{MAKE_LATEST\}"/)
-  assert.match(release.slice(promote), /if: steps\.promote\.outputs\.promoted == 'true'/)
+  assert.match(release.slice(promote, notify), /if \[ "\$was_prerelease" = true \]/)
+  assert.match(
+    release.slice(promote, notify),
+    /-F prerelease=false -f "make_latest=\$\{MAKE_LATEST\}"/,
+  )
+  assert.doesNotMatch(release.slice(promote, notify), /DISCORD_WEBHOOK/)
+  assert.match(release.slice(notify), /- promote-release/)
+  assert.match(release.slice(notify), /environment: release/)
+  assert.match(
+    release.slice(notify),
+    /if: needs\.promote-release\.outputs\.promoted == 'true'/,
+  )
+  assert.match(release.slice(notify), /DISCORD_WEBHOOK/)
   assert.doesNotMatch(release.slice(0, coordinate), /releases\/tags\/\$\{TAG_NAME\}/)
   assert.doesNotMatch(release.slice(0, coordinate), /-F prerelease=false/)
 })

--- a/docker/reef-publish.test.mjs
+++ b/docker/reef-publish.test.mjs
@@ -57,3 +57,45 @@ test('release waits for completed artifacts before publishing Reef', async () =>
   assert.match(workflow, /uses: \.\/\.github\/workflows\/reef-docker-publish\.yml/)
   assert.match(workflow, /commit-sha: \$\{\{ needs\.validate-release-ref\.outputs\.commit-sha \}\}/)
 })
+
+test('moving aliases have one coordinator after both immutable publishers', async () => {
+  const [release, coral, aliases] = await Promise.all([
+    read('../.github/workflows/release.yml'),
+    read('../.github/workflows/docker-publish.yml'),
+    read('../.github/workflows/docker-aliases.yml'),
+  ])
+
+  assert.doesNotMatch(coral, /\$\{IMAGE\}:(?:latest|\$\{MAJOR_MINOR\})/)
+  assert.match(release, /coordinate-docker-aliases:\n(?:.|\n)*- publish-docker\n(?:.|\n)*- publish-reef-docker/)
+  assert.match(aliases, /group: coordinated-docker-aliases/)
+  assert.match(aliases, /test "\$draft" = false/)
+  assert.match(aliases, /\[ "\$TAG" != "\$newest_line" \] \|\| aliases\+=\("\$line"\)/)
+  assert.match(aliases, /\[ "\$TAG" != "\$newest" \] \|\| aliases\+=\(latest\)/)
+})
+
+test('alias publication converges absent, same, mismatch, and partial-failure states', async () => {
+  const workflow = await read('../.github/workflows/docker-aliases.yml')
+  const coralWrite = workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/coral:${alias}"')
+  const reefWrite = workflow.indexOf('imagetools create --tag "ghcr.io/withcoral/reef:${alias}"')
+  const coralRead = workflow.indexOf('coral_actual="$(docker buildx imagetools inspect')
+  const reefRead = workflow.indexOf('reef_actual="$(docker buildx imagetools inspect')
+
+  // create is an idempotent upsert: absent, same, and mismatched aliases all converge.
+  assert.ok(coralWrite >= 0 && coralWrite < reefWrite)
+  assert.ok(reefWrite < coralRead && coralRead < reefRead)
+  assert.match(workflow, /test "\$coral_actual" = "\$CORAL_DIGEST"/)
+  assert.match(workflow, /test "\$reef_actual" = "\$REEF_DIGEST"/)
+  assert.match(workflow, /set -euo pipefail/)
+  assert.match(workflow, /retry is idempotent and converges both aliases before completion/)
+})
+
+test('GitHub release promotion is the final coordinated commit point', async () => {
+  const release = await read('../.github/workflows/release.yml')
+  const coordinate = release.indexOf('coordinate-docker-aliases:')
+  const promote = release.indexOf('promote-release:', coordinate)
+
+  assert.ok(coordinate >= 0 && coordinate < promote)
+  assert.match(release.slice(promote), /- coordinate-docker-aliases/)
+  assert.match(release.slice(promote), /-F prerelease=false -F make_latest=true/)
+  assert.doesNotMatch(release.slice(0, coordinate), /-F prerelease=false/)
+})


### PR DESCRIPTION
## Intent

Publish immutable Reef release images and coordinate Coral and Reef moving aliases through one release workflow.

## What it enables

Each `X.Y.Z` Reef tag is compare-and-set immutable, signed, and source-verified. Eligible `X.Y` and `latest` aliases advance as a verified Coral/Reef pair before the GitHub release is marked complete.

## Usage examples

Publishing a `v1.2.3` prerelease builds `ghcr.io/withcoral/reef:1.2.3`. If it is the newest stable release, the coordinator advances and re-reads both repositories' `1.2` and `latest` aliases; retries converge partial failures idempotently.
