### PR TITLE
test(reef): keep data fetching in route handlers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,13 @@
   resource routes using `apps/reef/app/lib/coral-request.server.ts`. Do not
   expose a generic renderer-to-Coral transport or Desktop sidecar proxy; add an
   explicit server route when browser-triggered Coral behavior is needed.
+- Keep Reef data access in React Router loaders and actions. Presentation
+  (`app/components`, `app/views`, `app/wax/components`) renders loader data and
+  submits through fetchers: it must not import `*.server` modules, open a network
+  connection, reach `window.coralDesktop`, or await inside `useEffect`. The
+  architecture test enforces all four at zero violations. An effect that awaits
+  is the specific mistake to watch for — it rebuilds the router's caching,
+  pending state, and revalidation in component state, worse each time.
 - The packaged Reef server resolves its external runtime packages from the
   Electron app. Keep every `apps/reef` production dependency represented in
   `apps/desktop` production dependencies; the desktop config tests enforce this

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -8,6 +8,23 @@ const componentsDir = path.join(appDir, 'components')
 const routesDir = path.join(appDir, 'routes')
 const waxComponentsDir = path.join(appDir, 'wax', 'components')
 const reefRoot = path.resolve(appDir, '..')
+const viewsDir = path.join(appDir, 'views')
+// Everything that renders. Data reaches it as loader data or through a fetcher;
+// it never goes looking for data itself.
+const presentationDirs = [componentsDir, viewsDir, waxComponentsDir]
+const effectHooks = ['useEffect', 'useLayoutEffect', 'useInsertionEffect']
+// Suspending inside an effect is how data loading keeps reappearing in
+// components, so the shape is banned rather than any particular caller.
+const suspendsInEffect = /\bawait\b|\.then\s*\(|\.catch\s*\(/
+const dataSources = [
+  {
+    label: 'network call',
+    pattern: /\bfetch\s*\(|\bnew (?:EventSource|WebSocket|XMLHttpRequest)\b/,
+  },
+  // The single handle onto the Electron host: reaching it is a request to
+  // another process, whatever method follows.
+  { label: 'desktop host access', pattern: /\bcoralDesktopApi\b|\bwindow\.coralDesktop\b/ },
+]
 
 function filesUnder(directory: string, matches: (name: string) => boolean): string[] {
   if (!fs.existsSync(directory)) return []
@@ -34,6 +51,26 @@ function isRouteImport(importer: string, specifier: string): boolean {
   return resolved === routesDir || resolved.startsWith(`${routesDir}${path.sep}`)
 }
 
+/** Every argument list passed to `hook`, so its callback can be read. */
+function hookArguments(source: string, hook: string): string[] {
+  const calls: string[] = []
+
+  for (const match of source.matchAll(new RegExp(`\\b${hook}\\s*\\(`, 'g'))) {
+    const open = match.index + match[0].length - 1
+    let depth = 0
+
+    for (let index = open; index < source.length; index += 1) {
+      if (source[index] === '(') depth += 1
+      else if (source[index] === ')' && --depth === 0) {
+        calls.push(source.slice(open + 1, index))
+        break
+      }
+    }
+  }
+
+  return calls
+}
+
 function isVisualTsx(name: string): boolean {
   return (
     name.endsWith('.tsx') &&
@@ -55,7 +92,50 @@ describe('architecture', () => {
         .map((specifier) => `${path.relative(appDir, file)} -> ${specifier}`),
     )
 
-    expect(violations, 'component modules must not import route modules').toEqual([])
+    expect(
+      violations,
+      'component modules must not import route modules. Take what you need as a prop and let ' +
+        'the route module pass it in: a component that names a route cannot be rendered from ' +
+        'anywhere else, and its story has to build a router to mount it',
+    ).toEqual([])
+  })
+
+  it('keeps data fetching out of presentation modules', () => {
+    const presentationFiles = presentationDirs
+      .flatMap((directory) => filesUnder(directory, (name) => /\.tsx?$/.test(name)))
+      .filter((file) => !/\.(?:test|spec|stories)\.tsx?$/.test(file) && !file.endsWith('.css.ts'))
+    const violations = presentationFiles.flatMap((file) => {
+      const source = fs.readFileSync(file, 'utf8')
+      const findings = new Set([
+        ...importsFrom(source)
+          .filter((specifier) => /\.server(?:$|\/)/.test(specifier))
+          .map((specifier) => `server module import: ${specifier}`),
+        ...dataSources.filter(({ pattern }) => pattern.test(source)).map(({ label }) => label),
+        ...effectHooks
+          .filter((hook) => hookArguments(source, hook).some((body) => suspendsInEffect.test(body)))
+          .map((hook) => `${hook} that awaits`),
+      ])
+
+      return [...findings].map((finding) => `${path.relative(appDir, file)} -> ${finding}`)
+    })
+
+    expect(
+      violations,
+      'presentation modules render loader data and submit through fetchers. Move the work into ' +
+        'a route module rather than reshaping it here:\n' +
+        '  reads -> export a loader, or clientLoader when only the browser can serve them, and ' +
+        'render the result from loaderData (see routes/settings-loader.ts)\n' +
+        '  writes -> export an action, or clientAction for the same reason, and submit to it ' +
+        'with useFetcher, which also gives you the pending state (see ' +
+        'routes/desktop-update-action.ts)\n' +
+        '  pushed events, which no loader can express -> hold them in an atom that subscribes ' +
+        'in onMount (see lib/desktop-update.ts)\n' +
+        'Re-exporting the same call from app/lib or app/utils and importing it back is not a ' +
+        'fix. This test stops looking there, but the request still runs outside the router, so ' +
+        'it still has no caching, no pending state, and no revalidation. Nor is dropping the ' +
+        'await while keeping the effect: a subscription belongs in an atom, and a request ' +
+        'belongs in a handler.',
+    ).toEqual([])
   })
 
   it('does not depend on Tailwind packages', () => {


### PR DESCRIPTION
## Summary

Adding an architecture test to try and prevent LLMs from fetching data from the client, and giving some guidance on what to do instead.