### PR TITLE
refactor(spec)!: collapse IrEntityCandidate to an entity name

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -650,7 +650,7 @@ mod tests {
                     cardinality: coral_spec::v4::OutputCardinality::List,
                     type_ref: "item".to_string(),
                 },
-                entity: None,
+                entity_name: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                     method: HttpMethod::Get,
                     path_template: "/items".to_string(),
@@ -723,7 +723,7 @@ mod tests {
                     cardinality: coral_spec::v4::OutputCardinality::List,
                     type_ref: "item".to_string(),
                 },
-                entity: None,
+                entity_name: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                     method: HttpMethod::Get,
                     path_template: "/items".to_string(),
@@ -865,7 +865,7 @@ mod tests {
                     cardinality: coral_spec::v4::OutputCardinality::List,
                     type_ref: "tool_result".to_string(),
                 },
-                entity: None,
+                entity_name: None,
                 execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
                     tool_name: operation_id.to_string(),
                 }),
@@ -917,7 +917,7 @@ mod tests {
                     cardinality: coral_spec::v4::OutputCardinality::Singleton,
                     type_ref: "envelope".to_string(),
                 },
-                entity: None,
+                entity_name: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                     method: HttpMethod::Get,
                     path_template: "/items".to_string(),

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -27,7 +27,10 @@ pub struct IrOperation {
     pub naming: Option<IrOperationNaming>,
     pub inputs: Vec<IrOperationInput>,
     pub output: IrOperationOutput,
-    pub entity: Option<IrEntityCandidate>,
+    /// Name of the rows this operation yields. Seeds the projection
+    /// name; when unset the namer falls back to the operation id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity_name: Option<String>,
     pub execution: IrExecutionAttachment,
     pub diagnostics: Vec<Diagnostic>,
 }
@@ -54,13 +57,6 @@ pub struct IrOperationInput {
 pub struct IrOperationOutput {
     pub cardinality: OutputCardinality,
     pub type_ref: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrEntityCandidate {
-    pub name: String,
-    pub type_ref: String,
-    pub identity_fields: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -197,7 +193,7 @@ mod tests {
                     cardinality: OutputCardinality::List,
                     type_ref: "issue".to_string(),
                 },
-                entity: None,
+                entity_name: None,
                 execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                     method: HttpMethod::Get,
                     path_template: "/issues".to_string(),
@@ -266,7 +262,7 @@ mod tests {
                     cardinality: OutputCardinality::List,
                     type_ref: "item".to_string(),
                 },
-                entity: None,
+                entity_name: None,
                 execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
                     tool_name: "list_items".to_string(),
                 }),

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -3,10 +3,10 @@
     reason = "DSL v4 contracts are field-heavy artifact models documented in the PRD."
 )]
 
-pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 5;
-pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v3";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v8";
-pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v3";
+pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 6;
+pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v4";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v9";
+pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v4";
 pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";
 
@@ -38,8 +38,8 @@ pub use artifacts::{
 };
 pub use diagnostics::Diagnostic;
 pub use ir::{
-    HttpMethod, IrEntityCandidate, IrExecutionAttachment, IrField, IrInputLocation, IrOperation,
-    IrOperationInput, IrOperationNaming, IrOperationOutput, IrScalarType, IrType, IrTypeShape,
+    HttpMethod, IrExecutionAttachment, IrField, IrInputLocation, IrOperation, IrOperationInput,
+    IrOperationNaming, IrOperationOutput, IrScalarType, IrType, IrTypeShape,
     McpExecutionAttachment, OutputCardinality, RestExecutionAttachment, RestParameterBinding,
     RestRequestBody, RestResponseAttachment, SemanticIr,
 };

--- a/crates/coral-spec/src/v4/operation_metadata/structural.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/structural.rs
@@ -193,13 +193,5 @@ fn validate_ir_operation(
         &format!("operation '{}' output", operation.id),
         operation.output.cardinality == OutputCardinality::None,
     )?;
-    if let Some(entity) = &operation.entity {
-        validate_type_ref(
-            types,
-            &entity.type_ref,
-            &format!("operation '{}' entity", operation.id),
-            false,
-        )?;
-    }
     Ok(())
 }

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -253,9 +253,9 @@ fn projection_entity_name(operation: &IrOperation, is_search: bool) -> String {
     if is_search && let Some(search_entity) = search_entity_from_path(operation) {
         return search_entity;
     }
-    operation.entity.as_ref().map_or_else(
+    operation.entity_name.as_deref().map_or_else(
         || normalize_identifier(&operation.id, "projection"),
-        |entity| normalize_entity_identifier(&entity.name),
+        normalize_entity_identifier,
     )
 }
 

--- a/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/operations.rs
@@ -1,6 +1,4 @@
-use crate::v4::ir::{
-    IrEntityCandidate, IrExecutionAttachment, IrOperation, McpExecutionAttachment,
-};
+use crate::v4::ir::{IrExecutionAttachment, IrOperation, McpExecutionAttachment};
 use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
 use crate::v4::{McpOperationPagination, OperationMetadata};
 
@@ -59,11 +57,7 @@ impl McpImporter<'_> {
             naming: None,
             inputs,
             output,
-            entity: Some(IrEntityCandidate {
-                name: operation_id.to_string(),
-                type_ref: format!("{operation_id}_row"),
-                identity_fields: Vec::new(),
-            }),
+            entity_name: Some(operation_id.to_string()),
             execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
                 tool_name: tool.name.clone(),
             }),

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -48,7 +48,7 @@ impl OpenApiImporter<'_> {
         let mut diagnostics = Vec::new();
         let parameters = self.import_parameters(path_item, op_obj, &operation_id, &mut diagnostics);
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
-        let (output, response, entity, pagination_context) =
+        let (output, response, entity_name, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
         let contract = detect_pagination_contract(self.document, &parameters, &pagination_context);
         let row_path = self.infer_row_path(
@@ -95,7 +95,7 @@ impl OpenApiImporter<'_> {
             naming,
             inputs: parameters,
             output,
-            entity,
+            entity_name,
             execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                 method,
                 path_template: path.to_string(),

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -4,9 +4,7 @@ use serde_json::{Map, Value};
 
 use crate::ResponseSpec;
 use crate::v4::diagnostics::Diagnostic;
-use crate::v4::ir::{
-    IrEntityCandidate, IrOperationOutput, OutputCardinality, RestResponseAttachment,
-};
+use crate::v4::ir::{IrOperationOutput, OutputCardinality, RestResponseAttachment};
 
 use super::import::OpenApiImporter;
 
@@ -44,7 +42,7 @@ impl OpenApiImporter<'_> {
     ) -> (
         IrOperationOutput,
         RestResponseAttachment,
-        Option<IrEntityCandidate>,
+        Option<String>,
         OpenApiResponsePaginationContext,
     ) {
         let Some(selected) = self.select_json_response(
@@ -91,7 +89,8 @@ impl OpenApiImporter<'_> {
                 },
             );
         };
-        let (cardinality, row_schema, entity_name) = classify_response_schema(path, &resolved);
+        let (cardinality, row_schema, schema_entity_name) =
+            classify_response_schema(path, &resolved);
         let type_ref = self
             .import_schema(
                 &row_schema,
@@ -101,13 +100,9 @@ impl OpenApiImporter<'_> {
             )
             .unwrap_or_else(|| "json".to_string());
         let response = ResponseSpec::default();
-        let entity = (cardinality != OutputCardinality::None
+        let entity_name = (cardinality != OutputCardinality::None
             && cardinality != OutputCardinality::Unknown)
-            .then(|| IrEntityCandidate {
-                name: entity_name.unwrap_or_else(|| entity_name_from_path(path)),
-                type_ref: type_ref.clone(),
-                identity_fields: vec!["id".to_string()],
-            });
+            .then(|| schema_entity_name.unwrap_or_else(|| entity_name_from_path(path)));
         (
             IrOperationOutput {
                 cardinality,
@@ -118,7 +113,7 @@ impl OpenApiImporter<'_> {
                 media_type: selected.media_type,
                 response,
             },
-            entity,
+            entity_name,
             OpenApiResponsePaginationContext {
                 schema: resolved,
                 headers: selected.headers,


### PR DESCRIPTION
## What

`IrOperation.entity` held an `IrEntityCandidate` with three fields. Two of them carried no information the IR did not already have:

| field | status |
|---|---|
| `type_ref` | Duplicated `output.type_ref` verbatim. OpenAPI assigned it a `.clone()` of the value it had just written to the output; MCP derived both from the same `{operation_id}_row`. Its only reader was a validation pass that re-checked a ref the output validation already covered. |
| `identity_fields` | Never read anywhere in the repo. OpenAPI hardcoded `["id"]`, MCP left it empty. |
| `name` | The one field that earns its place — see below. |

`name` matters for inline OpenAPI response schemas, where it yields a path-derived domain noun (`issues`) and the output type ref only offers an operation-derived id (`list_repo_issues_row`). For `$ref` responses the two are near-duplicates.

So this collapses the struct into `IrOperation.entity_name: Option<String>` — the single value `projection_entity_name` actually consumes.

## Behaviour

**Projection names are unchanged.** The name expression is identical on both importers: OpenAPI still computes `schema_entity_name.unwrap_or_else(|| entity_name_from_path(path))` under the same `cardinality != None && != Unknown` guard, MCP still uses `operation_id`, and `projection_entity_name` still passes whatever it gets to `normalize_entity_identifier`. Neither removed field was ever an input to naming.

Verified by dumping every generated projection name from the `github_openapi` fixture on `main` and on this branch. Identical:

```
get_issues    <- issues_get                        [Published]
issue         <- issues_list_for_repo              [Published]
issues        <- issues_update                     [Hidden]
search_issues <- search_issues_and_pull_requests   [Published]
```

The MCP importer keeps setting the field to the operation id rather than dropping to `None`, which looks redundant given the `None` fallback is also operation-id-derived. It isn't: the populated path runs `normalize_entity_identifier`, which strips `minimal`/`simple`/`base`/`short` tokens, while the fallback `normalize_identifier` preserves them. An MCP tool named `list_base_items` would change name if the field went to `None`.

## Artifact compatibility

`semantic-ir.yaml` is a real on-disk artifact — `coral-app` writes it during materialization and reads it back at source load. Nothing outside `coral-spec` reads the `entity` fields, and there are no checked-in fixtures or non-Rust consumers, but the serialized shape still changes.

**Existing materializations are not regenerated, and are not rejected.** Every version check on the load path is warning-only:

- `load_optional_fingerprint` pushes a `materialization_warning` on a header mismatch and still returns `Some(fingerprint)`.
- `read_validated_semantic_ir_with_reporter` runs `validate_semantic_ir` (which holds the `artifact_schema_version` check) through `if let Err(…) { push(…) }`, not `?`.
- The strict `validate_materialized_source`, which *does* return `Err` on a version mismatch, is only called at write time against a fingerprint just built from the current constants.

So a stale artifact emits two warnings and loads. `entity` becomes an unknown key that serde drops, and `entity_name` falls to `None` via `#[serde(default)]`.

That is safe because projection names are not recomputed at load — they come from `projections.yaml`, and `validate_projection_compatibility` matches operations by `operation_id`, columns and inputs, never by entity-derived naming. A stale artifact keeps the names it was materialized with; the `None` never reaches the namer. A re-added source runs the importer, which repopulates the field.

The version bumps (`V4_ARTIFACT_SCHEMA_VERSION` 5 → 6, plus the three importer versions, following `f9bf9bcf1`) therefore buy visibility rather than enforcement: they make the staleness show up as a diagnostic. `PROJECTION_GENERATOR_VERSION` and `OPERATION_METADATA_GENERATOR_VERSION` are left alone since neither output changes.

## Testing

`cargo clippy --workspace --all-targets` clean; `cargo test --workspace` green.

Two `search::manager` tests (`search_operation_records_safe_summary_metadata`, `search_operation_redacts_caller_visible_error_details_from_telemetry`) fail intermittently under parallel execution and pass in isolation. I confirmed this reproduces on a clean `main` checkout — pre-existing, unrelated to this change.

https://claude.ai/code/session_018oaL2JKqWd6w7ymUeqNqpK
