### PR TITLE
ci: validate the container images without building Rust

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -508,9 +508,12 @@ jobs:
 
   reef-image:
     name: Reef image
-    # Building the real Coral peer dominates this job. Give it a larger
-    # runner than the other jobs while Dockerfile.local's locked cache mounts
-    # retain registry, git, and target artifacts within the BuildKit builder.
+    # Building the real Coral peer dominates this job: the release build of
+    # coral-cli is ~85% of its wall time. Dockerfile.local's locked cache mounts
+    # hold the registry, git, and target artifacts, but they live in the
+    # BuildKit state dir, so they only survive across runs on the persistent
+    # builder configured below. Keep the larger runner until that cache is
+    # observed warming; it is sized for the cold-build case.
     runs-on: blacksmith-16vcpu-ubuntu-2404
     needs: changes
     if: ${{ needs.changes.outputs.reef-image == 'true' }}
@@ -519,9 +522,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      # Backs BuildKit with a sticky disk mounted at /var/lib/buildkit, so
+      # Dockerfile.local's cargo cache mounts persist across runs instead of
+      # recompiling every dependency from scratch. Falls back to a local
+      # builder if the Blacksmith setup fails.
+      - uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
         with:
-          cache-binary: false
+          cache-key: coral/reef-image
 
       - name: Check Reef image contract
         run: node --test docker/reef-image.test.mjs docker/reef-publish.test.mjs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -508,35 +508,52 @@ jobs:
 
   reef-image:
     name: Reef image
-    # Building the real Coral peer dominates this job: the release build of
-    # coral-cli is ~85% of its wall time. Dockerfile.local's locked cache mounts
-    # hold the registry, git, and target artifacts, but they live in the
-    # BuildKit state dir, so they only survive across runs on the persistent
-    # builder configured below. Keep the larger runner until that cache is
-    # observed warming; it is sized for the cold-build case.
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    # Pull requests smoke against a released Coral peer and never compile Rust,
+    # so they fit comfortably on a small runner. Pushes still build the peer
+    # from HEAD and keep the larger one for that release build.
+    runs-on: ${{ github.event_name == 'pull_request' && 'blacksmith-4vcpu-ubuntu-2404' || 'blacksmith-16vcpu-ubuntu-2404' }}
     needs: changes
     if: ${{ needs.changes.outputs.reef-image == 'true' }}
+    env:
+      # The smoke matrix only needs a peer that serves gRPC health on 14555, so
+      # it tracks the newest released Coral rather than pinning a version that
+      # would go stale. Pin this to a version or digest if a release ever breaks
+      # the matrix; pushes cover the HEAD peer either way.
+      CORAL_SMOKE_IMAGE: ghcr.io/withcoral/coral:latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      # Backs BuildKit with a sticky disk mounted at /var/lib/buildkit, so
-      # Dockerfile.local's cargo cache mounts persist across runs instead of
-      # recompiling every dependency from scratch. Falls back to a local
-      # builder if the Blacksmith setup fails.
-      - uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
-          cache-key: coral/reef-image
+          cache-binary: false
 
       - name: Check Reef image contract
         run: node --test docker/reef-image.test.mjs docker/reef-publish.test.mjs
 
-      - name: Build and smoke linux/amd64 Coral and Reef images
+      - name: Build the linux/amd64 Reef image
         run: |
-          make reef-docker-test DOCKER_IMAGE=coral:local REEF_DOCKER_IMAGE=reef:local
+          make reef-docker-build REEF_DOCKER_IMAGE=reef:local
           test "$(docker image inspect reef:local --format '{{.Os}}/{{.Architecture}}')" = linux/amd64
+
+      # docker/reef-smoke.sh only ever asks the peer to serve gRPC health on
+      # 14555 and report back through Reef's /readyz, so compiling coral-cli
+      # from HEAD -- ~85% of this job's wall time -- buys no extra signal on a
+      # pull request. Coral is published linux/amd64, matching this runner.
+      - name: Smoke Reef against the released Coral peer
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          docker pull --platform linux/amd64 "$CORAL_SMOKE_IMAGE"
+          make reef-docker-smoke DOCKER_IMAGE="$CORAL_SMOKE_IMAGE" REEF_DOCKER_IMAGE=reef:local
+
+      # Pushes build the peer from HEAD, so a Coral-side change to the health
+      # surface still fails here within one merge of landing.
+      - name: Smoke Reef against the Coral peer built from HEAD
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          make docker-build DOCKER_IMAGE=coral:local
+          make reef-docker-smoke DOCKER_IMAGE=coral:local REEF_DOCKER_IMAGE=reef:local
 
   desktop-checks:
     name: Desktop checks

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,7 @@ jobs:
       install-script: ${{ steps.filter.outputs.install-script }}
       ui-build: ${{ steps.filter.outputs.ui-build }}
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
+      coral-image: ${{ steps.filter.outputs.coral-image }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       reef-image: ${{ steps.filter.outputs.reef-image }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
@@ -98,6 +99,14 @@ jobs:
               - '.github/workflows/validate.yml'
               - 'crates/coral-api/proto/**'
               - 'apps/ui/**'
+            # Kept out of the reef-image block below: docker/reef-publish.test.mjs
+            # reads that block by slicing to the next filter key.
+            coral-image:
+              - '.github/workflows/validate.yml'
+              - 'Makefile'
+              - 'docker/Dockerfile'
+              - 'docker/entrypoint.sh'
+              - 'docker/coral-smoke.sh'
             reef-checks:
               - '.github/workflows/validate.yml'
               - 'crates/coral-api/proto/**'
@@ -113,15 +122,6 @@ jobs:
               - '.github/workflows/release.yml'
               - '.dockerignore'
               - 'Makefile'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - 'rust-toolchain'
-              - 'crates/**'
-              - 'sources/core/**'
-              - 'docker/Dockerfile.local'
-              - 'docker/Dockerfile'
-              - 'docker/entrypoint.sh'
               - 'docker/Dockerfile.reef'
               - 'docker/entrypoint-reef.sh'
               - 'docker/reef-smoke.sh'
@@ -506,20 +506,35 @@ jobs:
       - name: Smoke production Reef server
         run: npm run test:server --prefix apps/reef
 
+  coral-image:
+    name: Coral image
+    # Validates docker/Dockerfile and docker/entrypoint.sh against a stub
+    # binary. The entrypoint is pure shell up to its closing exec, so every
+    # branch it takes runs without compiling coral-cli: rust-checks covers the
+    # real binary, and docker-publish.yml smokes the real image at release.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: changes
+    if: ${{ needs.changes.outputs.coral-image == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          cache-binary: false
+
+      - name: Build and smoke the Coral image entrypoint
+        run: make coral-docker-stub-test CORAL_DOCKER_IMAGE=coral:stub
+
   reef-image:
     name: Reef image
-    # Pull requests smoke against a released Coral peer and never compile Rust,
-    # so they fit comfortably on a small runner. Pushes still build the peer
-    # from HEAD and keep the larger one for that release build.
-    runs-on: ${{ github.event_name == 'pull_request' && 'blacksmith-4vcpu-ubuntu-2404' || 'blacksmith-16vcpu-ubuntu-2404' }}
+    # The smoke matrix is peer-free, so nothing here compiles Rust or pulls a
+    # Coral image; readiness against a live peer is covered by the mocked
+    # health client in apps/reef/app/routes/readyz.server.test.ts.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
     if: ${{ needs.changes.outputs.reef-image == 'true' }}
-    env:
-      # The smoke matrix only needs a peer that serves gRPC health on 14555, so
-      # it tracks the newest released Coral rather than pinning a version that
-      # would go stale. Pin this to a version or digest if a release ever breaks
-      # the matrix; pushes cover the HEAD peer either way.
-      CORAL_SMOKE_IMAGE: ghcr.io/withcoral/coral:latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -532,28 +547,10 @@ jobs:
       - name: Check Reef image contract
         run: node --test docker/reef-image.test.mjs docker/reef-publish.test.mjs
 
-      - name: Build the linux/amd64 Reef image
+      - name: Build and smoke the linux/amd64 Reef image
         run: |
-          make reef-docker-build REEF_DOCKER_IMAGE=reef:local
+          make reef-docker-test REEF_DOCKER_IMAGE=reef:local
           test "$(docker image inspect reef:local --format '{{.Os}}/{{.Architecture}}')" = linux/amd64
-
-      # docker/reef-smoke.sh only ever asks the peer to serve gRPC health on
-      # 14555 and report back through Reef's /readyz, so compiling coral-cli
-      # from HEAD -- ~85% of this job's wall time -- buys no extra signal on a
-      # pull request. Coral is published linux/amd64, matching this runner.
-      - name: Smoke Reef against the released Coral peer
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          docker pull --platform linux/amd64 "$CORAL_SMOKE_IMAGE"
-          make reef-docker-smoke DOCKER_IMAGE="$CORAL_SMOKE_IMAGE" REEF_DOCKER_IMAGE=reef:local
-
-      # Pushes build the peer from HEAD, so a Coral-side change to the health
-      # surface still fails here within one merge of landing.
-      - name: Smoke Reef against the Coral peer built from HEAD
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          make docker-build DOCKER_IMAGE=coral:local
-          make reef-docker-smoke DOCKER_IMAGE=coral:local REEF_DOCKER_IMAGE=reef:local
 
   desktop-checks:
     name: Desktop checks
@@ -816,6 +813,7 @@ jobs:
         ui-tests,
         reef-checks,
         reef-image,
+        coral-image,
         desktop-checks,
         proto-lint,
         gha-security-audit-pr,
@@ -840,6 +838,7 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           REEF_IMAGE_RESULT: ${{ needs.reef-image.result }}
+          CORAL_IMAGE_RESULT: ${{ needs.coral-image.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
@@ -859,6 +858,7 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "reef-image:$REEF_IMAGE_RESULT"
+            "coral-image:$CORAL_IMAGE_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,17 @@
   loads disable provenance because that exporter cannot load attestation
   manifests. Local builds must not download a published Coral binary.
 - Use `make reef-docker-build` to build Reef from the current checkout and
-  `make reef-docker-smoke` to test already-built Coral and Reef images. Use the
-  self-contained `make reef-docker-test` to build both images and run the
-  topology/configuration matrix. Reef's runtime stage must remain COPY-only and
+  `make reef-docker-smoke` to run the configuration matrix against an
+  already-built Reef image. Use the self-contained `make reef-docker-test` for
+  both. That matrix is peer-free: it asserts which runtime configurations boot
+  and which fail fast, while readiness against a live Coral is covered by the
+  mocked health client in `apps/reef/app/routes/readyz.server.test.ts`.
+- Use `make coral-docker-stub-test` to build the Coral image with a stub binary
+  and exercise `docker/entrypoint.sh` (config seeding, seed-once semantics, and
+  the unwritable-volume failure). The entrypoint is pure shell up to its closing
+  exec, so this needs no Rust build; the real binary is covered by
+  `make rust-checks` and the real image by the release smoke in
+  `.github/workflows/docker-publish.yml`. Reef's runtime stage must remain COPY-only and
   non-root; build and dependency stages run on the build platform. Local builds
   follow the Docker daemon's architecture, while CI builds and verifies
   linux/amd64 only. TLS termination belongs to the operator and is

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install ui-build docker-build reef-docker-build reef-docker-smoke reef-docker-test rust-checks perf-check
+.PHONY: install ui-build docker-build reef-docker-build reef-docker-smoke reef-docker-test coral-docker-stub-build coral-docker-smoke coral-docker-stub-test rust-checks perf-check
 .PHONY: postgres-start postgres-url postgres-stop postgres-clean postgres-tests
 .PHONY: license-check lint-proto lint-sources fix-sources
 .PHONY: docs-generate docs-check schema-generate schema-check
@@ -8,6 +8,7 @@ LOCAL_POSTGRES_CONTAINER ?= coral-test-postgres
 LOCAL_POSTGRES_PORT ?=
 DOCKER_IMAGE ?= coral:local
 REEF_DOCKER_IMAGE ?= reef:local
+CORAL_DOCKER_IMAGE ?= coral:stub
 DOCKER_NO_CACHE ?= 0
 
 define docker_build_preflight
@@ -96,10 +97,48 @@ reef-docker-build:
 	echo "Built $(REEF_DOCKER_IMAGE)"
 
 reef-docker-smoke:
-	CORAL_IMAGE="$(DOCKER_IMAGE)" REEF_IMAGE="$(REEF_DOCKER_IMAGE)" docker/reef-smoke.sh
+	REEF_IMAGE="$(REEF_DOCKER_IMAGE)" docker/reef-smoke.sh
 
-reef-docker-test: docker-build reef-docker-build
-	CORAL_IMAGE="$(DOCKER_IMAGE)" REEF_IMAGE="$(REEF_DOCKER_IMAGE)" docker/reef-smoke.sh
+reef-docker-test: reef-docker-build reef-docker-smoke
+
+# ----------------------------------------------------------------------------
+# Coral image entrypoint checks
+# ----------------------------------------------------------------------------
+# docker/entrypoint.sh is pure shell up to its closing exec, so every branch it
+# takes can be exercised against a stub binary. That keeps image validation off
+# the Rust build; the real binary is covered by rust-checks, and the real image
+# by the release smoke in .github/workflows/docker-publish.yml.
+#
+#   make coral-docker-stub-test
+#   CORAL_DOCKER_IMAGE=coral:test make coral-docker-stub-test
+
+coral-docker-stub-build:
+	@set -eu; \
+	$(call docker_build_preflight,Coral) \
+	tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT HUP INT TERM; \
+	context="$$tmpdir/context"; \
+	mkdir -p "$$context/dist/$$image_arch" "$$context/docker"; \
+	printf '%s\n' '#!/bin/sh' 'echo "coral-stub: $$*" >&2' 'exec sleep infinity' \
+	  > "$$context/dist/$$image_arch/coral"; \
+	chmod 0755 "$$context/dist/$$image_arch/coral"; \
+	cp docker/Dockerfile docker/entrypoint.sh "$$context/docker/"; \
+	set -- docker buildx build \
+	  --platform "linux/$$image_arch" \
+	  --provenance=false \
+	  --file "$$context/docker/Dockerfile" \
+	  --load \
+	  --tag "$(CORAL_DOCKER_IMAGE)"; \
+	if [ "$$no_cache" -eq 1 ]; then set -- "$$@" --no-cache; fi; \
+	set -- "$$@" "$$context"; \
+	echo "Building $(CORAL_DOCKER_IMAGE) with a stub binary..."; \
+	"$$@"; \
+	echo "Built $(CORAL_DOCKER_IMAGE)"
+
+coral-docker-smoke:
+	CORAL_IMAGE="$(CORAL_DOCKER_IMAGE)" docker/coral-smoke.sh
+
+coral-docker-stub-test: coral-docker-stub-build coral-docker-smoke
 
 rust-checks:
 	cargo fmt --all -- --check

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,10 @@ reef-docker-build:
 reef-docker-smoke:
 	REEF_IMAGE="$(REEF_DOCKER_IMAGE)" docker/reef-smoke.sh
 
-reef-docker-test: reef-docker-build reef-docker-smoke
+# The smoke runs from the recipe, not as a second prerequisite: `make -j` runs
+# prerequisites concurrently and would start it against a half-built image.
+reef-docker-test: reef-docker-build
+	REEF_IMAGE="$(REEF_DOCKER_IMAGE)" docker/reef-smoke.sh
 
 # ----------------------------------------------------------------------------
 # Coral image entrypoint checks
@@ -138,7 +141,9 @@ coral-docker-stub-build:
 coral-docker-smoke:
 	CORAL_IMAGE="$(CORAL_DOCKER_IMAGE)" docker/coral-smoke.sh
 
-coral-docker-stub-test: coral-docker-stub-build coral-docker-smoke
+# Smoke from the recipe, for the same `make -j` ordering reason as above.
+coral-docker-stub-test: coral-docker-stub-build
+	CORAL_IMAGE="$(CORAL_DOCKER_IMAGE)" docker/coral-smoke.sh
 
 rust-checks:
 	cargo fmt --all -- --check

--- a/docker/coral-smoke.sh
+++ b/docker/coral-smoke.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# Exercises docker/entrypoint.sh inside the built Coral image. Every branch the
+# entrypoint takes runs before it execs the server binary, so this matrix is
+# valid against a stub binary (pull requests) and the real one alike. It
+# deliberately never waits for HEALTHCHECK, which needs a real gRPC server.
+set -eu
+
+CORAL_IMAGE=${CORAL_IMAGE:-coral:local}
+prefix="coral-smoke-$$"
+config_path=/var/lib/coral/config/config.toml
+containers=
+volumes=
+
+cleanup() {
+    for container in $containers; do
+        docker rm -f "$container" >/dev/null 2>&1 || true
+    done
+    for volume in $volumes; do
+        docker volume rm "$volume" >/dev/null 2>&1 || true
+    done
+}
+trap cleanup EXIT HUP INT TERM
+
+new_volume() {
+    name="$prefix-$1"
+    docker volume create "$name" >/dev/null
+    volumes="$volumes $name"
+    printf '%s' "$name"
+}
+
+start() {
+    name="$prefix-$1"
+    shift
+    containers="$containers $name"
+    docker run -d --name "$name" "$@" "$CORAL_IMAGE" >/dev/null
+    printf '%s' "$name"
+}
+
+wait_for_log() {
+    container=$1
+    needle=$2
+    attempts=0
+    while [ "$attempts" -lt 30 ]; do
+        if docker logs "$container" 2>&1 | grep -Fq "$needle"; then
+            return 0
+        fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    docker logs "$container" >&2 || true
+    echo "expected a log line containing: $needle" >&2
+    return 1
+}
+
+wait_for_exit() {
+    container=$1
+    attempts=0
+    while [ "$attempts" -lt 15 ]; do
+        [ "$(docker inspect --format '{{.State.Status}}' "$container")" = exited ] && return 0
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    docker logs "$container" >&2 || true
+    echo "container $container did not exit" >&2
+    return 1
+}
+
+# Read the seeded config back through the image itself, so this works no matter
+# which uid owns the volume.
+config_of() {
+    docker run --rm -v "$1:/var/lib/coral" --entrypoint /bin/sh "$CORAL_IMAGE" \
+        -c "cat $config_path"
+}
+
+# 1. First start on an empty volume seeds the built-in starter config.
+starter=$(new_volume starter)
+container=$(start starter -v "$starter:/var/lib/coral")
+wait_for_log "$container" 'seeded starter'
+config_of "$starter" | grep -Fq 'bind_addr = "0.0.0.0:14555"'
+docker rm -f "$container" >/dev/null
+
+# 2. A restart reuses the existing config and never rewrites it.
+before=$(config_of "$starter")
+container=$(start reuse -v "$starter:/var/lib/coral")
+wait_for_log "$container" 'using existing'
+[ "$(config_of "$starter")" = "$before" ] || {
+    echo 'restart rewrote an existing config' >&2
+    exit 1
+}
+docker rm -f "$container" >/dev/null
+
+# 3. CORAL_SEED_CONFIG is written verbatim on a first start.
+seed='# operator supplied
+[server]
+bind_addr = "0.0.0.0:14999"'
+seeded=$(new_volume seeded)
+container=$(start seeded -v "$seeded:/var/lib/coral" -e CORAL_SEED_CONFIG="$seed")
+wait_for_log "$container" "seeded $config_path from CORAL_SEED_CONFIG"
+[ "$(config_of "$seeded")" = "$seed" ] || {
+    echo 'CORAL_SEED_CONFIG was not written verbatim' >&2
+    exit 1
+}
+docker rm -f "$container" >/dev/null
+
+# 4. The seed applies only once: an existing config wins and says so.
+container=$(start seeded-again -v "$seeded:/var/lib/coral" -e CORAL_SEED_CONFIG='[server]')
+wait_for_log "$container" 'CORAL_SEED_CONFIG ignored'
+[ "$(config_of "$seeded")" = "$seed" ] || {
+    echo 'CORAL_SEED_CONFIG overwrote an existing config' >&2
+    exit 1
+}
+docker rm -f "$container" >/dev/null
+
+# 5. An unwritable volume fails fast with one actionable message.
+readonly_volume=$(new_volume readonly)
+container=$(start readonly -v "$readonly_volume:/var/lib/coral:ro")
+wait_for_exit "$container"
+[ "$(docker inspect --format '{{.State.ExitCode}}' "$container")" -ne 0 ]
+docker logs "$container" 2>&1 | grep -Fq 'coral-entrypoint: FATAL'
+docker logs "$container" 2>&1 | grep -Fq "run with '--user <uid>:0'"
+
+echo 'Coral image entrypoint matrix passed'

--- a/docker/coral-smoke.sh
+++ b/docker/coral-smoke.sh
@@ -10,35 +10,40 @@ prefix="coral-smoke-$$"
 config_path=/var/lib/coral/config/config.toml
 containers=
 volumes=
+# Set by new_volume/start for the caller. These helpers record what they create
+# so cleanup can reach it, which means they must run in this shell -- calling
+# them through $(...) would lose both the name and the bookkeeping.
+volume=
+container=
 
 cleanup() {
-    for container in $containers; do
-        docker rm -f "$container" >/dev/null 2>&1 || true
+    for name in $containers; do
+        docker rm -f "$name" >/dev/null 2>&1 || true
     done
-    for volume in $volumes; do
-        docker volume rm "$volume" >/dev/null 2>&1 || true
+    for name in $volumes; do
+        docker volume rm "$name" >/dev/null 2>&1 || true
     done
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 new_volume() {
-    name="$prefix-$1"
-    docker volume create "$name" >/dev/null
-    volumes="$volumes $name"
-    printf '%s' "$name"
+    volume="$prefix-$1"
+    docker volume create "$volume" >/dev/null
+    volumes="$volumes $volume"
 }
 
 start() {
-    name="$prefix-$1"
+    container="$prefix-$1"
     shift
-    containers="$containers $name"
-    docker run -d --name "$name" "$@" "$CORAL_IMAGE" >/dev/null
-    printf '%s' "$name"
+    containers="$containers $container"
+    docker run -d --name "$container" "$@" "$CORAL_IMAGE" >/dev/null
 }
 
 wait_for_log() {
-    container=$1
-    needle=$2
+    needle=$1
     attempts=0
     while [ "$attempts" -lt 30 ]; do
         if docker logs "$container" 2>&1 | grep -Fq "$needle"; then
@@ -53,7 +58,6 @@ wait_for_log() {
 }
 
 wait_for_exit() {
-    container=$1
     attempts=0
     while [ "$attempts" -lt 15 ]; do
         [ "$(docker inspect --format '{{.State.Status}}' "$container")" = exited ] && return 0
@@ -65,56 +69,74 @@ wait_for_exit() {
     return 1
 }
 
-# Read the seeded config back through the image itself, so this works no matter
-# which uid owns the volume.
-config_of() {
+# Read the config back through the image itself, so this works no matter which
+# uid owns the volume.
+config_text() {
     docker run --rm -v "$1:/var/lib/coral" --entrypoint /bin/sh "$CORAL_IMAGE" \
         -c "cat $config_path"
 }
 
+# Compare by digest rather than by shell string: command substitution strips
+# trailing newlines, so a string compare cannot see them and "verbatim" would
+# go unverified. Both sides are hashed by the same sha256sum in the same image.
+config_digest() {
+    docker run --rm -v "$1:/var/lib/coral" --entrypoint /bin/sh "$CORAL_IMAGE" \
+        -c "sha256sum < $config_path | cut -d' ' -f1"
+}
+
+digest_of_stdin() {
+    docker run --rm -i --entrypoint /bin/sh "$CORAL_IMAGE" \
+        -c "sha256sum | cut -d' ' -f1"
+}
+
 # 1. First start on an empty volume seeds the built-in starter config.
-starter=$(new_volume starter)
-container=$(start starter -v "$starter:/var/lib/coral")
-wait_for_log "$container" 'seeded starter'
-config_of "$starter" | grep -Fq 'bind_addr = "0.0.0.0:14555"'
+new_volume starter
+starter=$volume
+start starter -v "$starter:/var/lib/coral"
+wait_for_log 'seeded starter'
+config_text "$starter" | grep -Fq 'bind_addr = "0.0.0.0:14555"'
 docker rm -f "$container" >/dev/null
 
 # 2. A restart reuses the existing config and never rewrites it.
-before=$(config_of "$starter")
-container=$(start reuse -v "$starter:/var/lib/coral")
-wait_for_log "$container" 'using existing'
-[ "$(config_of "$starter")" = "$before" ] || {
+before=$(config_digest "$starter")
+start reuse -v "$starter:/var/lib/coral"
+wait_for_log 'using existing'
+[ "$(config_digest "$starter")" = "$before" ] || {
     echo 'restart rewrote an existing config' >&2
     exit 1
 }
 docker rm -f "$container" >/dev/null
 
-# 3. CORAL_SEED_CONFIG is written verbatim on a first start.
+# 3. CORAL_SEED_CONFIG is written verbatim on a first start, trailing bytes and
+# all.
 seed='# operator supplied
 [server]
-bind_addr = "0.0.0.0:14999"'
-seeded=$(new_volume seeded)
-container=$(start seeded -v "$seeded:/var/lib/coral" -e CORAL_SEED_CONFIG="$seed")
-wait_for_log "$container" "seeded $config_path from CORAL_SEED_CONFIG"
-[ "$(config_of "$seeded")" = "$seed" ] || {
+bind_addr = "0.0.0.0:14999"
+'
+seed_digest=$(printf '%s' "$seed" | digest_of_stdin)
+new_volume seeded
+seeded=$volume
+start seeded -v "$seeded:/var/lib/coral" -e CORAL_SEED_CONFIG="$seed"
+wait_for_log "seeded $config_path from CORAL_SEED_CONFIG"
+[ "$(config_digest "$seeded")" = "$seed_digest" ] || {
     echo 'CORAL_SEED_CONFIG was not written verbatim' >&2
     exit 1
 }
 docker rm -f "$container" >/dev/null
 
 # 4. The seed applies only once: an existing config wins and says so.
-container=$(start seeded-again -v "$seeded:/var/lib/coral" -e CORAL_SEED_CONFIG='[server]')
-wait_for_log "$container" 'CORAL_SEED_CONFIG ignored'
-[ "$(config_of "$seeded")" = "$seed" ] || {
+start seeded-again -v "$seeded:/var/lib/coral" -e CORAL_SEED_CONFIG='[server]'
+wait_for_log 'CORAL_SEED_CONFIG ignored'
+[ "$(config_digest "$seeded")" = "$seed_digest" ] || {
     echo 'CORAL_SEED_CONFIG overwrote an existing config' >&2
     exit 1
 }
 docker rm -f "$container" >/dev/null
 
 # 5. An unwritable volume fails fast with one actionable message.
-readonly_volume=$(new_volume readonly)
-container=$(start readonly -v "$readonly_volume:/var/lib/coral:ro")
-wait_for_exit "$container"
+new_volume readonly
+start readonly -v "$volume:/var/lib/coral:ro"
+wait_for_exit
 [ "$(docker inspect --format '{{.State.ExitCode}}' "$container")" -ne 0 ]
 docker logs "$container" 2>&1 | grep -Fq 'coral-entrypoint: FATAL'
 docker logs "$container" 2>&1 | grep -Fq "run with '--user <uid>:0'"

--- a/docker/reef-smoke.sh
+++ b/docker/reef-smoke.sh
@@ -17,7 +17,10 @@ secret=reef-smoke-session-secret-0123456789abcdef
 cleanup() {
     docker rm -f "$reef" >/dev/null 2>&1 || true
 }
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 wait_for_health() {
     container=$1

--- a/docker/reef-smoke.sh
+++ b/docker/reef-smoke.sh
@@ -1,136 +1,104 @@
 #!/bin/sh
+# Image-level checks for the built Reef image: that each accepted runtime
+# configuration boots and stays healthy, that each rejected one fails fast with
+# a named cause, and that the container runs unprivileged on a read-only root.
+#
+# No Coral peer takes part. Reef probes its own /healthz before listening
+# (apps/reef/server.js), so readiness against a live peer is a separate
+# concern, covered by the mocked health client in
+# apps/reef/app/routes/readyz.server.test.ts.
 set -eu
 
 REEF_IMAGE=${REEF_IMAGE:-reef:local}
-CORAL_IMAGE=${CORAL_IMAGE:-coral:local}
 prefix="reef-smoke-$$"
 reef="$prefix-reef"
-coral="$prefix-coral"
-network="$prefix-net"
 secret=reef-smoke-session-secret-0123456789abcdef
 
 cleanup() {
-  docker rm -f "$reef" "$coral" >/dev/null 2>&1 || true
-  docker network rm "$network" >/dev/null 2>&1 || true
-}
-
-wait_for_coral() {
-  attempts=0
-  while [ "$attempts" -lt 60 ]; do
-    docker exec "$coral" grpc_health_probe -addr=127.0.0.1:14555 >/dev/null 2>&1 && return 0
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  docker logs "$coral" >&2 || true
-  return 1
-}
-
-assert_ready() {
-  published_by=$1
-  address=$(docker port "$published_by" 3000/tcp)
-  attempts=0
-  while [ "$attempts" -lt 30 ]; do
-    curl -fsS "http://$address/readyz" | grep -F '"coral":"reachable"' >/dev/null && return 0
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  docker logs "$reef" >&2 || true
-  return 1
+    docker rm -f "$reef" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT HUP INT TERM
 
 wait_for_health() {
-  container=$1
-  attempts=0
-  while [ "$attempts" -lt 30 ]; do
-    status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container")
-    [ "$status" = healthy ] && return 0
-    [ "$status" = exited ] && break
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  docker logs "$container" >&2 || true
-  return 1
+    container=$1
+    attempts=0
+    while [ "$attempts" -lt 30 ]; do
+        status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container")
+        [ "$status" = healthy ] && return 0
+        [ "$status" = exited ] && break
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    docker logs "$container" >&2 || true
+    return 1
 }
 
 wait_for_exit() {
-  container=$1
-  attempts=0
-  while [ "$attempts" -lt 10 ]; do
-    status=$(docker inspect --format '{{.State.Status}}' "$container")
-    [ "$status" = exited ] && return 0
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  docker logs "$container" >&2 || true
-  return 1
+    container=$1
+    attempts=0
+    while [ "$attempts" -lt 10 ]; do
+        status=$(docker inspect --format '{{.State.Status}}' "$container")
+        [ "$status" = exited ] && return 0
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+    docker logs "$container" >&2 || true
+    return 1
 }
 
 assert_identity() {
-  container=$1
-  identity=$(docker exec "$container" node -e 'process.stdout.write(`${process.getuid()}:${process.getgid()}`)')
-  [ "$identity" = '1000:1000' ] || {
-    echo "expected non-root identity 1000:1000, got $identity" >&2
-    return 1
-  }
+    container=$1
+    identity=$(docker exec "$container" node -e 'process.stdout.write(`${process.getuid()}:${process.getgid()}`)')
+    [ "$identity" = '1000:1000' ] || {
+        echo "expected non-root identity 1000:1000, got $identity" >&2
+        return 1
+    }
 }
 
 run_required() {
-  name=$1
-  endpoint=$2
-  shift 2
-  docker run -d --read-only --name "$name" "$@" \
-    -e CORAL_ENDPOINT="$endpoint" \
+    endpoint=$1
+    shift
+    docker run -d --read-only --name "$reef" "$@" \
+        -e CORAL_ENDPOINT="$endpoint" \
+        -e REEF_AUTH_MODE=required \
+        -e REEF_SESSION_SECRET="$secret" \
+        -e REEF_AUTH_ISSUER=http://127.0.0.1:9080 \
+        -e REEF_PUBLIC_URL=http://127.0.0.1:3000 \
+        "$REEF_IMAGE" >/dev/null
+    wait_for_health "$reef"
+    assert_identity "$reef"
+}
+
+# A: explicit-loopback cleartext is accepted without an opt-in.
+run_required http://127.0.0.1:14555
+docker rm -f "$reef" >/dev/null
+
+# B: cleartext on an operator-controlled network needs the explicit opt-in.
+run_required http://coral:14555 -e REEF_ALLOW_INSECURE_CORAL_ENDPOINT=1
+docker rm -f "$reef" >/dev/null
+
+# C: the same non-loopback endpoint without the opt-in fails before listening
+# and reports the named cause.
+docker run -d --read-only --name "$reef" \
+    -e CORAL_ENDPOINT=http://coral.invalid:14555 \
     -e REEF_AUTH_MODE=required \
     -e REEF_SESSION_SECRET="$secret" \
     -e REEF_AUTH_ISSUER=http://127.0.0.1:9080 \
     -e REEF_PUBLIC_URL=http://127.0.0.1:3000 \
     "$REEF_IMAGE" >/dev/null
-  wait_for_health "$name"
-  assert_identity "$name"
-}
-
-# A: Reef and Coral share one network namespace and Reef uses explicit loopback.
-docker run -d --name "$coral" -p 127.0.0.1::3000 "$CORAL_IMAGE" >/dev/null
-wait_for_coral
-run_required "$reef" http://127.0.0.1:14555 --network "container:$coral"
-assert_ready "$coral"
-docker rm -f "$reef" "$coral" >/dev/null
-
-# B: cleartext h2c on an operator-controlled network requires the explicit opt-in.
-docker network create "$network" >/dev/null
-docker run -d --name "$coral" --network "$network" --network-alias coral "$CORAL_IMAGE" >/dev/null
-wait_for_coral
-run_required "$reef" http://coral:14555 --network "$network" -p 127.0.0.1::3000 \
-  -e REEF_ALLOW_INSECURE_CORAL_ENDPOINT=1
-assert_ready "$reef"
-docker stop "$coral" >/dev/null
-[ "$(docker inspect --format '{{.State.Health.Status}}' "$reef")" = healthy ]
-! curl -fsS "http://$(docker port "$reef" 3000/tcp)/readyz" >/dev/null 2>&1
-docker rm -f "$reef" "$coral" >/dev/null
-docker network rm "$network" >/dev/null
-
-# Invalid cleartext config fails before listening and reports the named cause.
-docker run -d --read-only --name "$reef" \
-  -e CORAL_ENDPOINT=http://coral.invalid:14555 \
-  -e REEF_AUTH_MODE=required \
-  -e REEF_SESSION_SECRET="$secret" \
-  -e REEF_AUTH_ISSUER=http://127.0.0.1:9080 \
-  -e REEF_PUBLIC_URL=http://127.0.0.1:3000 \
-  "$REEF_IMAGE" >/dev/null
 wait_for_exit "$reef" || {
-  echo 'invalid cleartext config unexpectedly stayed running' >&2
-  exit 1
+    echo 'invalid cleartext config unexpectedly stayed running' >&2
+    exit 1
 }
 [ "$(docker inspect --format '{{.State.ExitCode}}' "$reef")" -ne 0 ]
 docker logs "$reef" 2>&1 | grep -F 'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP' >/dev/null
 docker rm "$reef" >/dev/null
 
-# Auth-disabled mode is legal and noisy, and the container stays live.
+# D: auth-disabled mode is legal and noisy, and the container stays live.
 docker run -d --read-only --name "$reef" \
-  -e CORAL_ENDPOINT=http://127.0.0.1:14555 \
-  -e REEF_AUTH_MODE=' DISABLED ' \
-  "$REEF_IMAGE" >/dev/null
+    -e CORAL_ENDPOINT=http://127.0.0.1:14555 \
+    -e REEF_AUTH_MODE=' DISABLED ' \
+    "$REEF_IMAGE" >/dev/null
 wait_for_health "$reef"
 docker logs "$reef" 2>&1 | grep -F 'WARNING: REEF_AUTH_MODE=disabled' >/dev/null
 assert_identity "$reef"


### PR DESCRIPTION
Validates the Coral and Reef container images without compiling Rust, taking
image validation from ~5.9 min to ~39s.

## Intent

The `Reef image` job ran 5.4–9.0 min (median 5.9, n=36) on every PR touching
`crates/**`, `apps/reef/**`, or the Docker files. Step timings showed almost
none of it was Reef:

| phase | time |
| --- | --- |
| `cargo build --locked --release -p coral-cli` | **4m23s** |
| coral image assembly | 10s |
| reef image build (`npm ci` + vite) | 16s |
| reef smoke | 13s |

That compile existed only to produce a Coral peer for `docker/reef-smoke.sh`.
Reading what the peer was actually asked to do: `wait_for_coral` probed
`grpc_health_probe -addr=127.0.0.1:14555`, and `assert_ready` checked that
Reef's `/readyz` reported `"coral":"reachable"`. No Coral business logic, no
proto surface. Two of the four scenarios used no peer at all — and the two that
did were already covered by mocks:

| existing test | smoke scenario it duplicated |
| --- | --- |
| `readyz.server.test.ts` — ready only when Coral reports serving | A, `"coral":"reachable"` |
| `readyz.server.test.ts` — rejects a non-serving status | — |
| `readyz.server.test.ts` — propagates an upstream health failure | B, peer stopped → not ready |
| `coral-app/tests/grpc/health_service_tests.rs` | the peer's health contract itself |

A 4m23s release build was buying a gRPC health responder whose contract was
already under test on both sides.

## What it enables

Image validation is split by what each image owns, and neither half builds Rust.

**`reef-image`** runs a peer-free matrix over the runtime configurations: which
boot healthy (explicit-loopback cleartext, and non-loopback *with*
`REEF_ALLOW_INSECURE_CORAL_ENDPOINT`) and which fail fast with a named cause.
Reef probes its own `/healthz` before listening (`apps/reef/server.js:31`), so a
peer was never required for any of it. Non-root identity and the read-only root
are still asserted.

**`coral-image`** is new and owns `docker/Dockerfile` and
`docker/entrypoint.sh` — which previously had no dedicated job and were built
only as a side effect of the Reef smoke. The entrypoint is 108 lines of pure
shell up to its closing `exec`, so a stub binary reaches every branch: starter
seeding, seed-once semantics, verbatim `CORAL_SEED_CONFIG`, and the
unwritable-volume failure. That is the same matrix `docker-publish.yml` runs at
release, minus the compile. The real binary stays covered by `rust-checks`, the
real image by the release smoke.

Both jobs run on 4vcpu, in parallel. Neither triggers on `crates/**`, so
Rust-only PRs no longer run either.

## Usage examples

```bash
make reef-docker-test REEF_DOCKER_IMAGE=reef:local
```

```bash
make coral-docker-stub-test CORAL_DOCKER_IMAGE=coral:stub
```

`make docker-build` is unchanged for building a real local Coral image from the
current checkout.

## Coverage this gives up, deliberately

- **No live Reef↔Coral handshake anywhere in CI.** Both sides are covered by
  mocks, and clients are generated from shared protos, but nothing now proves
  the two real processes talk to each other. This is the one genuine reduction.
- **`docker/Dockerfile.local` is no longer built in CI.** It was only ever
  exercised as a side effect of the Reef smoke; it remains the local
  `make docker-build` path.
- **The Coral image `HEALTHCHECK` is not exercised on PRs**, since a shell stub
  cannot serve gRPC. The release smoke covers it against the real binary.

## Review notes

Three places in this workflow can swallow a job failure, and all three are
handled here — worth checking if you touch the filters:

- `validate` is the single required status check and enumerates results in an
  explicit bash array. Adding a job to `needs` alone lets its failure pass.
- A new filter key needs a matching entry in the `changes` job's `outputs`
  block, or the job silently never runs.
- `docker/reef-publish.test.mjs` reads the `reef-image` filter by slicing to the
  next key, so the new `coral-image` filter is placed *before* `reef-checks:`
  rather than between `reef-image:` and `desktop-checks:`.

The first two commits are superseded and contribute nothing to the net diff:
`94a6978` tried a persistent BuildKit cache and made the job **slower** (43 min
against a 5.9 min median); `1313521` swapped in a released Coral peer but left
the filter watching paths it no longer built. Both are retained rather than
force-pushed away.

## Validation

Measured on this PR's run, which touches `validate.yml`, `Makefile`, and both
smoke scripts, so both image jobs execute:

| job | result | duration |
| --- | --- | --- |
| Coral image | success | **18s** |
| Reef image | success | **39s** |

Both scripts printed their closing line — reachable only after every assertion,
since both run under `set -eu` with no conditionals:

```
Coral image entrypoint matrix passed
Reef image smoke matrix passed
```

Also: `node --test docker/reef-image.test.mjs docker/reef-publish.test.mjs`
12/12; `sh -n` clean on both scripts; `make -n` resolves every new target; the
workflow YAML parses and the new `changes` output is declared.

Not proven by this run: that a Rust-only PR no longer triggers either job. That
follows from the filters, but the first `crates/**`-only PR after merge is what
confirms it.
