### PR TITLE
feat(app)!: move existing workspace members between roles

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -109,6 +109,8 @@ that needs operator attention, not an alternate access path.
 The gRPC API is Coral's internal contract boundary. It is not a supported
 end-user workspace-administration or recovery surface.
 
+Adding an existing member with the same role is idempotent; requesting a different role atomically moves the membership to that role. Coral refuses to demote or remove the sole owner.
+
 ### Repository recovery tool
 
 The repository contains an off-by-default tool for recovering a legacy workspace with no non-local owner and for rebinding identities after an issuer rename. It is absent from shipped `coral` and default `xtask` builds. Use a checkout matching the deployment and back up first. Database possession is the authority: SQLite requires state-directory access; Postgres uses `[database].url_env` without a host-locality guarantee. The tool opens existing state without migrations or startup repair. Start the upgraded shared server, have the intended owner sign in once, then run:

--- a/crates/coral-api/proto/coral/v1/workspaces.proto
+++ b/crates/coral-api/proto/coral/v1/workspaces.proto
@@ -77,17 +77,17 @@ message ListWorkspaceMembersResponse {
   repeated WorkspaceMember members = 1;
 }
 
-// Adds one user to a workspace.
+// Adds a workspace member or moves an existing workspace membership to the desired role.
 message AddWorkspaceMemberRequest {
   // Workspace to modify.
   Workspace workspace = 1;
-  // User and role to add. The display name is ignored.
+  // User and desired role. The display name is ignored.
   WorkspaceMember member = 2;
 }
 
-// Returns the added or existing identical membership.
+// Returns the resulting workspace membership.
 message AddWorkspaceMemberResponse {
-  // Added workspace member.
+  // Resulting workspace member.
   WorkspaceMember member = 1;
 }
 
@@ -112,7 +112,7 @@ service WorkspaceService {
   rpc DeleteWorkspace(DeleteWorkspaceRequest) returns (DeleteWorkspaceResponse);
   // Lists members of one workspace.
   rpc ListWorkspaceMembers(ListWorkspaceMembersRequest) returns (ListWorkspaceMembersResponse);
-  // Adds one user to a workspace.
+  // Adds a workspace member or moves an existing workspace membership to the desired role.
   rpc AddWorkspaceMember(AddWorkspaceMemberRequest) returns (AddWorkspaceMemberResponse);
   // Removes one user from a workspace.
   rpc RemoveWorkspaceMember(RemoveWorkspaceMemberRequest) returns (RemoveWorkspaceMemberResponse);

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -42,15 +42,7 @@ pub enum AppError {
     /// A requested workspace already exists in config.
     #[error("workspace '{0}' already exists")]
     WorkspaceAlreadyExists(String),
-    /// A workspace member already exists with a different role.
-    #[error("user '{user_id}' already has a different role in workspace '{workspace}'")]
-    WorkspaceMemberRoleConflict {
-        /// Workspace containing the existing membership.
-        workspace: String,
-        /// User whose existing membership has the conflicting role.
-        user_id: String,
-    },
-    /// Removing this member would leave a workspace without an owner.
+    /// Removing or demoting this member would leave a workspace without an owner.
     #[error("workspace '{0}' must retain at least one owner")]
     LastWorkspaceOwner(String),
     /// Caller-supplied input was invalid.
@@ -321,9 +313,9 @@ fn app_code(error: &AppError) -> Code {
         | AppError::FunctionNotFound(_)
         | AppError::WorkspaceNotFound(_)
         | AppError::UserNotFound(_) => Code::NotFound,
-        AppError::FunctionAlreadyExists(_)
-        | AppError::WorkspaceAlreadyExists(_)
-        | AppError::WorkspaceMemberRoleConflict { .. } => Code::AlreadyExists,
+        AppError::FunctionAlreadyExists(_) | AppError::WorkspaceAlreadyExists(_) => {
+            Code::AlreadyExists
+        }
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::LastWorkspaceOwner(_)
@@ -394,13 +386,6 @@ mod tests {
                 Code::NotFound,
             ),
             (AppError::IssuerMismatch, Code::FailedPrecondition),
-            (
-                AppError::WorkspaceMemberRoleConflict {
-                    workspace: "work".to_string(),
-                    user_id: "user-id".to_string(),
-                },
-                Code::AlreadyExists,
-            ),
             (
                 AppError::LastWorkspaceOwner("work".to_string()),
                 Code::FailedPrecondition,

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -163,6 +163,21 @@ impl WorkspaceMembersRepo<'_, CoralTx<'_>> {
         self.session.execute(statement).await
     }
 
+    pub(crate) async fn update_role(
+        &mut self,
+        workspace_id: &str,
+        user_id: &str,
+        role: MemberRole,
+    ) -> Result<bool, DbError> {
+        let statement = Query::update()
+            .table(WorkspaceMembers::Table)
+            .value(WorkspaceMembers::Role, role.as_str())
+            .and_where(Expr::col(WorkspaceMembers::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(WorkspaceMembers::UserId).eq(user_id))
+            .to_owned();
+        Ok(self.session.execute_rows_affected(statement).await? == 1)
+    }
+
     pub(crate) async fn delete(
         &mut self,
         workspace_id: &str,

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -167,8 +167,7 @@ impl WorkspacesRepo<'_, &CoralDb> {
             .role_for_user_id(workspace_id, user_id)
             .await?
         {
-            tx.rollback().await?;
-            return Ok(existing_add_outcome(user, existing_role, role));
+            return update_existing_member(tx, workspace_id, user, existing_role, role).await;
         }
         match tx
             .workspace_members()
@@ -189,7 +188,7 @@ impl WorkspacesRepo<'_, &CoralDb> {
                 else {
                     return Err(error);
                 };
-                Ok(existing_add_outcome(user, existing_role, role))
+                existing_add_outcome(user, existing_role, role)
             }
             Err(error) => Err(error),
         }
@@ -282,15 +281,58 @@ impl WorkspacesRepo<'_, CoralTx<'_>> {
     }
 }
 
+async fn update_existing_member(
+    mut tx: CoralTx<'_>,
+    workspace_id: &str,
+    user: UserRecord,
+    existing_role: MemberRole,
+    requested_role: MemberRole,
+) -> Result<AddMemberOutcome, DbError> {
+    if existing_role == requested_role {
+        tx.rollback().await?;
+        return Ok(AddMemberOutcome::ExistingSameRole(member_view(
+            user,
+            requested_role,
+        )));
+    }
+    if existing_role == MemberRole::Owner
+        && requested_role == MemberRole::Member
+        && tx.workspace_members().owner_count(workspace_id).await? <= 1
+    {
+        tx.rollback().await?;
+        return Ok(AddMemberOutcome::LastOwnerProtected);
+    }
+    if !tx
+        .workspace_members()
+        .update_role(workspace_id, &user.user_id, requested_role)
+        .await?
+    {
+        tx.rollback().await?;
+        return Err(DbError::CorruptData(
+            "workspace membership disappeared after a locked read".to_string(),
+        ));
+    }
+    tx.commit().await?;
+    Ok(AddMemberOutcome::RoleUpdated(member_view(
+        user,
+        requested_role,
+    )))
+}
+
 fn existing_add_outcome(
     user: UserRecord,
     existing_role: MemberRole,
     requested_role: MemberRole,
-) -> AddMemberOutcome {
+) -> Result<AddMemberOutcome, DbError> {
     if existing_role == requested_role {
-        AddMemberOutcome::ExistingSameRole(member_view(user, existing_role))
+        Ok(AddMemberOutcome::ExistingSameRole(member_view(
+            user,
+            existing_role,
+        )))
     } else {
-        AddMemberOutcome::RoleConflict
+        Err(DbError::CorruptData(
+            "different-role membership became visible after a locked read".to_string(),
+        ))
     }
 }
 

--- a/crates/coral-app/src/state/db/workspace_member_state.rs
+++ b/crates/coral-app/src/state/db/workspace_member_state.rs
@@ -17,7 +17,8 @@ pub(crate) struct WorkspaceMemberView {
 pub(crate) enum AddMemberOutcome {
     Added(WorkspaceMemberView),
     ExistingSameRole(WorkspaceMemberView),
-    RoleConflict,
+    RoleUpdated(WorkspaceMemberView),
+    LastOwnerProtected,
     WorkspaceNotFound,
     UserNotFound,
 }
@@ -74,12 +75,15 @@ impl CoralDb {
 }
 #[cfg(test)]
 mod tests {
+    use sea_query::{Expr, ExprTrait, Query};
     use tempfile::tempdir;
 
     use super::{AddMemberOutcome, RemoveMemberOutcome};
     use crate::bootstrap;
     use crate::state::AppStateLayout;
+    use crate::state::db::DbSession;
     use crate::state::db::repositories::users::UpsertLoginOutcome;
+    use crate::state::db::schema::WorkspaceMembers;
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig, WorkspaceCreationOutcome,
     };
@@ -188,6 +192,16 @@ mod tests {
                 .count(),
             1
         );
+        let workspace = identical_add_workspace_id.as_str();
+        let user = member_id.as_str();
+        let identical_before = membership(db, workspace, user).await;
+        let identical = add(db, workspace, user, MemberRole::Member).await;
+        assert!(matches!(identical, AddMemberOutcome::ExistingSameRole(_)));
+        assert_eq!(
+            membership(db, workspace, user).await,
+            identical_before,
+            "an identical add must not rewrite the membership"
+        );
         assert_eq!(
             outcomes
                 .iter()
@@ -227,27 +241,17 @@ mod tests {
             member_add.expect("member-role add"),
             owner_add.expect("owner-role add"),
         ];
-        let added_role = outcomes
+        let settled_role = outcomes
             .iter()
             .find_map(|outcome| match outcome {
-                AddMemberOutcome::Added(member) => Some(member.role),
-                AddMemberOutcome::ExistingSameRole(_)
-                | AddMemberOutcome::RoleConflict
-                | AddMemberOutcome::WorkspaceNotFound
-                | AddMemberOutcome::UserNotFound => None,
+                AddMemberOutcome::RoleUpdated(member) => Some(member.role),
+                _ => None,
             })
-            .expect("one conflicting add must win");
+            .expect("one serialized different-role add must update the membership");
         assert_eq!(
             outcomes
                 .iter()
                 .filter(|outcome| matches!(outcome, AddMemberOutcome::Added(_)))
-                .count(),
-            1
-        );
-        assert_eq!(
-            outcomes
-                .iter()
-                .filter(|outcome| matches!(outcome, AddMemberOutcome::RoleConflict))
                 .count(),
             1
         );
@@ -257,9 +261,29 @@ mod tests {
                 .workspace_members()
                 .role_for_user_id(&conflicting_add_workspace_id, &conflicting_member_id)
                 .await
-                .expect("read role after conflicting adds"),
-            Some(added_role),
-            "the losing conflicting add must not mutate the winning role"
+                .expect("read role after different-role adds"),
+            Some(settled_role)
+        );
+        let created_at = membership(db, &conflicting_add_workspace_id, &conflicting_member_id)
+            .await
+            .expect("membership after different-role adds")
+            .1;
+        let workspace = conflicting_add_workspace_id.as_str();
+        let user = conflicting_member_id.as_str();
+        let other_role = match settled_role {
+            MemberRole::Owner => MemberRole::Member,
+            MemberRole::Member => MemberRole::Owner,
+        };
+        for role in [other_role, settled_role] {
+            assert!(matches!(
+                add(db, workspace, user, role).await,
+                AddMemberOutcome::RoleUpdated(member) if member.role == role
+            ));
+        }
+        assert_eq!(
+            membership(db, workspace, user).await,
+            Some((settled_role, created_at)),
+            "role moves must preserve membership identity and creation time"
         );
 
         let owner_removal_workspace_id = format!("owner-removal-{suffix}");
@@ -271,6 +295,9 @@ mod tests {
                 .expect("create owner-removal workspace"),
             WorkspaceCreationOutcome::Created
         );
+        let workspace = owner_removal_workspace_id.as_str();
+        let demotion = add(db, workspace, &owner_id, MemberRole::Member).await;
+        assert_eq!(demotion, AddMemberOutcome::LastOwnerProtected);
         let mut session = db;
         assert!(matches!(
             session
@@ -279,49 +306,79 @@ mod tests {
                     &owner_removal_workspace_id,
                     &other_owner_id,
                     MemberRole::Owner,
-                    31,
+                    32,
                 )
                 .await
                 .expect("add owner"),
             AddMemberOutcome::Added(_)
         ));
 
-        let mut first_remove_session = db;
-        let mut second_remove_session = db;
-        let mut first_remove_workspaces = first_remove_session.workspaces();
-        let mut second_remove_workspaces = second_remove_session.workspaces();
         let (first, second) = tokio::join!(
-            first_remove_workspaces.remove_member(&owner_removal_workspace_id, &owner_id),
-            second_remove_workspaces.remove_member(&owner_removal_workspace_id, &other_owner_id),
+            add(db, workspace, &owner_id, MemberRole::Member),
+            add(db, workspace, &other_owner_id, MemberRole::Member),
         );
-        let outcomes = [
-            first.expect("remove first owner"),
-            second.expect("remove second owner"),
-        ];
-        assert_eq!(
-            outcomes
-                .iter()
-                .filter(|outcome| matches!(outcome, RemoveMemberOutcome::Removed))
-                .count(),
-            1
+        assert!(matches!(
+            (first, second),
+            (
+                AddMemberOutcome::RoleUpdated(_),
+                AddMemberOutcome::LastOwnerProtected
+            ) | (
+                AddMemberOutcome::LastOwnerProtected,
+                AddMemberOutcome::RoleUpdated(_)
+            )
+        ));
+        for user_id in [&owner_id, &other_owner_id] {
+            add(db, workspace, user_id, MemberRole::Owner).await;
+        }
+        let mut remove_session = db;
+        let mut remove_workspaces = remove_session.workspaces();
+        let (demote, remove) = tokio::join!(
+            add(db, workspace, &owner_id, MemberRole::Member),
+            remove_workspaces.remove_member(workspace, &other_owner_id),
         );
-        assert_eq!(
-            outcomes
-                .iter()
-                .filter(|outcome| matches!(outcome, RemoveMemberOutcome::LastOwnerProtected))
-                .count(),
-            1
-        );
-        let mut tx = db.begin().await.expect("begin owner verification tx");
-        assert_eq!(
-            tx.workspace_members()
-                .owner_count(&owner_removal_workspace_id)
-                .await
-                .expect("count remaining owners"),
-            1,
-            "concurrent owner removals must preserve exactly one owner"
-        );
-        tx.rollback().await.expect("rollback owner verification tx");
+        assert!(matches!(
+            (demote, remove.expect("remove owner during mixed move")),
+            (
+                AddMemberOutcome::RoleUpdated(_),
+                RemoveMemberOutcome::LastOwnerProtected
+            ) | (
+                AddMemberOutcome::LastOwnerProtected,
+                RemoveMemberOutcome::Removed
+            )
+        ));
+    }
+
+    async fn add(
+        db: &CoralDb,
+        workspace_id: &str,
+        user_id: &str,
+        role: MemberRole,
+    ) -> AddMemberOutcome {
+        let mut session = db;
+        session
+            .workspaces()
+            .add_member(workspace_id, user_id, role, 99)
+            .await
+            .expect("add or update member")
+    }
+
+    async fn membership(
+        db: &CoralDb,
+        workspace_id: &str,
+        user_id: &str,
+    ) -> Option<(MemberRole, i64)> {
+        let statement = Query::select()
+            .columns([WorkspaceMembers::Role, WorkspaceMembers::CreatedAtUnixNanos])
+            .from(WorkspaceMembers::Table)
+            .and_where(Expr::col(WorkspaceMembers::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(WorkspaceMembers::UserId).eq(user_id))
+            .to_owned();
+        let mut session = db;
+        let row: Option<(String, i64)> = session
+            .fetch_optional(statement)
+            .await
+            .expect("read membership state");
+        row.map(|(role, created_at)| (MemberRole::parse(&role).expect("valid role"), created_at))
     }
 
     async fn create_user(db: &CoralDb, suffix: &str) -> String {

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -66,7 +66,6 @@ pub(crate) fn app_error_type(error: &AppError) -> &'static str {
         AppError::FunctionAlreadyExists(_) => "FUNCTION_ALREADY_EXISTS",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
-        AppError::WorkspaceMemberRoleConflict { .. } => "WORKSPACE_MEMBER_ROLE_CONFLICT",
         AppError::LastWorkspaceOwner(_) => "LAST_WORKSPACE_OWNER",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
@@ -783,13 +782,6 @@ mod tests {
             ),
             (AppError::UserNotFound(String::new()), "USER_NOT_FOUND"),
             (AppError::IssuerMismatch, "ISSUER_MISMATCH"),
-            (
-                AppError::WorkspaceMemberRoleConflict {
-                    workspace: String::new(),
-                    user_id: String::new(),
-                },
-                "WORKSPACE_MEMBER_ROLE_CONFLICT",
-            ),
             (
                 AppError::LastWorkspaceOwner(String::new()),
                 "LAST_WORKSPACE_OWNER",

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -252,13 +252,12 @@ impl WorkspaceManager {
             )
             .await?
         {
-            AddMemberOutcome::Added(member) | AddMemberOutcome::ExistingSameRole(member) => {
-                Ok(member)
+            AddMemberOutcome::Added(member)
+            | AddMemberOutcome::ExistingSameRole(member)
+            | AddMemberOutcome::RoleUpdated(member) => Ok(member),
+            AddMemberOutcome::LastOwnerProtected => {
+                Err(AppError::LastWorkspaceOwner(workspace_name.to_string()))
             }
-            AddMemberOutcome::RoleConflict => Err(AppError::WorkspaceMemberRoleConflict {
-                workspace: workspace_name.to_string(),
-                user_id: user_id.to_string(),
-            }),
             AddMemberOutcome::WorkspaceNotFound => {
                 Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
             }
@@ -561,7 +560,7 @@ mod tests {
                 principal,
             ))
             .await
-            .map(|response| response.into_inner().member.expect("added member"))
+            .map(|response| response.into_inner().member.expect("resulting member"))
     }
 
     async fn seed_concealed_workspaces(mut db: &CoralDb, member_id: &str) {
@@ -583,6 +582,30 @@ mod tests {
             .add_member("local-only", member_id, MemberRole::Member, 1)
             .await
             .expect("seed local-only member");
+    }
+
+    async fn assert_role_moves(
+        service: &WorkspaceService,
+        (owner, member): (&Principal, &Principal),
+        member_record: &impl Fn(i32) -> WorkspaceMember,
+    ) -> Result<(), tonic::Status> {
+        let owner_role = WorkspaceRole::Owner as i32;
+        let member_role = WorkspaceRole::Member as i32;
+        let promoted = add_member(service, owner, Some(member_record(owner_role))).await?;
+        assert_eq!(promoted.role, owner_role);
+        list_members(service, member).await?;
+        let demoted = add_member(service, owner, Some(member_record(member_role))).await?;
+        assert_eq!(demoted.role, member_role);
+        let access = list_members(service, member).await;
+        let error = access.expect_err("next request sees demotion");
+        assert_eq!(error.code(), Code::PermissionDenied);
+        let mut owner_record = member_record(member_role);
+        owner_record.user_id = owner.id().to_string();
+        let error = add_member(service, owner, Some(owner_record))
+            .await
+            .expect_err("sole owner demotion must fail");
+        assert_eq!(error.code(), Code::FailedPrecondition);
+        Ok(())
     }
 
     #[tokio::test]
@@ -658,14 +681,8 @@ mod tests {
             (added.user_id, added.role),
             (member_id.clone(), member_role)
         );
-        let error = add_member(
-            &service,
-            &owner,
-            Some(member_record(WorkspaceRole::Owner as i32)),
-        )
-        .await
-        .expect_err("changing a member role must fail");
-        assert_eq!(error.code(), Code::AlreadyExists);
+        let moves = assert_role_moves(&service, (&owner, &member), &member_record).await;
+        moves.expect("role moves");
         seed_concealed_workspaces(&db, &member_id).await;
         let memberships = service
             .list_workspaces(request(ListWorkspacesRequest {}, &member))


### PR DESCRIPTION
## Intent

Align `AddWorkspaceMember` with the membership role-management contract. Repeating the current role succeeds without rewriting the membership, while requesting a different role moves the existing member atomically.

## What it enables

Existing members can be promoted or demoted through the existing RPC without a separate role-change method. Membership writes and last-owner checks remain serialized under the workspace parent lock, and committed role changes affect authorization on the next request. The obsolete role-conflict error and telemetry classification are removed without changing the protobuf wire shape.

## Usage examples

- Requesting `Member` for an existing user who is not yet in the workspace creates and returns the membership.
- Requesting `Member` for an existing Member returns the same membership without rewriting its creation time.
- Requesting `Owner` for an existing Member promotes the member atomically and returns the resulting Owner membership.
- Requesting `Member` for an Owner demotes them when another Owner remains.
- Attempting to demote the sole Owner returns `FailedPrecondition` without changing the membership.

BREAKING CHANGE: `WorkspaceService.AddWorkspaceMember` now changes an existing member's role and returns success instead of returning `AlreadyExists` when the requested role differs. Attempting to demote the sole owner now returns `FailedPrecondition`.
