### PR TITLE
docs: don't require OpenAPI to be backticked in docstrings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,6 +2,7 @@ allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
 allow-dbg-in-tests = true
+doc-valid-idents = ["OpenAPI", ".."]
 
 disallowed-methods = [
   { path = "std::env::var", reason = "Read process environment only through crate-owned env modules." },

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -60,7 +60,7 @@ pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_
 /// Maximum gRPC message size for `SourceService` *responses*, in bytes.
 ///
 /// Source validation returns source metadata plus all exposed tables. Generated
-/// DSL v4 sources from large `OpenAPI` documents can exceed tonic's 4 MB default.
+/// DSL v4 sources from large OpenAPI documents can exceed tonic's 4 MB default.
 pub const SOURCE_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
 
 /// Maximum gRPC message size for `SearchService` *responses*, in bytes.

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -1,6 +1,6 @@
 //! Heuristic inference of lookup key joinability for REST surfaces.
 //!
-//! During `OpenAPI` import Coral guesses which REST query parameters are
+//! During OpenAPI import Coral guesses which REST query parameters are
 //! complete exact lookups and records the positive allowlist in operation
 //! metadata. Other parameters stay pushdown filters; they just cannot anchor dependent joins
 //! (`FilterSpec.lookup_key` stays false). MCP pagination is handled separately

--- a/crates/coral-spec/src/v4/response_cursors.rs
+++ b/crates/coral-spec/src/v4/response_cursors.rs
@@ -2,7 +2,7 @@
 //! either a continuation token or a whole next-page URL.
 //!
 //! Three callers ask the same question of a response schema: which property
-//! carries the next page? They ask it of different vocabularies — `OpenAPI`
+//! carries the next page? They ask it of different vocabularies — OpenAPI
 //! accepts a wider set of cursor names than MCP, and body next-URL detection
 //! has its own narrower lexicon — so the lexicon is a parameter, but the walk
 //! itself is shared.

--- a/crates/coral-spec/src/v4/wrapped_lists.rs
+++ b/crates/coral-spec/src/v4/wrapped_lists.rs
@@ -1,4 +1,4 @@
-//! Heuristic inference of wrapped-list row paths for `OpenAPI` and MCP surfaces.
+//! Heuristic inference of wrapped-list row paths for OpenAPI and MCP surfaces.
 //!
 //! A "wrapped list" response wraps rows inside an envelope: the declared type is
 //! an object, but the rows live at a nested path such as `items` or

--- a/sources/v4/microsoft_graph/README.md
+++ b/sources/v4/microsoft_graph/README.md
@@ -8,7 +8,7 @@ tables and table functions.
 
 ## Status
 
-This is a preview DSL v4 source. The full Microsoft Graph `OpenAPI`
+This is a preview DSL v4 source. The full Microsoft Graph OpenAPI
 descriptor is about 38 MB and produces a large generated catalog, so `source
 add` can take longer than curated sources.
 

--- a/xtask/src/detect.rs
+++ b/xtask/src/detect.rs
@@ -1,7 +1,7 @@
 //! Heuristic scanner for truncated column/table/source descriptions.
 //!
 //! A manifest's descriptions feed documentation, MCP surfaces, and the
-//! `coral.columns` catalog. When an upstream generation step (e.g. `OpenAPI`
+//! `coral.columns` catalog. When an upstream generation step (e.g. OpenAPI
 //! → YAML) applies a character cap, sentences get cut mid-phrase. This module
 //! walks each `sources/**/manifest.y{a,}ml` and flags descriptions that exhibit
 //! deterministic truncation signals.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@
 //!     artifacts.
 //!   - `release-desktop-macos-package` packages, signs, notarizes, and verifies
 //!     the prepared macOS desktop app.
-//!   - `openapi-hydrate` produces a self-contained JSON `OpenAPI` descriptor.
+//!   - `openapi-hydrate` produces a self-contained JSON OpenAPI descriptor.
 //!   - `v4-metadata-report` reports inferred row paths and pagination contracts
 //!     for the v4 source catalog, for diffing across inference changes.
 
@@ -74,7 +74,7 @@ enum Command {
     ReleaseMacosSignNotarize(release::MacosSignNotarizeArgs),
     /// Package, sign, notarize, and verify the prepared macOS desktop app.
     ReleaseDesktopMacosPackage(release::DesktopMacosPackageArgs),
-    /// Hydrate reachable external `OpenAPI` references into JSON.
+    /// Hydrate reachable external OpenAPI references into JSON.
     OpenapiHydrate(openapi::HydrateArgs),
     /// Report inferred row paths and pagination contracts for v4 sources.
     V4MetadataReport(metadata_report::Args),

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -41,7 +41,7 @@ const MAX_DESCRIPTOR_BYTES: u64 = 64 * 1024 * 1024;
 /// Timeout for descriptor fetches.
 const FETCH_TIMEOUT: Duration = Duration::from_mins(2);
 
-/// Every `PaginationSpec` field the `OpenAPI` importer can populate, plus the
+/// Every `PaginationSpec` field the OpenAPI importer can populate, plus the
 /// row path and the lookup-key allowlist.
 ///
 /// The narrower set this started with hid real inference changes: swapping the
@@ -159,7 +159,7 @@ fn escape_csv_field(field: &str) -> String {
     }
 }
 
-/// Import every v4 `OpenAPI` source under `--sources` and write the report.
+/// Import every v4 OpenAPI source under `--sources` and write the report.
 pub(crate) fn run(args: &Args) -> Result<bool> {
     let manifests = load_catalog_manifests(&args.sources)
         .with_context(|| format!("loading manifests from {}", args.sources.display()))?;

--- a/xtask/src/openapi/lib.rs
+++ b/xtask/src/openapi/lib.rs
@@ -1,4 +1,4 @@
-//! `OpenAPI` reference hydration for the `openapi-hydrate` xtask subcommand.
+//! OpenAPI reference hydration for the `openapi-hydrate` xtask subcommand.
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::fmt;
@@ -14,7 +14,7 @@ use serde_json::{Map, Number, Value};
 use thiserror::Error;
 use url::Url;
 
-/// Maximum number of bytes accepted for the root `OpenAPI` descriptor.
+/// Maximum number of bytes accepted for the root OpenAPI descriptor.
 pub(crate) const ROOT_DESCRIPTOR_MAX_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Maximum number of bytes accepted for a referenced external descriptor.
@@ -29,7 +29,7 @@ pub(crate) const USER_AGENT: &str = "openapi";
 /// Maximum number of external documents fetched at the same time.
 pub(crate) const MAX_CONCURRENT_FETCHES: usize = 32;
 
-/// Errors returned by `OpenAPI` hydration.
+/// Errors returned by OpenAPI hydration.
 #[derive(Debug, Error)]
 pub(crate) enum OpenApiToolsError {
     /// The input location or base URI is invalid.
@@ -161,7 +161,7 @@ struct RefTarget {
     fragment: String,
 }
 
-/// Hydrates an `OpenAPI` document from bytes and a base URI.
+/// Hydrates an OpenAPI document from bytes and a base URI.
 ///
 /// # Errors
 ///
@@ -180,7 +180,7 @@ pub(crate) fn hydrate_openapi(input: &[u8], base_uri: &str) -> Result<Value, Ope
     resolver.hydrate()
 }
 
-/// Hydrates an `OpenAPI` document from an HTTPS URL or local file path.
+/// Hydrates an OpenAPI document from an HTTPS URL or local file path.
 ///
 /// # Errors
 ///

--- a/xtask/src/openapi/mod.rs
+++ b/xtask/src/openapi/mod.rs
@@ -11,7 +11,7 @@ use lib::hydrate_openapi_from_location;
 /// Arguments for the `openapi-hydrate` subcommand.
 #[derive(Debug, clap::Args)]
 pub(crate) struct HydrateArgs {
-    /// HTTPS URL or local file path to the `OpenAPI` descriptor.
+    /// HTTPS URL or local file path to the OpenAPI descriptor.
     location: String,
 }
 

--- a/xtask/src/openapi/tests.rs
+++ b/xtask/src/openapi/tests.rs
@@ -1,4 +1,4 @@
-//! Integration coverage for `OpenAPI` hydration.
+//! Integration coverage for OpenAPI hydration.
 
 #![allow(
     clippy::indexing_slicing,


### PR DESCRIPTION
Clippy's [`doc_markdown` rule](https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#doc_markdown) thinks OpenAPI is an identifier and so mandates that it appears in backticks inside docstrings. That's cray cray. `doc-valid-idents` is our friend.