### PR TITLE
fix(reef): drop the dead desktop flag that fails lint on main

### DIFF
--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -22,7 +22,6 @@ import {
   useDesktopUpdateState,
 } from '@/components/desktop-update-indicator'
 import { WorkspaceCreationDialog } from '@/components/workspaces'
-import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { workspacePathForCurrentSection } from '@/lib/workspace-routing'
 import { routePath } from '@/routing/routemap'
 
@@ -45,7 +44,6 @@ export function Sidebar({
   const location = useLocation()
   const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
-  const desktop = isCoralDesktopBuild()
   const {
     isPending: isUpdatePending,
     onDownload: onUpdateDownload,


### PR DESCRIPTION
## Intent

`main` has been red since b37678e26. #2115 changed `useDesktopUpdateState(desktop)`
to `useDesktopUpdateState()`, which left `const desktop = isCoralDesktopBuild()`
with no reader and its import unused. `oxlint --deny-warnings` rejects that, so
the `Reef checks` job fails on every commit and therefore on every open PR.

```
app/components/sidebar/sidebar.tsx:48:9: error eslint(no-unused-vars):
  Variable 'desktop' is declared but never used.
```

| main commit | Validate |
|---|---|
| cb92f8010 (#2112) | success |
| b37678e26 (#2115) | failure |
| 4e0f30ae4 (#2184) | failure |

## What it enables

Green CI on `main` and on every PR branched from it.

This removes the flag rather than restoring a reader, because the desktop gate
already moved into the update state. `desktopUpdateStateAtom` opens the IPC
bridge only when `coralDesktopApi()` exists, so a web build stays `idle`, and the
sidebar's existing `updateState.status !== 'idle' && !== 'unsupported'` guard is
what hides the indicator. The atom's own comment says as much: "Web builds and
the server have no bridge and stay idle, which the sidebar hides." Behavior is
unchanged.

## Usage examples

```bash
npm ci --prefix apps/reef
npm run check --prefix apps/reef     # fails on main, passes here
```

Verified by running `oxlint --deny-warnings` against
`app/components/sidebar/sidebar.tsx` on this branch with and without the change:
the error reproduces on main's version and is gone here. The same two-line
removal was also applied on top of the Reef -> Coral UI rename branch, where the
full suite passed (`npm run check`, `typecheck`, and 396 tests).
