### PR TITLE
fix(reef): drop the unused desktop build flag from the sidebar

### DIFF
--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -22,7 +22,6 @@ import {
   useDesktopUpdateState,
 } from '@/components/desktop-update-indicator'
 import { WorkspaceCreationDialog } from '@/components/workspaces'
-import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { workspacePathForCurrentSection } from '@/lib/workspace-routing'
 import { routePath } from '@/routing/routemap'
 
@@ -45,7 +44,6 @@ export function Sidebar({
   const location = useLocation()
   const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
-  const desktop = isCoralDesktopBuild()
   const {
     isPending: isUpdatePending,
     onDownload: onUpdateDownload,


### PR DESCRIPTION
`desktop` had two readers, and two changes each removed one: #2112 made MCP client configuration available on both builds, so the nav item no longer gates on it, and #2115 dropped the argument to useDesktopUpdateState. Both were green against their own base and left the other reader standing, so oxlint only fails now that they sit together on main.