### PR TITLE
fix(reef): wrap long source error messages

### DIFF
--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -20,6 +20,11 @@ const DISCOVERY = {
   url: 'https://weather.example/openapi.yaml',
 }
 
+// Shaped like a real materialize failure: a Connect status prefix, unbreakable
+// Rust type paths, and the server's newline-separated `Hint:` line.
+const UNBREAKABLE_IMPORT_ERROR = `[unavailable] unavailable: failed to materialize source 'axiom': failed precondition: MCP HTTP server for source \`axiom\` returned a message error Transport [rmcp::transport::worker::WorkerTransport<rmcp::transport::streamable_http_client::StreamableHttpClientWorker>] error: Auth required, when send initialize request
+Hint: Install or update the source with the required OAuth or bearer credentials, then retry the query.`
+
 const SourceCreateStoryContext = createContext<SourceCreateDialogProps | null>(null)
 const SourceCreateRoutesStub = createRoutesStub([
   {
@@ -203,6 +208,52 @@ export const ImportError: Story = {
         within(credentialsDialog).getByText('The OpenAPI descriptor could not be loaded.'),
       ).toBeVisible()
     })
+  },
+}
+
+export const ImportErrorUnbreakableMessage: Story = {
+  args: {
+    actionData: {
+      intent: 'import',
+      message: UNBREAKABLE_IMPORT_ERROR,
+      name: 'weather_api',
+      status: 'error',
+    },
+  },
+  name: 'Import error with unbreakable message',
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Source URL'), DISCOVERY.url)
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+    await waitFor(() => expect(page.getByLabelText('Name')).toHaveValue('weather_api'))
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(3))
+    const banner = await waitFor(() => {
+      const match = page.getByText(/failed to materialize source 'axiom'/)
+      expect(match).toBeVisible()
+      return match
+    })
+    // The hint has to keep its own line, and the Rust type paths have to break
+    // inside the banner instead of spilling past the dialog edge.
+    await expect(banner.textContent).toContain('\nHint: Install or update the source')
+    const popup = banner.closest('[role="dialog"]')
+    if (!(popup instanceof HTMLElement)) throw new Error('Credentials dialog not found')
+    await expect(banner.getBoundingClientRect().right).toBeLessThanOrEqual(
+      popup.getBoundingClientRect().right,
+    )
+
+    // The icon belongs on the first line of the message, not centred on all of it.
+    const icon = banner.previousElementSibling
+    if (!(icon instanceof HTMLElement)) throw new Error('Error icon not found')
+    const message = canvasElement.ownerDocument.createRange()
+    message.selectNodeContents(banner)
+    const [firstLine] = message.getClientRects()
+    const iconBox = icon.getBoundingClientRect()
+    await expect(
+      Math.abs((iconBox.top + iconBox.bottom) / 2 - (firstLine.top + firstLine.bottom) / 2),
+    ).toBeLessThan(1.5)
   },
 }
 

--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -235,25 +235,13 @@ export const ImportErrorUnbreakableMessage: Story = {
       expect(match).toBeVisible()
       return match
     })
-    // The hint has to keep its own line, and the Rust type paths have to break
-    // inside the banner instead of spilling past the dialog edge.
-    await expect(banner.textContent).toContain('\nHint: Install or update the source')
+    // The Rust type paths have to break inside the banner instead of spilling
+    // past the dialog edge.
     const popup = banner.closest('[role="dialog"]')
     if (!(popup instanceof HTMLElement)) throw new Error('Credentials dialog not found')
     await expect(banner.getBoundingClientRect().right).toBeLessThanOrEqual(
       popup.getBoundingClientRect().right,
     )
-
-    // The icon belongs on the first line of the message, not centred on all of it.
-    const icon = banner.previousElementSibling
-    if (!(icon instanceof HTMLElement)) throw new Error('Error icon not found')
-    const message = canvasElement.ownerDocument.createRange()
-    message.selectNodeContents(banner)
-    const [firstLine] = message.getClientRects()
-    const iconBox = icon.getBoundingClientRect()
-    await expect(
-      Math.abs((iconBox.top + iconBox.bottom) / 2 - (firstLine.top + firstLine.bottom) / 2),
-    ).toBeLessThan(1.5)
   },
 }
 

--- a/apps/reef/app/views/sources/source-presentation.css.ts
+++ b/apps/reef/app/views/sources/source-presentation.css.ts
@@ -3,17 +3,23 @@ import { style } from '@vanilla-extract/css'
 import { theme } from '@/wax/theme/theme.css'
 
 export const error = style({
-  alignItems: 'center',
+  alignItems: 'flex-start',
   background: theme.pill.red.background,
   border: `1px solid ${theme.pill.red.stroke}`,
   borderRadius: 6,
   color: theme.pill.red.color,
   display: 'flex',
-  fontSize: 12,
   gap: 8,
-  lineHeight: '16px',
   paddingBlock: 8,
   paddingInline: 12,
+})
+
+// Coral renders errors as newline-separated summary / detail / `Hint:` lines, so
+// keep the server's line structure and break long type paths inside the banner.
+export const errorText = style({
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+  whiteSpace: 'pre-wrap',
 })
 
 export const header = style({

--- a/apps/reef/app/views/sources/source-presentation.tsx
+++ b/apps/reef/app/views/sources/source-presentation.tsx
@@ -16,8 +16,8 @@ import * as styles from './source-presentation.css'
 export function SourceError({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <div className={classNames(styles.error, className)}>
-      <Icon color="inherit" name="CircleAlert" size="14" />
-      <Typography.BodySmall>{children}</Typography.BodySmall>
+      <Icon color="inherit" name="CircleAlert" size="18" />
+      <Typography.BodySmall className={styles.errorText}>{children}</Typography.BodySmall>
     </div>
   )
 }


### PR DESCRIPTION
## Test plan

| Before | After |
| ------ | ------ |
| <img width="688" height="160" alt="image" src="https://github.com/user-attachments/assets/91a914c0-d86b-4fa3-9ad1-7faead3b8a9b" /> | <img width="669" height="192" alt="image" src="https://github.com/user-attachments/assets/000a5426-9ccc-467c-a1a5-ffd0dab7ea96" /> |
