### PR TITLE
test(app): fail hung OAuth tests instead of stalling CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# Bound every test so a wedged one fails the run instead of stalling it.
+#
+# Without `terminate-after`, nextest only *warns* about a slow test, once per
+# period, forever: a test that can never finish holds the job until someone
+# notices and cancels it. Terminating instead reports the test as TIMEOUT and
+# prints the output it had already produced, which is usually the panic that
+# explains the wedge.
+#
+# The slowest healthy test in CI runs in about 13s, so 60s marks a test as slow
+# and 5 periods (5 minutes) is a generous ceiling before it is killed.
+[profile.default]
+slow-timeout = { period = "60s", terminate-after = 5 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -190,6 +190,11 @@ jobs:
     name: Rust checks
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
+    # Healthy runs take 5-7 minutes. This is a backstop for a job that wedges
+    # outside nextest's reach — a stuck build, cache restore, or toolchain
+    # install — so it fails on its own instead of holding a runner until
+    # someone cancels it or GitHub's 6-hour default kills it.
+    timeout-minutes: 30
     if: ${{ needs.changes.outputs.rust_checks == 'true' }}
     steps:
       - name: Free Linux runner disk space

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -1891,7 +1891,6 @@ mod tests {
     )]
 
     use std::collections::BTreeMap;
-    use std::io::{Read as _, Write as _};
     use std::net::TcpListener as StdTcpListener;
     use std::sync::LazyLock;
     use std::time::Duration;
@@ -1914,6 +1913,7 @@ mod tests {
         ManifestOAuthScopeSpec, ManifestOAuthScopesSpec,
     };
     use serde_json::Value;
+    use tokio::net::{TcpListener as TokioTcpListener, TcpStream as TokioTcpStream};
     use tokio::sync::oneshot;
     use tokio::task::JoinHandle;
     use tokio::{io::AsyncReadExt as _, io::AsyncWriteExt as _};
@@ -2941,11 +2941,12 @@ mod tests {
             "http://{}/device/code",
             listener.local_addr().expect("addr")
         );
-        let server = tokio::task::spawn_blocking(move || {
-            let (mut stream, _) = listener.accept().expect("accept device request");
-            let request = read_http_request(&mut stream);
+        let listener = async_listener(listener);
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept device request");
+            let request = read_http_request(&mut stream).await;
             let mut closed = [0_u8; 1];
-            match stream.read(&mut closed) {
+            match stream.read(&mut closed).await {
                 Ok(_) | Err(_) => {}
             }
             request
@@ -3540,9 +3541,10 @@ mod tests {
                 "http://{}/token",
                 token_listener.local_addr().expect("addr")
             );
-            let token_server = tokio::task::spawn_blocking(move || {
-                let (mut stream, _) = token_listener.accept().expect("accept token request");
-                let request = read_http_request(&mut stream);
+            let token_listener = async_listener(token_listener);
+            let token_server = tokio::spawn(async move {
+                let (mut stream, _) = token_listener.accept().await.expect("accept token request");
+                let request = read_http_request(&mut stream).await;
                 let response_body = response_body.unwrap_or(
                     r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo read:org","expires_in":3600}"#,
                 );
@@ -3552,6 +3554,7 @@ mod tests {
                 );
                 stream
                     .write_all(response.as_bytes())
+                    .await
                     .expect("write token response");
                 request
             });
@@ -3574,10 +3577,14 @@ mod tests {
                 "http://{}/register",
                 listener.local_addr().expect("registration addr")
             );
-            let server = tokio::task::spawn_blocking(move || {
-                let (mut stream, _) = listener.accept().expect("accept registration request");
-                let request = read_http_request(&mut stream);
-                write_json_response(&mut stream, response_body);
+            let listener = async_listener(listener);
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener
+                    .accept()
+                    .await
+                    .expect("accept registration request");
+                let request = read_http_request(&mut stream).await;
+                write_json_response(&mut stream, response_body).await;
                 request
             });
             Self {
@@ -3599,16 +3606,18 @@ mod tests {
             let base_url = format!("http://{}", listener.local_addr().expect("addr"));
             let device_url = format!("{base_url}/device/code");
             let token_url = format!("{base_url}/access_token");
-            let server = tokio::task::spawn_blocking(move || {
-                let (mut device_stream, _) = listener.accept().expect("accept device request");
-                let device = read_http_request(&mut device_stream);
+            let listener = async_listener(listener);
+            let server = tokio::spawn(async move {
+                let (mut device_stream, _) =
+                    listener.accept().await.expect("accept device request");
+                let device = read_http_request(&mut device_stream).await;
                 let device_body = r#"{"device_code":"device-code","user_code":"ABCD-1234","verification_uri":"https://github.com/login/device","verification_uri_complete":"https://github.com/login/device?user_code=ABCD-1234","expires_in":900,"interval":1}"#;
-                write_json_response(&mut device_stream, device_body);
+                write_json_response(&mut device_stream, device_body).await;
 
-                let (mut token_stream, _) = listener.accept().expect("accept token request");
-                let token = read_http_request(&mut token_stream);
+                let (mut token_stream, _) = listener.accept().await.expect("accept token request");
+                let token = read_http_request(&mut token_stream).await;
                 let token_body = r#"{"access_token":"access-token","token_type":"Bearer","scope":"repo read:org"}"#;
-                write_json_response(&mut token_stream, token_body);
+                write_json_response(&mut token_stream, token_body).await;
 
                 CapturedDeviceFlowRequests { device, token }
             });
@@ -3632,11 +3641,25 @@ mod tests {
         form: BTreeMap<String, String>,
     }
 
-    fn read_http_request(stream: &mut std::net::TcpStream) -> CapturedTokenRequest {
+    /// Hands a bound listener to Tokio so fixture servers can await connections.
+    ///
+    /// Fixture servers must never block a thread on `accept`: a blocking accept
+    /// inside `spawn_blocking` cannot be cancelled, so a test that fails before
+    /// its request arrives leaves the blocking task parked forever. Runtime
+    /// shutdown then waits on that task and the process hangs instead of
+    /// reporting the failure — the panic never reaches the test report.
+    fn async_listener(listener: StdTcpListener) -> TokioTcpListener {
+        listener
+            .set_nonblocking(true)
+            .expect("set fixture listener non-blocking");
+        TokioTcpListener::from_std(listener).expect("adopt fixture listener")
+    }
+
+    async fn read_http_request(stream: &mut TokioTcpStream) -> CapturedTokenRequest {
         let mut buffer = Vec::new();
         let mut temp = [0_u8; 1024];
         loop {
-            let read = stream.read(&mut temp).expect("read token request");
+            let read = stream.read(&mut temp).await.expect("read token request");
             if read == 0 {
                 break;
             }
@@ -3659,7 +3682,7 @@ mod tests {
                     .and_then(|value| value.parse::<usize>().ok())
                     .unwrap_or(0);
                 while buffer.len() < header_end + content_length {
-                    let read = stream.read(&mut temp).expect("read token body");
+                    let read = stream.read(&mut temp).await.expect("read token body");
                     if read == 0 {
                         break;
                     }
@@ -3693,13 +3716,14 @@ mod tests {
         }
     }
 
-    fn write_json_response(stream: &mut std::net::TcpStream, body: &str) {
+    async fn write_json_response(stream: &mut TokioTcpStream, body: &str) {
         let response = format!(
             "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
             body.len()
         );
         stream
             .write_all(response.as_bytes())
+            .await
             .expect("write json response");
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1769,7 +1769,6 @@ fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) 
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
-    use std::io::{Read as _, Write as _};
     use std::net::TcpListener as StdTcpListener;
     use std::path::Path;
     use std::sync::mpsc as std_mpsc;
@@ -1777,8 +1776,10 @@ mod tests {
     use std::time::Duration;
 
     use tempfile::TempDir;
+    use tokio::net::{TcpListener as TokioTcpListener, TcpStream as TokioTcpStream};
     use tokio::sync::mpsc;
     use tokio::task::JoinHandle;
+    use tokio::{io::AsyncReadExt as _, io::AsyncWriteExt as _};
     use url::Url;
 
     use super::{
@@ -4052,9 +4053,10 @@ surface:
                 "http://{}/token",
                 token_listener.local_addr().expect("addr")
             );
-            let token_server = tokio::task::spawn_blocking(move || {
-                let (mut stream, _) = token_listener.accept().expect("accept token request");
-                let request = read_http_request(&mut stream);
+            let token_listener = async_listener(token_listener);
+            let token_server = tokio::spawn(async move {
+                let (mut stream, _) = token_listener.accept().await.expect("accept token request");
+                let request = read_http_request(&mut stream).await;
                 let response_body = r#"{"access_token":"access-token","token_type":"Bearer"}"#;
                 let response = format!(
                     "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
@@ -4062,6 +4064,7 @@ surface:
                 );
                 stream
                     .write_all(response.as_bytes())
+                    .await
                     .expect("write token response");
                 request
             });
@@ -4076,11 +4079,25 @@ surface:
         form: BTreeMap<String, String>,
     }
 
-    fn read_http_request(stream: &mut std::net::TcpStream) -> CapturedTokenRequest {
+    /// Hands a bound listener to Tokio so fixture servers can await connections.
+    ///
+    /// Fixture servers must never block a thread on `accept`: a blocking accept
+    /// inside `spawn_blocking` cannot be cancelled, so a test that fails before
+    /// its request arrives leaves the blocking task parked forever. Runtime
+    /// shutdown then waits on that task and the process hangs instead of
+    /// reporting the failure — the panic never reaches the test report.
+    fn async_listener(listener: StdTcpListener) -> TokioTcpListener {
+        listener
+            .set_nonblocking(true)
+            .expect("set fixture listener non-blocking");
+        TokioTcpListener::from_std(listener).expect("adopt fixture listener")
+    }
+
+    async fn read_http_request(stream: &mut TokioTcpStream) -> CapturedTokenRequest {
         let mut buffer = Vec::new();
         let mut temp = [0_u8; 1024];
         loop {
-            let read = stream.read(&mut temp).expect("read token request");
+            let read = stream.read(&mut temp).await.expect("read token request");
             if read == 0 {
                 break;
             }
@@ -4107,7 +4124,7 @@ surface:
                     .and_then(|value| value.parse::<usize>().ok())
                     .unwrap_or(0);
                 while buffer.len() < header_end + content_length {
-                    let read = stream.read(&mut temp).expect("read token body");
+                    let read = stream.read(&mut temp).await.expect("read token body");
                     if read == 0 {
                         break;
                     }


### PR DESCRIPTION
## Intent

[Run 31807298725](https://github.com/withcoral/coral/actions/runs/31807298725/job/94789326919) ran for 33 minutes before a human cancelled it — the last 28 of them waiting on a single test. That test — `coral-app credentials::oauth::tests::fixed_redirect_uri_is_sent_exactly_as_authored` — had already panicked, milliseconds in. Nothing reported the panic, and nothing stopped the job.

Two independent gaps produced that:

**The test process could not exit after the panic.** The OAuth fixtures served their stub HTTP responses from `spawn_blocking(|| listener.accept())` on a std listener. A blocking task cannot be cancelled, so when a test failed before its request arrived, that `accept` never returned; dropping the `#[tokio::test]` runtime waited on it, and the process wedged *after* the panic. nextest prints a test's captured output only when the test completes, so the panic never reached the log — CI showed nothing but `SLOW [>N s]`, once a minute, for 28 minutes.

**Nothing bounded the wedge.** The repo had no `.config/nextest.toml`, so nextest's slow timeout only warned and never terminated, and `rust-checks` had no `timeout-minutes`. Had nobody cancelled it, the job would have held a runner for GitHub's 6-hour default.

What triggered it that day was a port race — `free_loopback_port` reserves an ephemeral port and drops the listener, so the code under test rebinds it a moment later and can lose it to anything else on the runner. That race is worth closing too, but it is incidental here: *any* early failure in these fixtures produced the same hang, and a real user whose authored redirect port is occupied triggers the same bind failure (only the test fixtures could hang on it). This PR fixes the hang; the port allocation is left for a follow-up.

## What it enables

A wedged test now fails like a test instead of stalling the run:

- Fixture servers await connections on a Tokio listener, so runtime shutdown can drop them. A failing test reports its panic and exits.
- `slow-timeout.terminate-after` kills anything still running after five minutes, reports it as `TIMEOUT`, and prints the output it had produced — which is normally the panic explaining the wedge. This is repo-wide, so it also covers wedges that have nothing to do with OAuth.
- `timeout-minutes: 30` on `rust-checks` backstops wedges outside nextest's reach, such as a stuck build or cache restore.

The two timeouts are deliberately generous: the slowest healthy test in CI is ~13s against a 60s slow threshold, and healthy `rust-checks` runs take 5-7 minutes against the 30-minute cap.

## Usage examples

The fixture change is verified by forcing the exact collision — squatting the redirect port so `bind_redirect_listener` fails:

```rust
let redirect_port = free_loopback_port();
let _squatter = std::net::TcpListener::bind(("127.0.0.1", redirect_port)).unwrap();
```

Before, on `main`:

```
START [         ] coral-app credentials::oauth::tests::fixed_redirect_uri_is_sent_exactly_as_authored
(no further output; killed externally at 240s)
```

After:

```
FAIL [ 0.100s] coral-app credentials::oauth::tests::fixed_redirect_uri_is_sent_exactly_as_authored
thread '...' panicked at crates/coral-app/src/credentials/oauth.rs:3346:60:
authorization url: RecvError(())
```

And with the nextest config in place, a wedge that somehow survives the fixture fix is now reported rather than silent:

```
TERMINATING [> 20.000s] coral-app credentials::oauth::tests::fixed_redirect_uri_is_sent_exactly_as_authored
    TIMEOUT [  20.005s] coral-app credentials::oauth::tests::fixed_redirect_uri_is_sent_exactly_as_authored
```

(shown at a shortened period; the committed setting is 60s × 5)

No production code changes — the fixture rewrite is confined to `#[cfg(test)]` modules.
