### PR TITLE
feat(reef): add an invalid state to TextInput and TextArea

### DIFF
--- a/apps/reef/app/wax/components/inputs/base-input.css.ts
+++ b/apps/reef/app/wax/components/inputs/base-input.css.ts
@@ -31,11 +31,14 @@ export const input = style([
       '&:disabled::placeholder': {
         color: theme.content.disabled,
       },
-      '&:focus': {
+      '&:focus:not([data-invalid])': {
         borderColor: theme.input.stroke.focus,
       },
-      '&:hover:not(:focus):not(:disabled)': {
+      '&:hover:not(:focus):not(:disabled):not([data-invalid])': {
         borderColor: theme.input.stroke.hover,
+      },
+      '&[data-invalid]:not(:disabled)': {
+        borderColor: theme.input.stroke.error,
       },
     },
   },

--- a/apps/reef/app/wax/components/inputs/text/text-area.css.ts
+++ b/apps/reef/app/wax/components/inputs/text/text-area.css.ts
@@ -24,11 +24,14 @@ export const textAreaContainer = style({
       borderColor: theme.input.stroke.disabled,
       cursor: 'not-allowed',
     },
-    '&:focus-within': {
+    '&:focus-within:not(:has(textarea[data-invalid]))': {
       borderColor: theme.input.stroke.focus,
     },
-    '&:hover:not(:focus-within):not(:has(textarea:disabled))': {
+    '&:hover:not(:focus-within):not(:has(textarea:disabled)):not(:has(textarea[data-invalid]))': {
       borderColor: theme.input.stroke.hover,
+    },
+    '&:has(textarea[data-invalid]):not(:has(textarea:disabled))': {
+      borderColor: theme.input.stroke.error,
     },
   },
 })

--- a/apps/reef/app/wax/components/inputs/text/text-area.stories.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-area.stories.tsx
@@ -45,6 +45,19 @@ export const Disabled: Story = {
   },
 }
 
+export const Invalid: Story = {
+  args: {
+    invalid: true,
+    value: 'Too short.',
+  },
+  play: async ({ canvas }) => {
+    const textArea = canvas.getByRole('textbox')
+
+    await expect(textArea).toHaveAttribute('aria-invalid', 'true')
+    await expect(textArea).toHaveAttribute('data-invalid')
+  },
+}
+
 export const Controlled: Story = {
   render: () => {
     const [value, setValue] = useState('A longer description that can span multiple lines.')

--- a/apps/reef/app/wax/components/inputs/text/text-area.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-area.tsx
@@ -11,6 +11,7 @@ export interface TextAreaProps {
   className?: string
   disabled?: boolean
   id?: string
+  invalid?: boolean
   name?: string
   onBlur?: () => void
   onChange?: (value: string) => void
@@ -28,6 +29,7 @@ export function TextArea({
   className,
   disabled,
   id,
+  invalid,
   name,
   onBlur,
   onChange,
@@ -39,7 +41,7 @@ export function TextArea({
   value,
 }: TextAreaProps) {
   return (
-    <Field.Root disabled={disabled}>
+    <Field.Root disabled={disabled} invalid={invalid}>
       <ScrollArea
         className={styles.textAreaContainer}
         height="auto"

--- a/apps/reef/app/wax/components/inputs/text/text-input.stories.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-input.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
+import { expect } from 'storybook/test'
 
 import { Button } from '@/wax/components'
 
@@ -33,6 +34,20 @@ export const Disabled: Story = {
   args: {
     disabled: true,
     placeholder: 'Search...',
+  },
+}
+
+export const Invalid: Story = {
+  args: {
+    invalid: true,
+    placeholder: 'Type something...',
+    value: 'not-an-email',
+  },
+  play: async ({ canvas }) => {
+    const input = canvas.getByRole('textbox')
+
+    await expect(input).toHaveAttribute('aria-invalid', 'true')
+    await expect(input).toHaveAttribute('data-invalid')
   },
 }
 

--- a/apps/reef/app/wax/components/inputs/text/text-input.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-input.tsx
@@ -12,6 +12,7 @@ export interface TextInputProps {
   disabled?: boolean
   icon?: IconName
   id?: string
+  invalid?: boolean
   name?: string
   onBlur?: () => void
   onChange?: (value: string) => void
@@ -31,6 +32,7 @@ export function TextInput({
   disabled,
   icon,
   id,
+  invalid,
   name,
   onBlur,
   onChange,
@@ -47,7 +49,7 @@ export function TextInput({
   }
 
   return (
-    <Field.Root disabled={disabled}>
+    <Field.Root disabled={disabled} invalid={invalid}>
       <div className={styles.container}>
         {icon && (
           <Icon


### PR DESCRIPTION
## Summary

Says on the tin. These are useful to show users which field errored

## Test plan

<img width="392" height="106" alt="image" src="https://github.com/user-attachments/assets/8260562c-6bd2-4f6a-b9cc-50b28687e378" />
<img width="327" height="55" alt="image" src="https://github.com/user-attachments/assets/b043a17c-a94b-42ee-8889-6b9cc78f23e1" />
