### PR TITLE
feat(spec)!: import OpenAPI array query parameters

### DIFF
--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -1036,11 +1036,13 @@ Request query params, body fields, and headers support these `from` values:
 | `filter` | Read a table filter captured from the query `WHERE` clause and serialize it as a string |
 | `filter_int` | Read a table filter captured from the query `WHERE` clause and serialize it as a JSON integer |
 | `filter_bool` | Read a table filter captured from the query `WHERE` clause and serialize it as a JSON boolean |
+| `filter_string_array` | Read a table filter holding a JSON array literal and serialize it as a JSON array |
 | `filter_split` | Split a table filter string and serialize one part as a string |
 | `filter_split_int` | Split a table filter string and serialize one part as a JSON integer |
 | `arg` | Read a source function argument captured from the function call and serialize it as a string |
 | `arg_int` | Read a source function argument captured from the function call and serialize it as a JSON integer |
 | `arg_bool` | Read a source function argument captured from the function call and serialize it as a JSON boolean |
+| `arg_string_array` | Read a source function argument holding a JSON array literal and serialize it as a JSON array |
 | `arg_split` | Split a source function argument string and serialize one part as a string |
 | `arg_split_int` | Split a source function argument string and serialize one part as a JSON integer |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
@@ -1056,11 +1058,41 @@ arg value sources because their request values come from named function
 arguments such as `github.search_issues(q => 'flaky')`.
 
 The suffix controls the value type sent to the provider. Use the bare form for a
-string request value, `_int` for a JSON integer, and `_bool` for a JSON boolean.
+string request value, `_int` for a JSON integer, `_bool` for a JSON boolean, and
+`_string_array` for a JSON array.
 
 Boolean filters used with `filter_bool` can be written as normal SQL boolean
 predicates, for example `WHERE include_archived IS FALSE` or
 `WHERE include_archived = false`.
+
+### Multi-valued request values
+
+`filter_string_array` and `arg_string_array` read a list. The SQL value is a JSON
+array literal, and a bare value is accepted as a one-element list:
+
+```sql
+SELECT * FROM github.list_org_migrations(org => 'withcoral', exclude => '["repositories"]');
+SELECT * FROM github.list_org_migrations(org => 'withcoral', exclude => 'repositories');
+```
+
+In a request body the list becomes a JSON array. In a query parameter it expands
+according to the parameter's `explode` setting, which defaults to `true`:
+
+```yaml
+query:
+  # explode: true (the default) sends ?exclude=a&exclude=b
+  - name: exclude
+    from: filter_string_array
+    key: exclude
+  # explode: false sends ?$select=a,b
+  - name: $select
+    explode: false
+    from: filter_string_array
+    key: select
+```
+
+An empty list sends no query parameter at all. `explode` has no effect on
+single-valued value sources.
 
 Use `filter_split` and `filter_split_int` when a provider requires structured
 request fields but users naturally have one compound identifier. For example,

--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -1065,35 +1065,6 @@ Boolean filters used with `filter_bool` can be written as normal SQL boolean
 predicates, for example `WHERE include_archived IS FALSE` or
 `WHERE include_archived = false`.
 
-### Multi-valued request values
-
-`filter_string_array` and `arg_string_array` read a list. The SQL value is a JSON
-array literal, and a bare value is accepted as a one-element list:
-
-```sql
-SELECT * FROM github.list_org_migrations(org => 'withcoral', exclude => '["repositories"]');
-SELECT * FROM github.list_org_migrations(org => 'withcoral', exclude => 'repositories');
-```
-
-In a request body the list becomes a JSON array. In a query parameter it expands
-according to the parameter's `explode` setting, which defaults to `true`:
-
-```yaml
-query:
-  # explode: true (the default) sends ?exclude=a&exclude=b
-  - name: exclude
-    from: filter_string_array
-    key: exclude
-  # explode: false sends ?$select=a,b
-  - name: $select
-    explode: false
-    from: filter_string_array
-    key: select
-```
-
-An empty list sends no query parameter at all. `explode` has no effect on
-single-valued value sources.
-
 Use `filter_split` and `filter_split_int` when a provider requires structured
 request fields but users naturally have one compound identifier. For example,
 `SOURCE-496` can become a string team key and integer issue number:
@@ -1134,6 +1105,39 @@ request:
       separator: "-"
       part: 1
 ```
+
+### Multi-valued request values
+
+`filter_string_array` and `arg_string_array` read a list. The SQL value is a JSON
+array literal, and a bare value is accepted as a one-element list:
+
+```sql
+SELECT * FROM github.list_org_migrations(org => 'withcoral', exclude => '["repositories"]');
+SELECT * FROM github.list_org_migrations(org => 'withcoral', exclude => 'repositories');
+```
+
+In a request body the list becomes a JSON array. In a query parameter it expands
+according to the parameter's `explode` setting, which defaults to `true`:
+
+```yaml
+query:
+  # explode: true (the default) sends ?exclude=a&exclude=b
+  - name: exclude
+    from: filter_string_array
+    key: exclude
+  # explode: false sends ?$select=a,b
+  - name: $select
+    explode: false
+    from: filter_string_array
+    key: select
+```
+
+An empty list sends no query parameter at all. `explode` has no effect on
+single-valued value sources. Text that starts with `[` is always read as a JSON
+array, so a malformed one is an error rather than a single literal value.
+
+Declare the backing filter or argument as `Utf8`. A `Json` argument's value must
+parse as JSON before the value source runs, which rejects the bare form.
 
 ### HTTP response fields
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -998,6 +998,7 @@ mod tests {
             location,
             required: false,
             data_type: IrScalarType::Integer,
+            collection_encoding: None,
             default_value: None,
             description: String::new(),
         }
@@ -1063,6 +1064,7 @@ mod tests {
             wire_name: name.to_string(),
             required: false,
             data_type: ManifestDataType::Int64,
+            collection_encoding: None,
             default_value: None,
             description: String::new(),
             lookup_key,

--- a/crates/coral-engine/src/backends/http/filter_usage.rs
+++ b/crates/coral-engine/src/backends/http/filter_usage.rs
@@ -95,6 +95,7 @@ fn collect_value_source_filters(source: &ValueSourceSpec, filters: &mut HashSet<
         | ValueSourceSpec::Arg { .. }
         | ValueSourceSpec::ArgInt { .. }
         | ValueSourceSpec::ArgBool { .. }
+        | ValueSourceSpec::ArgStringArray { .. }
         | ValueSourceSpec::ArgSplit { .. }
         | ValueSourceSpec::ArgSplitInt { .. }
         | ValueSourceSpec::Input { .. }
@@ -120,6 +121,7 @@ mod tests {
             path: ParsedTemplate::parse("/repos/{{filter.owner}}/{{filter.repo}}")
                 .expect("path template"),
             query: vec![QueryParamSpec {
+                explode: true,
                 name: "state".to_string(),
                 value: ValueSourceSpec::Filter {
                     key: "state".to_string(),

--- a/crates/coral-engine/src/backends/http/request.rs
+++ b/crates/coral-engine/src/backends/http/request.rs
@@ -20,8 +20,24 @@ pub(super) fn build_query_pairs(
 
     for param in &request.query {
         let value = resolve_value_source(&param.value, render_context)?;
-        if let Some(value) = value {
-            params.push((param.name.clone(), value_to_string(&value)));
+        match value {
+            // A list value expands per OpenAPI's `form` style: one pair per
+            // item when exploded, otherwise one comma-joined pair. An empty
+            // list contributes nothing rather than an empty parameter, which
+            // providers read as an explicit empty selection.
+            Some(Value::Array(items)) => {
+                if items.is_empty() {
+                    continue;
+                }
+                let items = items.iter().map(value_to_string);
+                if param.explode {
+                    params.extend(items.map(|item| (param.name.clone(), item)));
+                } else {
+                    params.push((param.name.clone(), items.collect::<Vec<_>>().join(",")));
+                }
+            }
+            Some(value) => params.push((param.name.clone(), value_to_string(&value))),
+            None => {}
         }
     }
 
@@ -120,11 +136,142 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{RequestBody, build_request_body, set_path_value};
+    use super::{RequestBody, build_query_pairs, build_request_body, set_path_value};
     use crate::backends::shared::template::RenderContext;
     use coral_spec::{
-        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, RequestSpec, ValueSourceSpec,
+        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, QueryParamSpec, RequestSpec,
+        ValueSourceSpec,
     };
+
+    fn query_request(params: Vec<QueryParamSpec>) -> RequestSpec {
+        RequestSpec {
+            method: HttpMethod::GET,
+            path: ParsedTemplate::parse("/items").expect("template"),
+            query: params,
+            body: BodySpec::default(),
+            headers: vec![],
+        }
+    }
+
+    fn query_pairs(params: Vec<QueryParamSpec>, filters: &[(&str, &str)]) -> Vec<(String, String)> {
+        let request = query_request(params);
+        let filters = filters
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect::<HashMap<_, _>>();
+        let args = HashMap::new();
+        let state = HashMap::new();
+        let resolved_inputs = BTreeMap::new();
+        let context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
+
+        build_query_pairs(&request, &context).expect("query pairs should render")
+    }
+
+    fn string_array_param(name: &str, key: &str, explode: bool) -> QueryParamSpec {
+        QueryParamSpec {
+            name: name.to_string(),
+            explode,
+            value: ValueSourceSpec::FilterStringArray {
+                key: key.to_string(),
+                default: None,
+            },
+        }
+    }
+
+    #[test]
+    fn build_query_pairs_repeats_the_name_for_an_exploded_array() {
+        let pairs = query_pairs(
+            vec![string_array_param("exclude", "exclude", true)],
+            &[("exclude", r#"["repositories","tags"]"#)],
+        );
+
+        assert_eq!(
+            pairs,
+            vec![
+                ("exclude".to_string(), "repositories".to_string()),
+                ("exclude".to_string(), "tags".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_query_pairs_joins_an_unexploded_array_with_commas() {
+        let pairs = query_pairs(
+            vec![string_array_param("$select", "select", false)],
+            &[("select", r#"["id","displayName"]"#)],
+        );
+
+        assert_eq!(
+            pairs,
+            vec![("$select".to_string(), "id,displayName".to_string())]
+        );
+    }
+
+    #[test]
+    fn build_query_pairs_omits_an_empty_array() {
+        // An empty parameter is an explicit empty selection to most providers,
+        // which is not what "the caller filtered on nothing" means.
+        let pairs = query_pairs(
+            vec![string_array_param("exclude", "exclude", true)],
+            &[("exclude", "[]")],
+        );
+
+        assert!(pairs.is_empty(), "{pairs:?}");
+    }
+
+    #[test]
+    fn build_query_pairs_renders_non_string_array_items() {
+        let pairs = query_pairs(
+            vec![string_array_param("creator_id", "creator_id", true)],
+            &[("creator_id", "[1,2]")],
+        );
+
+        assert_eq!(
+            pairs,
+            vec![
+                ("creator_id".to_string(), "1".to_string()),
+                ("creator_id".to_string(), "2".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_query_pairs_accepts_a_bare_value_as_a_one_element_array() {
+        // `WHERE exclude = 'repositories'` is what a caller reaches for first.
+        let pairs = query_pairs(
+            vec![string_array_param("exclude", "exclude", true)],
+            &[("exclude", "repositories")],
+        );
+
+        assert_eq!(
+            pairs,
+            vec![("exclude".to_string(), "repositories".to_string())]
+        );
+    }
+
+    #[test]
+    fn build_query_pairs_ignores_explode_for_scalar_values() {
+        let pairs = query_pairs(
+            vec![QueryParamSpec {
+                name: "state".to_string(),
+                explode: false,
+                value: ValueSourceSpec::Filter {
+                    key: "state".to_string(),
+                    default: None,
+                },
+            }],
+            &[("state", "open")],
+        );
+
+        assert_eq!(pairs, vec![("state".to_string(), "open".to_string())]);
+    }
+
+    #[test]
+    fn build_query_pairs_omits_unbound_parameters() {
+        let pairs = query_pairs(vec![string_array_param("exclude", "exclude", true)], &[]);
+
+        assert!(pairs.is_empty(), "{pairs:?}");
+    }
 
     #[test]
     fn build_request_body_omits_json_body_when_no_fields_resolve() {

--- a/crates/coral-engine/src/backends/http/test_support.rs
+++ b/crates/coral-engine/src/backends/http/test_support.rs
@@ -116,6 +116,9 @@ fn value_source_json(value: &ValueSourceSpec) -> Value {
         ValueSourceSpec::ArgBool { key, default } => {
             key_default_json("arg_bool", key, default.as_ref())
         }
+        ValueSourceSpec::ArgStringArray { key, default } => {
+            key_default_json("arg_string_array", key, default.as_ref())
+        }
         ValueSourceSpec::ArgSplit {
             key,
             separator,

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -63,6 +63,10 @@ impl RuntimeValueNamespace {
 }
 
 /// Resolve one declarative value source into an optional JSON value.
+#[expect(
+    clippy::too_many_lines,
+    reason = "One arm per value source keeps the whole vocabulary visible in one dispatch table; splitting it by family would hide which variants exist."
+)]
 pub(crate) fn resolve_value_source(
     value: &ValueSourceSpec,
     context: &RenderContext<'_>,
@@ -99,7 +103,10 @@ pub(crate) fn resolve_value_source(
             parse_bool_value(context, RuntimeValueNamespace::Filter, key, *default)
         }
         ValueSourceSpec::FilterStringArray { key, default } => {
-            parse_filter_strings(context, key, default.as_deref())
+            Ok(parse_filter_strings(context, key, default.as_deref()))
+        }
+        ValueSourceSpec::ArgStringArray { key, default } => {
+            Ok(parse_arg_strings(context, key, default.as_deref()))
         }
         ValueSourceSpec::FilterSplit {
             key,
@@ -244,30 +251,57 @@ fn parse_bool_value(
     Ok(Some(json!(parsed)))
 }
 
+/// Reads a list-valued filter or argument out of the string-keyed runtime maps.
+///
+/// The wire form is a JSON array literal, but a bare value is accepted as a
+/// one-element list. SQL callers reach for `= 'id'` long before `= '["id"]'`,
+/// and failing that mid-scan reads as a bug rather than as a syntax lesson.
+/// Items are stringified rather than required to be JSON strings, so a numeric
+/// list such as `[1,2]` works for integer-item parameters.
 fn parse_string_array_value(
     context: &RenderContext<'_>,
     namespace: RuntimeValueNamespace,
     key: &str,
     default: Option<&[String]>,
-) -> Result<Option<Value>> {
+) -> Option<Value> {
     let Some(raw) = namespace.values(context).get(key) else {
-        return Ok(default.map(|values| json!(values)));
+        return default.map(|values| json!(values));
     };
-    let parsed = serde_json::from_str::<Vec<String>>(raw).map_err(|error| {
-        let label = namespace.label();
-        DataFusionError::Execution(format!(
-            "{label} '{key}' value '{raw}' is not a valid JSON array of strings: {error}"
-        ))
-    })?;
-    Ok(Some(json!(parsed)))
+    let parsed = serde_json::from_str::<Vec<Value>>(raw)
+        .ok()
+        .and_then(|items| {
+            items
+                .iter()
+                .map(|item| match item {
+                    Value::Null | Value::Array(_) | Value::Object(_) => None,
+                    Value::String(item) => Some(item.clone()),
+                    item => Some(item.to_string()),
+                })
+                .collect::<Option<Vec<String>>>()
+        })
+        .unwrap_or_else(|| vec![raw.clone()]);
+    Some(json!(parsed))
 }
 
 fn parse_filter_strings(
     context: &RenderContext<'_>,
     key: &str,
     default: Option<&[String]>,
-) -> Result<Option<Value>> {
+) -> Option<Value> {
     parse_string_array_value(context, RuntimeValueNamespace::Filter, key, default)
+}
+
+fn parse_arg_strings(
+    context: &RenderContext<'_>,
+    key: &str,
+    default: Option<&[String]>,
+) -> Option<Value> {
+    parse_string_array_value(
+        context,
+        RuntimeValueNamespace::FunctionArgument,
+        key,
+        default,
+    )
 }
 
 fn parse_split_i64_value(
@@ -463,6 +497,7 @@ pub(crate) fn validate_value_source_inputs(
         | ValueSourceSpec::Arg { .. }
         | ValueSourceSpec::ArgInt { .. }
         | ValueSourceSpec::ArgBool { .. }
+        | ValueSourceSpec::ArgStringArray { .. }
         | ValueSourceSpec::ArgSplit { .. }
         | ValueSourceSpec::ArgSplitInt { .. }
         | ValueSourceSpec::State { .. }
@@ -748,26 +783,87 @@ mod tests {
     }
 
     #[test]
-    fn resolve_value_source_rejects_invalid_filter_string_arrays() {
-        let filters = HashMap::from([(
-            "log_stream_names".to_string(),
-            r#"["stream-a",42]"#.to_string(),
-        )]);
+    fn resolve_value_source_stringifies_non_string_array_entries() {
+        // OpenAPI array parameters are not all arrays of strings — GitHub's
+        // `creator_id` takes integers — and the wire form is text either way.
+        let filters = HashMap::from([("creator_id".to_string(), "[1,2]".to_string())]);
 
-        let error = resolve_value_source(
+        let value = resolve_value_source(
             &ValueSourceSpec::FilterStringArray {
-                key: "log_stream_names".to_string(),
+                key: "creator_id".to_string(),
                 default: None,
             },
             &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
-        .expect_err("non-string array entries should fail");
+        .expect("numeric array entries should resolve");
 
-        assert!(
-            error.to_string().contains(
-                "filter 'log_stream_names' value '[\"stream-a\",42]' is not a valid JSON array of strings"
-            )
-        );
+        assert_eq!(value, Some(json!(["1", "2"])));
+    }
+
+    #[test]
+    fn resolve_value_source_reads_a_bare_value_as_a_one_element_array() {
+        // `WHERE exclude = 'repositories'` is the first thing a SQL caller
+        // reaches for, and failing it mid-scan reads as a bug rather than as a
+        // syntax lesson.
+        let filters = HashMap::from([("exclude".to_string(), "repositories".to_string())]);
+
+        let value = resolve_value_source(
+            &ValueSourceSpec::FilterStringArray {
+                key: "exclude".to_string(),
+                default: None,
+            },
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
+        )
+        .expect("bare values should resolve");
+
+        assert_eq!(value, Some(json!(["repositories"])));
+    }
+
+    #[test]
+    fn resolve_value_source_parses_arg_string_arrays_as_json_arrays() {
+        let args = HashMap::from([("exclude".to_string(), r#"["repositories"]"#.to_string())]);
+
+        let value = resolve_value_source(
+            &ValueSourceSpec::ArgStringArray {
+                key: "exclude".to_string(),
+                default: None,
+            },
+            &test_render_context(&HashMap::new(), &args, &BTreeMap::new()),
+        )
+        .expect("string array arg should resolve");
+
+        assert_eq!(value, Some(json!(["repositories"])));
+    }
+
+    #[test]
+    fn resolve_value_source_reads_arg_string_arrays_only_from_arguments() {
+        // The filter namespace must not satisfy an argument value source.
+        let filters = HashMap::from([("exclude".to_string(), r#"["repositories"]"#.to_string())]);
+
+        let value = resolve_value_source(
+            &ValueSourceSpec::ArgStringArray {
+                key: "exclude".to_string(),
+                default: None,
+            },
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
+        )
+        .expect("unbound arg should resolve to nothing");
+
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn resolve_value_source_uses_arg_string_array_default() {
+        let value = resolve_value_source(
+            &ValueSourceSpec::ArgStringArray {
+                key: "exclude".to_string(),
+                default: Some(vec!["repositories".to_string()]),
+            },
+            &test_render_context(&HashMap::new(), &HashMap::new(), &BTreeMap::new()),
+        )
+        .expect("string array arg default should resolve");
+
+        assert_eq!(value, Some(json!(["repositories"])));
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -103,10 +103,10 @@ pub(crate) fn resolve_value_source(
             parse_bool_value(context, RuntimeValueNamespace::Filter, key, *default)
         }
         ValueSourceSpec::FilterStringArray { key, default } => {
-            Ok(parse_filter_strings(context, key, default.as_deref()))
+            parse_filter_strings(context, key, default.as_deref())
         }
         ValueSourceSpec::ArgStringArray { key, default } => {
-            Ok(parse_arg_strings(context, key, default.as_deref()))
+            parse_arg_strings(context, key, default.as_deref())
         }
         ValueSourceSpec::FilterSplit {
             key,
@@ -258,36 +258,50 @@ fn parse_bool_value(
 /// and failing that mid-scan reads as a bug rather than as a syntax lesson.
 /// Items are stringified rather than required to be JSON strings, so a numeric
 /// list such as `[1,2]` works for integer-item parameters.
+///
+/// Text that opens a `[` was *meant* as an array, so a parse failure there is a
+/// malformed value and stays an error. Without that split the bare-value
+/// fallback would quietly forward `["a" "b"]` as one element literally named
+/// `["a" "b"]`.
 fn parse_string_array_value(
     context: &RenderContext<'_>,
     namespace: RuntimeValueNamespace,
     key: &str,
     default: Option<&[String]>,
-) -> Option<Value> {
+) -> Result<Option<Value>> {
     let Some(raw) = namespace.values(context).get(key) else {
-        return default.map(|values| json!(values));
+        return Ok(default.map(|values| json!(values)));
     };
-    let parsed = serde_json::from_str::<Vec<Value>>(raw)
-        .ok()
-        .and_then(|items| {
-            items
-                .iter()
-                .map(|item| match item {
-                    Value::Null | Value::Array(_) | Value::Object(_) => None,
-                    Value::String(item) => Some(item.clone()),
-                    item => Some(item.to_string()),
-                })
-                .collect::<Option<Vec<String>>>()
+    if !raw.trim_start().starts_with('[') {
+        return Ok(Some(json!([raw])));
+    }
+    let items = serde_json::from_str::<Vec<Value>>(raw).map_err(|error| {
+        let label = namespace.label();
+        DataFusionError::Execution(format!(
+            "{label} '{key}' value '{raw}' is not a valid JSON array: {error}"
+        ))
+    })?;
+    let items = items
+        .iter()
+        .map(|item| match item {
+            Value::String(item) => Ok(item.clone()),
+            Value::Null | Value::Array(_) | Value::Object(_) => {
+                let label = namespace.label();
+                Err(DataFusionError::Execution(format!(
+                    "{label} '{key}' value '{raw}' must be a JSON array of scalars"
+                )))
+            }
+            item => Ok(item.to_string()),
         })
-        .unwrap_or_else(|| vec![raw.clone()]);
-    Some(json!(parsed))
+        .collect::<Result<Vec<String>>>()?;
+    Ok(Some(json!(items)))
 }
 
 fn parse_filter_strings(
     context: &RenderContext<'_>,
     key: &str,
     default: Option<&[String]>,
-) -> Option<Value> {
+) -> Result<Option<Value>> {
     parse_string_array_value(context, RuntimeValueNamespace::Filter, key, default)
 }
 
@@ -295,7 +309,7 @@ fn parse_arg_strings(
     context: &RenderContext<'_>,
     key: &str,
     default: Option<&[String]>,
-) -> Option<Value> {
+) -> Result<Option<Value>> {
     parse_string_array_value(
         context,
         RuntimeValueNamespace::FunctionArgument,
@@ -798,6 +812,48 @@ mod tests {
         .expect("numeric array entries should resolve");
 
         assert_eq!(value, Some(json!(["1", "2"])));
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_a_malformed_json_array() {
+        // Text that opens a `[` was meant as an array, so the bare-value
+        // fallback must not quietly forward it as one literal element.
+        let filters = HashMap::from([("exclude".to_string(), r#"["a" "b"]"#.to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::FilterStringArray {
+                key: "exclude".to_string(),
+                default: None,
+            },
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
+        )
+        .expect_err("a malformed array should fail");
+
+        assert!(
+            error.to_string().contains("is not a valid JSON array"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_non_scalar_array_entries() {
+        let filters = HashMap::from([("exclude".to_string(), r#"["a",{"k":1}]"#.to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::FilterStringArray {
+                key: "exclude".to_string(),
+                default: None,
+            },
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
+        )
+        .expect_err("object entries should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must be a JSON array of scalars"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3905,7 +3905,7 @@ async fn array_function_arguments_expand_into_repeated_query_parameters() {
             "name": "list_users",
             "description": "HTTP users",
             "args": [
-                { "name": "exclude", "type": "Json", "bind": { "arg": "exclude" } }
+                { "name": "exclude", "type": "Utf8", "bind": { "arg": "exclude" } }
             ],
             "request": {
                 "method": "GET",
@@ -3987,4 +3987,59 @@ fn exclude_filter_column() -> Value {
         "virtual": true,
         "expr": { "kind": "from_filter", "key": "exclude" }
     })
+}
+
+#[tokio::test]
+async fn array_function_arguments_accept_a_bare_value_as_a_one_element_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("exclude", "repositories"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "data": [json!({"id": 2, "name": "Grace", "email": "grace@example.com"})] }),
+        ))
+        .mount(&server)
+        .await;
+
+    // The argument is declared `Utf8` rather than `Json` precisely so this
+    // works: a `Json` argument's literal must parse as JSON inside
+    // `bind_function_arg`, long before the value source runs.
+    let manifest = json!({
+        "name": "http_bare_arg",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": server.uri(),
+        "functions": [{
+            "name": "list_users",
+            "description": "HTTP users",
+            "args": [
+                { "name": "exclude", "type": "Utf8", "bind": { "arg": "exclude" } }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/users",
+                "query": [
+                    { "name": "exclude", "from": "arg_string_array", "key": "exclude" }
+                ]
+            },
+            "response": { "rows_path": ["data"] },
+            "columns": [
+                { "name": "id", "type": "Int64" }
+            ]
+        }]
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id FROM http_bare_arg.list_users(exclude => 'repositories')",
+        )
+        .await
+        .expect("a bare argument value should be read as a one-element list"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 2})]);
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3792,3 +3792,199 @@ async fn query_parameters_bind_in_where_clauses() {
 
     assert_eq!(rows, vec![json!({ "title": "Flaky workspace cleanup" })]);
 }
+
+#[tokio::test]
+async fn array_filters_expand_into_repeated_query_parameters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "data": [json!({"id": 2, "name": "Grace", "email": "grace@example.com"})] }),
+        ))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_array_filter", &server.uri());
+    let table = &mut manifest["tables"][0];
+    table["filters"] = json!([{ "name": "exclude", "type": "Json" }]);
+    table["columns"]
+        .as_array_mut()
+        .expect("columns")
+        .push(exclude_filter_column());
+    table["request"]["query"] = json!([
+        { "name": "exclude", "from": "filter_string_array", "key": "exclude" }
+    ]);
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            r#"SELECT id, name FROM http_array_filter.users WHERE exclude = '["repositories","tags"]'"#,
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let query = requests[0].url.query().expect("query string");
+    assert_eq!(query, "exclude=repositories&exclude=tags");
+}
+
+#[tokio::test]
+async fn unexploded_array_filters_join_their_values_with_commas() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "data": [json!({"id": 2, "name": "Grace", "email": "grace@example.com"})] }),
+        ))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_comma_filter", &server.uri());
+    let table = &mut manifest["tables"][0];
+    table["filters"] = json!([{ "name": "select", "type": "Json" }]);
+    table["columns"]
+        .as_array_mut()
+        .expect("columns")
+        .push(json!({
+            "name": "select",
+            "type": "Json",
+            "nullable": true,
+            "virtual": true,
+            "expr": { "kind": "from_filter", "key": "select" }
+        }));
+    table["request"]["query"] = json!([
+        {
+            "name": "$select",
+            "explode": false,
+            "from": "filter_string_array",
+            "key": "select"
+        }
+    ]);
+    let source = build_source(manifest);
+
+    execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            // `select` is a SQL reserved word, and DataFusion accepts it
+            // unquoted as a column reference.
+            r#"SELECT id FROM http_comma_filter.users WHERE select = '["id","mail"]'"#,
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let query = requests[0].url.query().expect("query string");
+    assert_eq!(query, "%24select=id%2Cmail");
+}
+
+#[tokio::test]
+async fn array_function_arguments_expand_into_repeated_query_parameters() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "data": [json!({"id": 2, "name": "Grace", "email": "grace@example.com"})] }),
+        ))
+        .mount(&server)
+        .await;
+
+    let manifest = json!({
+        "name": "http_array_arg",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": server.uri(),
+        "functions": [{
+            "name": "list_users",
+            "description": "HTTP users",
+            "args": [
+                { "name": "exclude", "type": "Json", "bind": { "arg": "exclude" } }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/users",
+                "query": [
+                    { "name": "exclude", "from": "arg_string_array", "key": "exclude" }
+                ]
+            },
+            "response": { "rows_path": ["data"] },
+            "columns": [
+                { "name": "id", "type": "Int64" },
+                { "name": "name", "type": "Utf8" }
+            ]
+        }]
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            r#"SELECT id, name FROM http_array_arg.list_users(exclude => '["repositories","tags"]')"#,
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+
+    let requests = server.received_requests().await.expect("recorded requests");
+    let query = requests[0].url.query().expect("query string");
+    assert_eq!(query, "exclude=repositories&exclude=tags");
+}
+
+#[tokio::test]
+async fn array_filters_accept_a_bare_value_as_a_one_element_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("exclude", "repositories"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "data": [json!({"id": 2, "name": "Grace", "email": "grace@example.com"})] }),
+        ))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_bare_filter", &server.uri());
+    let table = &mut manifest["tables"][0];
+    table["filters"] = json!([{ "name": "exclude", "type": "Json" }]);
+    table["columns"]
+        .as_array_mut()
+        .expect("columns")
+        .push(exclude_filter_column());
+    table["request"]["query"] = json!([
+        { "name": "exclude", "from": "filter_string_array", "key": "exclude" }
+    ]);
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id FROM http_bare_filter.users WHERE exclude = 'repositories'",
+        )
+        .await
+        .expect("a bare value should be read as a one-element list"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 2})]);
+}
+
+/// The virtual column a list-valued filter is addressed through. DSL v4
+/// derives this automatically; a v3 manifest declares it.
+fn exclude_filter_column() -> Value {
+    json!({
+        "name": "exclude",
+        "type": "Json",
+        "nullable": true,
+        "virtual": true,
+        "expr": { "kind": "from_filter", "key": "exclude" }
+    })
+}

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -831,6 +831,7 @@ fn validate_table_tool_arg_value_source(
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
         | ValueSourceSpec::ArgBool { key, .. }
+        | ValueSourceSpec::ArgStringArray { key, .. }
         | ValueSourceSpec::ArgSplit { key, .. }
         | ValueSourceSpec::ArgSplitInt { key, .. } => Err(ManifestError::validation(format!(
             "{context} uses function argument '{key}' but tables do not take arguments",
@@ -898,6 +899,7 @@ fn validate_source_scoped_value_source(source: &ValueSourceSpec, context: &str) 
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
         | ValueSourceSpec::ArgBool { key, .. }
+        | ValueSourceSpec::ArgStringArray { key, .. }
         | ValueSourceSpec::ArgSplit { key, .. }
         | ValueSourceSpec::ArgSplitInt { key, .. } => Err(ManifestError::validation(format!(
             "{context} uses function argument '{key}' but the value is source-scoped",

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -468,12 +468,38 @@ pub enum HttpMethod {
     POST,
 }
 
+/// How a multi-valued request parameter is serialized onto the wire.
+///
+/// Coral only models OpenAPI's `form` style, which is the only style that
+/// appears across the ingested catalog. The two variants are that style's two
+/// `explode` settings.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CollectionEncoding {
+    /// OpenAPI `style: form, explode: true` — one `k=v` pair per item.
+    Repeated,
+    /// OpenAPI `style: form, explode: false` — one `k=v1,v2` pair.
+    Comma,
+}
+
 /// One query parameter emitted into an HTTP request.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct QueryParamSpec {
     pub name: String,
+    /// Whether a multi-valued parameter repeats its name once per item
+    /// (`k=a&k=b`) instead of joining the items with commas (`k=a,b`).
+    ///
+    /// Applies only when the resolved value is a JSON array; a scalar value
+    /// ignores it. Defaults to `true`, matching OpenAPI's default for the
+    /// `form` style.
+    #[serde(default = "default_explode")]
+    pub explode: bool,
     #[serde(flatten)]
     pub value: ValueSourceSpec,
+}
+
+const fn default_explode() -> bool {
+    true
 }
 
 /// One body field emitted into an HTTP request payload.
@@ -634,6 +660,11 @@ pub enum ValueSourceSpec {
         key: String,
         #[serde(default)]
         default: Option<bool>,
+    },
+    ArgStringArray {
+        key: String,
+        #[serde(default)]
+        default: Option<Vec<String>>,
     },
     ArgSplit {
         key: String,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -104,13 +104,13 @@ pub use backends::mcp::{
 };
 pub use bundle::{IdentityManifestDocument, ManifestBundle, parse_manifest_bundle_yaml};
 pub use common::{
-    BodyFieldSpec, BodySpec, ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY, DetailHintSpec,
-    ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType,
-    PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec,
-    ResponseBodyFormat, ResponseSpec, RowStrategy, SearchLimitsSpec, SourceBackend,
-    SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
-    TableFunctionArgSpec, TimestampInput, ValidatedPagination, ValidatedPaginationMode,
-    ValueSourceSpec,
+    BodyFieldSpec, BodySpec, CollectionEncoding, ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY,
+    DetailHintSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, HeaderSpec, HttpMethod,
+    ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
+    RequestRouteSpec, RequestSpec, ResponseBodyFormat, ResponseSpec, RowStrategy, SearchLimitsSpec,
+    SourceBackend, SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec,
+    TableCommon, TableFunctionArgSpec, TimestampInput, ValidatedPagination,
+    ValidatedPaginationMode, ValueSourceSpec,
 };
 pub(crate) use common::{
     validate_reserved_source_schema_name, validate_source_name, validate_test_queries,

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1178,6 +1178,17 @@
         },
         {
           "properties": {
+            "from": { "const": "arg_string_array" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
             "from": { "const": "arg_split" },
             "key": { "type": "string", "minLength": 1 },
             "separator": { "type": "string", "minLength": 1 },

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -1182,6 +1182,32 @@
             "key": {
               "type": "string"
             },
+            "default": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_string_array"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string"
+            },
             "separator": {
               "type": "string"
             },
@@ -1550,6 +1576,32 @@
             "from": {
               "type": "string",
               "const": "arg_bool"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "default": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_string_array"
             }
           },
           "required": [

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -53,11 +53,15 @@ pub struct IrOperationInput {
     /// Set when this input takes a list of values rather than one, and how
     /// that list is encoded onto the wire.
     ///
-    /// `data_type` is [`IrScalarType::Json`] whenever this is set, and the SQL
-    /// value is a JSON array literal. Keeping the list out of `data_type`
-    /// means every match on the scalar vocabulary — pagination inference,
-    /// operation-metadata policy — excludes lists by construction rather than
-    /// by remembering to guard.
+    /// `data_type` is [`IrScalarType::Json`] whenever this is set. Keeping the
+    /// list out of `data_type` means every match on the scalar vocabulary —
+    /// pagination inference, operation-metadata policy — excludes lists by
+    /// construction rather than by remembering to guard.
+    ///
+    /// This is the import-side type only. Projections deliberately do not
+    /// lower it through [`IrScalarType::lower`]: the SQL binding type is
+    /// `Utf8`, so a caller may pass either JSON array text or a bare single
+    /// value.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collection_encoding: Option<CollectionEncoding>,
     pub default_value: Option<String>,

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::CollectionEncoding;
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::mcp::McpExecutionAttachment;
 use crate::v4::ir::rest::RestExecutionAttachment;
@@ -49,6 +50,16 @@ pub struct IrOperationInput {
     pub location: IrInputLocation,
     pub required: bool,
     pub data_type: IrScalarType,
+    /// Set when this input takes a list of values rather than one, and how
+    /// that list is encoded onto the wire.
+    ///
+    /// `data_type` is [`IrScalarType::Json`] whenever this is set, and the SQL
+    /// value is a JSON array literal. Keeping the list out of `data_type`
+    /// means every match on the scalar vocabulary — pagination inference,
+    /// operation-metadata policy — excludes lists by construction rather than
+    /// by remembering to guard.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection_encoding: Option<CollectionEncoding>,
     pub default_value: Option<String>,
     pub description: String,
 }
@@ -251,6 +262,7 @@ mod tests {
                     location: IrInputLocation::ToolArg,
                     required: false,
                     data_type: IrScalarType::String,
+                    collection_encoding: None,
                     default_value: None,
                     description: String::new(),
                 }],
@@ -351,6 +363,7 @@ future_generator_metadata:
             location: IrInputLocation::Path,
             required: true,
             data_type: IrScalarType::String,
+            collection_encoding: None,
             default_value: None,
             description: String::new(),
         };

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -55,6 +55,11 @@ pub(in crate::v4) fn infer_rest_lookup_keys(
         .iter()
         .filter(|input| input.location == IrInputLocation::Query)
         .filter(|input| !pagination_params.contains(input.name.as_str()))
+        // A multi-valued parameter is never an exact lookup: its SQL value is a
+        // JSON array, while a dependent join binds a bare scalar. Letting one
+        // through would push `alice` where `["alice"]` is expected and fail the
+        // scan at execution time.
+        .filter(|input| input.collection_encoding.is_none())
         .filter(|input| joinable_param_name(&input.name))
         .map(|input| input.name.clone())
         .collect()
@@ -142,6 +147,7 @@ mod tests {
                 location: IrInputLocation::Query,
                 required: false,
                 data_type: IrScalarType::String,
+                collection_encoding: None,
                 default_value: None,
                 description: String::new(),
             })

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -3,12 +3,12 @@
     reason = "DSL v4 contracts are field-heavy artifact models documented in the PRD."
 )]
 
-pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 7;
+pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 8;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v4";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v11";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v12";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v5";
 pub const OPERATION_METADATA_GENERATOR_VERSION: &str = "operation-metadata-v4";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v13";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v14";
 
 mod artifacts;
 mod diagnostics;

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 
 use super::*;
 use crate::{
-    ManifestDataType, PaginationMode, PaginationSpec, SourceTableFunctionKind,
+    CollectionEncoding, ManifestDataType, PaginationMode, PaginationSpec, SourceTableFunctionKind,
     parse_source_manifest_yaml,
 };
 
@@ -2972,14 +2972,12 @@ components:
 /// The fixture above declares only `$top` and `$skip`, which is not what a real
 /// Graph collection looks like: they also declare a boolean `$count`.
 ///
-/// `find_numeric_query_input` picks the first candidate-named input and only
-/// then filters by type, so `$count` is chosen and rejected and `$top` is never
-/// reached — page-size detection finds nothing. Pinning it here so the
-/// follow-up that fixes the ordering has an assertion to flip; pagination
-/// itself is unaffected, since the next link carries the paging state and Coral
-/// just accepts Graph's server-side default page size.
+/// `$count` is a boolean that shares a candidate name with the page size, and
+/// it sorts ahead of the integer `$top`. `find_numeric_query_input` filters by
+/// type as it searches rather than after choosing, so the boolean is skipped
+/// and `$top` is still found.
 #[test]
-fn importer_misses_the_page_size_a_boolean_count_parameter_masks() {
+fn importer_finds_the_page_size_a_boolean_count_parameter_shares_a_name_with() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: graph
@@ -3040,16 +3038,17 @@ components:
     )
     .expect("import");
 
-    // The collection still reads as a paginated row table — only the page size
-    // is lost.
+    // The collection reads as a paginated row table with its page size intact.
     assert_eq!(imported_row_path(&ir, "me_listchats"), ["value"]);
     let pagination = imported_rest_pagination(&ir, "me_listchats");
     assert_eq!(pagination.mode, PaginationMode::NextUrlBody);
     assert_eq!(pagination.next_url_path, ["@odata.nextLink"]);
-    assert!(
-        pagination.page_size.is_none(),
-        "boolean $count sorts ahead of $top and masks it; flip this when \
-         find_numeric_query_input filters by type before choosing"
+    assert_eq!(
+        pagination
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("$top")
     );
 }
 
@@ -4065,4 +4064,259 @@ paths:
             .collect::<Vec<_>>(),
         ["id", "name"]
     );
+}
+
+fn import_parameter_surface(paths: &str) -> ImportedSurface {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: params
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    import_openapi_surface(
+        v4,
+        surface,
+        format!("openapi: 3.0.3\npaths:\n{paths}").as_bytes(),
+    )
+    .expect("surface imports")
+}
+
+fn imported_input<'a>(ir: &'a ImportedSurface, name: &str) -> &'a IrOperationInput {
+    ir.operations
+        .first()
+        .expect("operation")
+        .inputs
+        .iter()
+        .find(|input| input.name == name)
+        .unwrap_or_else(|| panic!("input '{name}' was not imported"))
+}
+
+fn operation_diagnostics(ir: &ImportedSurface) -> Vec<String> {
+    ir.operations
+        .first()
+        .expect("operation")
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.message.clone())
+        .collect()
+}
+
+#[test]
+fn importer_reads_array_query_parameters_as_json_collections() {
+    let ir = import_parameter_surface(
+        r"
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - name: exclude
+          in: query
+          schema: {type: array, items: {type: string}}
+        - name: $select
+          in: query
+          style: form
+          explode: false
+          schema: {uniqueItems: true, type: array, items: {type: string}}
+        - name: creator_id
+          in: query
+          schema: {type: array, items: {type: integer}}
+      responses:
+        '200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}
+",
+    );
+
+    // An absent `explode` takes OpenAPI's `form`-style default of true.
+    let exclude = imported_input(&ir, "exclude");
+    assert_eq!(exclude.data_type, IrScalarType::Json);
+    assert_eq!(
+        exclude.collection_encoding,
+        Some(CollectionEncoding::Repeated)
+    );
+
+    let select = imported_input(&ir, "$select");
+    assert_eq!(select.data_type, IrScalarType::Json);
+    assert_eq!(select.collection_encoding, Some(CollectionEncoding::Comma));
+
+    // The item type only gates acceptance; every list lowers to `Json`.
+    let creator_id = imported_input(&ir, "creator_id");
+    assert_eq!(creator_id.data_type, IrScalarType::Json);
+    assert_eq!(
+        creator_id.collection_encoding,
+        Some(CollectionEncoding::Repeated)
+    );
+
+    assert!(
+        operation_diagnostics(&ir).is_empty(),
+        "{:?}",
+        operation_diagnostics(&ir)
+    );
+}
+
+#[test]
+fn importer_leaves_scalar_parameters_without_a_collection_encoding() {
+    let ir = import_parameter_surface(
+        r"
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: state, in: query, schema: {type: string}}
+      responses:
+        '200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}
+",
+    );
+
+    let state = imported_input(&ir, "state");
+    assert_eq!(state.data_type, IrScalarType::String);
+    assert_eq!(state.collection_encoding, None);
+}
+
+#[test]
+fn importer_rejects_array_parameters_it_cannot_serialize() {
+    let cases = [
+        (
+            "objects",
+            "{type: array, items: {type: object}}",
+            "unsupported array item type 'object'",
+            None,
+        ),
+        (
+            "nested",
+            "{type: array, items: {type: array, items: {type: string}}}",
+            "unsupported array item type 'array'",
+            None,
+        ),
+        (
+            "itemless",
+            "{type: array}",
+            "array without a declared item type",
+            None,
+        ),
+        (
+            "spaced",
+            "{type: array, items: {type: string}}",
+            "unsupported serialization style 'spaceDelimited'",
+            Some("spaceDelimited"),
+        ),
+    ];
+
+    for (name, schema, expected, style) in cases {
+        let style = style.map_or_else(String::new, |style| format!("          style: {style}\n"));
+        let ir = import_parameter_surface(&format!(
+            r"
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - name: {name}
+          in: query
+{style}          schema: {schema}
+      responses:
+        '200': {{content: {{application/json: {{schema: {{type: array, items: {{type: object}}}}}}}}}}
+"
+        ));
+
+        let operation = ir.operations.first().expect("operation");
+        assert!(
+            !operation.inputs.iter().any(|input| input.name == name),
+            "'{name}' should not be imported"
+        );
+        let diagnostics = operation_diagnostics(&ir);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains(expected)),
+            "'{name}' expected a diagnostic containing '{expected}', got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn importer_rejects_array_parameters_outside_the_query() {
+    let ir = import_parameter_surface(
+        r"
+  /items/{ids}:
+    get:
+      operationId: items/list
+      parameters:
+        - name: ids
+          in: path
+          required: true
+          schema: {type: array, items: {type: string}}
+      responses:
+        '200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}
+",
+    );
+
+    let diagnostics = operation_diagnostics(&ir);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("is an array in Path position")),
+        "{diagnostics:?}"
+    );
+}
+
+#[test]
+fn array_query_parameters_never_shadow_numeric_pagination_parameters() {
+    // `limit` matches a page-size candidate token by name but is list-valued,
+    // so detection must keep looking and settle on `per_page`.
+    let ir = import_parameter_surface(
+        r"
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: limit, in: query, schema: {type: array, items: {type: string}}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+      responses:
+        '200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}
+",
+    );
+
+    let pagination = imported_rest_pagination(&ir, "items_list");
+    assert_eq!(pagination.mode, PaginationMode::Page);
+    assert_eq!(
+        pagination
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("per_page")
+    );
+}
+
+#[test]
+fn array_query_parameters_are_never_lookup_keys() {
+    // `owner` is outside the presentation lexicon, so only its list-valued
+    // shape keeps it from anchoring a dependent join.
+    let ir = import_parameter_surface(
+        r"
+  /tokens:
+    get:
+      operationId: tokens/list
+      parameters:
+        - {name: owner, in: query, schema: {type: array, items: {type: string}}}
+        - {name: repository, in: query, schema: {type: string}}
+      responses:
+        '200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}
+",
+    );
+
+    let OperationMetadata::Rest { lookup_keys, .. } = ir
+        .operation_metadata
+        .operations
+        .get("tokens_list")
+        .expect("operation metadata")
+    else {
+        panic!("expected REST metadata");
+    };
+    assert_eq!(lookup_keys, &["repository".to_string()]);
 }

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -4205,6 +4205,14 @@ fn importer_rejects_array_parameters_it_cannot_serialize() {
             "unsupported serialization style 'spaceDelimited'",
             Some("spaceDelimited"),
         ),
+        // A present-but-wrongly-typed `style` must not read as absent, which
+        // would silently reinterpret it as the default `form`.
+        (
+            "numeric_style",
+            "{type: array, items: {type: string}}",
+            "unsupported serialization style",
+            Some("123"),
+        ),
     ];
 
     for (name, schema, expected, style) in cases {
@@ -4319,4 +4327,37 @@ fn array_query_parameters_are_never_lookup_keys() {
         panic!("expected REST metadata");
     };
     assert_eq!(lookup_keys, &["repository".to_string()]);
+}
+
+#[test]
+fn importer_rejects_array_parameters_with_a_non_boolean_explode() {
+    // Defaulting a malformed `explode` would pick a wire encoding the
+    // descriptor never asked for.
+    let ir = import_parameter_surface(
+        r#"
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - name: exclude
+          in: query
+          explode: "false"
+          schema: {type: array, items: {type: string}}
+      responses:
+        '200': {content: {application/json: {schema: {type: array, items: {type: object}}}}}
+"#,
+    );
+
+    let operation = ir.operations.first().expect("operation");
+    assert!(
+        !operation.inputs.iter().any(|input| input.name == "exclude"),
+        "a malformed explode should not be imported"
+    );
+    let diagnostics = operation_diagnostics(&ir);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("non-boolean explode")),
+        "{diagnostics:?}"
+    );
 }

--- a/crates/coral-spec/src/v4/operation_metadata/tests.rs
+++ b/crates/coral-spec/src/v4/operation_metadata/tests.rs
@@ -90,6 +90,7 @@ fn plan_rejects_rest_operation_with_tool_arg_input() {
             location: IrInputLocation::ToolArg,
             required: false,
             data_type: IrScalarType::String,
+            collection_encoding: None,
             default_value: None,
             description: String::new(),
         });
@@ -144,6 +145,7 @@ fn plan_rejects_mcp_offset_pagination_starting_past_first_page() {
             location: IrInputLocation::ToolArg,
             required: false,
             data_type: IrScalarType::Integer,
+            collection_encoding: None,
             default_value: None,
             description: String::new(),
         });

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -2487,9 +2487,12 @@ fn collection_inputs_lower_to_json_and_keep_their_encoding() {
     let catalog = collection_catalog();
     let items = projection(&catalog, "list_items");
 
+    // Utf8, not Json: `bind_function_arg` requires a Json argument's literal to
+    // parse as JSON before the value source runs, which would reject the bare
+    // single-value form that `parse_string_array_value` exists to accept.
     let exclude = input(items, "exclude");
     assert_eq!(exclude.sql_exposure, SqlInputExposure::Filter);
-    assert_eq!(exclude.data_type, ManifestDataType::Json);
+    assert_eq!(exclude.data_type, ManifestDataType::Utf8);
     assert_eq!(
         exclude.collection_encoding,
         Some(CollectionEncoding::Repeated)
@@ -2497,7 +2500,7 @@ fn collection_inputs_lower_to_json_and_keep_their_encoding() {
 
     let select = input(items, "select");
     assert_eq!(select.wire_name, "$select");
-    assert_eq!(select.data_type, ManifestDataType::Json);
+    assert_eq!(select.data_type, ManifestDataType::Utf8);
     assert_eq!(select.collection_encoding, Some(CollectionEncoding::Comma));
 
     let state = input(items, "state");
@@ -2527,6 +2530,28 @@ fn collection_inputs_document_the_json_array_convention() {
         project_items.guide.contains("JSON array"),
         "{:?}",
         project_items.guide
+    );
+}
+
+#[test]
+fn collection_guide_sentence_agrees_in_number() {
+    let catalog = collection_catalog();
+
+    // Two collection inputs.
+    assert!(
+        projection(&catalog, "list_items")
+            .guide
+            .contains("select and exclude take a JSON array"),
+        "{:?}",
+        projection(&catalog, "list_items").guide
+    );
+    // One collection input.
+    assert!(
+        projection(&catalog, "list_project_items")
+            .guide
+            .contains("exclude takes a JSON array"),
+        "{:?}",
+        projection(&catalog, "list_project_items").guide
     );
 }
 

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -5,7 +5,8 @@ use super::test_support::github_openapi;
 use super::*;
 use crate::backends::mcp::McpPaginationSpec;
 use crate::{
-    ManifestDataType, PaginationMode, SourceTableFunctionKind, parse_source_manifest_yaml,
+    CollectionEncoding, ManifestDataType, PaginationMode, SourceTableFunctionKind,
+    parse_source_manifest_yaml,
 };
 
 #[test]
@@ -2410,4 +2411,224 @@ fn projection_compatibility_accepts_empty_operation_and_projection_catalogs() {
     assert!(catalog.projections.is_empty());
     validate_projection_compatibility(&plan, &catalog)
         .expect("empty operation and projection catalogs are compatible");
+}
+
+fn collection_catalog() -> ProjectionCatalog {
+    collection_surface().0
+}
+
+fn collection_surface() -> (ProjectionCatalog, ImportedSurface) {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: collections_api
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    // `list_items` has no required input, so it is a table whose inputs are
+    // filters; `list_project_items` requires a path input, so it is a table
+    // function whose inputs are arguments. Both exposures matter.
+    let spec = r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: list_items
+      parameters:
+        - name: exclude
+          in: query
+          schema: {type: array, items: {type: string}}
+        - name: $select
+          in: query
+          explode: false
+          schema: {type: array, items: {type: string}}
+        - {name: state, in: query, schema: {type: string}}
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object, properties: {id: {type: string}}}}}}}}
+  /projects/{project_id}/items:
+    get:
+      operationId: list_project_items
+      parameters:
+        - {name: project_id, in: path, required: true, schema: {type: string}}
+        - name: exclude
+          in: query
+          schema: {type: array, items: {type: string}}
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object, properties: {id: {type: string}}}}}}}}
+";
+    let ir = import_openapi_surface(v4, surface, spec.as_bytes()).expect("import");
+    let catalog =
+        generate_projection_catalog(v4, &ir.validated_plan().expect("plan")).expect("catalog");
+    (catalog, ir)
+}
+
+fn projection<'a>(catalog: &'a ProjectionCatalog, operation_id: &str) -> &'a Projection {
+    catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == operation_id)
+        .expect("projection")
+}
+
+fn input<'a>(projection: &'a Projection, name: &str) -> &'a ProjectionInput {
+    projection
+        .inputs
+        .iter()
+        .find(|input| input.name == name)
+        .unwrap_or_else(|| panic!("input '{name}' is missing"))
+}
+
+#[test]
+fn collection_inputs_lower_to_json_and_keep_their_encoding() {
+    let catalog = collection_catalog();
+    let items = projection(&catalog, "list_items");
+
+    let exclude = input(items, "exclude");
+    assert_eq!(exclude.sql_exposure, SqlInputExposure::Filter);
+    assert_eq!(exclude.data_type, ManifestDataType::Json);
+    assert_eq!(
+        exclude.collection_encoding,
+        Some(CollectionEncoding::Repeated)
+    );
+
+    let select = input(items, "select");
+    assert_eq!(select.wire_name, "$select");
+    assert_eq!(select.data_type, ManifestDataType::Json);
+    assert_eq!(select.collection_encoding, Some(CollectionEncoding::Comma));
+
+    let state = input(items, "state");
+    assert_eq!(state.data_type, ManifestDataType::Utf8);
+    assert_eq!(state.collection_encoding, None);
+}
+
+#[test]
+fn collection_inputs_document_the_json_array_convention() {
+    let catalog = collection_catalog();
+    let items = projection(&catalog, "list_items");
+
+    assert!(
+        input(items, "exclude").description.contains("JSON array"),
+        "{:?}",
+        input(items, "exclude").description
+    );
+
+    // Function arguments carry no description of their own, so the guide is
+    // the only place a caller of the table-function form can learn this.
+    let project_items = projection(&catalog, "list_project_items");
+    assert_eq!(
+        input(project_items, "exclude").sql_exposure,
+        SqlInputExposure::FunctionArg
+    );
+    assert!(
+        project_items.guide.contains("JSON array"),
+        "{:?}",
+        project_items.guide
+    );
+}
+
+#[test]
+fn collection_inputs_stay_out_of_the_most_useful_filters_hint() {
+    let catalog = collection_catalog();
+    let items = projection(&catalog, "list_items");
+
+    // `$select`/`exclude` sort ahead of `state`, so without the exclusion they
+    // would crowd the only genuinely selective filter out of the hint.
+    assert!(
+        items.guide.contains("Most useful optional filters: state."),
+        "{:?}",
+        items.guide
+    );
+}
+
+#[test]
+fn collection_filters_are_not_indexed_as_observed_values() {
+    let catalog = collection_catalog();
+    let items = projection(&catalog, "list_items");
+    let columns = projection_column_specs(items);
+
+    let exclude = columns
+        .iter()
+        .find(|column| column.name == "exclude")
+        .expect("virtual column");
+    assert!(exclude.r#virtual);
+    assert!(exclude.do_not_index);
+
+    let state = columns
+        .iter()
+        .find(|column| column.name == "state")
+        .expect("virtual column");
+    assert!(!state.do_not_index);
+}
+
+#[test]
+fn collection_query_params_lower_to_array_value_sources() {
+    let (catalog, ir) = collection_surface();
+
+    let items = projection(&catalog, "list_items");
+    let items_operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == "list_items")
+        .expect("operation");
+    let request = request_spec_for_projection(items, items_operation).expect("request");
+
+    let exclude = request
+        .query
+        .iter()
+        .find(|param| param.name == "exclude")
+        .expect("exclude query param");
+    assert!(exclude.explode);
+    assert!(
+        matches!(
+            &exclude.value,
+            crate::ValueSourceSpec::FilterStringArray { key, .. } if key == "exclude"
+        ),
+        "{:?}",
+        exclude.value
+    );
+
+    let select = request
+        .query
+        .iter()
+        .find(|param| param.name == "$select")
+        .expect("$select query param");
+    assert!(!select.explode);
+
+    // A scalar filter keeps the single-valued value source, and its `explode`
+    // is inert.
+    let state = request
+        .query
+        .iter()
+        .find(|param| param.name == "state")
+        .expect("state query param");
+    assert!(matches!(
+        &state.value,
+        crate::ValueSourceSpec::Filter { .. }
+    ));
+
+    // The table-function form binds the same parameter as an argument.
+    let project_items = projection(&catalog, "list_project_items");
+    let project_operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == "list_project_items")
+        .expect("operation");
+    let request = request_spec_for_projection(project_items, project_operation).expect("request");
+    let exclude = request
+        .query
+        .iter()
+        .find(|param| param.name == "exclude")
+        .expect("exclude query param");
+    assert!(
+        matches!(
+            &exclude.value,
+            crate::ValueSourceSpec::ArgStringArray { key, .. } if key == "exclude"
+        ),
+        "{:?}",
+        exclude.value
+    );
 }

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -2483,7 +2483,7 @@ fn input<'a>(projection: &'a Projection, name: &str) -> &'a ProjectionInput {
 }
 
 #[test]
-fn collection_inputs_lower_to_json_and_keep_their_encoding() {
+fn collection_inputs_bind_as_utf8_and_keep_their_encoding() {
     let catalog = collection_catalog();
     let items = projection(&catalog, "list_items");
 

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -122,7 +122,7 @@ fn generate_projection(
                 source_location: input.location,
                 wire_name: input.name.clone(),
                 required: projection_input_required(input),
-                data_type: input.data_type.lower(),
+                data_type: projection_input_data_type(input),
                 collection_encoding: input.collection_encoding,
                 default_value: input.default_value.clone(),
                 description: projection_input_description(input),
@@ -234,6 +234,25 @@ fn generated_projection_name(operation: &IrOperation, is_search: bool) -> String
         normalize_identifier(&operation.id, "projection")
     } else {
         name
+    }
+}
+
+/// The SQL type a caller binds this input as.
+///
+/// List-valued inputs are `Utf8`, not `Json`, even though their conventional
+/// value is JSON array text. `Json` would be a worse description of the same
+/// bytes and a strictly worse contract: `bind_function_arg` requires a `Json`
+/// argument's literal to parse as JSON *before* the value source ever runs, so
+/// `sort => 'created'` would fail at plan time with "expected Json: expected
+/// value at line 1 column 1". `Utf8` accepts both the array form and a bare
+/// single value, uniformly for filters and arguments. `ManifestDataType::Json`
+/// advertises a column worth reading with `json_get`; these are values a caller
+/// writes.
+fn projection_input_data_type(input: &IrOperationInput) -> ManifestDataType {
+    if input.collection_encoding.is_some() {
+        ManifestDataType::Utf8
+    } else {
+        input.data_type.lower()
     }
 }
 

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -123,8 +123,9 @@ fn generate_projection(
                 wire_name: input.name.clone(),
                 required: projection_input_required(input),
                 data_type: input.data_type.lower(),
+                collection_encoding: input.collection_encoding,
                 default_value: input.default_value.clone(),
-                description: input.description.clone(),
+                description: projection_input_description(input),
                 lookup_key: rest_filter_is_lookup_key(plan, operation, input, exposure),
             }
         })
@@ -233,6 +234,25 @@ fn generated_projection_name(operation: &IrOperation, is_search: bool) -> String
         normalize_identifier(&operation.id, "projection")
     } else {
         name
+    }
+}
+
+/// The description SQL callers see, with the JSON-array convention spelled out
+/// for list-valued inputs.
+///
+/// This reaches filter inputs through `coral.filters` and the virtual column in
+/// `coral.columns`. Function arguments carry no description at all, so the
+/// projection guide states the convention for them.
+fn projection_input_description(input: &IrOperationInput) -> String {
+    if input.collection_encoding.is_none() {
+        return input.description.clone();
+    }
+    let description = input.description.trim_end();
+    let hint = "Takes a JSON array of values, for example '[\"a\",\"b\"]'.";
+    if description.is_empty() {
+        hint.to_string()
+    } else {
+        format!("{description}\n\n{hint}")
     }
 }
 

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::IrInputLocation;
-use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
+use crate::{
+    CollectionEncoding, DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectionCatalog {
@@ -55,6 +57,11 @@ pub struct ProjectionInput {
     pub wire_name: String,
     pub required: bool,
     pub data_type: ManifestDataType,
+    /// Set when this input takes a list of values rather than one, and how
+    /// that list is encoded onto the wire. `data_type` is
+    /// [`ManifestDataType::Json`] whenever this is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection_encoding: Option<CollectionEncoding>,
     pub default_value: Option<String>,
     pub description: String,
     /// Whether this filter input is a complete exact lookup: the API returns
@@ -87,11 +94,12 @@ pub struct ProjectionColumn {
 #[cfg(test)]
 mod tests {
     use super::{
-        Projection, ProjectionCatalog, ProjectionColumn, ProjectionKind, ProjectionVisibility,
-        SqlInputExposure,
+        Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,
+        ProjectionVisibility, SqlInputExposure,
     };
+    use crate::v4::ir::IrInputLocation;
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
-    use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
+    use crate::{CollectionEncoding, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
     #[test]
     fn projection_catalog_yaml_uses_editor_friendly_enum_shapes() {
@@ -238,5 +246,59 @@ diagnostics: []
 
         assert_eq!(exposure.trim(), "filter");
         assert_eq!(data_type.trim(), "Utf8");
+    }
+
+    #[test]
+    fn projection_input_collection_encoding_round_trips_as_a_plain_scalar() {
+        let input = ProjectionInput {
+            name: "select".to_string(),
+            sql_exposure: SqlInputExposure::Filter,
+            source_location: IrInputLocation::Query,
+            wire_name: "$select".to_string(),
+            required: false,
+            data_type: ManifestDataType::Json,
+            collection_encoding: Some(CollectionEncoding::Comma),
+            default_value: None,
+            description: String::new(),
+            lookup_key: false,
+        };
+
+        let yaml = serde_yaml::to_string(&input).expect("serialize input");
+        assert!(
+            yaml.contains("collection_encoding: comma"),
+            "unexpected serialized input: {yaml}"
+        );
+        assert!(
+            !yaml.contains('!'),
+            "projection input should not use YAML local tags: {yaml}"
+        );
+
+        let decoded: ProjectionInput = serde_yaml::from_str(&yaml).expect("deserialize input");
+        assert_eq!(decoded.collection_encoding, Some(CollectionEncoding::Comma));
+    }
+
+    #[test]
+    fn projection_input_omits_collection_encoding_for_scalars() {
+        let input = ProjectionInput {
+            name: "state".to_string(),
+            sql_exposure: SqlInputExposure::Filter,
+            source_location: IrInputLocation::Query,
+            wire_name: "state".to_string(),
+            required: false,
+            data_type: ManifestDataType::Utf8,
+            collection_encoding: None,
+            default_value: None,
+            description: String::new(),
+            lookup_key: false,
+        };
+
+        let yaml = serde_yaml::to_string(&input).expect("serialize input");
+        assert!(
+            !yaml.contains("collection_encoding"),
+            "scalar inputs should not carry the key: {yaml}"
+        );
+
+        let decoded: ProjectionInput = serde_yaml::from_str(&yaml).expect("deserialize input");
+        assert_eq!(decoded.collection_encoding, None);
     }
 }

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -58,8 +58,13 @@ pub struct ProjectionInput {
     pub required: bool,
     pub data_type: ManifestDataType,
     /// Set when this input takes a list of values rather than one, and how
-    /// that list is encoded onto the wire. `data_type` is
-    /// [`ManifestDataType::Json`] whenever this is set.
+    /// that list is encoded onto the wire.
+    ///
+    /// `data_type` is [`ManifestDataType::Utf8`] whenever this is set, even
+    /// though the conventional value is JSON array text. `Json` would reject
+    /// the bare single-value form at plan time, because a `Json` argument's
+    /// literal must parse as JSON before the value source runs. The list shape
+    /// lives here, not in `data_type`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collection_encoding: Option<CollectionEncoding>,
     pub default_value: Option<String>,

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -180,6 +180,11 @@ pub(super) fn projection_guide(
         .iter()
         .filter(|input| !input.required)
         .filter(|input| !matches!(input.name.as_str(), "page" | "per_page"))
+        // List-valued inputs are overwhelmingly presentation knobs such as
+        // OData's `$select` and `$expand`, and they sort ahead of real filters
+        // because `$` precedes every letter. Promoting them here would push
+        // genuinely selective filters out of a list capped at three.
+        .filter(|input| input.collection_encoding.is_none())
         .map(|input| input.name.as_str())
         .take(3)
         .collect::<Vec<_>>();
@@ -202,6 +207,21 @@ pub(super) fn projection_guide(
         sentences.push(format!(
             "Most useful optional filters: {}.",
             optional.join(", ")
+        ));
+    }
+
+    // Function arguments have no description field of their own, so this is the
+    // only place a caller learns that a `Json` input wants a JSON array rather
+    // than a bare value.
+    let collections = exposed_inputs
+        .iter()
+        .filter(|input| input.collection_encoding.is_some())
+        .map(|input| input.name.as_str())
+        .collect::<Vec<_>>();
+    if !collections.is_empty() {
+        sentences.push(format!(
+            "{} take a JSON array of values, for example '[\"a\",\"b\"]'.",
+            human_join(&collections)
         ));
     }
 

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -219,8 +219,13 @@ pub(super) fn projection_guide(
         .map(|input| input.name.as_str())
         .collect::<Vec<_>>();
     if !collections.is_empty() {
+        let takes = if collections.len() == 1 {
+            "takes"
+        } else {
+            "take"
+        };
         sentences.push(format!(
-            "{} take a JSON array of values, for example '[\"a\",\"b\"]'.",
+            "{} {takes} a JSON array of values, for example '[\"a\",\"b\"]'.",
             human_join(&collections)
         ));
     }

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -4,8 +4,8 @@ use serde_json::Value;
 
 use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation};
 use crate::{
-    ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, ParsedTemplate, RequestSpec,
-    Result, TableFunctionArgSpec,
+    CollectionEncoding, ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
+    ParsedTemplate, RequestSpec, Result, TableFunctionArgSpec,
 };
 
 use super::model::{Projection, SqlInputExposure};
@@ -95,7 +95,10 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
                 expr: Some(ExprSpec::FromFilter {
                     key: input.name.clone(),
                 }),
-                do_not_index: false,
+                // A list-valued filter's virtual column only ever echoes the
+                // JSON array the caller passed in. Indexing those observed
+                // values offers nothing to search and dilutes the index.
+                do_not_index: input.collection_encoding.is_some(),
             }),
     );
     columns
@@ -131,25 +134,36 @@ pub fn request_spec_for_projection(
         .iter()
         .filter(|input| input.source_location == IrInputLocation::Query)
         .filter_map(|input| {
-            let value = match input.sql_exposure {
-                SqlInputExposure::Filter => crate::ValueSourceSpec::Filter {
+            let value = match (input.sql_exposure, input.collection_encoding) {
+                (SqlInputExposure::Filter, None) => crate::ValueSourceSpec::Filter {
                     key: input.name.clone(),
                     default: input
                         .default_value
                         .as_ref()
                         .map(|value| Value::String(value.clone())),
                 },
-                SqlInputExposure::FunctionArg => crate::ValueSourceSpec::Arg {
+                (SqlInputExposure::FunctionArg, None) => crate::ValueSourceSpec::Arg {
                     key: input.name.clone(),
                     default: input
                         .default_value
                         .as_ref()
                         .map(|value| Value::String(value.clone())),
                 },
-                SqlInputExposure::Internal => return None,
+                (SqlInputExposure::Filter, Some(_)) => crate::ValueSourceSpec::FilterStringArray {
+                    key: input.name.clone(),
+                    default: collection_default(input.default_value.as_deref()),
+                },
+                (SqlInputExposure::FunctionArg, Some(_)) => {
+                    crate::ValueSourceSpec::ArgStringArray {
+                        key: input.name.clone(),
+                        default: collection_default(input.default_value.as_deref()),
+                    }
+                }
+                (SqlInputExposure::Internal, _) => return None,
             };
             Some(crate::QueryParamSpec {
                 name: input.wire_name.clone(),
+                explode: !matches!(input.collection_encoding, Some(CollectionEncoding::Comma)),
                 value,
             })
         })
@@ -161,6 +175,24 @@ pub fn request_spec_for_projection(
         body: crate::BodySpec::default(),
         headers: Vec::new(),
     })
+}
+
+/// Reads a list-valued input's schema default, which the importer stringified
+/// as JSON array text.
+///
+/// A default that is not a JSON array of scalars is dropped rather than
+/// coerced: sending a malformed default on every unfiltered query is worse than
+/// sending none.
+fn collection_default(default_value: Option<&str>) -> Option<Vec<String>> {
+    let parsed = serde_json::from_str::<Vec<Value>>(default_value?).ok()?;
+    parsed
+        .iter()
+        .map(|item| match item {
+            Value::String(item) => Some(item.clone()),
+            Value::Null | Value::Array(_) | Value::Object(_) => None,
+            item => Some(item.to_string()),
+        })
+        .collect()
 }
 
 fn path_template_token(namespace: &str, key: &str, default: Option<&str>) -> String {

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -66,6 +66,10 @@ impl McpImporter<'_> {
                     location: IrInputLocation::ToolArg,
                     required: shape.required.contains(name.as_str()),
                     data_type,
+                    // MCP tool arguments are sent as JSON, so a list-valued
+                    // argument needs no wire encoding: `Json` already carries
+                    // the array through to the tool call intact.
+                    collection_encoding: None,
                     default_value: property.get("default").map(json_schema_default_to_string),
                     description: schema_description(property),
                 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -317,16 +317,21 @@ impl OpenApiImporter<'_> {
         }
 
         // `style` and `explode` are siblings of `schema` on the parameter
-        // object, not properties of the schema itself.
-        if let Some(style) = parameter_obj.get("style").and_then(Value::as_str)
-            && style != "form"
-        {
-            return reject(
-                format!(
-                    "parameter '{name}' is an array with unsupported serialization style '{style}'"
-                ),
-                diagnostics,
-            );
+        // object, not properties of the schema itself. A present-but-wrongly
+        // typed one is rejected rather than read as absent: silently falling
+        // back to the default would reinterpret the author's stated intent.
+        match parameter_obj.get("style") {
+            None => {}
+            Some(Value::String(style)) if style == "form" => {}
+            Some(style) => {
+                let style = json_schema_default_to_string(style);
+                return reject(
+                    format!(
+                        "parameter '{name}' is an array with unsupported serialization style '{style}'"
+                    ),
+                    diagnostics,
+                );
+            }
         }
 
         let items = self.read_schema(resolved.get("items").unwrap_or(&Value::Null));
@@ -352,11 +357,21 @@ impl OpenApiImporter<'_> {
             );
         }
 
-        // OpenAPI defaults `explode` to true for the `form` style.
-        let explode = parameter_obj
-            .get("explode")
-            .and_then(Value::as_bool)
-            .unwrap_or(true);
+        // OpenAPI defaults `explode` to true for the `form` style. A
+        // present-but-non-boolean value is rejected for the same reason as
+        // `style`: defaulting it would pick a wire encoding the author did not
+        // ask for.
+        let explode = match parameter_obj.get("explode") {
+            None => true,
+            Some(Value::Bool(explode)) => *explode,
+            Some(explode) => {
+                let explode = json_schema_default_to_string(explode);
+                return reject(
+                    format!("parameter '{name}' is an array with non-boolean explode '{explode}'"),
+                    diagnostics,
+                );
+            }
+        };
         Some(if explode {
             CollectionEncoding::Repeated
         } else {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -18,7 +18,7 @@ use crate::v4::surfaces::json_schema::{
 };
 use crate::v4::wrapped_lists::{WrappedListInferenceContext, infer_wrapped_list_row_path};
 use crate::{
-    ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
+    CollectionEncoding, ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result,
     v4::resolve_output_row_type_ref,
 };
 
@@ -209,13 +209,20 @@ impl OpenApiImporter<'_> {
                     .and_then(Value::as_str)
                     .and_then(parse_parameter_location)?;
                 let schema = self.read_schema(parameter_obj.get("schema").unwrap_or(&Value::Null));
-                let scalar =
-                    self.import_parameter_scalar(&schema, &name, operation_id, diagnostics)?;
+                let (scalar, collection_encoding) = self.import_parameter_type(
+                    parameter_obj,
+                    &schema,
+                    &name,
+                    location,
+                    operation_id,
+                    diagnostics,
+                )?;
                 Some(IrOperationInput {
                     name,
                     location,
                     required: parameter_is_required(parameter_obj, location),
                     data_type: scalar,
+                    collection_encoding,
                     // A null default declares that the parameter has none, so
                     // it is dropped rather than stringified. `default: null`
                     // beside a nullable union is what Pydantic emits for
@@ -237,25 +244,124 @@ impl OpenApiImporter<'_> {
             .collect()
     }
 
-    fn import_parameter_scalar(
+    /// Reads a parameter's declared type as a scalar, or as a list of scalars
+    /// plus the wire encoding that list needs.
+    ///
+    /// Lists lower to [`IrScalarType::Json`] rather than to a list-shaped data
+    /// type: the SQL value is a JSON array literal, which is the same
+    /// convention the MCP importer already uses for array tool arguments.
+    fn import_parameter_type(
         &mut self,
+        parameter_obj: &Map<String, Value>,
         schema: &Value,
         name: &str,
+        location: IrInputLocation,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> Option<IrScalarType> {
+    ) -> Option<(IrScalarType, Option<CollectionEncoding>)> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
-        let Some(scalar) = json_schema_scalar_type_or_string(&resolved) else {
-            diagnostics.push(Diagnostic::new(
-                format!(
-                    "parameter '{name}' has unsupported schema type '{}'",
-                    json_schema_type_display(&resolved)
-                ),
-                Some(operation_id.to_string()),
-            ));
-            return None;
+        if let Some(scalar) = json_schema_scalar_type_or_string(&resolved) {
+            return Some((scalar, None));
+        }
+        if json_schema_type_contains(&resolved, "array") {
+            let encoding = self.import_collection_encoding(
+                parameter_obj,
+                &resolved,
+                name,
+                location,
+                operation_id,
+                diagnostics,
+            )?;
+            return Some((IrScalarType::Json, Some(encoding)));
+        }
+        diagnostics.push(Diagnostic::new(
+            format!(
+                "parameter '{name}' has unsupported schema type '{}'",
+                json_schema_type_display(&resolved)
+            ),
+            Some(operation_id.to_string()),
+        ));
+        None
+    }
+
+    /// Validates that an array parameter is one Coral can put on the wire, and
+    /// returns how its items are serialized.
+    ///
+    /// Every rejection keeps a diagnostic naming the actual cause, so the
+    /// parameter is still dropped but the reason is no longer the misleading
+    /// "unsupported schema type 'array'".
+    fn import_collection_encoding(
+        &mut self,
+        parameter_obj: &Map<String, Value>,
+        resolved: &Value,
+        name: &str,
+        location: IrInputLocation,
+        operation_id: &str,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<CollectionEncoding> {
+        let reject = |reason: String, diagnostics: &mut Vec<Diagnostic>| {
+            diagnostics.push(Diagnostic::new(reason, Some(operation_id.to_string())));
+            None::<CollectionEncoding>
         };
-        Some(scalar)
+
+        // Only query parameters expand into repeated or delimited values. Path
+        // and header lowering render a single string, and no array parameter in
+        // either ingested descriptor sits outside the query.
+        if location != IrInputLocation::Query {
+            return reject(
+                format!(
+                    "parameter '{name}' is an array in {location:?} position, which is not supported"
+                ),
+                diagnostics,
+            );
+        }
+
+        // `style` and `explode` are siblings of `schema` on the parameter
+        // object, not properties of the schema itself.
+        if let Some(style) = parameter_obj.get("style").and_then(Value::as_str)
+            && style != "form"
+        {
+            return reject(
+                format!(
+                    "parameter '{name}' is an array with unsupported serialization style '{style}'"
+                ),
+                diagnostics,
+            );
+        }
+
+        let items = self.read_schema(resolved.get("items").unwrap_or(&Value::Null));
+        let Some(items) = self.resolve_ref(&items, operation_id, diagnostics) else {
+            return reject(
+                format!("parameter '{name}' is an array whose item type could not be resolved"),
+                diagnostics,
+            );
+        };
+        if items.as_object().is_none_or(Map::is_empty) {
+            return reject(
+                format!("parameter '{name}' is an array without a declared item type"),
+                diagnostics,
+            );
+        }
+        if json_schema_scalar_type_or_string(&items).is_none() {
+            return reject(
+                format!(
+                    "parameter '{name}' has unsupported array item type '{}'",
+                    json_schema_type_display(&items)
+                ),
+                diagnostics,
+            );
+        }
+
+        // OpenAPI defaults `explode` to true for the `form` style.
+        let explode = parameter_obj
+            .get("explode")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        Some(if explode {
+            CollectionEncoding::Repeated
+        } else {
+            CollectionEncoding::Comma
+        })
     }
 
     fn import_request_body(
@@ -624,16 +730,6 @@ fn find_numeric_page_input(inputs: &[IrOperationInput]) -> Option<&IrOperationIn
     )
 }
 
-fn find_query_input<'a>(
-    inputs: &'a [IrOperationInput],
-    candidate_tokens: &[&str],
-) -> Option<&'a IrOperationInput> {
-    inputs
-        .iter()
-        .filter(|input| input.location == IrInputLocation::Query)
-        .find(|input| candidate_tokens.contains(&name_token(&input.name).as_str()))
-}
-
 /// Pagination metadata validation only accepts numeric inputs for page,
 /// offset, and page-size parameters, so detection must not select inputs of
 /// any other type.
@@ -641,12 +737,20 @@ fn find_numeric_query_input<'a>(
     inputs: &'a [IrOperationInput],
     candidate_tokens: &[&str],
 ) -> Option<&'a IrOperationInput> {
-    find_query_input(inputs, candidate_tokens).filter(|input| {
-        matches!(
-            input.data_type,
-            IrScalarType::Integer | IrScalarType::Number
-        )
-    })
+    // The type predicate belongs inside the search, not after it. Filtering
+    // afterwards lets a same-named non-numeric input shadow a numeric one that
+    // appears later in the list and abandon pagination entirely — reachable as
+    // soon as a parameter the importer used to drop starts being imported.
+    inputs
+        .iter()
+        .filter(|input| input.location == IrInputLocation::Query)
+        .filter(|input| {
+            matches!(
+                input.data_type,
+                IrScalarType::Integer | IrScalarType::Number
+            )
+        })
+        .find(|input| candidate_tokens.contains(&name_token(&input.name).as_str()))
 }
 
 fn find_optional_string_query_input<'a>(

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -596,6 +596,7 @@ fn validate_value_source(
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
         | ValueSourceSpec::ArgBool { key, .. }
+        | ValueSourceSpec::ArgStringArray { key, .. }
         | ValueSourceSpec::ArgSplit { key, .. }
         | ValueSourceSpec::ArgSplitInt { key, .. } => {
             return Err(ManifestError::validation(format!(
@@ -710,6 +711,7 @@ fn validate_arg_value_source(
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
         | ValueSourceSpec::ArgBool { key, .. }
+        | ValueSourceSpec::ArgStringArray { key, .. }
         | ValueSourceSpec::ArgSplit { key, .. }
         | ValueSourceSpec::ArgSplitInt { key, .. }
             if !request_arg_names.contains(key.as_str()) =>
@@ -1159,6 +1161,7 @@ mod tests {
             request: RequestSpec {
                 path: ParsedTemplate::parse("/search").expect("request path"),
                 query: vec![QueryParamSpec {
+                    explode: true,
                     name: "q".to_string(),
                     value,
                 }],
@@ -1399,6 +1402,7 @@ mod tests {
     fn validate_http_table_rejects_unknown_filter_in_default_request_bindings() {
         let request = RequestSpec {
             query: vec![QueryParamSpec {
+                explode: true,
                 name: "user_id".to_string(),
                 value: ValueSourceSpec::Filter {
                     key: "missing".to_string(),
@@ -1424,6 +1428,7 @@ mod tests {
             when_filters: vec!["id".to_string()],
             request: RequestSpec {
                 query: vec![QueryParamSpec {
+                    explode: true,
                     name: "cursor".to_string(),
                     value: ValueSourceSpec::Filter {
                         key: "missing".to_string(),
@@ -1448,6 +1453,7 @@ mod tests {
     fn validate_http_table_rejects_unknown_filter_split_bindings() {
         let request = RequestSpec {
             query: vec![QueryParamSpec {
+                explode: true,
                 name: "team_key".to_string(),
                 value: ValueSourceSpec::FilterSplit {
                     key: "missing".to_string(),
@@ -1472,6 +1478,7 @@ mod tests {
     fn validate_http_table_rejects_unknown_filter_split_int_bindings() {
         let request = RequestSpec {
             query: vec![QueryParamSpec {
+                explode: true,
                 name: "issue_number".to_string(),
                 value: ValueSourceSpec::FilterSplitInt {
                     key: "missing".to_string(),
@@ -1522,6 +1529,7 @@ mod tests {
         for value in cases {
             let request = RequestSpec {
                 query: vec![QueryParamSpec {
+                    explode: true,
                     name: "value".to_string(),
                     value,
                 }],
@@ -1559,6 +1567,7 @@ mod tests {
     fn validate_http_table_rejects_function_arg_one_of_value_sources() {
         let request = RequestSpec {
             query: vec![QueryParamSpec {
+                explode: true,
                 name: "value".to_string(),
                 value: ValueSourceSpec::OneOf {
                     values: vec![
@@ -1589,6 +1598,7 @@ mod tests {
     fn validate_http_table_rejects_unknown_filter_one_of_value_sources() {
         let request = RequestSpec {
             query: vec![QueryParamSpec {
+                explode: true,
                 name: "value".to_string(),
                 value: ValueSourceSpec::OneOf {
                     values: vec![


### PR DESCRIPTION
Closes #1990.

## Why

The DSL v4 OpenAPI importer could only model scalar request parameters. A `type: array` parameter was dropped outright and replaced with a diagnostic:

```
parameter '$select' has unsupported schema type 'array'
```

That fires **14,380 times** in `microsoft_graph_v4` (5,989 of 17,531 operations) and **11 times** in `github_v4`. Because the parameter vanished from both `IrOperation.inputs` and `RestExecutionAttachment.parameters`, the capability was simply unreachable from SQL.

## What this does

Array **query** parameters become first-class v4 inputs whose SQL value is a JSON array literal:

```sql
SELECT * FROM github_v4.migrations_list_for_org(org => 'withcoral', exclude => '["repositories"]');
SELECT * FROM microsoft_graph_v4.list_users WHERE select = '["id","displayName"]';
```

A bare value is accepted as a one-element list (`exclude => 'repositories'`), since that is what a caller reaches for first.

This connects two conventions that already existed rather than inventing a third:

- the MCP importer already maps array tool args to `data_type: json`, and `bind_function_arg` already parses a `Json` argument from a SQL string literal;
- `ValueSourceSpec::FilterStringArray` already carries a JSON-array-shaped value out of the filter map — it was just wired into request bodies only, never `query:`.

### Shape of the change

`IrOperationInput` and `ProjectionInput` gain one field, `collection_encoding: Option<CollectionEncoding>` (`repeated` | `comma`), read from the parameter's OpenAPI `style`/`explode`.

The two type layers deliberately diverge, so it is worth being precise about which is which:

- **In the IR**, `data_type` is `IrScalarType::Json`. That is the load-bearing choice: every existing match on the scalar vocabulary — pagination inference, `ExpectedInputType::accepts` — then excludes lists **by construction**, so no guards were needed.
- **At the SQL boundary**, `ProjectionInput.data_type` is `ManifestDataType::Utf8`, *not* the `Json` that `IrScalarType::lower()` would produce. `bind_function_arg` requires a `Json` argument's literal to parse as JSON before the value source runs, so `Json` would reject the bare single-value form at plan time. `Utf8` accepts both spellings. See the review follow-up comment below for the measurements behind this.

Lowering emits `filter_string_array` / the new `arg_string_array`, and `build_query_pairs` expands the array per `QueryParamSpec.explode`. `transport.rs` already hands reqwest a `&[(String, String)]`, which repeats duplicate keys, so repeated-key encoding needed no transport change.

`explode` already existed in the v3 JSON schema and is set in 288 places across five shipped manifests (clickup, stripe, gitlab, pagerduty, posthog) with **no Rust field behind it**. It is now live, and provably inert for all 288: every one resolves from a `Utf8` filter and can never produce an array.

### Scope

Deliberately out: no `ManifestDataType::List` / Arrow list type; no array path or header parameters (neither occurs in the corpus, both keep a diagnostic); no `WHERE col IN ('a','b')` multi-value pushdown; no `spaceDelimited`/`pipeDelimited`/`deepObject`. Only `style: form` appears anywhere across both descriptors.

Rejections that remain keep a diagnostic naming the actual cause (`unsupported array item type 'object'`, `unsupported serialization style 'spaceDelimited'`) instead of the misleading `unsupported schema type 'array'`.

## Verified against the real descriptors

Re-imported both cached OpenAPI documents:

| | before | after |
| --- | --- | --- |
| `unsupported schema type 'array'` | 14,380 Graph / 11 GitHub | **0 / 0** |
| imported collection params | 0 | 14,380 / 11 |
| Graph `diagnostics.yaml` | 6.3 MB | 2.4 MB |

Graph's "Most useful optional filters" hints are **byte-identical** to before — `$select`/`$expand` sort ahead of real filters and would otherwise have displaced `search` on ~648 projections. Guides instead gained a convention sentence, which is the only channel that reaches function-argument callers: 12,422 of the 14,380 collection inputs are function args, and `TableFunctionArgSpec` has no description field.

`make rust-checks` (fmt, clippy `-D warnings`, 2,646 tests, doc), `make schema-check`, and `make docs-check` all pass.

## Reviewer note: an unplanned behavior change

The new inputs made a latent pagination bug reachable. `find_numeric_query_input` picked the first candidate-named input and only *then* filtered by type, so Graph's boolean `$count` masked the integer `$top`. The type predicate now applies during the search.

On the Graph catalog this takes page-size detection from **1 → 2,523** operations, and correctly drops `$top` from lookup keys on those 2,522 (it is a paging control, never joinable). Row paths are byte-identical and nothing else moved — the only lookup-key diff is `$top` removed, nothing added.

There was an existing test pinning the old behavior whose own comment said to flip it when this was fixed; it is flipped.

## Not run

`make perf-check` — `hyperfine` is not installed locally. It measures the bundled **v3** `github` source, so it would not exercise the v4 catalog growth anyway; CI covers it.

## How this closes #1990

#1990 reports that a `createdDateTime` filter on Graph chat messages is silently ignored: `chatMessage` only honours that filter when the request also carries a matching `orderby`, and the issue notes that "the connector exposes no `orderby` control, so a `createdDateTime` filter cannot be made to work at all."

That is a direct consequence of this bug. `$orderby` is declared `type: array`, so the importer dropped it. The currently-installed catalog shows `chats.ListMessages` exposing `$filter` but not `$orderby`:

```
  - name: $count
  - name: $filter
  - name: $search
  - name: $skip
  - name: $top
  - message: parameter '$expand' has unsupported schema type 'array'
  - message: parameter '$orderby' has unsupported schema type 'array'
  - message: parameter '$select' has unsupported schema type 'array'
```

With this change `$orderby` imports as a `comma`-encoded list input, so the two can be paired:

```sql
SELECT * FROM microsoft_graph_v4.chats_listmessages(
  chat_id => '...',
  filter  => 'createdDateTime gt 2026-01-01T00:00:00Z',
  orderby => '["createdDateTime desc"]'
);
```

This is the first of the three outcomes #1990 asks for ("expose `orderby` so the filter can be paired correctly"). It deliberately does **not** implement the other two: the connector does not pair `orderby` automatically, and does not reject an unpaired date filter.

That is a decision, not an omission. Exposing `orderby` is enough for an agent to self-heal — it can see the input in the catalog and pair it itself. Automatic pairing would mean either a Microsoft Graph exception in the importer, or teaching the general OpenAPI machinery about a provider-specific coupling between `$filter` and `$orderby` on one entity type. Neither is worth it to save a step an agent can take on its own, and the second would bend generic machinery to one vendor's shape.

## Follow-up

Exposing `$select`/`$expand` uniformly leaves a footgun: setting `$select` makes Graph return only the named properties, so every other declared column silently becomes NULL. The mechanism to suppress them (`SqlInputExposure::Internal`) already exists, so it is a policy question, not plumbing.

Note that it is the same question settled above for `orderby`, and the same answer applies: suppressing them would mean carrying an OData-flavoured name lexicon in a generic OpenAPI importer. Worth a separate issue, but the bar is showing that an agent *cannot* recover on its own — not merely that it can be led astray.

https://claude.ai/code/session_01KTdyE7SX7rZq7oQbcuR3g4




