### PR TITLE
ci(release): build every target on a native Blacksmith runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,16 +111,15 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: blacksmith-4vcpu-ubuntu-2404
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            cross: true
+            os: blacksmith-4vcpu-ubuntu-2404-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-26
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: blacksmith-6vcpu-macos-26
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: blacksmith-4vcpu-windows-2025
     runs-on: ${{ matrix.os }}
     env:
       TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
@@ -141,17 +140,10 @@ jobs:
           path: apps/ui/dist
       # No Rust cache here — release builds must compile from a clean state
       # to guard against cache poisoning attacks.
-      - name: Install cross
-        if: matrix.cross
-        run: |
-          set -euo pipefail
-          cargo install cargo-binstall --locked
-          cargo binstall --no-confirm --force --disable-strategies compile cross@0.2.5
       - name: Build Unix
         if: runner.os != 'Windows'
         shell: bash
         env:
-          CROSS: ${{ matrix.cross }}
           HAS_UI: ${{ needs.build-ui.outputs.has-ui }}
           TARGET: ${{ matrix.target }}
         run: |
@@ -160,11 +152,7 @@ jobs:
             feature_args=(--features embedded-ui)
           fi
 
-          if [ "$CROSS" = "true" ]; then
-            cross build --locked --release --target "$TARGET" "${feature_args[@]}"
-          else
-            cargo build --locked --release --target "$TARGET" "${feature_args[@]}"
-          fi
+          cargo build --locked --release --target "$TARGET" "${feature_args[@]}"
 
       - name: Build Windows
         if: runner.os == 'Windows'
@@ -579,7 +567,7 @@ jobs:
       - validate-release-ref
       - coordinate-docker-aliases
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
     outputs:
@@ -621,7 +609,7 @@ jobs:
       - promote-release
     if: needs.promote-release.outputs.promoted == 'true'
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What changed

- Linux/arm64 releases build on `blacksmith-4vcpu-ubuntu-2404-arm` instead of cross-compiling under `cross`.
- The rest of the release matrix moves to Blacksmith: `blacksmith-4vcpu-ubuntu-2404`, `blacksmith-6vcpu-macos-26`, `blacksmith-4vcpu-windows-2025`.
- `promote-release` and `notify-release` move off `ubuntu-latest` too, so every job in `release.yml` is now on Blacksmith.
- The `Install cross` step and the `CROSS` branch in `Build Unix` are gone; `Build Unix` is a plain `cargo build`.

Net 8 insertions, 20 deletions.

## Why

The arm64 build ran inside a `cross` container on an x86_64 host. That was fine until `openssl-sys` entered the dependency tree via `datafusion-table-providers` (#1895). Its build script is compiled for the **host** and looks for the **target's** OpenSSL, which the cross sysroot does not supply:

```
error: failed to run custom build command for `openssl-sys v0.9.117`
  Could not find directory of OpenSSL installation...
  $HOST = x86_64-unknown-linux-gnu
  $TARGET = aarch64-unknown-linux-gnu
```

That is what failed the v0.10.0 release build. `fail-fast` then cancelled the other four targets, so `checksums`, `publish-version` and `publish-docker` never ran — and since `promote-release` is what clears the prerelease flag, v0.10.0 is still marked prerelease with zero assets.

Building natively removes the host/target split, so the OpenSSL that `openssl-sys` finds is the right architecture by construction. It also drops a `cargo-binstall` + `cross` install from every release.

Sizes match existing usage: `4vcpu` for Linux/Windows as in `validate.yml`, `6vcpu-macos-26` as already used by `sign-notarize-macos` and `build-desktop-macos` in this same workflow.

## User-visible impact

arm64 Linux binaries now link against the runner's glibc rather than the older one baked into the `cross` image, raising their minimum glibc. This matches what x86_64 Linux binaries already required — that target has always built with plain `cargo` on `ubuntu-latest` — so this removes an asymmetry rather than introducing a new constraint. No glibc floor is documented in `apps/docs`, `README.md`, or `scripts`.

If we do want to support older distros, the coherent fix is an older base for **both** Linux targets, not just arm64.

## Follow-on work and known limitations

- **This does not ship v0.10.0.** `workflow_dispatch` reads the workflow file from the ref it runs against, and the `v0.10.0` tag still has `cross: true`. Shipping it means either moving the tag to a commit containing this fix, or letting release-please cut the next version from `main`.
- Two things this PR cannot verify ahead of the first release run: whether the Blacksmith arm64 pool is enabled on our plan, and whether their `ubuntu-2404-arm` image ships `libssl-dev`. Both fail loudly and early. An explicit `apt-get install libssl-dev pkg-config` step was considered and deliberately left out; add it if the first run needs it.
- Separately, releases were also delayed by a wedged `release-please` run holding its concurrency group for 7 days. Not addressed here.

https://claude.ai/code/session_01BVH4nr3dCs6K6673qsKJ9G
