### PR TITLE
feat(desktop): isolate Coral state

### DIFF
--- a/apps/desktop/src/main/coral-config.test.ts
+++ b/apps/desktop/src/main/coral-config.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { ensureDesktopCoralConfig } from './coral-config'
+
+describe('ensureDesktopCoralConfig', () => {
+  it('creates an isolated ephemeral-loopback server configuration', async () => {
+    const userData = await mkdtemp(join(tmpdir(), 'coral-desktop-'))
+    const configDir = await ensureDesktopCoralConfig(userData)
+
+    expect(configDir).toBe(join(userData, 'coral'))
+    await expect(readFile(join(configDir, 'config.toml'), 'utf8')).resolves.toBe(
+      'version = 1\n\n[server]\nbind_addr = "127.0.0.1:0"\n',
+    )
+  })
+
+  it('preserves an existing Desktop configuration', async () => {
+    const userData = await mkdtemp(join(tmpdir(), 'coral-desktop-'))
+    const configDir = await ensureDesktopCoralConfig(userData)
+    await writeFile(join(configDir, 'config.toml'), '[server]\nbind_addr = "127.0.0.1:1457"\n')
+
+    await ensureDesktopCoralConfig(userData)
+
+    await expect(readFile(join(configDir, 'config.toml'), 'utf8')).resolves.toBe(
+      '[server]\nbind_addr = "127.0.0.1:1457"\n',
+    )
+  })
+})

--- a/apps/desktop/src/main/coral-config.ts
+++ b/apps/desktop/src/main/coral-config.ts
@@ -1,0 +1,20 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const DESKTOP_CORAL_CONFIG = 'version = 1\n\n[server]\nbind_addr = "127.0.0.1:0"\n'
+
+export function desktopCoralConfigDir(userDataDir: string): string {
+  return join(userDataDir, 'coral')
+}
+
+/** Creates Desktop's isolated Coral state only on first launch. */
+export async function ensureDesktopCoralConfig(userDataDir: string): Promise<string> {
+  const configDir = desktopCoralConfigDir(userDataDir)
+  await mkdir(configDir, { recursive: true })
+  try {
+    await writeFile(join(configDir, 'config.toml'), DESKTOP_CORAL_CONFIG, { encoding: 'utf8', flag: 'wx' })
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+  }
+  return configDir
+}

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -4,6 +4,7 @@ import { constants } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { app } from 'electron'
+import { ensureDesktopCoralConfig } from './coral-config'
 
 export interface CoralSidecar {
   url: string
@@ -105,8 +106,8 @@ function startupTimeoutMs(): number | null {
   return app.isPackaged ? PACKAGED_STARTUP_TIMEOUT_MS : null
 }
 
-function envWithLoopbackNoProxy(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env, CORAL_DESKTOP: '1' }
+function envWithLoopbackNoProxy(configDir: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, CORAL_CONFIG_DIR: configDir, CORAL_DESKTOP: '1' }
   for (const key of ['NO_PROXY', 'no_proxy']) {
     const existing = env[key]
       ?.split(',')
@@ -131,12 +132,13 @@ export function killAllTrackedChildren(): void {
   }
 }
 
-export function startCoralSidecar(): Promise<CoralSidecar> {
+export async function startCoralSidecar(): Promise<CoralSidecar> {
+  const configDir = await ensureDesktopCoralConfig(app.getPath('userData'))
   const command = sidecarCommand()
   const child = spawn(command.command, command.args, {
     cwd: command.cwd,
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: envWithLoopbackNoProxy(),
+    env: envWithLoopbackNoProxy(configDir),
   })
   liveChildren.add(child)
   child.once('exit', () => liveChildren.delete(child))


### PR DESCRIPTION
Desktop owns a distinct Coral configuration and runtime state so it cannot inherit a terminal user's standalone server settings.

Constraint: The Desktop sidecar must bind its native server to an ephemeral loopback address without mutating global Coral configuration.\nRejected: Reusing the global CORAL_CONFIG_DIR | it mixes Desktop state with standalone CLI state.\nConfidence: high\nScope-risk: narrow\nDirective: Desktop-launched Coral processes must receive the Desktop-owned CORAL_CONFIG_DIR.\nTested: npm run check --prefix apps/desktop; npm test --prefix apps/desktop -- coral-config