### PR TITLE
fix(reef): improve relative times labels

### DIFF
--- a/apps/reef/app/utils/format-time.test.ts
+++ b/apps/reef/app/utils/format-time.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDuration, nanosToMs, timeAgo } from './format-time'
+
+const SECOND = 1_000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+const NOW = Date.UTC(2026, 7, 13, 12, 0, 0)
+
+function ago(elapsedMs: number): string {
+  return timeAgo(NOW - elapsedMs, NOW)
+}
+
+describe('timeAgo', () => {
+  it.each([
+    [0, 'Just now'],
+    [4.9 * SECOND, 'Just now'],
+    [5 * SECOND, '5s ago'],
+    [42 * SECOND, '42s ago'],
+    [59 * SECOND, '59s ago'],
+    [MINUTE, '1m ago'],
+    [7 * MINUTE, '7m ago'],
+    [59 * MINUTE, '59m ago'],
+    [HOUR, '1h ago'],
+    [3 * HOUR, '3h ago'],
+    [23 * HOUR, '23h ago'],
+    [DAY, '1d ago'],
+    [6 * DAY, '6d ago'],
+    [7 * DAY, '1w ago'],
+    [21 * DAY, '3w ago'],
+    [29 * DAY, '4w ago'],
+    [30 * DAY, '1mo ago'],
+    [150 * DAY, '5mo ago'],
+    [364 * DAY, '11mo ago'],
+    [365 * DAY, '1y ago'],
+    [729 * DAY, '1y ago'],
+    [730 * DAY, '2y ago'],
+  ])('renders an age of %dms as %j', (elapsed, expected) => {
+    expect(ago(elapsed)).toBe(expected)
+  })
+
+  it('never renders a number of weeks that belongs in months', () => {
+    for (let days = 7; days < 30; days += 1) {
+      expect(ago(days * DAY)).toMatch(/^[1-4]w ago$/)
+    }
+  })
+
+  it('never renders twelve months', () => {
+    for (let days = 30; days < 365; days += 1) {
+      expect(ago(days * DAY)).not.toBe('12mo ago')
+    }
+  })
+
+  it('treats a future timestamp as just now', () => {
+    expect(timeAgo(NOW + HOUR, NOW)).toBe('Just now')
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY])('treats %j as just now', (timestamp) => {
+    expect(timeAgo(timestamp, NOW)).toBe('Just now')
+  })
+})
+
+describe('formatDuration', () => {
+  it.each([
+    [-1, '—'],
+    [Number.NaN, '—'],
+    [Number.POSITIVE_INFINITY, '—'],
+    [0, '0ms'],
+    [0.4, '<1ms'],
+    [0.999, '<1ms'],
+    [1, '1ms'],
+    [842, '842ms'],
+    [999, '999ms'],
+    // Rounds past the millisecond tier, so it must render as seconds rather than "1000ms".
+    [999.6, '1.00s'],
+    [1_000, '1.00s'],
+    [3_400, '3.40s'],
+    [59_499, '59.50s'],
+    // Rounds past the seconds tier, so it must render as minutes rather than "60.00s".
+    [59_999, '1m'],
+    [60_000, '1m'],
+    [303_000, '5m 3s'],
+    [303_400, '5m 3s'],
+    // Rounds past the minutes tier, so it must render as hours rather than "60m".
+    [3_599_999, '1h'],
+    [3_600_000, '1h'],
+    [8_040_000, '2h 14m'],
+    [86_400_000, '24h'],
+  ])('renders %dms as %j', (ms, expected) => {
+    expect(formatDuration(ms)).toBe(expected)
+  })
+
+  it('never renders a sixty-second or sixty-minute component', () => {
+    // Anchored on a component boundary so "2.60s" is not mistaken for a 60 second value.
+    const sixty = /(?:^|\s)60(?:\.\d+)?[sm]\b/
+    for (let ms = 0; ms < 4 * HOUR; ms += 137) {
+      expect(formatDuration(ms)).not.toMatch(sixty)
+    }
+  })
+})
+
+describe('nanosToMs', () => {
+  it('keeps sub-millisecond spans instead of truncating them to zero', () => {
+    expect(nanosToMs('500000')).toBe(0.5)
+    expect(formatDuration(nanosToMs('500000'))).toBe('<1ms')
+  })
+
+  it('converts a realistic span duration', () => {
+    expect(nanosToMs('1234567890')).toBeCloseTo(1234.56789, 5)
+  })
+
+  it('converts epoch nanos to a usable millisecond timestamp', () => {
+    expect(nanosToMs('1755086400000000000')).toBe(1_755_086_400_000)
+  })
+
+  it('accepts bigint and empty input', () => {
+    expect(nanosToMs(2_000_000n)).toBe(2)
+    expect(nanosToMs('')).toBe(0)
+  })
+})

--- a/apps/reef/app/utils/format-time.ts
+++ b/apps/reef/app/utils/format-time.ts
@@ -1,0 +1,96 @@
+const SECOND_MS = 1_000
+const MINUTE_MS = 60 * SECOND_MS
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+const WEEK_MS = 7 * DAY_MS
+
+const DAYS_PER_WEEK = 7
+const DAYS_PER_MONTH = 30
+const DAYS_PER_YEAR = 365
+const MONTHS_PER_YEAR = 12
+
+/** Anything more recent than this reads as "Just now" rather than a second count. */
+const JUST_NOW_MS = 5 * SECOND_MS
+
+export function nanosToMs(nanos: string | bigint | number): number {
+  const value = typeof nanos === 'bigint' ? nanos : BigInt(nanos || 0)
+  return Number(value) / 1_000_000
+}
+
+/**
+ * Formats a millisecond span, picking the coarsest unit that keeps the number small.
+ *
+ * @example
+ * formatDuration(0) // "0ms"
+ * formatDuration(0.4) // "<1ms"
+ * formatDuration(842) // "842ms"
+ * formatDuration(3_400) // "3.40s"
+ * formatDuration(303_000) // "5m 3s"
+ * formatDuration(8_040_000) // "2h 14m"
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—'
+  if (ms === 0) return '0ms'
+  if (ms < 1) return '<1ms'
+
+  // Round to display precision before choosing a tier, so a value that rounds up past a
+  // boundary lands in the next tier instead of rendering "1000ms" or "5m 60s".
+  const milliseconds = Math.round(ms)
+  if (milliseconds < SECOND_MS) return `${milliseconds}ms`
+
+  const seconds = Math.round(ms / 10) / 100
+  if (seconds < 60) return `${seconds.toFixed(2)}s`
+
+  const wholeSeconds = Math.round(ms / SECOND_MS)
+  if (wholeSeconds < 3_600) {
+    const minutes = Math.floor(wholeSeconds / 60)
+    const remainder = wholeSeconds % 60
+    return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`
+  }
+
+  const wholeMinutes = Math.round(ms / MINUTE_MS)
+  const hours = Math.floor(wholeMinutes / 60)
+  const remainder = wholeMinutes % 60
+  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`
+}
+
+export function formatDurationFromNanos(nanos: string): string {
+  return formatDuration(nanosToMs(nanos))
+}
+
+export function formatTimestamp(timestamp: number): string {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'Unknown time'
+  return new Date(timestamp).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  })
+}
+
+/**
+ * Formats how long ago `timestamp` was, rolling up through weeks, months and years so the
+ * number stays small. Months and years are approximate rather than calendar-correct.
+ *
+ * A timestamp in the future reads as "Just now", so a client clock running behind the
+ * server never renders a negative age.
+ *
+ * @example
+ * timeAgo(now - 42_000, now) // "42s ago"
+ * timeAgo(now - 6 * DAY_MS, now) // "6d ago"
+ * timeAgo(now - 21 * DAY_MS, now) // "3w ago"
+ */
+export function timeAgo(timestamp: number, referenceTimeMs: number): string {
+  const elapsed = referenceTimeMs - timestamp
+  if (!Number.isFinite(elapsed) || elapsed < JUST_NOW_MS) return 'Just now'
+  if (elapsed < MINUTE_MS) return `${Math.floor(elapsed / SECOND_MS)}s ago`
+  if (elapsed < HOUR_MS) return `${Math.floor(elapsed / MINUTE_MS)}m ago`
+  if (elapsed < DAY_MS) return `${Math.floor(elapsed / HOUR_MS)}h ago`
+  if (elapsed < WEEK_MS) return `${Math.floor(elapsed / DAY_MS)}d ago`
+
+  const days = Math.floor(elapsed / DAY_MS)
+  if (days < DAYS_PER_MONTH) return `${Math.floor(days / DAYS_PER_WEEK)}w ago`
+  if (days < DAYS_PER_YEAR) {
+    // Clamp so the last few days of the year cannot render as "12mo ago".
+    return `${Math.min(MONTHS_PER_YEAR - 1, Math.floor(days / DAYS_PER_MONTH))}mo ago`
+  }
+  return `${Math.floor(days / DAYS_PER_YEAR)}y ago`
+}

--- a/apps/reef/app/utils/use-now.ts
+++ b/apps/reef/app/utils/use-now.ts
@@ -1,0 +1,58 @@
+import * as React from 'react'
+
+export function useNow({
+  refreshAfterMs,
+  refreshOnTheHour,
+  seedMs,
+}: {
+  refreshAfterMs?: number
+  refreshOnTheHour?: boolean
+  /** The timestamp the server rendered with. Seeding from it keeps hydration consistent. */
+  seedMs: number
+}) {
+  const [tickedAtMs, setTickedAtMs] = React.useState(0)
+
+  const refresh = React.useCallback(() => {
+    setTickedAtMs(Date.now())
+  }, [])
+
+  // The later of the two, so a fresh seed is picked up even when nothing is ticking, and
+  // a client clock behind the server cannot run the result backwards.
+  const now = new Date(Math.max(seedMs, tickedAtMs))
+
+  React.useEffect(() => {
+    if (!refreshAfterMs) return
+
+    const interval = setInterval(refresh, refreshAfterMs)
+
+    return () => clearInterval(interval)
+  }, [refresh, refreshAfterMs])
+
+  React.useEffect(() => {
+    if (!refreshOnTheHour) return
+
+    const getMsUntilNextHour = () => {
+      const current = new Date()
+      const next = new Date(current)
+      next.setHours(next.getHours() + 1)
+      next.setMinutes(0)
+      next.setSeconds(0)
+
+      return Number(next) - Number(current)
+    }
+
+    // using individual timeouts instead of an interval allows us to calculate
+    // the time until the next hour on every iteration and avoid drift over time
+    let timeout: ReturnType<typeof setTimeout>
+    const interval = () => {
+      refresh()
+      timeout = setTimeout(interval, getMsUntilNextHour())
+    }
+
+    timeout = setTimeout(interval, getMsUntilNextHour())
+
+    return () => clearTimeout(timeout)
+  }, [refresh, refreshOnTheHour])
+
+  return { now, refresh }
+}

--- a/apps/reef/app/utils/use-now.ts
+++ b/apps/reef/app/utils/use-now.ts
@@ -13,7 +13,7 @@ export function useNow({
   const [tickedAtMs, setTickedAtMs] = React.useState(0)
 
   const refresh = React.useCallback(() => {
-    setTickedAtMs(Date.now())
+    setTickedAtMs((previous) => Math.max(previous, Date.now()))
   }, [])
 
   // The later of the two, so a fresh seed is picked up even when nothing is ticking, and
@@ -37,6 +37,7 @@ export function useNow({
       next.setHours(next.getHours() + 1)
       next.setMinutes(0)
       next.setSeconds(0)
+      next.setMilliseconds(0)
 
       return Number(next) - Number(current)
     }

--- a/apps/reef/app/views/traces/http-span-detail.tsx
+++ b/apps/reef/app/views/traces/http-span-detail.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
 import classNames from 'classnames'
 
+import { formatDuration, formatDurationFromNanos } from '@/utils/format-time'
 import { Button, ScrollArea } from '@/wax/components'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import { Typography } from '@/wax/components/typography'
 
 import * as s from './traces.css'
 import {
-  formatDuration,
-  formatDurationFromNanos,
   parseJsonObject,
   spanRequestEndpoint,
   spanRequestLine,

--- a/apps/reef/app/views/traces/trace-detail.tsx
+++ b/apps/reef/app/views/traces/trace-detail.tsx
@@ -9,6 +9,7 @@ import { Typography } from '@/wax/components/typography'
 import { EmptyPage } from '@/components/empty-page'
 import { QueryDetailSummary } from '@/components/query-detail'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import { formatDuration, formatDurationFromNanos, nanosToMs } from '@/utils/format-time'
 
 import * as s from './traces.css'
 import { HttpSpanDetail } from './http-span-detail'
@@ -17,11 +18,8 @@ import type { TracesOutletContext } from './traces-index'
 import { routePath } from '@/routing/routemap'
 import { useTimelineTree, type TimelineRow } from './use-timeline-tree'
 import {
-  formatDuration,
-  formatDurationFromNanos,
   formatRows,
   isHttpSpan,
-  nanosToMs,
   operationCodeLanguage,
   operationDetailLabel,
   operationDetailText,

--- a/apps/reef/app/views/traces/trace-list.tsx
+++ b/apps/reef/app/views/traces/trace-list.tsx
@@ -3,31 +3,33 @@ import { NavLink, useLocation } from 'react-router'
 
 import { HighlightedCode } from '@/components/code-block'
 import { routePath } from '@/routing/routemap'
+import { formatDurationFromNanos, formatTimestamp, timeAgo } from '@/utils/format-time'
+import { useNow } from '@/utils/use-now'
 import { Tooltip } from '@/wax/components/tooltip'
 import { Typography } from '@/wax/components/typography'
 
 import * as s from './traces.css'
 import {
   durationClass,
-  formatDurationFromNanos,
-  formatTimestamp,
   operationCodeLanguage,
   operationPreview,
   startMs,
   statusTone,
-  timeAgo,
   type TraceSummaryData,
 } from './trace-utils'
 
+/** How recent the newest trace must be for a label to count seconds. */
+const SECONDS_LABEL_WINDOW_MS = 60_000
+
 function TraceRow({
   active,
-  referenceTimeMs,
+  nowMs,
   search,
   trace,
   workspaceId,
 }: {
   active: boolean
-  referenceTimeMs: number
+  nowMs: number
   search: string
   trace: TraceSummaryData
   workspaceId: string
@@ -46,7 +48,7 @@ function TraceRow({
       <div className={classNames(s.cell, s.cellTimestamp)}>
         <Tooltip content={formatTimestamp(startMs(trace))} side="right">
           <Typography.Body as="span" variant="tertiary">
-            {timeAgo(startMs(trace), referenceTimeMs)}
+            {timeAgo(startMs(trace), nowMs)}
           </Typography.Body>
         </Tooltip>
       </div>
@@ -82,13 +84,22 @@ export function TraceList({
   workspaceId: string
 }) {
   const location = useLocation()
+  // The list revalidates every 30s, which refreshes referenceTimeMs and so keeps
+  // minute-scale labels current on its own. Tick only for second-scale labels.
+  const newestStartMs = Math.max(0, ...traces.map(startMs))
+  const shouldCountSeconds = referenceTimeMs - newestStartMs < SECONDS_LABEL_WINDOW_MS
+  const { now } = useNow({
+    refreshAfterMs: shouldCountSeconds ? 1_000 : undefined,
+    seedMs: referenceTimeMs,
+  })
+
   return (
     <div className={s.traceList}>
       {traces.map((trace) => (
         <TraceRow
           active={trace.traceId === activeTraceId}
           key={trace.traceId}
-          referenceTimeMs={referenceTimeMs}
+          nowMs={now.getTime()}
           search={location.search}
           trace={trace}
           workspaceId={workspaceId}

--- a/apps/reef/app/views/traces/trace-utils.ts
+++ b/apps/reef/app/views/traces/trace-utils.ts
@@ -4,6 +4,7 @@ import {
   type TraceSpan,
   type TraceSummary,
 } from '@/generated/coral/v1/traces_pb'
+import { nanosToMs } from '@/utils/format-time'
 
 export type JsonObject = Record<string, unknown>
 export type TraceSpanData = Omit<TraceSpan, '$typeName' | '$unknown'>
@@ -13,39 +14,8 @@ export interface TraceDetailData {
   summary?: TraceSummaryData
 }
 
-export function nanosToMs(nanos: string | bigint | number): number {
-  const value = typeof nanos === 'bigint' ? nanos : BigInt(nanos || 0)
-  return Number(value / 1_000_000n)
-}
-
 export function startMs(trace: TraceSummaryData): number {
   return nanosToMs(trace.startTimeUnixNanos)
-}
-
-export function formatDuration(ms: number): string {
-  if (!Number.isFinite(ms) || ms < 0) return '—'
-  if (ms < 1000) return `${Math.max(1, Math.round(ms))}ms`
-  return `${(ms / 1000).toFixed(2)}s`
-}
-
-export function formatDurationFromNanos(nanos: string): string {
-  return formatDuration(nanosToMs(nanos))
-}
-
-export function formatTimestamp(timestamp: number): string {
-  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'Unknown time'
-  return new Date(timestamp).toLocaleString(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'medium',
-  })
-}
-
-export function timeAgo(timestamp: number, referenceTimeMs: number): string {
-  const diff = Math.floor((referenceTimeMs - timestamp) / 1000)
-  if (diff < 5) return 'Just now'
-  if (diff < 60) return `${diff}s ago`
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  return `${Math.floor(diff / 3600)}h ago`
 }
 
 export function formatRows(trace: TraceSummaryData): string {
@@ -71,7 +41,7 @@ export function durationClass(nanos: string, warningClass: string, defaultClass:
 export function formatTraceError(message: string): string {
   const normalized = message.toLowerCase()
   if (normalized.includes('unimplemented') || normalized.includes('http 404')) {
-    return 'Trace storage is not enabled for this Coral server. Enable [local_traces].enabled = true, restart the Coral server, then run an operation.'
+    return 'This Coral server does not serve trace history. Trace history is on by default, so check that config.toml does not set [trace_history].enabled = false, then restart the Coral server.'
   }
   return message
 }


### PR DESCRIPTION
## Summary

Just a round of polish:
- Extracting utils, and adding a `useNow` effect
- Improving the Traces view:
  - Show better relative times (see test plan)
  - Refresh the relative times

## Test plan

Before
<img width="238" height="779" alt="image" src="https://github.com/user-attachments/assets/f99f6e24-9a44-4cdb-a3e3-3d2b86d84454" />

After (now we also update this in real time)
<img width="145" height="781" alt="image" src="https://github.com/user-attachments/assets/1f1e21c5-d00b-421d-afd4-5c1eb7267d33" />
