### PR TITLE
ci: drop redundant disk cleanup and add Docker layer caching to image jobs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -511,7 +511,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: useblacksmith/setup-docker-builder@v2
+      - uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
         with:
           cache-key: coral/docker/Dockerfile
 
@@ -531,7 +531,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: useblacksmith/setup-docker-builder@v2
+      - uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
         with:
           cache-key: coral/docker/Dockerfile.reef
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -192,19 +192,10 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust_checks == 'true' }}
     steps:
-      - name: Free Linux runner disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          # Rust comes from rustup; this job does not use the hosted language tool cache.
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          # Keep swap for the memory-intensive clippy, test, and docs phases.
-          swap-storage: false
-
+      # No disk-space reclamation step here: the Blacksmith runner boots with a
+      # 145 GB root filesystem and ~81 GB free before any workflow step runs, so
+      # the GitHub-hosted-runner cleanup dance cost ~50s per run to reclaim space
+      # this job never needed (and evicted pre-pulled Docker images along the way).
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -520,9 +511,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: useblacksmith/setup-docker-builder@v2
         with:
-          cache-binary: false
+          cache-key: coral/docker/Dockerfile
 
       - name: Build and smoke the Coral image entrypoint
         run: make coral-docker-stub-test CORAL_DOCKER_IMAGE=coral:stub
@@ -540,9 +531,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: useblacksmith/setup-docker-builder@v2
         with:
-          cache-binary: false
+          cache-key: coral/docker/Dockerfile.reef
 
       - name: Check Reef image contract
         run: node --test docker/reef-image.test.mjs docker/reef-publish.test.mjs


### PR DESCRIPTION
Two caching wins measured against real Validate runs over the last 30 days.

**`Rust checks` spent ~50s per run reclaiming disk it already had.** `jlumbroso/free-disk-space` is a workaround for GitHub-hosted runners and their 14 GB disks. On the Blacksmith runner this job actually uses, the step's own output shows the root filesystem before it does anything:

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   57G   81G  42% /
...
=> Saved 25GiB
##[end-action id=__jlumbroso_free-disk-space.__run;outcome=success;duration_ms=49693]
```

81 GB free, and it burned 49.7s to free 25 GiB nobody was going to use. It also passed `docker-images: true`, which deletes the runner's pre-pulled images. `Rust checks` ran 1,296 times in the last 30 days and averages 338s, so this is ~15% of the job's wall clock and ~18 hours of runtime per month on the critical path of every Rust PR. Removed, with a comment recording why so it does not get re-added.

**`Coral image` and `Reef image` built with no layer cache at all.** Both jobs run on Blacksmith runners but used `docker/setup-buildx-action`, which provisions an ephemeral builder, so every run rebuilt every layer. `docker/Dockerfile.reef` in particular has two `npm ci` layers that were re-resolving from scratch each time. Swapped to the Blacksmith builder with one sticky-disk-backed cache key per Dockerfile:

```yaml
- uses: useblacksmith/setup-docker-builder@v2
  with:
    cache-key: coral/docker/Dockerfile.reef
```

| Job | Dockerfile | `cache-key` |
| --- | --- | --- |
| `Coral image` | `docker/Dockerfile` | `coral/docker/Dockerfile` |
| `Reef image` | `docker/Dockerfile.reef` | `coral/docker/Dockerfile.reef` |

Separate keys because the two images share no layers and would otherwise evict each other. The `cache-binary: false` input is buildx-specific and dropped. Both jobs keep invoking `make coral-docker-stub-test` / `make reef-docker-test` unchanged: the Makefile's raw `docker buildx build ... --load` doesn't map cleanly onto `build-push-action` inputs, but the v2 builder becomes the default builder, so those raw builds pick up the persistent layer cache anyway. `--load` still works on the container driver, and neither Dockerfile `FROM`s a daemon-local image.

Note this changes the builder driver for those two jobs, not just cache scoping. The first run on each key is cold; every run after hits the per-image cache.

Left alone deliberately: `docker-publish.yml`, `reef-docker-publish.yml`, and `docker-aliases.yml` all build on `ubuntu-latest`. There is no persistent Blacksmith builder on GitHub-hosted runners, so migrating them would strip caching rather than add it.

Docs: [Docker layer caching](https://docs.blacksmith.sh/blacksmith-caching/docker-builds).