### PR TITLE
ci: right-size 5 GitHub Actions runners

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint:
     name: Validate PR title
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - id: lint_pr_title
         name: Validate PR title

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     permissions:
       contents: read
@@ -188,7 +188,7 @@ jobs:
 
   rust-checks:
     name: Rust checks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     needs: changes
     # Healthy runs take 5-7 minutes. This is a backstop for a job that wedges
     # outside nextest's reach — a stuck build, cache restore, or toolchain
@@ -234,7 +234,7 @@ jobs:
 
   postgres-database-tests:
     name: Postgres database tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     needs: changes
     if: ${{ needs.changes.outputs.postgres_database_tests == 'true' }}
     services:
@@ -770,7 +770,7 @@ jobs:
 
   performance-regression:
     name: Performance regression
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     needs: changes
     if: ${{ needs.changes.outputs.performance-regression == 'true' }}
     steps:


### PR DESCRIPTION
Applies the five runner-sizing changes selected from the right-sizing card, based on 30 days of observed CPU, memory, and runtime data. Three CPU-saturated `Validate` jobs move up a tier to recover wall time, and two near-idle jobs move down a tier. Net estimated spend change is about +$41/month, buying roughly 15-42% off the runtime of the three slowest saturated jobs.

Every change is a single `runs-on:` line, for example:

```yaml
  performance-regression:
    name: Performance regression
    runs-on: blacksmith-8vcpu-ubuntu-2404
```

## Apply for speed

**`Validate` / Performance regression** (`.github/workflows/validate.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, high confidence.
Fully CPU-bound: average CPU is 89.4% and the job spends 89% of its time above 80% CPU with every core saturated. Doubling cores is projected to cut p50 from 174s to 99s and p95 from 470s to 288s (about -42%), for roughly +$8.22/month across ~1,631 monthly runs. Clearest win on the board.
Samples: [median run](https://app.blacksmith.sh/withcoral/runs/30110562509/jobs/89538809287?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/withcoral/runs/30546414987/jobs/90883705060?tab=metrics)

**`Validate` / Postgres database tests** (`.github/workflows/validate.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, medium confidence.
95th percentile CPU is 98.1% with all cores busy and a third of the run above 80% CPU, while peak memory stays at 20.5%. Projected p50 192s -> 162s and p95 395s -> 345s (about -15%), for roughly +$9.73/month across ~411 monthly runs.
Samples: [median run](https://app.blacksmith.sh/withcoral/runs/30550559039/jobs/90897902550?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/withcoral/runs/31708350488/jobs/94474574260?tab=metrics)

## Apply for savings

**`Validate` / Detect changes** (`.github/workflows/validate.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-2vcpu-ubuntu-2404`, medium confidence.
Average CPU is only 2.5% with 95th percentile CPU at 13.2% and peak memory at 2.2%, so the smaller runner fits with no projected wall-time growth (p50 stays at 7s, p95 at 126s). Saves about $10.93/month across ~2,414 monthly runs.
Samples: [median run](https://app.blacksmith.sh/withcoral/runs/31708132192/jobs/94473798841?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/withcoral/runs/30562731078/jobs/90939684627?tab=metrics)

## Test before applying

**`Validate` / Rust checks** (`.github/workflows/validate.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, medium confidence.
The job already uses most cores at its peak, with 95th percentile CPU at 99.3% and about a third of its time above 80% CPU. Projected p50 354s -> 301s and p95 611s -> 536s (about -14%), but it is the largest spend increase here at roughly +$67.10/month across ~1,637 monthly runs. Worth confirming the runtime gain holds on this branch before keeping it.
Samples: [median run](https://app.blacksmith.sh/withcoral/runs/31492689363/jobs/93782793786?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/withcoral/runs/29839686336/jobs/88665941386?tab=metrics)

**`Lint PR Title` / Validate PR title** (`.github/workflows/pr-title.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-2vcpu-ubuntu-2404`, low confidence.
Largest single saving at about $33.29/month, driven by ~8,706 monthly runs rather than by headroom: 95th percentile CPU is 58.7% with about two cores busy, so the smaller runner is a tight fit. Projected p50 5.0s -> 5.2s and p95 6.0s -> 6.3s (about +5% on a 5-second job), which is cheap in absolute terms but is real growth.
Samples: [median run](https://app.blacksmith.sh/withcoral/runs/31397031582/jobs/93482358899?tab=metrics) - [slow run (p95)](https://app.blacksmith.sh/withcoral/runs/31700304422/jobs/94447578501?tab=metrics)

## Note for reviewers

`Performance regression` runs `make perf-check`, which fails when release `coral sql "select * from coral.tables"` has a hyperfine mean above 750 ms. Running it on 8 vCPU shifts the baseline that threshold is measured against, so the gate becomes slightly more permissive relative to the hardware developers ship on. No threshold change is included here.