### PR TITLE
refactor(engine): narrow installed functions to Coral SQL

### DIFF
--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -17,6 +17,8 @@ root.
   `coral-spec`
 - assembly of query-engine runtime packages from app-owned installed state,
   including DSL v4 materialized artifacts and generated runtime components
+- selection of authored function implementations and assembly of backend-ready
+  Coral SQL function definitions before calling `coral-engine`
 - query-time selection of installed sources before calling `coral-engine`
 - workspace-scoped catalog discovery behavior over query-visible tables:
   matching, pagination, exact lookup, column filtering, and missing-table

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -5,13 +5,13 @@ use std::future::Future;
 use std::sync::Arc;
 
 use coral_engine::{PreparedQueryRuntime, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
-use coral_spec::{FunctionSpec, parse_function_sql};
+use coral_spec::{FunctionSpec, parse_function_artifact as parse_authored_function_artifact};
 
 use crate::bootstrap::AppError;
 use crate::functions::model::{FunctionName, FunctionWriteSurface, InstalledFunction};
 use crate::functions::runtime::{
     infer_runtime_function, infer_runtime_functions, infer_runtime_functions_in_prepared_runtime,
-    runtime_function_without_signature,
+    lower_runtime_function_without_signature,
 };
 use crate::functions::store::{FsFunctionArtifactStore, FunctionArtifactStore};
 use crate::functions::validation::{
@@ -96,14 +96,14 @@ impl FunctionManager {
     pub(crate) fn install_validated_user_function(
         &self,
         workspace_name: &WorkspaceName,
-        raw_sql: &str,
+        artifact: &str,
         runtime_function: &UdfRuntimeDefinition,
     ) -> Result<InstalledFunction, AppError> {
-        let function_name = validated_function_name(raw_sql, runtime_function)?;
+        let function_name = validated_function_name(artifact, runtime_function)?;
         self.install_user_function_artifact(
             workspace_name,
             &function_name,
-            raw_sql,
+            artifact,
             FunctionInstallMode::ReplaceExisting,
             FunctionWriteSurface::Unknown,
         )?;
@@ -116,23 +116,23 @@ impl FunctionManager {
     pub(crate) async fn install_validated_user_function_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
-        raw_sql: &str,
+        artifact: &str,
         runtime_function: &UdfRuntimeDefinition,
         revision: WorkspaceLifecycleRevision,
         mode: FunctionInstallMode,
         write_surface: FunctionWriteSurface,
     ) -> Result<ValidatedFunctionInstall, AppError> {
-        let function_name = validated_function_name(raw_sql, runtime_function)?;
+        let function_name = validated_function_name(artifact, runtime_function)?;
         let manager = self.clone();
         let operation_workspace_name = workspace_name.clone();
-        let raw_sql = raw_sql.to_string();
+        let artifact = artifact.to_string();
         let Some(replaced) = self
             .lifecycle_lock
             .run_blocking_workspace_write_if_unchanged(revision, workspace_name, move || {
                 manager.install_user_function_artifact_with_lifecycle_lock(
                     &operation_workspace_name,
                     &function_name,
-                    &raw_sql,
+                    &artifact,
                     mode,
                     write_surface,
                 )
@@ -149,7 +149,7 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
-        raw_sql: &str,
+        artifact: &str,
         mode: FunctionInstallMode,
         write_surface: FunctionWriteSurface,
     ) -> Result<bool, AppError> {
@@ -157,7 +157,7 @@ impl FunctionManager {
         self.install_user_function_artifact_with_lifecycle_lock(
             workspace_name,
             function_name,
-            raw_sql,
+            artifact,
             mode,
             write_surface,
         )
@@ -167,7 +167,7 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
-        raw_sql: &str,
+        artifact: &str,
         mode: FunctionInstallMode,
         write_surface: FunctionWriteSurface,
     ) -> Result<bool, AppError> {
@@ -191,7 +191,7 @@ impl FunctionManager {
 
         let previous_artifact =
             self.artifacts
-                .write_user_function_artifact(workspace_name, function_name, raw_sql)?;
+                .write_user_function_artifact(workspace_name, function_name, artifact)?;
         let replaced = match self
             .config_store
             .upsert_function_unlocked(workspace_name, installed)
@@ -214,14 +214,14 @@ impl FunctionManager {
         Ok(replaced)
     }
 
-    pub(crate) async fn validate_user_function_sql(
+    pub(crate) async fn validate_user_function_artifact(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
         mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
-        raw_sql: &str,
+        artifact: &str,
     ) -> Result<UdfRuntimeDefinition, AppError> {
-        let function = parse_function_sql(raw_sql).map_err(|error| {
+        let function = parse_authored_function_artifact(artifact).map_err(|error| {
             AppError::InvalidInput(format!("function validation failed: {error}"))
         })?;
         let function_name = FunctionName::parse(function.name())?;
@@ -232,7 +232,7 @@ impl FunctionManager {
             &mut sql_publish_targets,
         )?;
         let runtime_function =
-            infer_runtime_function(selected_sources, runtime_config()?, &function).await?;
+            infer_runtime_function(selected_sources, &mut runtime_config, &function).await?;
         record_sql_publish_target(&runtime_function, &mut sql_publish_targets)?;
         Ok(runtime_function)
     }
@@ -304,7 +304,17 @@ impl FunctionManager {
                     continue;
                 }
             };
-            let runtime_function = runtime_function_without_signature(&spec);
+            let runtime_function = match lower_runtime_function_without_signature(&spec) {
+                Ok(runtime_function) => runtime_function,
+                Err(error) => {
+                    candidates.push(FunctionCandidate::Listing(invalid_listing(
+                        artifact.name,
+                        artifact.write_surface,
+                        error.to_string(),
+                    )));
+                    continue;
+                }
+            };
             let unchecked_source_schemas =
                 unchecked_source_publish_schemas(&runtime_function, &checked_source_schemas);
             if !unchecked_source_schemas.is_empty() {
@@ -460,7 +470,17 @@ impl FunctionManager {
                     continue;
                 }
             };
-            let runtime_function = runtime_function_without_signature(&spec);
+            let runtime_function = match lower_runtime_function_without_signature(&spec) {
+                Ok(runtime_function) => runtime_function,
+                Err(error) => {
+                    tracing::warn!(
+                        function = %artifact.name,
+                        detail = %error,
+                        "ignoring unsupported installed function during publish collision validation"
+                    );
+                    continue;
+                }
+            };
             record_sql_publish_target(&runtime_function, publish_targets)?;
         }
         Ok(())
@@ -468,10 +488,10 @@ impl FunctionManager {
 }
 
 fn validated_function_name(
-    raw_sql: &str,
+    artifact: &str,
     runtime_function: &UdfRuntimeDefinition,
 ) -> Result<FunctionName, AppError> {
-    let function = parse_function_sql(raw_sql)
+    let function = parse_authored_function_artifact(artifact)
         .map_err(|error| AppError::InvalidInput(format!("function validation failed: {error}")))?;
     let function_name = FunctionName::parse(function.name())?;
     if function_name.as_str() != runtime_function.name {
@@ -484,12 +504,12 @@ fn validated_function_name(
 }
 
 fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, String> {
-    let raw_sql = match &artifact.content {
-        FunctionArtifactContent::Sql(raw_sql) => raw_sql,
+    let content = match &artifact.content {
+        FunctionArtifactContent::Sql(content) => content,
         FunctionArtifactContent::Unavailable(error) => return Err(error.clone()),
     };
-    let spec =
-        parse_function_sql(raw_sql).map_err(|error| format!("function is invalid: {error}"))?;
+    let spec = parse_authored_function_artifact(content)
+        .map_err(|error| format!("function is invalid: {error}"))?;
     let declared_name = FunctionName::parse(spec.name()).map_err(|error| error.to_string())?;
     if declared_name != artifact.name {
         return Err(format!(
@@ -580,9 +600,32 @@ select 1 as id
         )
     }
 
-    fn validated_function(raw_sql: &str) -> UdfRuntimeDefinition {
-        let spec = parse_function_sql(raw_sql).expect("function spec");
-        runtime_function_without_signature(&spec)
+    fn typescript_function(name: &str) -> String {
+        format!(
+            r"/*
+name: {name}
+schema: functions
+description: Test TypeScript function
+language: typescript
+signature:
+  arguments:
+    - name: owner
+      data_type: Utf8
+  result_columns:
+    - name: title
+      data_type: Utf8
+*/
+
+export async function run(owner: string): Promise<string> {{
+  return `queue for ${{owner}}`;
+}}
+"
+        )
+    }
+
+    fn validated_function(artifact: &str) -> UdfRuntimeDefinition {
+        let spec = parse_authored_function_artifact(artifact).expect("function spec");
+        lower_runtime_function_without_signature(&spec).expect("supported function")
     }
 
     #[derive(Clone)]
@@ -698,6 +741,94 @@ select 1 as id
         assert_eq!(runtime_builds.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 
+    #[test]
+    fn sql_lowering_uses_generic_group_as_sql_schema() {
+        let artifact = function_sql_with_publish("review_queue", "github.review_queue");
+        let spec = parse_authored_function_artifact(&artifact).expect("function spec");
+
+        let definition =
+            lower_runtime_function_without_signature(&spec).expect("SQL lowering should succeed");
+
+        assert_eq!(spec.group(), "github");
+        assert_eq!(definition.publish.table_function.schema, "github");
+        assert_eq!(definition.publish.table_function.name, "review_queue");
+    }
+
+    #[tokio::test]
+    async fn unsupported_function_does_not_enter_inference_or_persistence() {
+        let (_temp, layout, config_store, manager) = fixture();
+        let workspace = workspace();
+        let artifact = typescript_function("review_queue");
+        let runtime_builds = std::sync::atomic::AtomicUsize::new(0);
+
+        let error = manager
+            .validate_user_function_artifact(
+                &workspace,
+                &[],
+                || {
+                    runtime_builds.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(QueryRuntimeConfig::default())
+                },
+                &artifact,
+            )
+            .await
+            .expect_err("TypeScript should be rejected before inference");
+
+        assert!(
+            error
+                .to_string()
+                .contains("no TypeScript executor is available")
+        );
+        assert_eq!(runtime_builds.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(
+            config_store
+                .list_workspace_functions(&workspace)
+                .expect("list inventory")
+                .is_empty()
+        );
+        let function_name = FunctionName::parse("review_queue").expect("function name");
+        assert!(!layout.function_dir(&workspace, &function_name).exists());
+    }
+
+    #[tokio::test]
+    async fn manually_present_unsupported_function_is_invalid_without_inference() {
+        let (_temp, _layout, config_store, manager) = fixture();
+        let workspace = workspace();
+        let function_name = FunctionName::parse("review_queue").expect("function name");
+        manager
+            .install_user_function_artifact(
+                &workspace,
+                &function_name,
+                &typescript_function("review_queue"),
+                FunctionInstallMode::ReplaceExisting,
+                FunctionWriteSurface::Unknown,
+            )
+            .expect("manually install artifact");
+        let runtime_builds = std::sync::atomic::AtomicUsize::new(0);
+
+        let listed = manager
+            .list_functions(&workspace, &[], || {
+                runtime_builds.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(QueryRuntimeConfig::default())
+            })
+            .await
+            .expect("list functions");
+
+        assert_eq!(runtime_builds.load(std::sync::atomic::Ordering::SeqCst), 0);
+        let listing = listed.first().expect("installed function remains visible");
+        let FunctionRuntimeStatus::Invalid(error) = &listing.runtime else {
+            panic!("unsupported function should be invalid");
+        };
+        assert!(error.contains("no TypeScript executor is available"));
+        assert_eq!(
+            config_store
+                .list_workspace_functions(&workspace)
+                .expect("list inventory")
+                .len(),
+            1
+        );
+    }
+
     #[tokio::test]
     async fn list_functions_keeps_runtime_invalid_artifacts_visible() {
         let (_temp, layout, _config_store, manager) = fixture();
@@ -765,7 +896,7 @@ select 1 as id
             .expect("remove existing artifact");
 
         let validated = manager
-            .validate_user_function_sql(
+            .validate_user_function_artifact(
                 &workspace,
                 &[],
                 || Ok(QueryRuntimeConfig::default()),

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeSet;
 use std::future::Future;
 use std::sync::Arc;
 
-use coral_engine::{PreparedQueryRuntime, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
+use coral_engine::{
+    CoralSqlFunctionDefinition, PreparedQueryRuntime, QueryRuntimeConfig, QuerySource,
+};
 use coral_spec::{FunctionSpec, parse_function_artifact as parse_authored_function_artifact};
 
 use crate::bootstrap::AppError;
@@ -50,7 +52,7 @@ pub(crate) struct FunctionListing {
 }
 
 pub(crate) enum FunctionRuntimeStatus {
-    Ready(Box<UdfRuntimeDefinition>),
+    Ready(Box<CoralSqlFunctionDefinition>),
     Invalid(String),
 }
 
@@ -70,7 +72,7 @@ enum FunctionCandidate {
     Pending {
         name: FunctionName,
         write_surface: FunctionWriteSurface,
-        definition: Box<UdfRuntimeDefinition>,
+        definition: Box<CoralSqlFunctionDefinition>,
     },
 }
 
@@ -97,7 +99,7 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         artifact: &str,
-        runtime_function: &UdfRuntimeDefinition,
+        runtime_function: &CoralSqlFunctionDefinition,
     ) -> Result<InstalledFunction, AppError> {
         let function_name = validated_function_name(artifact, runtime_function)?;
         self.install_user_function_artifact(
@@ -117,7 +119,7 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         artifact: &str,
-        runtime_function: &UdfRuntimeDefinition,
+        runtime_function: &CoralSqlFunctionDefinition,
         revision: WorkspaceLifecycleRevision,
         mode: FunctionInstallMode,
         write_surface: FunctionWriteSurface,
@@ -220,7 +222,7 @@ impl FunctionManager {
         selected_sources: &[QuerySource],
         mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
         artifact: &str,
-    ) -> Result<UdfRuntimeDefinition, AppError> {
+    ) -> Result<CoralSqlFunctionDefinition, AppError> {
         let function = parse_authored_function_artifact(artifact).map_err(|error| {
             AppError::InvalidInput(format!("function validation failed: {error}"))
         })?;
@@ -254,7 +256,7 @@ impl FunctionManager {
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
         runtime: &PreparedQueryRuntime,
-    ) -> Result<Vec<UdfRuntimeDefinition>, AppError> {
+    ) -> Result<Vec<CoralSqlFunctionDefinition>, AppError> {
         let listings = self
             .evaluate_function_listings(workspace_name, selected_sources, |pending| {
                 infer_runtime_functions_in_prepared_runtime(runtime, pending)
@@ -281,8 +283,9 @@ impl FunctionManager {
         infer: Infer,
     ) -> Result<Vec<FunctionListing>, AppError>
     where
-        Infer: FnOnce(Vec<UdfRuntimeDefinition>) -> InferFuture,
-        InferFuture: Future<Output = Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError>>,
+        Infer: FnOnce(Vec<CoralSqlFunctionDefinition>) -> InferFuture,
+        InferFuture:
+            Future<Output = Result<Vec<Result<CoralSqlFunctionDefinition, AppError>>, AppError>>,
     {
         let artifacts = self.load_function_artifacts(workspace_name)?;
         if artifacts.is_empty() {
@@ -489,7 +492,7 @@ impl FunctionManager {
 
 fn validated_function_name(
     artifact: &str,
-    runtime_function: &UdfRuntimeDefinition,
+    runtime_function: &CoralSqlFunctionDefinition,
 ) -> Result<FunctionName, AppError> {
     let function = parse_authored_function_artifact(artifact)
         .map_err(|error| AppError::InvalidInput(format!("function validation failed: {error}")))?;
@@ -523,7 +526,7 @@ fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, 
 fn ready_listing(
     name: FunctionName,
     write_surface: FunctionWriteSurface,
-    definition: UdfRuntimeDefinition,
+    definition: CoralSqlFunctionDefinition,
 ) -> FunctionListing {
     FunctionListing {
         name,
@@ -623,7 +626,7 @@ export async function run(owner: string): Promise<string> {{
         )
     }
 
-    fn validated_function(artifact: &str) -> UdfRuntimeDefinition {
+    fn validated_function(artifact: &str) -> CoralSqlFunctionDefinition {
         let spec = parse_authored_function_artifact(artifact).expect("function spec");
         lower_runtime_function_without_signature(&spec).expect("supported function")
     }
@@ -750,8 +753,8 @@ export async function run(owner: string): Promise<string> {{
             lower_runtime_function_without_signature(&spec).expect("SQL lowering should succeed");
 
         assert_eq!(spec.group(), "github");
-        assert_eq!(definition.publish.table_function.schema, "github");
-        assert_eq!(definition.publish.table_function.name, "review_queue");
+        assert_eq!(definition.publish.schema, "github");
+        assert_eq!(definition.publish.name, "review_queue");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -1,7 +1,7 @@
 use coral_engine::{
-    CoralQuery, PreparedQueryRuntime, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
-    UdfRuntimeTableFunctionPublish,
+    CoralQuery, CoralSqlFunctionDefinition, CoralSqlFunctionInferenceDefinition,
+    CoralSqlFunctionSignature, CoralSqlTableFunctionPublish, PreparedQueryRuntime,
+    QueryRuntimeConfig, QuerySource,
 };
 use coral_spec::{FunctionImplementationSpec, FunctionSpec};
 
@@ -11,7 +11,7 @@ pub(crate) async fn infer_runtime_function(
     selected_sources: &[QuerySource],
     mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     spec: &FunctionSpec,
-) -> Result<UdfRuntimeDefinition, AppError> {
+) -> Result<CoralSqlFunctionDefinition, AppError> {
     let runtime_function = lower_runtime_function_without_signature(spec)?;
     let mut results =
         infer_runtime_functions(selected_sources, runtime_config()?, vec![runtime_function])
@@ -24,8 +24,8 @@ pub(crate) async fn infer_runtime_function(
 pub(crate) async fn infer_runtime_functions(
     selected_sources: &[QuerySource],
     runtime_config: QueryRuntimeConfig,
-    runtime_functions: Vec<UdfRuntimeDefinition>,
-) -> Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError> {
+    runtime_functions: Vec<CoralSqlFunctionDefinition>,
+) -> Result<Vec<Result<CoralSqlFunctionDefinition, AppError>>, AppError> {
     let sql_definitions = runtime_functions
         .iter()
         .map(runtime_sql_definition)
@@ -45,8 +45,8 @@ pub(crate) async fn infer_runtime_functions(
 
 pub(crate) async fn infer_runtime_functions_in_prepared_runtime(
     runtime: &PreparedQueryRuntime,
-    runtime_functions: Vec<UdfRuntimeDefinition>,
-) -> Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError> {
+    runtime_functions: Vec<CoralSqlFunctionDefinition>,
+) -> Result<Vec<Result<CoralSqlFunctionDefinition, AppError>>, AppError> {
     let sql_definitions = runtime_functions
         .iter()
         .map(runtime_sql_definition)
@@ -60,9 +60,9 @@ pub(crate) async fn infer_runtime_functions_in_prepared_runtime(
 }
 
 fn apply_signatures(
-    runtime_functions: Vec<UdfRuntimeDefinition>,
-    signatures: Vec<Result<UdfRuntimeSignature, coral_engine::CoreError>>,
-) -> Vec<Result<UdfRuntimeDefinition, AppError>> {
+    runtime_functions: Vec<CoralSqlFunctionDefinition>,
+    signatures: Vec<Result<CoralSqlFunctionSignature, coral_engine::CoreError>>,
+) -> Vec<Result<CoralSqlFunctionDefinition, AppError>> {
     runtime_functions
         .into_iter()
         .zip(signatures)
@@ -82,15 +82,13 @@ fn runtime_validation_error(error: &coral_engine::CoreError) -> AppError {
 
 pub(crate) fn lower_runtime_function_without_signature(
     spec: &FunctionSpec,
-) -> Result<UdfRuntimeDefinition, AppError> {
+) -> Result<CoralSqlFunctionDefinition, AppError> {
     match spec.implementation() {
-        FunctionImplementationSpec::CoralSql(implementation) => Ok(UdfRuntimeDefinition {
+        FunctionImplementationSpec::CoralSql(implementation) => Ok(CoralSqlFunctionDefinition {
             name: spec.name().to_string(),
             description: spec.description().to_string(),
             arguments: Vec::new(),
-            implementation: UdfRuntimeImplementation::CoralSql {
-                query: implementation.query.clone(),
-            },
+            query: implementation.query.clone(),
             publish: runtime_publish(spec),
             result_columns: Vec::new(),
             source_names: Vec::new(),
@@ -99,21 +97,21 @@ pub(crate) fn lower_runtime_function_without_signature(
     }
 }
 
-fn runtime_sql_definition(function: &UdfRuntimeDefinition) -> UdfRuntimeSqlDefinition {
-    UdfRuntimeSqlDefinition {
+fn runtime_sql_definition(
+    function: &CoralSqlFunctionDefinition,
+) -> CoralSqlFunctionInferenceDefinition {
+    CoralSqlFunctionInferenceDefinition {
         name: function.name.clone(),
-        implementation: function.implementation.clone(),
+        query: function.query.clone(),
     }
 }
 
-fn runtime_publish(spec: &FunctionSpec) -> UdfRuntimePublish {
-    UdfRuntimePublish {
-        table_function: UdfRuntimeTableFunctionPublish {
-            schema: spec.group().to_string(),
-            name: spec.name().to_string(),
-            description: String::new(),
-            guide: spec.guide().to_string(),
-        },
+fn runtime_publish(spec: &FunctionSpec) -> CoralSqlTableFunctionPublish {
+    CoralSqlTableFunctionPublish {
+        schema: spec.group().to_string(),
+        name: spec.name().to_string(),
+        description: String::new(),
+        guide: spec.guide().to_string(),
     }
 }
 

--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -9,12 +9,13 @@ use crate::bootstrap::AppError;
 
 pub(crate) async fn infer_runtime_function(
     selected_sources: &[QuerySource],
-    runtime_config: QueryRuntimeConfig,
+    mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     spec: &FunctionSpec,
 ) -> Result<UdfRuntimeDefinition, AppError> {
-    let runtime_function = runtime_function_without_signature(spec);
+    let runtime_function = lower_runtime_function_without_signature(spec)?;
     let mut results =
-        infer_runtime_functions(selected_sources, runtime_config, vec![runtime_function]).await?;
+        infer_runtime_functions(selected_sources, runtime_config()?, vec![runtime_function])
+            .await?;
     results.pop().ok_or_else(|| {
         AppError::FailedPrecondition("function runtime validation returned no result".to_string())
     })?
@@ -79,15 +80,22 @@ fn runtime_validation_error(error: &coral_engine::CoreError) -> AppError {
     AppError::FailedPrecondition(format!("function failed runtime validation: {error}"))
 }
 
-pub(crate) fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRuntimeDefinition {
-    UdfRuntimeDefinition {
-        name: spec.name().to_string(),
-        description: spec.description().to_string(),
-        arguments: Vec::new(),
-        implementation: runtime_implementation(spec.implementation()),
-        publish: runtime_publish(spec),
-        result_columns: Vec::new(),
-        source_names: Vec::new(),
+pub(crate) fn lower_runtime_function_without_signature(
+    spec: &FunctionSpec,
+) -> Result<UdfRuntimeDefinition, AppError> {
+    match spec.implementation() {
+        FunctionImplementationSpec::CoralSql(implementation) => Ok(UdfRuntimeDefinition {
+            name: spec.name().to_string(),
+            description: spec.description().to_string(),
+            arguments: Vec::new(),
+            implementation: UdfRuntimeImplementation::CoralSql {
+                query: implementation.query.clone(),
+            },
+            publish: runtime_publish(spec),
+            result_columns: Vec::new(),
+            source_names: Vec::new(),
+        }),
+        FunctionImplementationSpec::TypeScript(_) => Err(unsupported_typescript_error()),
     }
 }
 
@@ -98,19 +106,20 @@ fn runtime_sql_definition(function: &UdfRuntimeDefinition) -> UdfRuntimeSqlDefin
     }
 }
 
-fn runtime_implementation(spec: &FunctionImplementationSpec) -> UdfRuntimeImplementation {
-    UdfRuntimeImplementation::CoralSql {
-        query: spec.coral_sql.query.clone(),
-    }
-}
-
 fn runtime_publish(spec: &FunctionSpec) -> UdfRuntimePublish {
     UdfRuntimePublish {
         table_function: UdfRuntimeTableFunctionPublish {
-            schema: spec.schema().to_string(),
+            schema: spec.group().to_string(),
             name: spec.name().to_string(),
             description: String::new(),
             guide: spec.guide().to_string(),
         },
     }
+}
+
+fn unsupported_typescript_error() -> AppError {
+    AppError::FailedPrecondition(
+        "TypeScript functions are not supported by this Coral build because no TypeScript executor is available"
+            .to_string(),
+    )
 }

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -51,8 +51,9 @@ impl FunctionServiceApi for FunctionService {
                 FunctionInstallMode::ReplaceExisting
             };
             let write_surface = function_write_surface_from_proto(inner.write_surface);
+            let artifact = inner.sql;
             let added = queries
-                .add_user_function(&workspace_name, &inner.sql, mode, write_surface)
+                .add_user_function(&workspace_name, &artifact, mode, write_surface)
                 .await
                 .map_err(query_status)?;
             Ok(Response::new(AddFunctionResponse {

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -7,9 +7,7 @@ use coral_api::v1::{
     FunctionTableFunctionPublish, FunctionWriteSurface as ProtoFunctionWriteSurface,
     ListFunctionsRequest, ListFunctionsResponse, TableFunctionResultColumn, function,
 };
-use coral_engine::{
-    UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimeTableFunctionPublish,
-};
+use coral_engine::{CoralSqlFunctionDefinition, CoralSqlTableFunctionPublish};
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
@@ -133,13 +131,10 @@ fn function_listing_to_proto(workspace_name: &WorkspaceName, listing: FunctionLi
 
 fn runtime_function_to_proto(
     workspace_name: &WorkspaceName,
-    function: UdfRuntimeDefinition,
+    function: CoralSqlFunctionDefinition,
     write_surface: FunctionWriteSurface,
 ) -> Function {
     let name = function.name;
-    let UdfRuntimeImplementation::CoralSql { query: sql_body } = function.implementation else {
-        unreachable!("unsupported function runtime implementation")
-    };
     Function {
         workspace: Some(workspace_to_proto(workspace_name)),
         name,
@@ -153,9 +148,7 @@ fn runtime_function_to_proto(
                     data_type: argument.data_type.as_manifest_str().to_string(),
                 })
                 .collect(),
-            table_function: Some(function_table_function_publish_to_proto(
-                function.publish.table_function,
-            )),
+            table_function: Some(function_table_function_publish_to_proto(function.publish)),
             result_columns: function
                 .result_columns
                 .into_iter()
@@ -166,7 +159,7 @@ fn runtime_function_to_proto(
                     description: String::new(),
                 })
                 .collect(),
-            sql_body,
+            sql_body: function.query,
             source_names: function.source_names,
         })),
         write_surface: function_write_surface_to_proto(write_surface),
@@ -190,7 +183,7 @@ fn function_write_surface_to_proto(value: FunctionWriteSurface) -> i32 {
 }
 
 fn function_table_function_publish_to_proto(
-    publish: UdfRuntimeTableFunctionPublish,
+    publish: CoralSqlTableFunctionPublish,
 ) -> FunctionTableFunctionPublish {
     FunctionTableFunctionPublish {
         schema_name: publish.schema,

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashSet};
 
-use coral_engine::{QuerySource, RuntimeSourceComponent, UdfRuntimeDefinition};
+use coral_engine::{CoralSqlFunctionDefinition, QuerySource, RuntimeSourceComponent};
 
 use crate::bootstrap::AppError;
 
@@ -11,13 +11,10 @@ pub(crate) fn initial_sql_publish_targets(selected_sources: &[QuerySource]) -> S
 }
 
 pub(crate) fn record_sql_publish_target(
-    function: &UdfRuntimeDefinition,
+    function: &CoralSqlFunctionDefinition,
     publish_targets: &mut SqlPublishTargets,
 ) -> Result<(), AppError> {
-    let target = SqlPublishTarget::new(
-        &function.publish.table_function.schema,
-        &function.publish.table_function.name,
-    );
+    let target = SqlPublishTarget::new(&function.publish.schema, &function.publish.name);
     if !publish_targets.insert(target.clone()) {
         return Err(AppError::FailedPrecondition(format!(
             "function publish target '{}' is installed more than once",
@@ -43,10 +40,10 @@ pub(crate) fn source_sql_publish_targets_for_schemas(
 }
 
 pub(crate) fn unchecked_source_publish_schemas(
-    function: &UdfRuntimeDefinition,
+    function: &CoralSqlFunctionDefinition,
     checked: &BTreeSet<String>,
 ) -> BTreeSet<String> {
-    let schema = &function.publish.table_function.schema;
+    let schema = &function.publish.schema;
     if checked.contains(schema) {
         BTreeSet::new()
     } else {
@@ -125,10 +122,7 @@ impl SqlPublishTarget {
 mod tests {
     use std::collections::BTreeMap;
 
-    use coral_engine::{
-        RuntimeSourcePackage, UdfRuntimeImplementation, UdfRuntimePublish,
-        UdfRuntimeTableFunctionPublish,
-    };
+    use coral_engine::{CoralSqlTableFunctionPublish, RuntimeSourcePackage};
     use coral_spec::parse_source_manifest_yaml;
 
     use super::*;
@@ -185,21 +179,17 @@ tables:
         .expect("multi-schema source")
     }
 
-    fn runtime_function() -> UdfRuntimeDefinition {
-        UdfRuntimeDefinition {
+    fn runtime_function() -> CoralSqlFunctionDefinition {
+        CoralSqlFunctionDefinition {
             name: "review_queue".to_string(),
             description: String::new(),
             arguments: Vec::new(),
-            implementation: UdfRuntimeImplementation::CoralSql {
-                query: "select 1 as id".to_string(),
-            },
-            publish: UdfRuntimePublish {
-                table_function: UdfRuntimeTableFunctionPublish {
-                    schema: "functions".to_string(),
-                    name: "review_queue".to_string(),
-                    description: String::new(),
-                    guide: String::new(),
-                },
+            query: "select 1 as id".to_string(),
+            publish: CoralSqlTableFunctionPublish {
+                schema: "functions".to_string(),
+                name: "review_queue".to_string(),
+                description: String::new(),
+                guide: String::new(),
             },
             result_columns: Vec::new(),
             source_names: Vec::new(),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -890,21 +890,21 @@ impl QueryManager {
     pub(crate) async fn validate_udf_sql(
         &self,
         workspace_name: &WorkspaceName,
-        raw_sql: &str,
+        artifact: &str,
     ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
         self.require_workspace(workspace_name)
             .await
             .map_err(QueryManagerError::App)?;
         let _lifecycle_snapshot = self.lifecycle_lock.snapshot_async().await;
         let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
-        self.validate_udf_sql_against_snapshot(workspace_name, raw_sql, &loaded_sources, &config)
+        self.validate_udf_sql_against_snapshot(workspace_name, artifact, &loaded_sources, &config)
             .await
     }
 
     pub(crate) async fn add_user_function(
         &self,
         workspace_name: &WorkspaceName,
-        raw_sql: &str,
+        artifact: &str,
         mode: FunctionInstallMode,
         write_surface: FunctionWriteSurface,
     ) -> Result<AddedUserFunction, QueryManagerError> {
@@ -922,7 +922,7 @@ impl QueryManager {
             let runtime_function = self
                 .validate_udf_sql_against_snapshot(
                     workspace_name,
-                    raw_sql,
+                    artifact,
                     &loaded_sources,
                     &config,
                 )
@@ -931,7 +931,7 @@ impl QueryManager {
                 .function_manager
                 .install_validated_user_function_if_unchanged(
                     workspace_name,
-                    raw_sql,
+                    artifact,
                     &runtime_function,
                     revision,
                     mode,
@@ -991,13 +991,13 @@ impl QueryManager {
     async fn validate_udf_sql_against_snapshot(
         &self,
         workspace_name: &WorkspaceName,
-        raw_sql: &str,
+        artifact: &str,
         loaded_sources: &[LoadedQuerySource],
         config: &AppConfig,
     ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
         let sources = query_sources_from_loaded(loaded_sources);
         self.function_manager
-            .validate_user_function_sql(
+            .validate_user_function_artifact(
                 workspace_name,
                 &sources,
                 || {
@@ -1007,7 +1007,7 @@ impl QueryManager {
                         config,
                     )
                 },
-                raw_sql,
+                artifact,
             )
             .await
             .map_err(QueryManagerError::App)

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -6,11 +6,11 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use coral_engine::{
-    CatalogInfo, CoralQuery, CoreError, DescribeCatalogSurfaceInfo, PreparedQueryRuntime,
-    QueryExecution, QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, ResolvedQueryResources, SourceDecorator, SourceDecoratorError,
-    SourceFailurePolicy, SourceInputResolver, SourceTables, SourceValidationReport, StatusCode,
-    TableInfo, UdfRuntimeDefinition,
+    CatalogInfo, CoralQuery, CoralSqlFunctionDefinition, CoreError, DescribeCatalogSurfaceInfo,
+    PreparedQueryRuntime, QueryExecution, QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig,
+    QueryRuntimeContext, QuerySource, ResolvedQueryResources, SourceDecorator,
+    SourceDecoratorError, SourceFailurePolicy, SourceInputResolver, SourceTables,
+    SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -76,7 +76,7 @@ pub(crate) struct ValidatedSource {
 
 #[derive(Debug)]
 pub(crate) struct AddedUserFunction {
-    pub(crate) definition: UdfRuntimeDefinition,
+    pub(crate) definition: CoralSqlFunctionDefinition,
     pub(crate) replaced: bool,
     pub(crate) write_surface: FunctionWriteSurface,
 }
@@ -891,7 +891,7 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         artifact: &str,
-    ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
+    ) -> Result<CoralSqlFunctionDefinition, QueryManagerError> {
         self.require_workspace(workspace_name)
             .await
             .map_err(QueryManagerError::App)?;
@@ -994,7 +994,7 @@ impl QueryManager {
         artifact: &str,
         loaded_sources: &[LoadedQuerySource],
         config: &AppConfig,
-    ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
+    ) -> Result<CoralSqlFunctionDefinition, QueryManagerError> {
         let sources = query_sources_from_loaded(loaded_sources);
         self.function_manager
             .validate_user_function_artifact(
@@ -3158,7 +3158,7 @@ where type = $kind
         else {
             panic!("function should be runtime-ready");
         };
-        assert_eq!(definition.publish.table_function.guide, expected_guide);
+        assert_eq!(definition.publish.guide, expected_guide);
         let column = definition
             .result_columns
             .first()

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -202,6 +202,66 @@ async fn untyped_function_is_not_persisted() {
 }
 
 #[tokio::test]
+async fn typescript_function_is_rejected_without_persistence() {
+    let harness = GrpcHarness::new().await;
+    let artifact = r"/*
+name: review_summary
+schema: functions
+description: Summarize a review queue.
+language: typescript
+signature:
+  arguments:
+    - name: owner
+      data_type: Utf8
+  result_columns:
+    - name: title
+      data_type: Utf8
+*/
+
+export async function run(owner: string): Promise<string> {
+  return `queue for ${owner}`;
+}
+";
+
+    let error = harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            workspace: Some(default_workspace()),
+            sql: artifact.to_string(),
+            fail_if_exists: false,
+            write_surface: FunctionWriteSurface::Cli as i32,
+        }))
+        .await
+        .expect_err("TypeScript function should be rejected");
+
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("no TypeScript executor is available")
+    );
+    let functions = harness
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list functions")
+        .into_inner()
+        .functions;
+    assert!(functions.is_empty());
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(!config_raw.contains("review_summary"));
+    assert!(
+        !harness
+            .config_dir()
+            .join("workspaces/default/functions/review_summary")
+            .exists()
+    );
+}
+
+#[tokio::test]
 async fn create_only_preserves_an_existing_function_and_legacy_add_replaces_it() {
     let harness = GrpcHarness::new().await;
     let workspace = default_workspace();

--- a/crates/coral-engine/AGENTS.md
+++ b/crates/coral-engine/AGENTS.md
@@ -33,6 +33,8 @@ registration, and query execution.
 - Runtime components are the app-to-engine package boundary. Do not add a
   backend that reaches back into DSL v4 materialization or authored-manifest
   types when `coral-app` can assemble existing backend-ready component specs.
+- Installed-function inputs are executable Coral SQL definitions. Do not add
+  placeholder variants for languages that `DataFusion` cannot execute.
 - Reuse database connection pools only through an explicit
   `DatabasePoolRegistry` supplied by the caller and key its pool map directly
   by the workspace-local, unique SQL catalog name. Keep pool implementation in

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -20,9 +20,8 @@ pub use query::{
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 pub use udfs::{
-    UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
-    UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
-    UdfRuntimeTableFunctionPublish,
+    CoralSqlFunctionArgument, CoralSqlFunctionDefinition, CoralSqlFunctionInferenceDefinition,
+    CoralSqlFunctionSignature, CoralSqlResultColumn, CoralSqlTableFunctionPublish,
 };
 
 #[cfg(test)]

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -664,8 +664,8 @@ pub struct QueryRuntimeConfig {
         Option<RequestIdentityHttpAuthenticatorFactory>,
     /// Runtime policy for dependent predicate pushdown.
     pub dependent_join: DependentJoinConfig,
-    /// Validated UDFs available in this runtime build.
-    pub udfs: Vec<super::UdfRuntimeDefinition>,
+    /// Executable Coral SQL functions available in this runtime build.
+    pub udfs: Vec<super::CoralSqlFunctionDefinition>,
 }
 
 impl QueryRuntimeConfig {
@@ -684,9 +684,9 @@ impl QueryRuntimeConfig {
         }
     }
 
-    /// Attaches validated UDFs to this runtime config.
+    /// Attaches executable Coral SQL functions to this runtime config.
     #[must_use]
-    pub fn with_udfs(mut self, udfs: Vec<super::UdfRuntimeDefinition>) -> Self {
+    pub fn with_udfs(mut self, udfs: Vec<super::CoralSqlFunctionDefinition>) -> Self {
         self.udfs = udfs;
         self
     }

--- a/crates/coral-engine/src/contracts/udfs.rs
+++ b/crates/coral-engine/src/contracts/udfs.rs
@@ -1,67 +1,58 @@
-//! Engine runtime UDF contracts supplied by the app layer.
+//! Executable Coral SQL function contracts supplied by the app layer.
 
 use coral_spec::ManifestDataType;
 
-/// Typed UDF signature inferred by planning its SQL body.
+/// Typed function signature inferred by planning its Coral SQL query.
 #[derive(Debug, Clone)]
-pub struct UdfRuntimeSignature {
-    /// Arguments referenced by the UDF SQL body.
-    pub arguments: Vec<UdfRuntimeArgument>,
-    /// Columns returned by the UDF SQL body.
-    pub result_columns: Vec<UdfRuntimeResultColumn>,
-    /// Canonical installed source names referenced by the UDF SQL body.
+pub struct CoralSqlFunctionSignature {
+    /// Arguments referenced by the function query.
+    pub arguments: Vec<CoralSqlFunctionArgument>,
+    /// Columns returned by the function query.
+    pub result_columns: Vec<CoralSqlResultColumn>,
+    /// Canonical installed source names referenced by the function query.
     pub source_names: Vec<String>,
 }
 
-/// One SQL UDF body to validate before runtime registration.
+/// One Coral SQL query to validate before runtime registration.
 #[derive(Debug, Clone)]
-pub struct UdfRuntimeSqlDefinition {
-    /// Stable UDF id within one workspace.
+pub struct CoralSqlFunctionInferenceDefinition {
+    /// Stable function id within one workspace.
     pub name: String,
-    /// Executable UDF implementation.
-    pub implementation: UdfRuntimeImplementation,
+    /// Read-only Coral SQL query using `DataFusion` value parameters like `$argument`.
+    pub query: String,
 }
 
-impl UdfRuntimeSqlDefinition {
-    /// Returns the SQL body for this definition.
-    #[must_use]
-    pub fn sql(&self) -> &str {
-        let UdfRuntimeImplementation::CoralSql { query } = &self.implementation;
-        query
-    }
-}
-
-/// One validated UDF made available to the query runtime.
+/// One executable Coral SQL function made available to the query runtime.
 #[derive(Debug, Clone)]
-pub struct UdfRuntimeDefinition {
-    /// Stable UDF id within one workspace.
+pub struct CoralSqlFunctionDefinition {
+    /// Stable function id within one workspace.
     pub name: String,
-    /// User-facing UDF description.
+    /// User-facing function description.
     pub description: String,
-    /// Typed arguments accepted by the UDF.
-    pub arguments: Vec<UdfRuntimeArgument>,
-    /// Executable UDF implementation.
-    pub implementation: UdfRuntimeImplementation,
-    /// Public surfaces requested by the UDF.
-    pub publish: UdfRuntimePublish,
-    /// Columns inferred by planning the UDF SQL body.
-    pub result_columns: Vec<UdfRuntimeResultColumn>,
-    /// Canonical installed source names referenced by the UDF SQL body.
+    /// Typed arguments accepted by the function.
+    pub arguments: Vec<CoralSqlFunctionArgument>,
+    /// Read-only Coral SQL query executed after typed argument binding.
+    pub query: String,
+    /// Public SQL table-function target.
+    pub publish: CoralSqlTableFunctionPublish,
+    /// Columns inferred by planning the function query.
+    pub result_columns: Vec<CoralSqlResultColumn>,
+    /// Canonical installed source names referenced by the function query.
     pub source_names: Vec<String>,
 }
 
-/// One typed UDF argument.
+/// One typed Coral SQL function argument.
 #[derive(Debug, Clone)]
-pub struct UdfRuntimeArgument {
+pub struct CoralSqlFunctionArgument {
     /// Argument name.
     pub name: String,
     /// Argument type in manifest spelling.
     pub data_type: ManifestDataType,
 }
 
-/// One column returned by a UDF table function.
+/// One column returned by a Coral SQL table function.
 #[derive(Debug, Clone)]
-pub struct UdfRuntimeResultColumn {
+pub struct CoralSqlResultColumn {
     /// Column name.
     pub name: String,
     /// Arrow/DataFusion type expected for the column.
@@ -70,27 +61,9 @@ pub struct UdfRuntimeResultColumn {
     pub nullable: bool,
 }
 
-/// Executable UDF implementation.
+/// Canonical SQL table-function surface for one Coral SQL function.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
-pub enum UdfRuntimeImplementation {
-    /// Read-only Coral SQL using `DataFusion` value parameters like `$argument`.
-    CoralSql {
-        /// SQL query executed by Coral after typed argument binding.
-        query: String,
-    },
-}
-
-/// Public surfaces requested by one UDF.
-#[derive(Debug, Clone)]
-pub struct UdfRuntimePublish {
-    /// Canonical public SQL table-function wrapper.
-    pub table_function: UdfRuntimeTableFunctionPublish,
-}
-
-/// Canonical SQL table-function surface for one UDF.
-#[derive(Debug, Clone)]
-pub struct UdfRuntimeTableFunctionPublish {
+pub struct CoralSqlTableFunctionPublish {
     /// SQL schema.
     pub schema: String,
     /// SQL function name.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -80,16 +80,16 @@ pub use composition::{
     SourceObservationPublisher, SourceObservationSurfaceKind, SourceScanObservation, SourceTables,
 };
 pub use contracts::{
-    CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
+    CatalogInfo, ColumnInfo, CoralSqlFunctionArgument, CoralSqlFunctionDefinition,
+    CoralSqlFunctionInferenceDefinition, CoralSqlFunctionSignature, CoralSqlResultColumn,
+    CoralSqlTableFunctionPublish, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeCatalogSurfaceInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
     QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
     QueryTestFailure, QueryTestResult, QueryTestSuccess, ResolvedQueryResources,
     RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
     StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo, UdfRuntimeArgument, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 pub use runtime::normalize_catalog_name;
 
@@ -190,11 +190,11 @@ impl PreparedQueryRuntime {
     /// source runtime.
     pub async fn infer_udf_signatures(
         &self,
-        udfs: Vec<UdfRuntimeSqlDefinition>,
-    ) -> Result<Vec<Result<UdfRuntimeSignature, CoreError>>, CoreError> {
+        udfs: Vec<CoralSqlFunctionInferenceDefinition>,
+    ) -> Result<Vec<Result<CoralSqlFunctionSignature, CoreError>>, CoreError> {
         let mut results = Vec::with_capacity(udfs.len());
         for udf in udfs {
-            if udf.sql().trim().is_empty() {
+            if udf.query.trim().is_empty() {
                 results.push(Err(CoreError::InvalidInput(format!(
                     "udf '{}' SQL body cannot be empty",
                     udf.name
@@ -212,7 +212,10 @@ impl PreparedQueryRuntime {
     ///
     /// Returns [`CoreError`] if UDF publication conflicts with the prepared
     /// catalog or a UDF body cannot be planned.
-    pub async fn with_udfs(mut self, udfs: Vec<UdfRuntimeDefinition>) -> Result<Self, CoreError> {
+    pub async fn with_udfs(
+        mut self,
+        udfs: Vec<CoralSqlFunctionDefinition>,
+    ) -> Result<Self, CoreError> {
         self.inner.install_udfs(udfs).await?;
         Ok(self)
     }
@@ -429,8 +432,8 @@ impl CoralQuery {
     pub async fn infer_udf_signature(
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
-        udf: UdfRuntimeSqlDefinition,
-    ) -> Result<UdfRuntimeSignature, CoreError> {
+        udf: CoralSqlFunctionInferenceDefinition,
+    ) -> Result<CoralSqlFunctionSignature, CoreError> {
         let mut results = Self::infer_udf_signatures(sources, runtime, vec![udf]).await?;
         results.pop().ok_or_else(|| {
             CoreError::InvalidInput("UDF signature inference returned no result".to_string())
@@ -448,8 +451,8 @@ impl CoralQuery {
     pub async fn infer_udf_signatures(
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
-        udfs: Vec<UdfRuntimeSqlDefinition>,
-    ) -> Result<Vec<Result<UdfRuntimeSignature, CoreError>>, CoreError> {
+        udfs: Vec<CoralSqlFunctionInferenceDefinition>,
+    ) -> Result<Vec<Result<CoralSqlFunctionSignature, CoreError>>, CoreError> {
         if udfs.is_empty() {
             return Ok(Vec::new());
         }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -44,15 +44,16 @@ use crate::runtime::udf_calls::{
 };
 use crate::runtime::udfs::published_table_functions;
 use crate::{
-    BoundRequestIdentityHttpAuthenticator, CatalogInfo, CoreError, DependentJoinConfig,
-    DescribeCatalogSurfaceInfo, MemorySize, QueryExecution, QueryExecutionProvenance,
+    BoundRequestIdentityHttpAuthenticator, CatalogInfo, CoralSqlFunctionDefinition, CoreError,
+    DependentJoinConfig, DescribeCatalogSurfaceInfo, MemorySize, QueryExecution,
+    QueryExecutionProvenance,
     QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan, QueryResultObserver,
     QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator,
     RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
     RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
     ResolvedQueryResources, SelectedRequestIdentity, SourceDecorator, SourceInputResolver,
-    SourceObservationPublisher, TableFunctionInfo, TableInfo, UdfRuntimeDefinition,
+    SourceObservationPublisher, TableFunctionInfo, TableInfo,
     normalize_catalog_name,
 };
 
@@ -116,7 +117,7 @@ struct FallbackRuntimeConfig {
     database_pool_registry: Arc<crate::DatabasePoolRegistry>,
     dependent_join: DependentJoinConfig,
     memory: QueryMemoryConfig,
-    udfs: Vec<UdfRuntimeDefinition>,
+    udfs: Vec<CoralSqlFunctionDefinition>,
     extension_hooks: RuntimeExtensionHooks,
     request_identity_http_authenticators: BoundRequestIdentityHttpAuthenticators,
 }
@@ -141,7 +142,7 @@ struct RuntimeBuildInputs<'a> {
     source_decorators: &'a mut [Box<dyn SourceDecorator>],
     dependent_join: &'a DependentJoinConfig,
     memory: &'a QueryMemoryConfig,
-    udfs: &'a [UdfRuntimeDefinition],
+    udfs: &'a [CoralSqlFunctionDefinition],
 }
 
 enum SqlExecutionFailure {
@@ -400,7 +401,7 @@ async fn install_table_function_call_planners(
     ctx: &SessionContext,
     source_functions: SourceFunctionRegistry,
     source_table_function_names: HashSet<ScopedTableFunctionName>,
-    udfs: &[UdfRuntimeDefinition],
+    udfs: &[CoralSqlFunctionDefinition],
     tables: &[TableInfo],
 ) -> Result<(), CoreError> {
     match (!source_functions.is_empty(), !udfs.is_empty()) {
@@ -449,7 +450,7 @@ fn validate_catalog_surface_namespace(
 
 async fn install_udf_call_planner(
     ctx: &SessionContext,
-    udfs: &[UdfRuntimeDefinition],
+    udfs: &[CoralSqlFunctionDefinition],
     source_table_function_names: HashSet<ScopedTableFunctionName>,
     tables: &[TableInfo],
 ) -> Result<(), CoreError> {
@@ -552,7 +553,7 @@ async fn register_runtime_sources(
 impl QueryRuntimeAdapter {
     pub(crate) async fn install_udfs(
         &mut self,
-        udfs: Vec<UdfRuntimeDefinition>,
+        udfs: Vec<CoralSqlFunctionDefinition>,
     ) -> Result<(), CoreError> {
         if udfs.is_empty() {
             return Ok(());
@@ -1581,9 +1582,8 @@ mod tests {
     use crate::backends::common::RegisteredColumn;
     use crate::backends::{RegisteredTable, SourceQualifiedName};
     use crate::{
-        DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext,
-        UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
-        UdfRuntimeTableFunctionPublish,
+        CoralSqlResultColumn, CoralSqlTableFunctionPublish, DependentJoinConfig, MemorySize,
+        QueryMemoryConfig, QueryRuntimeContext,
     };
 
     fn adapter_with_sources(active_sources: Vec<RegisteredSource>) -> QueryRuntimeAdapter {
@@ -2007,22 +2007,18 @@ mod tests {
             .await
             .expect("primary runtime");
         runtime
-            .install_udfs(vec![UdfRuntimeDefinition {
+            .install_udfs(vec![CoralSqlFunctionDefinition {
                 name: "constant_value".to_string(),
                 description: "Returns one value".to_string(),
                 arguments: Vec::new(),
-                implementation: UdfRuntimeImplementation::CoralSql {
-                    query: "select 1 as value".to_string(),
+                query: "select 1 as value".to_string(),
+                publish: CoralSqlTableFunctionPublish {
+                    schema: "functions".to_string(),
+                    name: "constant_value".to_string(),
+                    description: "Returns one value".to_string(),
+                    guide: String::new(),
                 },
-                publish: UdfRuntimePublish {
-                    table_function: UdfRuntimeTableFunctionPublish {
-                        schema: "functions".to_string(),
-                        name: "constant_value".to_string(),
-                        description: "Returns one value".to_string(),
-                        guide: String::new(),
-                    },
-                },
-                result_columns: vec![UdfRuntimeResultColumn {
+                result_columns: vec![CoralSqlResultColumn {
                     name: "value".to_string(),
                     data_type: DataType::Int64,
                     nullable: false,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -46,15 +46,13 @@ use crate::runtime::udfs::published_table_functions;
 use crate::{
     BoundRequestIdentityHttpAuthenticator, CatalogInfo, CoralSqlFunctionDefinition, CoreError,
     DependentJoinConfig, DescribeCatalogSurfaceInfo, MemorySize, QueryExecution,
-    QueryExecutionProvenance,
-    QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan, QueryResultObserver,
-    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
+    QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator,
     RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
     RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
     ResolvedQueryResources, SelectedRequestIdentity, SourceDecorator, SourceInputResolver,
-    SourceObservationPublisher, TableFunctionInfo, TableInfo,
-    normalize_catalog_name,
+    SourceObservationPublisher, TableFunctionInfo, TableInfo, normalize_catalog_name,
 };
 
 pub(crate) struct QueryRuntimeAdapter {

--- a/crates/coral-engine/src/runtime/udf_calls.rs
+++ b/crates/coral-engine/src/runtime/udf_calls.rs
@@ -34,8 +34,8 @@ use crate::runtime::scoped_table_functions::{
     reject_settings, reject_unbound_parameters as reject_unbound_table_function_parameters,
     reject_unsupported_modifiers,
 };
-use crate::runtime::udfs::{udf_argument_values, udf_arrow_schema, udf_param_values, udf_sql};
-use crate::{QueryParameters, UdfRuntimeDefinition};
+use crate::runtime::udfs::{udf_argument_values, udf_arrow_schema, udf_param_values};
+use crate::{CoralSqlFunctionDefinition, QueryParameters};
 
 pub(crate) const UDF_CALL_NODE_NAME: &str = "CoralUdfCall";
 
@@ -49,7 +49,7 @@ pub(crate) struct UdfCallRegistry {
 impl UdfCallRegistry {
     pub(crate) async fn new(
         ctx: &SessionContext,
-        udfs: &[UdfRuntimeDefinition],
+        udfs: &[CoralSqlFunctionDefinition],
         source_functions: HashSet<ScopedTableFunctionName>,
     ) -> Result<Self> {
         let source_function_schemas = source_functions
@@ -63,7 +63,7 @@ impl UdfCallRegistry {
         };
 
         for udf in udfs {
-            let body_plan = ctx.state().create_logical_plan(udf_sql(udf)).await?;
+            let body_plan = ctx.state().create_logical_plan(&udf.query).await?;
             read_only_sql_options().verify_plan(&body_plan)?;
             registry.insert_function(udf, &body_plan)?;
         }
@@ -80,10 +80,10 @@ impl UdfCallRegistry {
 
     fn insert_function(
         &mut self,
-        udf: &UdfRuntimeDefinition,
+        udf: &CoralSqlFunctionDefinition,
         body_plan: &LogicalPlan,
     ) -> Result<()> {
-        let publish = &udf.publish.table_function;
+        let publish = &udf.publish;
         let key = ScopedTableFunctionName::from_parts(&publish.schema, &publish.name);
         if self
             .functions
@@ -166,7 +166,7 @@ struct UdfCallTarget {
     display_name: String,
     table_reference: TableReference,
     arg_names: Vec<String>,
-    udf: UdfRuntimeDefinition,
+    udf: CoralSqlFunctionDefinition,
     body_plan: LogicalPlan,
     schema: DFSchemaRef,
 }
@@ -175,7 +175,7 @@ impl UdfCallTarget {
     fn new(
         schema: &str,
         name: &str,
-        udf: &UdfRuntimeDefinition,
+        udf: &CoralSqlFunctionDefinition,
         body_plan: &LogicalPlan,
     ) -> Result<Self> {
         validate_argument_definitions(udf)?;
@@ -231,7 +231,7 @@ pub(crate) struct UdfCallNode {
     arg_names: Vec<String>,
     args: Vec<Expr>,
     schema: DFSchemaRef,
-    udf: UdfRuntimeDefinition,
+    udf: CoralSqlFunctionDefinition,
     body_plan: LogicalPlan,
 }
 
@@ -310,7 +310,7 @@ impl UdfCallNode {
     }
 }
 
-fn validate_argument_definitions(udf: &UdfRuntimeDefinition) -> Result<()> {
+fn validate_argument_definitions(udf: &CoralSqlFunctionDefinition) -> Result<()> {
     let mut seen = BTreeSet::new();
     for argument in &udf.arguments {
         if !seen.insert(argument.name.to_ascii_lowercase()) {
@@ -324,7 +324,7 @@ fn validate_argument_definitions(udf: &UdfRuntimeDefinition) -> Result<()> {
 }
 
 fn validate_declared_result_schema(
-    udf: &UdfRuntimeDefinition,
+    udf: &CoralSqlFunctionDefinition,
     body_plan: &LogicalPlan,
     declared_schema: &Schema,
 ) -> Result<()> {

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -17,20 +17,16 @@ use crate::runtime::query::{QueryRuntimeAdapter, query_parameter_scalar_value};
 use crate::runtime::scoped_table_functions::{ScopedTableFunctionName, qualified_name};
 use crate::types::parameter_binding_is_string_shaped;
 use crate::{
-    CoreError, QueryParameterValue, QueryParameters, UdfRuntimeArgument, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+    CoralSqlFunctionArgument, CoralSqlFunctionDefinition, CoralSqlFunctionInferenceDefinition,
+    CoralSqlFunctionSignature, CoralSqlResultColumn, CoreError, QueryParameterValue,
+    QueryParameters,
 };
-
-pub(crate) fn udf_sql(udf: &UdfRuntimeDefinition) -> &str {
-    let UdfRuntimeImplementation::CoralSql { query } = &udf.implementation;
-    query
-}
 
 pub(crate) async fn infer_udf_signature(
     query_runtime: &QueryRuntimeAdapter,
-    udf: &UdfRuntimeSqlDefinition,
-) -> Result<UdfRuntimeSignature, CoreError> {
-    let signature = query_runtime.infer_sql_signature(udf.sql()).await?;
+    udf: &CoralSqlFunctionInferenceDefinition,
+) -> Result<CoralSqlFunctionSignature, CoreError> {
+    let signature = query_runtime.infer_sql_signature(&udf.query).await?;
     let mut arguments = Vec::new();
     for (placeholder, field) in signature.parameter_fields {
         let name = placeholder
@@ -56,22 +52,22 @@ pub(crate) async fn infer_udf_signature(
                 })?
             }
         };
-        arguments.push(UdfRuntimeArgument { name, data_type });
+        arguments.push(CoralSqlFunctionArgument { name, data_type });
     }
     arguments.sort_by(|left, right| left.name.cmp(&right.name));
 
-    Ok(UdfRuntimeSignature {
+    Ok(CoralSqlFunctionSignature {
         arguments,
         result_columns: result_columns(signature.planned_schema.as_ref()),
         source_names: signature.source_names,
     })
 }
 
-fn result_columns(schema: &Schema) -> Vec<UdfRuntimeResultColumn> {
+fn result_columns(schema: &Schema) -> Vec<CoralSqlResultColumn> {
     schema
         .fields()
         .iter()
-        .map(|field| UdfRuntimeResultColumn {
+        .map(|field| CoralSqlResultColumn {
             name: field.name().clone(),
             data_type: field.data_type().clone(),
             nullable: field.is_nullable(),
@@ -80,14 +76,14 @@ fn result_columns(schema: &Schema) -> Vec<UdfRuntimeResultColumn> {
 }
 
 pub(crate) fn udf_query_parameters(
-    udf: &UdfRuntimeDefinition,
+    udf: &CoralSqlFunctionDefinition,
     arguments: &QueryParameters,
 ) -> DataFusionResult<QueryParameters> {
     UdfArgumentBinding::new(udf, arguments).into_query_params()
 }
 
 pub(crate) fn published_table_functions(
-    udfs: &[UdfRuntimeDefinition],
+    udfs: &[CoralSqlFunctionDefinition],
     source_function_names: &HashSet<ScopedTableFunctionName>,
 ) -> DataFusionResult<Vec<CatalogTableFunction>> {
     PublishedTableFunctions::new(source_function_names).build(udfs)
@@ -110,7 +106,7 @@ impl<'a> PublishedTableFunctions<'a> {
 
     fn build(
         mut self,
-        udfs: &[UdfRuntimeDefinition],
+        udfs: &[CoralSqlFunctionDefinition],
     ) -> DataFusionResult<Vec<CatalogTableFunction>> {
         for udf in udfs {
             self.push_udf(udf)?;
@@ -122,8 +118,8 @@ impl<'a> PublishedTableFunctions<'a> {
         Ok(self.rows)
     }
 
-    fn push_udf(&mut self, udf: &UdfRuntimeDefinition) -> DataFusionResult<()> {
-        let publish = &udf.publish.table_function;
+    fn push_udf(&mut self, udf: &CoralSqlFunctionDefinition) -> DataFusionResult<()> {
+        let publish = &udf.publish;
         let key = ScopedTableFunctionName::from_parts(&publish.schema, &publish.name);
         self.reject_duplicate_udf(&key)?;
         self.reject_source_collision(&key)?;
@@ -154,10 +150,10 @@ impl<'a> PublishedTableFunctions<'a> {
 }
 
 fn catalog_table_function(
-    udf: &UdfRuntimeDefinition,
+    udf: &CoralSqlFunctionDefinition,
     key: &ScopedTableFunctionName,
 ) -> CatalogTableFunction {
-    let publish = &udf.publish.table_function;
+    let publish = &udf.publish;
     CatalogTableFunction {
         schema_name: key.schema.clone(),
         function_name: key.function.clone(),
@@ -190,7 +186,7 @@ fn catalog_table_function(
 }
 
 pub(crate) fn udf_argument_values(
-    udf: &UdfRuntimeDefinition,
+    udf: &CoralSqlFunctionDefinition,
     args: &[Expr],
 ) -> DataFusionResult<QueryParameters> {
     if args.len() > udf.arguments.len() {
@@ -215,8 +211,8 @@ pub(crate) fn udf_argument_values(
 }
 
 fn udf_argument_value(
-    udf: &UdfRuntimeDefinition,
-    argument: &UdfRuntimeArgument,
+    udf: &CoralSqlFunctionDefinition,
+    argument: &CoralSqlFunctionArgument,
     expr: &Expr,
 ) -> DataFusionResult<QueryParameterValue> {
     let Some(value) = literal_scalar_value(expr)? else {
@@ -245,7 +241,7 @@ pub(crate) fn udf_param_values(params: &QueryParameters) -> Vec<(String, ScalarV
         .collect()
 }
 
-pub(crate) fn udf_arrow_schema(udf: &UdfRuntimeDefinition) -> DataFusionResult<Arc<Schema>> {
+pub(crate) fn udf_arrow_schema(udf: &CoralSqlFunctionDefinition) -> DataFusionResult<Arc<Schema>> {
     if udf.result_columns.is_empty() {
         return Err(DataFusionError::Plan(format!(
             "published udf '{}' requires declared result columns",
@@ -261,17 +257,17 @@ pub(crate) fn udf_arrow_schema(udf: &UdfRuntimeDefinition) -> DataFusionResult<A
     Ok(Arc::new(Schema::new(fields)))
 }
 
-fn udf_result_field(column: &UdfRuntimeResultColumn) -> Field {
+fn udf_result_field(column: &CoralSqlResultColumn) -> Field {
     Field::new(&column.name, column.data_type.clone(), column.nullable)
 }
 
 struct UdfArgumentBinding<'a> {
-    udf: &'a UdfRuntimeDefinition,
+    udf: &'a CoralSqlFunctionDefinition,
     arguments: &'a QueryParameters,
 }
 
 impl<'a> UdfArgumentBinding<'a> {
-    fn new(udf: &'a UdfRuntimeDefinition, arguments: &'a QueryParameters) -> Self {
+    fn new(udf: &'a CoralSqlFunctionDefinition, arguments: &'a QueryParameters) -> Self {
         Self { udf, arguments }
     }
 
@@ -302,7 +298,7 @@ impl<'a> UdfArgumentBinding<'a> {
 
     fn bind_argument(
         &self,
-        argument: &UdfRuntimeArgument,
+        argument: &CoralSqlFunctionArgument,
         params: &mut QueryParameters,
     ) -> DataFusionResult<()> {
         let binding = UdfParameterTypeBinding::new(argument.data_type);
@@ -482,28 +478,24 @@ mod tests {
     use arrow::datatypes::TimeUnit;
     use datafusion::logical_expr::expr::{Cast, TryCast};
 
-    fn argument(name: &str, data_type: ManifestDataType) -> UdfRuntimeArgument {
-        UdfRuntimeArgument {
+    fn argument(name: &str, data_type: ManifestDataType) -> CoralSqlFunctionArgument {
+        CoralSqlFunctionArgument {
             name: name.to_string(),
             data_type,
         }
     }
 
-    fn udf() -> UdfRuntimeDefinition {
-        UdfRuntimeDefinition {
+    fn udf() -> CoralSqlFunctionDefinition {
+        CoralSqlFunctionDefinition {
             name: "open_pull_requests".to_string(),
             description: String::new(),
             arguments: vec![argument("author", ManifestDataType::Utf8)],
-            implementation: UdfRuntimeImplementation::CoralSql {
-                query: "select * from github.pull_requests where author = $author".to_string(),
-            },
-            publish: crate::UdfRuntimePublish {
-                table_function: crate::UdfRuntimeTableFunctionPublish {
-                    schema: "udfs".to_string(),
-                    name: "open_pull_requests".to_string(),
-                    description: String::new(),
-                    guide: String::new(),
-                },
+            query: "select * from github.pull_requests where author = $author".to_string(),
+            publish: crate::CoralSqlTableFunctionPublish {
+                schema: "udfs".to_string(),
+                name: "open_pull_requests".to_string(),
+                description: String::new(),
+                guide: String::new(),
             },
             result_columns: Vec::new(),
             source_names: vec!["github".to_string()],

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -6,11 +6,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryExecutionProvenance, QueryParameterValue,
-    QueryParameters, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, RuntimeSourcePackage, StatusCode, UdfRuntimeArgument,
-    UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
-    UdfRuntimeSignature, UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    CoralQuery, CoralSqlFunctionArgument, CoralSqlFunctionDefinition,
+    CoralSqlFunctionInferenceDefinition, CoralSqlFunctionSignature, CoralSqlResultColumn,
+    CoralSqlTableFunctionPublish, CoreError, EngineExtensions, QueryExecutionProvenance,
+    QueryParameterValue, QueryParameters, QueryResultObserver, QueryResultObserverError,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage, StatusCode,
 };
 use coral_spec::ManifestDataType;
 use serde_json::{Value, json};
@@ -172,23 +172,21 @@ fn events_source(source_name: &str) -> (tempfile::TempDir, coral_engine::QuerySo
     (temp, source)
 }
 
-fn udf_sql(name: &str, query: impl Into<String>) -> UdfRuntimeSqlDefinition {
-    UdfRuntimeSqlDefinition {
+fn udf_sql(name: &str, query: impl Into<String>) -> CoralSqlFunctionInferenceDefinition {
+    CoralSqlFunctionInferenceDefinition {
         name: name.to_string(),
-        implementation: UdfRuntimeImplementation::CoralSql {
-            query: query.into(),
-        },
+        query: query.into(),
     }
 }
 
-fn min_id_sql_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
+fn min_id_sql_udf(source_name: &str) -> CoralSqlFunctionInferenceDefinition {
     udf_sql(
         "min_id_events",
         format!("select id from {source_name}.events where id >= $min_id order by id"),
     )
 }
 
-fn review_queue_sql_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
+fn review_queue_sql_udf(source_name: &str) -> CoralSqlFunctionInferenceDefinition {
     udf_sql(
         "review_queue",
         format!(
@@ -197,25 +195,23 @@ fn review_queue_sql_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
     )
 }
 
-fn udf_publish(name: &str) -> UdfRuntimePublish {
-    UdfRuntimePublish {
-        table_function: UdfRuntimeTableFunctionPublish {
-            schema: "udfs".to_string(),
-            name: name.to_string(),
-            description: String::new(),
-            guide: String::new(),
-        },
+fn udf_publish(name: &str) -> CoralSqlTableFunctionPublish {
+    CoralSqlTableFunctionPublish {
+        schema: "udfs".to_string(),
+        name: name.to_string(),
+        description: String::new(),
+        guide: String::new(),
     }
 }
 
-fn udf_argument(name: &str, data_type: ManifestDataType) -> UdfRuntimeArgument {
-    UdfRuntimeArgument {
+fn udf_argument(name: &str, data_type: ManifestDataType) -> CoralSqlFunctionArgument {
+    CoralSqlFunctionArgument {
         name: name.to_string(),
         data_type,
     }
 }
 
-fn udf_result_column(name: &str, data_type: DataType) -> UdfRuntimeResultColumn {
+fn udf_result_column(name: &str, data_type: DataType) -> CoralSqlResultColumn {
     udf_result_column_with_nullability(name, data_type, true)
 }
 
@@ -223,29 +219,27 @@ fn udf_result_column_with_nullability(
     name: &str,
     data_type: DataType,
     nullable: bool,
-) -> UdfRuntimeResultColumn {
-    UdfRuntimeResultColumn {
+) -> CoralSqlResultColumn {
+    CoralSqlResultColumn {
         name: name.to_string(),
         data_type,
         nullable,
     }
 }
 
-fn min_id_udf(source_name: &str) -> UdfRuntimeDefinition {
-    UdfRuntimeDefinition {
+fn min_id_udf(source_name: &str) -> CoralSqlFunctionDefinition {
+    CoralSqlFunctionDefinition {
         name: "min_id_events".to_string(),
         description: "Events above an id".to_string(),
         arguments: vec![udf_argument("min_id", ManifestDataType::Int64)],
-        implementation: UdfRuntimeImplementation::CoralSql {
-            query: format!("select id from {source_name}.events where id >= $min_id order by id"),
-        },
+        query: format!("select id from {source_name}.events where id >= $min_id order by id"),
         publish: udf_publish("min_id_events"),
         result_columns: vec![udf_result_column("id", DataType::Int64)],
         source_names: vec![source_name.to_string()],
     }
 }
 
-fn min_id_udf_without_columns(source_name: &str) -> UdfRuntimeDefinition {
+fn min_id_udf_without_columns(source_name: &str) -> CoralSqlFunctionDefinition {
     let mut udf = min_id_udf(source_name);
     udf.result_columns.clear();
     udf
@@ -255,22 +249,22 @@ fn min_id_udf_with_result_column(
     source_name: &str,
     column_name: &str,
     data_type: DataType,
-) -> UdfRuntimeDefinition {
+) -> CoralSqlFunctionDefinition {
     let mut udf = min_id_udf(source_name);
     udf.result_columns = vec![udf_result_column(column_name, data_type)];
     udf
 }
 
-fn min_id_udf_with_body(source_name: &str, body: impl Into<String>) -> UdfRuntimeDefinition {
+fn min_id_udf_with_body(source_name: &str, body: impl Into<String>) -> CoralSqlFunctionDefinition {
     let mut udf = min_id_udf(source_name);
-    udf.implementation = UdfRuntimeImplementation::CoralSql { query: body.into() };
+    udf.query = body.into();
     udf
 }
 
 fn min_id_udf_with_non_nullable_result(
     source_name: &str,
     body: impl Into<String>,
-) -> UdfRuntimeDefinition {
+) -> CoralSqlFunctionDefinition {
     let mut udf = min_id_udf_with_body(source_name, body);
     udf.result_columns = vec![udf_result_column_with_nullability(
         "id",
@@ -280,34 +274,30 @@ fn min_id_udf_with_non_nullable_result(
     udf
 }
 
-fn mixed_case_published_min_id_udf(source_name: &str) -> UdfRuntimeDefinition {
+fn mixed_case_published_min_id_udf(source_name: &str) -> CoralSqlFunctionDefinition {
     let mut udf = min_id_udf(source_name);
-    udf.publish = UdfRuntimePublish {
-        table_function: UdfRuntimeTableFunctionPublish {
-            schema: "Udfs".to_string(),
-            name: "Min_Id_Events".to_string(),
-            description: String::new(),
-            guide: String::new(),
-        },
+    udf.publish = CoralSqlTableFunctionPublish {
+        schema: "Udfs".to_string(),
+        name: "Min_Id_Events".to_string(),
+        description: String::new(),
+        guide: String::new(),
     };
     udf
 }
 
-fn published_limited_events_udf(source_name: &str) -> UdfRuntimeDefinition {
-    UdfRuntimeDefinition {
+fn published_limited_events_udf(source_name: &str) -> CoralSqlFunctionDefinition {
+    CoralSqlFunctionDefinition {
         name: "limited_events".to_string(),
         description: "Limited events".to_string(),
         arguments: Vec::new(),
-        implementation: UdfRuntimeImplementation::CoralSql {
-            query: format!("select id from {source_name}.events limit 1"),
-        },
+        query: format!("select id from {source_name}.events limit 1"),
         publish: udf_publish("limited_events"),
         result_columns: vec![udf_result_column("id", DataType::Int64)],
         source_names: vec![source_name.to_string()],
     }
 }
 
-fn argument_types(signature: &UdfRuntimeSignature) -> Vec<(&str, ManifestDataType)> {
+fn argument_types(signature: &CoralSqlFunctionSignature) -> Vec<(&str, ManifestDataType)> {
     signature
         .arguments
         .iter()
@@ -315,7 +305,7 @@ fn argument_types(signature: &UdfRuntimeSignature) -> Vec<(&str, ManifestDataTyp
         .collect()
 }
 
-fn column_types(signature: &UdfRuntimeSignature) -> Vec<(&str, &DataType)> {
+fn column_types(signature: &CoralSqlFunctionSignature) -> Vec<(&str, &DataType)> {
     signature
         .result_columns
         .iter()
@@ -323,8 +313,8 @@ fn column_types(signature: &UdfRuntimeSignature) -> Vec<(&str, &DataType)> {
         .collect()
 }
 
-fn review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
-    UdfRuntimeDefinition {
+fn review_queue_udf(source_name: &str) -> CoralSqlFunctionDefinition {
+    CoralSqlFunctionDefinition {
         name: "review_queue".to_string(),
         description: "Review queue".to_string(),
         arguments: vec![
@@ -334,18 +324,16 @@ fn review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
             udf_argument("query", ManifestDataType::Utf8),
             udf_argument("since", ManifestDataType::Timestamp),
         ],
-        implementation: UdfRuntimeImplementation::CoralSql {
-            query: format!(
-                "select title, score from {source_name}.search_issues(q => $query, mode => $mode, min_score => $min_score, payload => $payload, since => $since)"
-            ),
-        },
+        query: format!(
+            "select title, score from {source_name}.search_issues(q => $query, mode => $mode, min_score => $min_score, payload => $payload, since => $since)"
+        ),
         publish: udf_publish("review_queue"),
         result_columns: Vec::new(),
         source_names: vec![source_name.to_string()],
     }
 }
 
-fn published_review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
+fn published_review_queue_udf(source_name: &str) -> CoralSqlFunctionDefinition {
     let mut udf = review_queue_udf(source_name);
     udf.result_columns = vec![
         udf_result_column("title", DataType::Utf8),
@@ -354,7 +342,7 @@ fn published_review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
     udf
 }
 
-fn review_queue_udf_published_as(source_name: &str, schema: &str) -> UdfRuntimeDefinition {
+fn review_queue_udf_published_as(source_name: &str, schema: &str) -> CoralSqlFunctionDefinition {
     review_queue_udf_published_at(source_name, schema, "review_queue")
 }
 
@@ -362,15 +350,13 @@ fn review_queue_udf_published_at(
     source_name: &str,
     schema: &str,
     name: &str,
-) -> UdfRuntimeDefinition {
+) -> CoralSqlFunctionDefinition {
     let mut udf = published_review_queue_udf(source_name);
-    udf.publish = UdfRuntimePublish {
-        table_function: UdfRuntimeTableFunctionPublish {
-            schema: schema.to_string(),
-            name: name.to_string(),
-            description: String::new(),
-            guide: String::new(),
-        },
+    udf.publish = CoralSqlTableFunctionPublish {
+        schema: schema.to_string(),
+        name: name.to_string(),
+        description: String::new(),
+        guide: String::new(),
     };
     udf
 }
@@ -393,7 +379,7 @@ fn assert_invalid_input_contains(error: CoreError, expected: &str) {
 
 async fn assert_udf_sql_error(
     source_name: &str,
-    udfs: Vec<UdfRuntimeDefinition>,
+    udfs: Vec<CoralSqlFunctionDefinition>,
     sql: &str,
     expected: &str,
 ) {
@@ -409,7 +395,7 @@ async fn assert_udf_sql_error(
 
 async fn assert_source_udf_sql_error(
     source_name: &str,
-    udfs: Vec<UdfRuntimeDefinition>,
+    udfs: Vec<CoralSqlFunctionDefinition>,
     sql: &str,
     expected: &str,
 ) {
@@ -720,13 +706,11 @@ async fn published_udf_table_function_executes_udf_sql() {
 
 #[tokio::test]
 async fn published_udf_table_function_coerces_arguments_in_the_expanded_body() {
-    let udf = UdfRuntimeDefinition {
+    let udf = CoralSqlFunctionDefinition {
         name: "format_id".to_string(),
         description: "Formats an id".to_string(),
         arguments: vec![udf_argument("id", ManifestDataType::Int64)],
-        implementation: UdfRuntimeImplementation::CoralSql {
-            query: "select concat($id, '-x') as formatted_id".to_string(),
-        },
+        query: "select concat($id, '-x') as formatted_id".to_string(),
         publish: udf_publish("format_id"),
         result_columns: vec![udf_result_column("formatted_id", DataType::Utf8View)],
         source_names: Vec::new(),
@@ -780,10 +764,8 @@ async fn published_udf_table_function_normalizes_argument_identifiers() {
         .first_mut()
         .expect("test UDF should have one argument")
         .name = "minId".to_string();
-    udf.implementation = UdfRuntimeImplementation::CoralSql {
-        query: "select id from mixed_case_arg_udf_events.events where id >= $minId order by id"
-            .to_string(),
-    };
+    udf.query = "select id from mixed_case_arg_udf_events.events where id >= $minId order by id"
+        .to_string();
     let runtime = test_runtime().with_udfs(vec![udf]);
 
     let execution = CoralQuery::execute_sql(
@@ -1072,7 +1054,7 @@ async fn published_udf_table_function_is_cataloged() {
     let server = MockServer::start().await;
     let source = search_source(&server, "catalog_udf_search");
     let mut udf = published_review_queue_udf("catalog_udf_search");
-    udf.publish.table_function.guide = "Use this function for review queue lookups.".to_string();
+    udf.publish.guide = "Use this function for review queue lookups.".to_string();
     let runtime = test_runtime().with_udfs(vec![udf]);
 
     let catalog = CoralQuery::list_catalog(&[source], runtime, None, Some("udfs"))

--- a/crates/coral-mcp/src/surface/function.rs
+++ b/crates/coral-mcp/src/surface/function.rs
@@ -186,7 +186,7 @@ pub(crate) fn function_added_value(function: &Function) -> Result<Value, tonic::
 
 #[cfg(test)]
 mod tests {
-    use coral_spec::parse_function_sql;
+    use coral_spec::{FunctionImplementationSpec, parse_function_artifact};
 
     use super::{AddFunctionArguments, render_function_artifact};
 
@@ -222,13 +222,16 @@ select cast($owner as VARCHAR) as owner
         let description = "Owner's */ queue\nwith \\ paths";
         let artifact = render_function_artifact(&arguments(description))
             .expect("function artifact should render");
-        let function = parse_function_sql(&artifact).expect("rendered artifact should parse");
+        let function = parse_function_artifact(&artifact).expect("rendered artifact should parse");
 
         assert_eq!(function.name(), "open_prs");
         assert_eq!(function.schema(), "functions");
         assert_eq!(function.description(), description);
+        let FunctionImplementationSpec::CoralSql(implementation) = function.implementation() else {
+            panic!("MCP artifact should produce a Coral SQL implementation");
+        };
         assert_eq!(
-            function.implementation().coral_sql.query,
+            implementation.query,
             "select cast($owner as VARCHAR) as owner"
         );
     }

--- a/crates/coral-mcp/src/surface/function.rs
+++ b/crates/coral-mcp/src/surface/function.rs
@@ -225,7 +225,7 @@ select cast($owner as VARCHAR) as owner
         let function = parse_function_artifact(&artifact).expect("rendered artifact should parse");
 
         assert_eq!(function.name(), "open_prs");
-        assert_eq!(function.schema(), "functions");
+        assert_eq!(function.group(), "functions");
         assert_eq!(function.description(), description);
         let FunctionImplementationSpec::CoralSql(implementation) = function.implementation() else {
             panic!("MCP artifact should produce a Coral SQL implementation");

--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -25,6 +25,8 @@ discovery, and normalized source-definition models.
   types.
 - Keep runtime execution concerns out of this crate. Engine behavior belongs in
   `coral-engine`.
+- Keep authored function language, generic identity, and declared signatures
+  transport-neutral and execution-neutral.
 - Backends that declare SQL relations, including tables and source-scoped table
   functions, must project those names into the shared declared-relation
   namespace validator in `src/validate.rs`; do not hand-roll backend-local

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -136,8 +136,9 @@ pub use parser::{
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub use udf::{
-    FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec,
-    parse_function_sql,
+    FunctionCoralSqlImplementationSpec, FunctionDeclaredArgument, FunctionDeclaredResultColumn,
+    FunctionDeclaredSignature, FunctionImplementationSpec, FunctionLanguage, FunctionSpec,
+    FunctionTypeScriptImplementationSpec, parse_function_artifact, parse_function_sql,
 };
 pub(crate) use validate::{
     DeclaredRelation, DetailHintDeclaringSurface, DetailHintTargetTable, HttpTableValidation,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -138,7 +138,7 @@ pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToke
 pub use udf::{
     FunctionCoralSqlImplementationSpec, FunctionDeclaredArgument, FunctionDeclaredResultColumn,
     FunctionDeclaredSignature, FunctionImplementationSpec, FunctionLanguage, FunctionSpec,
-    FunctionTypeScriptImplementationSpec, parse_function_artifact, parse_function_sql,
+    FunctionTypeScriptImplementationSpec, parse_function_artifact,
 };
 pub(crate) use validate::{
     DeclaredRelation, DetailHintDeclaringSurface, DetailHintTargetTable, HttpTableValidation,

--- a/crates/coral-spec/src/udf/mod.rs
+++ b/crates/coral-spec/src/udf/mod.rs
@@ -14,4 +14,4 @@ pub use model::{
     FunctionDeclaredSignature, FunctionImplementationSpec, FunctionLanguage, FunctionSpec,
     FunctionTypeScriptImplementationSpec,
 };
-pub use parser::{parse_function_artifact, parse_function_sql};
+pub use parser::parse_function_artifact;

--- a/crates/coral-spec/src/udf/mod.rs
+++ b/crates/coral-spec/src/udf/mod.rs
@@ -9,5 +9,9 @@ mod model;
 mod parser;
 mod validation;
 
-pub use model::{FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec};
-pub use parser::parse_function_sql;
+pub use model::{
+    FunctionCoralSqlImplementationSpec, FunctionDeclaredArgument, FunctionDeclaredResultColumn,
+    FunctionDeclaredSignature, FunctionImplementationSpec, FunctionLanguage, FunctionSpec,
+    FunctionTypeScriptImplementationSpec,
+};
+pub use parser::{parse_function_artifact, parse_function_sql};

--- a/crates/coral-spec/src/udf/model.rs
+++ b/crates/coral-spec/src/udf/model.rs
@@ -110,12 +110,6 @@ impl FunctionSpec {
         &self.group
     }
 
-    /// Returns the compatibility SQL schema derived from the generic group.
-    #[must_use]
-    pub fn schema(&self) -> &str {
-        self.group()
-    }
-
     /// Returns the user-facing function description.
     #[must_use]
     pub fn description(&self) -> &str {

--- a/crates/coral-spec/src/udf/model.rs
+++ b/crates/coral-spec/src/udf/model.rs
@@ -1,22 +1,38 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::ManifestDataType;
+
 /// Validated function artifact.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionSpec {
     pub(super) name: String,
-    pub(super) schema: String,
+    pub(super) group: String,
     pub(super) description: String,
     pub(super) guide: String,
     pub(super) implementation: FunctionImplementationSpec,
+    pub(super) signature: Option<FunctionDeclaredSignature>,
 }
 
 /// The executable body behind a function.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct FunctionImplementationSpec {
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum FunctionImplementationSpec {
     /// Read-only Coral SQL using `DataFusion` value parameters like `$argument`.
-    pub coral_sql: FunctionCoralSqlImplementationSpec,
+    CoralSql(FunctionCoralSqlImplementationSpec),
+    /// TypeScript source for a future function executor.
+    TypeScript(FunctionTypeScriptImplementationSpec),
+}
+
+impl FunctionImplementationSpec {
+    /// Returns the authored implementation language.
+    #[must_use]
+    pub fn language(&self) -> FunctionLanguage {
+        match self {
+            Self::CoralSql(_) => FunctionLanguage::Sql,
+            Self::TypeScript(_) => FunctionLanguage::TypeScript,
+        }
+    }
 }
 
 /// Read-only Coral SQL implementation for a function.
@@ -27,6 +43,60 @@ pub struct FunctionCoralSqlImplementationSpec {
     pub query: String,
 }
 
+/// TypeScript implementation for a function.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionTypeScriptImplementationSpec {
+    /// TypeScript source supplied by the author.
+    pub source: String,
+}
+
+/// Authored implementation language.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FunctionLanguage {
+    /// Coral SQL body.
+    #[default]
+    #[serde(rename = "sql")]
+    Sql,
+    /// TypeScript body.
+    #[serde(rename = "typescript")]
+    TypeScript,
+}
+
+/// Signature declared in a function artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub struct FunctionDeclaredSignature {
+    /// Typed arguments accepted by the function.
+    pub arguments: Vec<FunctionDeclaredArgument>,
+    /// Typed columns returned by the function.
+    pub result_columns: Vec<FunctionDeclaredResultColumn>,
+}
+
+/// One declared function argument.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionDeclaredArgument {
+    /// Argument name.
+    pub name: String,
+    /// Argument type in manifest spelling.
+    pub data_type: ManifestDataType,
+}
+
+/// One declared function result column.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionDeclaredResultColumn {
+    /// Column name.
+    pub name: String,
+    /// Column type in manifest spelling.
+    pub data_type: ManifestDataType,
+    /// Whether the column can contain null values.
+    #[serde(default)]
+    pub nullable: bool,
+}
+
 impl FunctionSpec {
     /// Returns the stable function id within one workspace.
     #[must_use]
@@ -34,10 +104,16 @@ impl FunctionSpec {
         &self.name
     }
 
-    /// Returns the SQL schema where this function is published.
+    /// Returns the generic group for this function.
+    #[must_use]
+    pub fn group(&self) -> &str {
+        &self.group
+    }
+
+    /// Returns the compatibility SQL schema derived from the generic group.
     #[must_use]
     pub fn schema(&self) -> &str {
-        &self.schema
+        self.group()
     }
 
     /// Returns the user-facing function description.
@@ -56,5 +132,17 @@ impl FunctionSpec {
     #[must_use]
     pub fn implementation(&self) -> &FunctionImplementationSpec {
         &self.implementation
+    }
+
+    /// Returns the authored implementation language.
+    #[must_use]
+    pub fn language(&self) -> FunctionLanguage {
+        self.implementation.language()
+    }
+
+    /// Returns the declared signature, when one is present.
+    #[must_use]
+    pub fn declared_signature(&self) -> Option<&FunctionDeclaredSignature> {
+        self.signature.as_ref()
     }
 }

--- a/crates/coral-spec/src/udf/parser.rs
+++ b/crates/coral-spec/src/udf/parser.rs
@@ -194,12 +194,16 @@ export async function run(owner: string): Promise<string> {
         };
         assert!(implementation.source.contains("export async function run"));
         let signature = function.declared_signature().expect("declared signature");
-        assert_eq!(signature.arguments.len(), 1);
-        assert_eq!(signature.arguments[0].name, "owner");
-        assert_eq!(signature.arguments[0].data_type, ManifestDataType::Utf8);
-        assert_eq!(signature.result_columns.len(), 1);
-        assert_eq!(signature.result_columns[0].name, "title");
-        assert!(signature.result_columns[0].nullable);
+        let [argument] = signature.arguments.as_slice() else {
+            panic!("expected one declared argument");
+        };
+        assert_eq!(argument.name, "owner");
+        assert_eq!(argument.data_type, ManifestDataType::Utf8);
+        let [result_column] = signature.result_columns.as_slice() else {
+            panic!("expected one declared result column");
+        };
+        assert_eq!(result_column.name, "title");
+        assert!(result_column.nullable);
     }
 
     #[test]

--- a/crates/coral-spec/src/udf/parser.rs
+++ b/crates/coral-spec/src/udf/parser.rs
@@ -70,11 +70,6 @@ pub fn parse_function_artifact(raw: &str) -> Result<FunctionSpec> {
     })
 }
 
-/// Compatibility wrapper for callers that still use the SQL-specific name.
-pub fn parse_function_sql(raw: &str) -> Result<FunctionSpec> {
-    parse_function_artifact(raw)
-}
-
 fn split_frontmatter(raw: &str) -> Result<(&str, &str)> {
     let Some(after_open) = raw.strip_prefix("/*") else {
         return Err(ManifestError::validation(
@@ -98,7 +93,7 @@ fn split_frontmatter(raw: &str) -> Result<(&str, &str)> {
 mod tests {
     use crate::{FunctionImplementationSpec, ManifestDataType};
 
-    use super::{parse_function_artifact, parse_function_sql};
+    use super::parse_function_artifact;
 
     #[derive(Clone, Copy)]
     enum ExpectedError {
@@ -167,8 +162,8 @@ export async function run(owner: string): Promise<string> {
     }
 
     #[test]
-    fn parse_function_sql_accepts_valid_function() {
-        let function = parse_function_sql(valid_function()).expect("function should parse");
+    fn parse_function_artifact_accepts_valid_sql_function() {
+        let function = parse_function_artifact(valid_function()).expect("function should parse");
 
         assert_eq!(function.name(), "github_review_queue");
         assert_eq!(function.group(), "functions");
@@ -207,17 +202,17 @@ export async function run(owner: string): Promise<string> {
     }
 
     #[test]
-    fn parse_function_sql_defaults_omitted_guide() {
+    fn parse_function_artifact_defaults_omitted_guide() {
         let artifact =
             function_with(&[("guide: Use this function for review queue lookups.\n", "")]);
 
-        let function = parse_function_sql(&artifact).expect("function should parse");
+        let function = parse_function_artifact(&artifact).expect("function should parse");
 
         assert!(function.guide().is_empty());
     }
 
     #[test]
-    fn parse_function_sql_rejects_invalid_frontmatter() {
+    fn parse_function_artifact_rejects_invalid_frontmatter() {
         let cases = [
             (
                 "missing frontmatter",
@@ -267,8 +262,8 @@ export async function run(owner: string): Promise<string> {
     }
 
     #[test]
-    fn parse_function_sql_preserves_body_after_frontmatter_comment() {
-        let function = parse_function_sql(valid_function()).expect("function should parse");
+    fn parse_function_artifact_preserves_body_after_frontmatter_comment() {
+        let function = parse_function_artifact(valid_function()).expect("function should parse");
         let FunctionImplementationSpec::CoralSql(implementation) = function.implementation() else {
             panic!("SQL artifact should produce a Coral SQL implementation");
         };
@@ -299,14 +294,30 @@ export async function run(owner: string): Promise<string> {
     }
 
     #[test]
+    fn parse_function_artifact_rejects_declared_signature_for_sql() {
+        let artifact = function_with(&[(
+            "description: GitHub PR review queue",
+            "description: GitHub PR review queue\nsignature:\n  result_columns:\n    - name: title\n      data_type: Utf8",
+        )]);
+
+        assert_function_error(
+            "declared SQL signature",
+            &artifact,
+            ExpectedError::Exact(
+                "function 'github_review_queue' SQL implementation must not declare a signature because Coral infers it from SQL",
+            ),
+        );
+    }
+
+    #[test]
     fn parse_function_artifact_rejects_duplicate_declared_names() {
         let duplicate_arguments = function_with(&[(
             "description: GitHub PR review queue",
-            "signature:\n  arguments:\n    - name: owner\n      data_type: Utf8\n    - name: owner\n      data_type: Int64\n  result_columns:\n    - name: title\n      data_type: Utf8",
+            "language: typescript\nsignature:\n  arguments:\n    - name: owner\n      data_type: Utf8\n    - name: owner\n      data_type: Int64\n  result_columns:\n    - name: title\n      data_type: Utf8",
         )]);
         let duplicate_columns = function_with(&[(
             "description: GitHub PR review queue",
-            "signature:\n  result_columns:\n    - name: title\n      data_type: Utf8\n    - name: title\n      data_type: Int64",
+            "language: typescript\nsignature:\n  result_columns:\n    - name: title\n      data_type: Utf8\n    - name: title\n      data_type: Int64",
         )]);
 
         assert_function_error(
@@ -347,7 +358,7 @@ export async function run(owner: string): Promise<string> {
     }
 
     #[test]
-    fn parse_function_sql_rejects_invalid_schema() {
+    fn parse_function_artifact_rejects_invalid_schema() {
         let cases = [
             (
                 "mixed-case table-function schema",

--- a/crates/coral-spec/src/udf/parser.rs
+++ b/crates/coral-spec/src/udf/parser.rs
@@ -167,7 +167,6 @@ export async function run(owner: string): Promise<string> {
 
         assert_eq!(function.name(), "github_review_queue");
         assert_eq!(function.group(), "functions");
-        assert_eq!(function.schema(), "functions");
         assert_eq!(
             function.guide(),
             "Use this function for review queue lookups."

--- a/crates/coral-spec/src/udf/parser.rs
+++ b/crates/coral-spec/src/udf/parser.rs
@@ -2,7 +2,11 @@ use serde::Deserialize;
 
 use crate::{ManifestError, Result};
 
-use super::model::{FunctionCoralSqlImplementationSpec, FunctionImplementationSpec, FunctionSpec};
+use super::model::{
+    FunctionCoralSqlImplementationSpec, FunctionDeclaredArgument, FunctionDeclaredResultColumn,
+    FunctionImplementationSpec, FunctionLanguage, FunctionSpec,
+    FunctionTypeScriptImplementationSpec,
+};
 use super::validation::validate_raw_function;
 
 #[derive(Debug, Deserialize)]
@@ -14,6 +18,18 @@ pub(super) struct RawFunctionFrontmatter {
     pub(super) description: String,
     #[serde(default)]
     pub(super) guide: String,
+    #[serde(default)]
+    pub(super) language: FunctionLanguage,
+    pub(super) signature: Option<RawFunctionSignature>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) struct RawFunctionSignature {
+    #[serde(default)]
+    pub(super) arguments: Vec<FunctionDeclaredArgument>,
+    #[serde(default)]
+    pub(super) result_columns: Vec<FunctionDeclaredResultColumn>,
 }
 
 #[derive(Debug)]
@@ -22,28 +38,41 @@ pub(super) struct RawFunctionSpec {
     pub(super) implementation: FunctionImplementationSpec,
 }
 
-/// Parses and statically validates one function SQL artifact.
+/// Parses and statically validates one function artifact.
 ///
 /// # Errors
 ///
-/// Returns [`ManifestError`] when the frontmatter cannot be parsed, the SQL
-/// body is empty, or the artifact violates function-local invariants.
-pub fn parse_function_sql(raw: &str) -> Result<FunctionSpec> {
-    let (frontmatter, sql) = split_frontmatter(raw)?;
+/// Returns [`ManifestError`] when the frontmatter cannot be parsed, the body is
+/// empty, or the artifact violates function-local invariants.
+pub fn parse_function_artifact(raw: &str) -> Result<FunctionSpec> {
+    let (frontmatter, body) = split_frontmatter(raw)?;
     let frontmatter: RawFunctionFrontmatter =
         serde_yaml::from_str(frontmatter).map_err(|error| {
             ManifestError::validation(format!(
                 "function artifact SQL comment frontmatter is invalid: {error}"
             ))
         })?;
+    let implementation = match frontmatter.language {
+        FunctionLanguage::Sql => {
+            FunctionImplementationSpec::CoralSql(FunctionCoralSqlImplementationSpec {
+                query: body.trim().to_string(),
+            })
+        }
+        FunctionLanguage::TypeScript => {
+            FunctionImplementationSpec::TypeScript(FunctionTypeScriptImplementationSpec {
+                source: body.trim().to_string(),
+            })
+        }
+    };
     validate_raw_function(RawFunctionSpec {
         frontmatter,
-        implementation: FunctionImplementationSpec {
-            coral_sql: FunctionCoralSqlImplementationSpec {
-                query: sql.trim().to_string(),
-            },
-        },
+        implementation,
     })
+}
+
+/// Compatibility wrapper for callers that still use the SQL-specific name.
+pub fn parse_function_sql(raw: &str) -> Result<FunctionSpec> {
+    parse_function_artifact(raw)
 }
 
 fn split_frontmatter(raw: &str) -> Result<(&str, &str)> {
@@ -67,7 +96,9 @@ fn split_frontmatter(raw: &str) -> Result<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_function_sql;
+    use crate::{FunctionImplementationSpec, ManifestDataType};
+
+    use super::{parse_function_artifact, parse_function_sql};
 
     #[derive(Clone, Copy)]
     enum ExpectedError {
@@ -88,6 +119,28 @@ from github.pulls(owner => $owner, repo => $repo)
 "
     }
 
+    fn valid_typescript_function() -> &'static str {
+        r"/*
+name: review_summary
+schema: functions
+description: Summarize a pull request review queue.
+language: typescript
+signature:
+  arguments:
+    - name: owner
+      data_type: Utf8
+  result_columns:
+    - name: title
+      data_type: Utf8
+      nullable: true
+*/
+
+export async function run(owner: string): Promise<string> {
+  return `queue for ${owner}`;
+}
+"
+    }
+
     fn function_with(replacements: &[(&str, &str)]) -> String {
         let mut artifact = valid_function().to_string();
         for (from, to) in replacements {
@@ -101,7 +154,7 @@ from github.pulls(owner => $owner, repo => $repo)
     }
 
     fn assert_function_error(name: &str, artifact: &str, expected: ExpectedError) {
-        let error = parse_function_sql(artifact).unwrap_err();
+        let error = parse_function_artifact(artifact).unwrap_err();
         match expected {
             ExpectedError::Exact(message) => assert_eq!(error.to_string(), message, "{name}"),
             ExpectedError::Contains(message) => {
@@ -118,18 +171,35 @@ from github.pulls(owner => $owner, repo => $repo)
         let function = parse_function_sql(valid_function()).expect("function should parse");
 
         assert_eq!(function.name(), "github_review_queue");
+        assert_eq!(function.group(), "functions");
         assert_eq!(function.schema(), "functions");
         assert_eq!(
             function.guide(),
             "Use this function for review queue lookups."
         );
-        assert!(
-            function
-                .implementation()
-                .coral_sql
-                .query
-                .contains("github.pulls")
-        );
+        let FunctionImplementationSpec::CoralSql(implementation) = function.implementation() else {
+            panic!("SQL artifact should produce a Coral SQL implementation");
+        };
+        assert!(implementation.query.contains("github.pulls"));
+    }
+
+    #[test]
+    fn parse_function_artifact_selects_typescript_and_declared_signature() {
+        let function = parse_function_artifact(valid_typescript_function())
+            .expect("TypeScript function should parse");
+
+        let FunctionImplementationSpec::TypeScript(implementation) = function.implementation()
+        else {
+            panic!("TypeScript artifact should produce a TypeScript implementation");
+        };
+        assert!(implementation.source.contains("export async function run"));
+        let signature = function.declared_signature().expect("declared signature");
+        assert_eq!(signature.arguments.len(), 1);
+        assert_eq!(signature.arguments[0].name, "owner");
+        assert_eq!(signature.arguments[0].data_type, ManifestDataType::Utf8);
+        assert_eq!(signature.result_columns.len(), 1);
+        assert_eq!(signature.result_columns[0].name, "title");
+        assert!(signature.result_columns[0].nullable);
     }
 
     #[test]
@@ -195,7 +265,10 @@ from github.pulls(owner => $owner, repo => $repo)
     #[test]
     fn parse_function_sql_preserves_body_after_frontmatter_comment() {
         let function = parse_function_sql(valid_function()).expect("function should parse");
-        let query = &function.implementation().coral_sql.query;
+        let FunctionImplementationSpec::CoralSql(implementation) = function.implementation() else {
+            panic!("SQL artifact should produce a Coral SQL implementation");
+        };
+        let query = &implementation.query;
 
         assert!(
             query.starts_with("select title"),
@@ -203,6 +276,70 @@ from github.pulls(owner => $owner, repo => $repo)
         );
         assert!(!query.contains("github_review_queue"));
         assert!(!query.contains("*/"));
+    }
+
+    #[test]
+    fn parse_function_artifact_rejects_typescript_without_declared_signature() {
+        let artifact = function_with(&[(
+            "description: GitHub PR review queue",
+            "language: typescript\ndescription: GitHub PR review queue",
+        )]);
+
+        assert_function_error(
+            "missing TypeScript signature",
+            &artifact,
+            ExpectedError::Exact(
+                "function 'github_review_queue' TypeScript implementation requires a declared signature",
+            ),
+        );
+    }
+
+    #[test]
+    fn parse_function_artifact_rejects_duplicate_declared_names() {
+        let duplicate_arguments = function_with(&[(
+            "description: GitHub PR review queue",
+            "signature:\n  arguments:\n    - name: owner\n      data_type: Utf8\n    - name: owner\n      data_type: Int64\n  result_columns:\n    - name: title\n      data_type: Utf8",
+        )]);
+        let duplicate_columns = function_with(&[(
+            "description: GitHub PR review queue",
+            "signature:\n  result_columns:\n    - name: title\n      data_type: Utf8\n    - name: title\n      data_type: Int64",
+        )]);
+
+        assert_function_error(
+            "duplicate argument",
+            &duplicate_arguments,
+            ExpectedError::Exact(
+                "function 'github_review_queue' declares argument 'owner' more than once",
+            ),
+        );
+        assert_function_error(
+            "duplicate result column",
+            &duplicate_columns,
+            ExpectedError::Exact(
+                "function 'github_review_queue' declares result column 'title' more than once",
+            ),
+        );
+    }
+
+    #[test]
+    fn parse_function_artifact_rejects_empty_typescript_body_and_unknown_language() {
+        let empty_body = valid_typescript_function().replace(
+            "export async function run(owner: string): Promise<string> {\n  return `queue for ${owner}`;\n}",
+            "   ",
+        );
+        let unknown_language =
+            function_with(&[("description: GitHub PR review queue", "language: python")]);
+
+        assert_function_error(
+            "empty TypeScript body",
+            &empty_body,
+            ExpectedError::Exact("function 'review_summary' TypeScript body must not be empty"),
+        );
+        assert_function_error(
+            "unknown language",
+            &unknown_language,
+            ExpectedError::Contains("function artifact SQL comment frontmatter is invalid"),
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/udf/validation.rs
+++ b/crates/coral-spec/src/udf/validation.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
+
 use crate::{ManifestError, Result, validate_identifier, validate_reserved_source_schema_name};
 
-use super::model::FunctionSpec;
-use super::parser::RawFunctionSpec;
+use super::model::{FunctionDeclaredSignature, FunctionImplementationSpec, FunctionSpec};
+use super::parser::{RawFunctionSignature, RawFunctionSpec};
 
 const RESERVED_FUNCTION_SCHEMA_NAMES: &[&str] = &["__coral_udfs"];
 
@@ -44,23 +46,98 @@ impl FunctionValidator {
     }
 
     fn validate_implementation(&self) -> Result<()> {
-        if self.raw.implementation.coral_sql.query.trim().is_empty() {
+        match &self.raw.implementation {
+            FunctionImplementationSpec::CoralSql(implementation) => {
+                if implementation.query.trim().is_empty() {
+                    return Err(ManifestError::validation(format!(
+                        "function '{}' SQL body must not be empty",
+                        self.raw.frontmatter.name
+                    )));
+                }
+            }
+            FunctionImplementationSpec::TypeScript(implementation) => {
+                if implementation.source.trim().is_empty() {
+                    return Err(ManifestError::validation(format!(
+                        "function '{}' TypeScript body must not be empty",
+                        self.raw.frontmatter.name
+                    )));
+                }
+                if self.raw.frontmatter.signature.is_none() {
+                    return Err(ManifestError::validation(format!(
+                        "function '{}' TypeScript implementation requires a declared signature",
+                        self.raw.frontmatter.name
+                    )));
+                }
+            }
+        }
+        if let Some(signature) = &self.raw.frontmatter.signature {
+            self.validate_declared_signature(signature)?;
+        }
+        Ok(())
+    }
+
+    fn validate_declared_signature(&self, signature: &RawFunctionSignature) -> Result<()> {
+        if signature.result_columns.is_empty() {
             return Err(ManifestError::validation(format!(
-                "function '{}' SQL body must not be empty",
+                "function '{}' declared signature must declare at least one result column",
                 self.raw.frontmatter.name
             )));
+        }
+        self.validate_signature_names(
+            signature
+                .arguments
+                .iter()
+                .map(|argument| argument.name.as_str()),
+            "argument",
+            "argument",
+        )?;
+        self.validate_signature_names(
+            signature
+                .result_columns
+                .iter()
+                .map(|column| column.name.as_str()),
+            "column",
+            "result column",
+        )
+    }
+
+    fn validate_signature_names<'a>(
+        &self,
+        names: impl Iterator<Item = &'a str>,
+        kind: &str,
+        display_kind: &str,
+    ) -> Result<()> {
+        let mut seen = HashSet::new();
+        for name in names {
+            validate_lowercase_identifier(
+                name,
+                &format!("function '{}' {kind} '{name}'", self.raw.frontmatter.name),
+            )?;
+            if !seen.insert(name) {
+                return Err(ManifestError::validation(format!(
+                    "function '{}' declares {display_kind} '{name}' more than once",
+                    self.raw.frontmatter.name
+                )));
+            }
         }
         Ok(())
     }
 
     fn finish(self) -> FunctionSpec {
         let frontmatter = self.raw.frontmatter;
+        let signature = frontmatter
+            .signature
+            .map(|signature| FunctionDeclaredSignature {
+                arguments: signature.arguments,
+                result_columns: signature.result_columns,
+            });
         FunctionSpec {
             name: frontmatter.name,
-            schema: frontmatter.schema,
+            group: frontmatter.schema,
             description: frontmatter.description,
             guide: frontmatter.guide,
             implementation: self.raw.implementation,
+            signature,
         }
     }
 }

--- a/crates/coral-spec/src/udf/validation.rs
+++ b/crates/coral-spec/src/udf/validation.rs
@@ -54,6 +54,12 @@ impl FunctionValidator {
                         self.raw.frontmatter.name
                     )));
                 }
+                if self.raw.frontmatter.signature.is_some() {
+                    return Err(ManifestError::validation(format!(
+                        "function '{}' SQL implementation must not declare a signature because Coral infers it from SQL",
+                        self.raw.frontmatter.name
+                    )));
+                }
             }
             FunctionImplementationSpec::TypeScript(implementation) => {
                 if implementation.source.trim().is_empty() {


### PR DESCRIPTION
[Artifacts](https://cloud.humanlayer.com/artifacts/019ffa73-5cc0-79c3-9f62-4b51f15c51fe) | [Research](https://cloud.humanlayer.com/artifacts/019ffa96-1aa8-727d-a0f5-299a4e9ec3ed) | [Design](https://cloud.humanlayer.com/artifacts/019ffaa7-cf71-71f5-b4b1-0836d83e142c) | [Implementation outline](https://cloud.humanlayer.com/artifacts/019ffae4-cd42-725a-b0d3-29b1d910426e)

## What problems was I solving

Installed functions were intended to support more than one implementation language, but the app-to-engine contract mixed generic function identity with DataFusion and Coral SQL execution details. That shape made an unsupported implementation look like an engine concern and required language filters inside the SQL runtime.

This PR makes the ownership boundary explicit: `coral-spec` describes the authored language and signature, `coral-app` selects a supported implementation, and `coral-engine` receives only executable Coral SQL definitions. Current Coral SQL invocation, storage, protobuf fields, catalog data, search data, and query results stay unchanged.

This PR is based directly on `main` and contains only the function-boundary work.

## What user-facing changes did I ship

- There is no change to supported Coral SQL function behavior, CLI syntax, MCP input, protobuf fields, `function.sql` storage, or SQL invocation.
- [`crates/coral-app/src/functions/runtime.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-97b5df84c1d972971956ca25903d6aa7750676acf13108d8ad59ac63fcdb38c1) - A TypeScript artifact now fails with a clear `FAILED_PRECONDITION` because no TypeScript executor is available.
- [`crates/coral-app/tests/grpc/function_lifecycle_tests.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-34f4f4b1d8e1c08c4854ca17eefceda5d359d8e3370f09249109da70c658d31b) - The transport-level regression test proves that rejection leaves no function inventory or artifact directory.

## How I implemented it

### Authored function model

- [`crates/coral-spec/src/udf/model.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-f26d8fc595e2cdd03371e8ea1436cb33b6c4584e4a7ab62cbf7e72349ac0b8b1) - Separates generic function group and declared signature data from `CoralSql` and `TypeScript` implementation variants.
- [`crates/coral-spec/src/udf/parser.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-f9fbb1ec381416720a51703d02e30e2441fa4378891b7322bbcddd3f10ddade7) - Adds `parse_function_artifact` as the single parser and keeps SQL as the default authored language. The unused internal `parse_function_sql` name was removed to avoid two parser contracts.
- [`crates/coral-spec/src/udf/validation.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-f3499620c3bc71e68738f83f9c3e05c5d67c0cacf8b9dd0831fa4bbd554979f4) - Validates language-specific bodies and declared signature names. TypeScript requires a declared signature; Coral SQL rejects one because DataFusion inference is authoritative.

### Application ownership

- [`crates/coral-app/src/functions/runtime.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-97b5df84c1d972971956ca25903d6aa7750676acf13108d8ad59ac63fcdb38c1) - Becomes the language-selection seam. It lowers Coral SQL to an engine definition and rejects TypeScript before it creates an inference runtime.
- [`crates/coral-app/src/functions/manager.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-c7bafa69809e386006ed72da27d95b626eace02943fcf42621ed855717fc79cc) - Uses the same lowering path for add, list, collision checks, and runtime loading. Manually present unsupported artifacts remain visible as invalid, but new unsupported artifacts cannot be persisted.
- [`crates/coral-app/src/functions/service.rs`](https://github.com/withcoral/coral/pull/2171/files) - Keeps the gRPC adapter thin and preserves the existing `sql` and `sql_body` wire fields.

### SQL engine contract

- [`crates/coral-engine/src/contracts/udfs.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-4e3ba7d5b368b27b50b3d72b856a77dfa0f8d4d2c74dcc6ef88fac8c944391e5) - Replaces the mixed UDF contract with required-query `CoralSqlFunctionDefinition` and inference types.
- [`crates/coral-engine/src/runtime/query.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-f791d7c008ff098ce0a182f2e73aacd727e3207137ecd00ccff3db559a523911) - Registers every supplied definition as Coral SQL and removes unsupported-language filtering from DataFusion runtime assembly.
- [`crates/coral-engine/src/runtime/udf_calls.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-0ea3491b592f951a4e5b5015996494d7555031e5ca531eb9cd9629b3fceb39ac) - Plans the required query directly while preserving named argument binding and logical-plan expansion.
- [`crates/coral-engine/src/runtime/udfs.rs`](https://github.com/withcoral/coral/pull/2171/files#diff-d915db060ee51cda8a58fb2df4eeea4a193a9575e8524bcf22af168173adcb03) - Keeps SQL signature inference, publication collision checks, result schemas, and catalog metadata in the engine.

### Ownership guidance

- `crates/coral-spec/AGENTS.md`, `crates/coral-app/AGENTS.md`, and `crates/coral-engine/AGENTS.md` record the new contributor boundary: authored language in spec, selection in app, executable Coral SQL in engine.

## Deviations from the plan

### Implemented as planned

- The implementation follows both phases: app-owned language selection and a Coral-SQL-only engine contract.
- Unsupported TypeScript fails before inference and persistence; current SQL behavior and public transport fields stay unchanged.
- The required crate guidance and focused parser, manager, gRPC, and engine tests are present.

### Deviations/surprises

- No material architecture deviation exists.
- Generic parser errors still refer to “SQL comment frontmatter” because the artifact continues to use the existing SQL-comment envelope.
- The outline allowed a `parse_function_sql` compatibility wrapper if it remained useful. The final implementation removes that unused internal symbol and exposes only `parse_function_artifact`, so the parser name matches its language-neutral result.

### Additions not in plan

- Runtime configuration is supplied lazily, which proves unsupported TypeScript does not create a DataFusion inference runtime.
- Listing partitions supported SQL definitions from unsupported artifacts before batch inference, so unsupported installed artifacts stay visible as invalid.

### Items planned but not implemented

- None. Files for protobuf, CLI, Reef, catalog discovery, and search did not need edits because their existing behavior remains the compatibility contract.

## How to verify it

### Worktree setup

```bash
git fetch origin
git switch audit-generic-udf-execution-layer-architecture
git pull --ff-only
```

### Manual testing

- [x] Add an existing Coral SQL function, list it, call its `schema.function(named_args)` target, and compare its catalog metadata and result rows.
- [x] Add a valid TypeScript artifact and confirm the error says that no TypeScript executor is available.
- [x] List functions and inspect `CORAL_CONFIG_DIR`; confirm the rejected TypeScript function has no inventory entry or function directory.

### Automated tests

```bash
cargo test --locked -p coral-spec udf
cargo test --locked -p coral-app functions::
cargo test --locked -p coral-app --test grpc function_lifecycle
cargo test --locked -p coral-engine --test engine udf
cargo test --locked -p coral-engine --test engine catalog
cargo test --locked -p coral-app --test grpc catalog_discovery
cargo test --locked -p coral-app --test grpc search
cargo test --locked -p coral-cli --test cli_e2e functions
cargo test --locked -p coral-mcp function
make rust-checks
```

All listed checks and manual paths passed during implementation. Adversarial checks also covered malformed signatures, unsupported languages, mutating SQL, replacement safety, manually injected unsupported artifacts, and 20 concurrent rejected TypeScript replacements.

## Description for the changelog

Clarified installed-function ownership by selecting authored languages in the app and keeping the engine contract specific to executable Coral SQL.
