### PR TITLE
ci: teach actionlint our Blacksmith runner labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,15 @@
+# Configuration for actionlint (https://github.com/rhysd/actionlint).
+#
+# Our workflows run on Blacksmith runners, whose labels actionlint cannot know
+# about. Without this list every `runs-on:` is reported as an unknown label,
+# which drowns out real findings. Keep it in sync when adding a runner size:
+#
+#   grep -rhoE '\bblacksmith-[a-z0-9.-]+' .github/ | sort -u
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-4vcpu-windows-2025
+    - blacksmith-6vcpu-macos-26
+    - blacksmith-8vcpu-ubuntu-2404


### PR DESCRIPTION
## What

Adds `.github/actionlint.yaml` declaring our Blacksmith runner labels.

[actionlint](https://github.com/rhysd/actionlint) has no way to know about self-hosted or third-party runner labels, so it flagged every `runs-on:` in the repo as unknown. That was **38 of the 43 findings** across `.github/` — enough noise to bury the 5 real ones and make the tool close to useless locally.

With the config, the same run reports **5 findings, all genuine**:

- `docker-aliases.yml`, `docker-publish.yml` ×2, `reef-docker-publish.yml` — `unexpected key "queue" for "concurrency" section`
- `reef-docker-publish.yml:195` — shellcheck `SC2329`, function never invoked

Those are pre-existing and left alone here; this PR is only about making them visible.

## Labels declared

Collected from the whole of `.github/`:

```
blacksmith-2vcpu-ubuntu-2404
blacksmith-4vcpu-ubuntu-2404
blacksmith-4vcpu-ubuntu-2404-arm
blacksmith-4vcpu-windows-2025
blacksmith-6vcpu-macos-26
blacksmith-8vcpu-ubuntu-2404
```

The file carries the one-liner for regenerating that list, since it needs a new entry whenever we add a runner size:

```
grep -rhoE '\bblacksmith-[a-z0-9.-]+' .github/ | sort -u
```

## Scope

actionlint isn't currently wired into CI anywhere, so this changes nothing about what runs on a PR — it only affects local and editor invocations. Happy to add a CI job in a follow-up if we want the 5 remaining findings enforced rather than merely visible.

Based on `main`, independent of #2193.

https://claude.ai/code/session_01CkhwFPaGGcHq3YnFkBythS
