### PR TITLE
ci: make Discord release notes non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -612,6 +612,10 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
+    # The release is already published and promoted by this point, so an
+    # undelivered changelog post must never redden the run. Failures surface as
+    # warning annotations instead, and the job can be re-run on its own.
+    continue-on-error: true
     steps:
       - name: Post promoted release to Discord
         env:
@@ -620,11 +624,22 @@ jobs:
           TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
         run: |
           set -euo pipefail
-          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}")"
+          skip() {
+            echo "::warning title=Discord release notes not posted::$1"
+            exit 0
+          }
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            skip "DISCORD_CHANGELOG_WEBHOOK is not configured"
+          fi
+          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}")" ||
+            skip "could not read the ${TAG_NAME} release"
           name="$(printf '%s' "$release" | jq -r '.name // ""')"
           url="$(printf '%s' "$release" | jq -r .html_url)"
           body="$(printf '%s' "$release" | jq -r '.body // ""')"
           title="🪸 ${name:-$TAG_NAME}"
-          jq -n --arg title "${title:0:253}" --arg desc "${body:0:3500}" --arg url "$url" \
-            '{embeds:[{title:$title,description:$desc,url:$url,color:16744272,footer:{text:"Fresh from the reef"}}]}' |
-            curl -sf -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+          payload="$(jq -n --arg title "${title:0:253}" --arg desc "${body:0:3500}" --arg url "$url" \
+            '{embeds:[{title:$title,description:$desc,url:$url,color:16744272,footer:{text:"Fresh from the reef"}}]}')" ||
+            skip "could not build the Discord payload for ${TAG_NAME}"
+          printf '%s' "$payload" |
+            curl -sf --max-time 30 -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK" ||
+            skip "the Discord webhook rejected the post for ${TAG_NAME}"


### PR DESCRIPTION
## What

The `notify-release` job posts the promoted release's changelog to Discord. It's the last job in the release workflow and nothing depends on it, but until now any failure — an unset webhook secret, a transient Discord outage, a hung request — turned an otherwise successful release run red.

Delivery is strictly a nice-to-have, so this makes it degrade rather than fail.

## How

- **Job level**: `continue-on-error: true`, so even an unexpected failure (runner death, `gh` blowing up in a way the script doesn't anticipate) leaves the run green. By this point the release is already published and promoted.
- **Step level**: each fallible operation now emits a `::warning::` annotation and exits cleanly, so the reason shows up in the run summary instead of being buried in a red log. Covered cases:
  - missing/empty `DISCORD_CHANGELOG_WEBHOOK` — previously `curl` would fail on an empty URL
  - the release lookup failing
  - payload construction failing
  - the webhook rejecting the post
- **`--max-time 30`** on the `curl`, so a hung webhook can't hold a runner open indefinitely.

The existing comment about keeping delivery in its own job so a failed webhook can be retried still holds — re-running `notify-release` on its own remains the recovery path, and it now reports a soft failure rather than sinking the release.

## Testing

Workflow YAML parses, `bash -n` is clean on the extracted script, and `actionlint` reports nothing on the changed lines (its only output is the pre-existing unknown-`blacksmith-*`-runner-label warnings across the whole file, from there being no local `actionlint.yaml` runner config).

https://claude.ai/code/session_01CkhwFPaGGcHq3YnFkBythS
