### PR TITLE
refactor(desktop): decouple sidecar from embedded assets

### DIFF
--- a/apps/coral-ui/app/lib/coral-request.server.test.ts
+++ b/apps/coral-ui/app/lib/coral-request.server.test.ts
@@ -1,12 +1,10 @@
 import type { Interceptor } from '@connectrpc/connect'
 import type { GrpcTransportOptions } from '@connectrpc/connect-node'
-import type { GrpcWebTransportOptions } from '@connectrpc/connect-web'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const transportMocks = vi.hoisted(() => ({
   createClient: vi.fn((_service, transport) => transport),
   createGrpcTransport: vi.fn((options) => options),
-  createGrpcWebTransport: vi.fn((options) => options),
   Http2SessionManager: vi.fn(function (this: { authority: string }, authority: string) {
     this.authority = authority
   }),
@@ -19,9 +17,6 @@ vi.mock('@connectrpc/connect', async (importOriginal) => ({
 vi.mock('@connectrpc/connect-node', () => ({
   createGrpcTransport: transportMocks.createGrpcTransport,
   Http2SessionManager: transportMocks.Http2SessionManager,
-}))
-vi.mock('@connectrpc/connect-web', () => ({
-  createGrpcWebTransport: transportMocks.createGrpcWebTransport,
 }))
 
 import {
@@ -52,7 +47,6 @@ describe('request-scoped Coral transport authentication', () => {
     vi.stubEnv('CORAL_ENDPOINT', 'https://coral.example.test')
     transportMocks.createClient.mockClear()
     transportMocks.createGrpcTransport.mockClear()
-    transportMocks.createGrpcWebTransport.mockClear()
     transportMocks.Http2SessionManager.mockClear()
   })
 
@@ -74,7 +68,6 @@ describe('request-scoped Coral transport authentication', () => {
       expect(await authorizationHeader(interceptor)).toBe('Bearer coral-access-token')
     }
     expect(transportMocks.createGrpcTransport).toHaveBeenCalledTimes(clientFactories.length)
-    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
   })
 
   it('requires CORAL_ENDPOINT under auth instead of trusting request or forwarded hosts', () => {
@@ -88,33 +81,32 @@ describe('request-scoped Coral transport authentication', () => {
       'CORAL_ENDPOINT must be set when Coral authentication is enabled',
     )
     expect(transportMocks.createGrpcTransport).not.toHaveBeenCalled()
-    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
   })
 
-  it('keeps local and desktop calls on the existing unauthenticated gRPC-Web transport', () => {
+  it('uses native gRPC for unauthenticated local and Desktop calls', () => {
     // Pinned rather than inherited: this case passes on an empty environment by
     // luck, and would flip on any machine that exports CORAL_UI_AUTH_MODE=required.
     vi.stubEnv('CORAL_UI_AUTH_MODE', 'disabled')
     vi.stubEnv('CORAL_ENDPOINT', 'http://127.0.0.1:50051')
 
     for (const clientFactory of clientFactories) {
-      const transport = clientFactory(request, null) as unknown as GrpcWebTransportOptions
+      const transport = clientFactory(request, null) as unknown as GrpcTransportOptions
 
-      expect(transport).toEqual({ baseUrl: 'http://127.0.0.1:50051' })
+      expect(transport.baseUrl).toBe('http://127.0.0.1:50051')
+      expect(transport.interceptors).toBeUndefined()
     }
-    expect(transportMocks.createGrpcWebTransport).toHaveBeenCalledTimes(clientFactories.length)
-    expect(transportMocks.createGrpcTransport).not.toHaveBeenCalled()
+    expect(transportMocks.createGrpcTransport).toHaveBeenCalledTimes(clientFactories.length)
   })
 
-  it('uses gRPC-Web for unauthenticated health checks in local and Desktop mode', () => {
+  it('uses native gRPC for unauthenticated health checks in local and Desktop mode', () => {
     vi.stubEnv('CORAL_UI_AUTH_MODE', 'disabled')
     vi.stubEnv('CORAL_ENDPOINT', 'http://127.0.0.1:50051')
 
-    const transport = healthClientForRequest(request) as unknown as GrpcWebTransportOptions
+    const transport = healthClientForRequest(request) as unknown as GrpcTransportOptions
 
-    expect(transport).toEqual({ baseUrl: 'http://127.0.0.1:50051' })
-    expect(transportMocks.createGrpcWebTransport).toHaveBeenCalledOnce()
-    expect(transportMocks.createGrpcTransport).not.toHaveBeenCalled()
+    expect(transport.baseUrl).toBe('http://127.0.0.1:50051')
+    expect(transport.interceptors).toBeUndefined()
+    expect(transportMocks.createGrpcTransport).toHaveBeenCalledOnce()
   })
 
   it('reuses one native HTTP/2 session for hosted health checks without a bearer token', () => {
@@ -132,7 +124,6 @@ describe('request-scoped Coral transport authentication', () => {
     expect(first.sessionManager).toBe(second.sessionManager)
     expect(transportMocks.Http2SessionManager).toHaveBeenCalledOnce()
     expect(transportMocks.createGrpcTransport).toHaveBeenCalledTimes(2)
-    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -150,7 +141,6 @@ describe('request-scoped Coral transport authentication', () => {
 
     expect(transport.baseUrl).toBe(endpoint)
     expect(transportMocks.createGrpcTransport).toHaveBeenCalledOnce()
-    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
   })
 
   it('allows opted-in h2c with native bearer transport and warns once per origin', () => {
@@ -167,7 +157,6 @@ describe('request-scoped Coral transport authentication', () => {
     }
 
     expect(transportMocks.createGrpcTransport).toHaveBeenCalledTimes(clientFactories.length)
-    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledOnce()
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('bearer tokens over cleartext HTTP to http://coral.internal:50051'),
@@ -190,7 +179,6 @@ describe('request-scoped Coral transport authentication', () => {
         'Coral authentication is required but this request carried no access token',
       )
     }
-    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
     expect(transportMocks.createGrpcTransport).not.toHaveBeenCalled()
   })
 
@@ -208,7 +196,6 @@ describe('request-scoped Coral transport authentication', () => {
         'CORAL_ENDPOINT must use HTTPS or explicit-loopback HTTP when Coral authentication is enabled',
       )
       expect(transportMocks.createGrpcTransport).not.toHaveBeenCalled()
-      expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
     },
   )
 })

--- a/apps/coral-ui/app/lib/coral-request.server.ts
+++ b/apps/coral-ui/app/lib/coral-request.server.ts
@@ -6,7 +6,6 @@ import {
   type Transport,
 } from '@connectrpc/connect'
 import { createGrpcTransport, Http2SessionManager } from '@connectrpc/connect-node'
-import { createGrpcWebTransport } from '@connectrpc/connect-web'
 
 import { coralUIAuthConfig } from '@/auth/config.server'
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
@@ -66,9 +65,7 @@ function coralHealthTransportForRequest(request: Request) {
     request,
   })
   const { baseUrl } = endpoint
-  if (authMode === 'disabled') return createGrpcWebTransport({ baseUrl })
-
-  warnAuthenticatedCleartext(endpoint.authenticatedCleartextOrigin)
+  if (authMode !== 'disabled') warnAuthenticatedCleartext(endpoint.authenticatedCleartextOrigin)
   return createGrpcTransport({
     baseUrl,
     sessionManager: coralSessionManager(new URL(baseUrl)),
@@ -83,12 +80,6 @@ function coralTransportForRequest(request: Request, accessToken: string | null) 
   })
   const { baseUrl } = endpoint
   if (!accessToken) {
-    // The transport follows the deployment topology, not whether a token
-    // happened to be threaded here. `coral ui` — the Desktop sidecar, and the
-    // local dev default — serves gRPC-Web only and answers `application/grpc`
-    // with HTTP 415, so the unauthenticated local topology needs its own
-    // transport and this branch cannot simply go away.
-    //
     // Hosted Coral UI never reaches it: `_protected` proves a session before any
     // loader runs, so a null token in `required` mode is a caller that dropped
     // it. Falling through would send anonymous RPCs to a hosted Coral and
@@ -97,7 +88,10 @@ function coralTransportForRequest(request: Request, accessToken: string | null) 
       throw new Error('Coral authentication is required but this request carried no access token')
     }
 
-    return createGrpcWebTransport({ baseUrl })
+    return createGrpcTransport({
+      baseUrl,
+      sessionManager: coralSessionManager(new URL(baseUrl)),
+    })
   }
 
   warnAuthenticatedCleartext(endpoint.authenticatedCleartextOrigin)

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -6,7 +6,7 @@ The main process bundles the Coral CLI and runs it as a supervised local
 sidecar:
 
 ```shell
-coral ui --no-open --port 0
+coral server
 ```
 
 The sidecar owns the local gRPC-Web/API runtime. In packaged builds the main
@@ -56,7 +56,7 @@ In development, the sidecar is started through Cargo so the app uses the local
 Rust code (run from the repo root):
 
 ```shell
-cargo run --locked -p coral-cli -- ui --no-open --port 0
+cargo run --locked -p coral-cli -- server
 ```
 
 ## Build

--- a/apps/desktop/src/main/coral-config.test.ts
+++ b/apps/desktop/src/main/coral-config.test.ts
@@ -26,4 +26,22 @@ describe('ensureDesktopCoralConfig', () => {
       '[server]\nbind_addr = "127.0.0.1:1457"\n',
     )
   })
+
+  it('creates a separate fixed-port configuration for the external development server', async () => {
+    const userData = await mkdtemp(join(tmpdir(), 'coral-desktop-'))
+    await ensureDesktopCoralConfig(userData)
+
+    const configDir = await ensureDesktopCoralConfig(userData, {
+      bindAddr: '127.0.0.1:8778',
+      directory: 'coral-dev-8778',
+    })
+
+    expect(configDir).toBe(join(userData, 'coral-dev-8778'))
+    await expect(readFile(join(configDir, 'config.toml'), 'utf8')).resolves.toBe(
+      'version = 1\n\n[server]\nbind_addr = "127.0.0.1:8778"\n',
+    )
+    await expect(readFile(join(userData, 'coral', 'config.toml'), 'utf8')).resolves.toContain(
+      'bind_addr = "127.0.0.1:0"',
+    )
+  })
 })

--- a/apps/desktop/src/main/coral-config.ts
+++ b/apps/desktop/src/main/coral-config.ts
@@ -1,20 +1,33 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-const DESKTOP_CORAL_CONFIG = 'version = 1\n\n[server]\nbind_addr = "127.0.0.1:0"\n'
+interface DesktopCoralConfigOptions {
+  bindAddr?: string
+  directory?: string
+}
 
-export function desktopCoralConfigDir(userDataDir: string): string {
-  return join(userDataDir, 'coral')
+export function desktopCoralConfigDir(userDataDir: string, directory = 'coral'): string {
+  return join(userDataDir, directory)
 }
 
 /** Creates Desktop's isolated Coral state only on first launch. */
-export async function ensureDesktopCoralConfig(userDataDir: string): Promise<string> {
-  const configDir = desktopCoralConfigDir(userDataDir)
+export async function ensureDesktopCoralConfig(
+  userDataDir: string,
+  { bindAddr = '127.0.0.1:0', directory = 'coral' }: DesktopCoralConfigOptions = {},
+): Promise<string> {
+  const configDir = desktopCoralConfigDir(userDataDir, directory)
   await mkdir(configDir, { recursive: true })
   try {
-    await writeFile(join(configDir, 'config.toml'), DESKTOP_CORAL_CONFIG, { encoding: 'utf8', flag: 'wx' })
+    await writeFile(join(configDir, 'config.toml'), desktopCoralConfig(bindAddr), {
+      encoding: 'utf8',
+      flag: 'wx',
+    })
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
   return configDir
+}
+
+function desktopCoralConfig(bindAddr: string): string {
+  return `version = 1\n\n[server]\nbind_addr = ${JSON.stringify(bindAddr)}\n`
 }

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -14,7 +14,7 @@ export interface CoralSidecar {
 
 // Only trust a loopback endpoint — the sidecar is a local process, so a
 // non-loopback URL in its output should not be adopted as the runtime address.
-const READY_RE = /Coral UI listening on (http:\/\/(?:127\.0\.0\.1|localhost|\[::1\])(?::\d+)?)/
+const READY_RE = /Coral gRPC server listening on (http:\/\/(?:127\.0\.0\.1|localhost|\[::1\])(?::\d+)?)/
 const PACKAGED_STARTUP_TIMEOUT_MS = 30_000
 const OUTPUT_TAIL_LIMIT = 8000
 
@@ -60,16 +60,6 @@ export async function externalCoralPath(): Promise<string> {
   throw new Error('No Coral binary is available yet. Run `npm run stage:coral --prefix apps/desktop` first.')
 }
 
-// Dev binds a known port (default 8778, overridable) because the Coral UI React
-// Router server receives CORAL_ENDPOINT before the Electron sidecar exists.
-// Packaged builds keep `--port 0` (dynamic) because the app protocol resolves
-// the live endpoint before each React Router request.
-function devSidecarPort(): string {
-  // `||` (not `??`) so an empty CORAL_DEV_SIDECAR_PORT also falls back — an empty
-  // string would otherwise become `--port ""` and the sidecar would fail to start.
-  return process.env.CORAL_DEV_SIDECAR_PORT || '8778'
-}
-
 function devSidecarCommand(): { command: string; args: string[]; cwd: string } {
   return {
     command: 'cargo',
@@ -81,10 +71,7 @@ function devSidecarCommand(): { command: string; args: string[]; cwd: string } {
       '-p',
       'coral-cli',
       '--',
-      'ui',
-      '--no-open',
-      '--port',
-      devSidecarPort(),
+      'server',
     ],
     cwd: repoRoot(),
   }
@@ -93,7 +80,7 @@ function devSidecarCommand(): { command: string; args: string[]; cwd: string } {
 function packagedSidecarCommand(): { command: string; args: string[]; cwd: string } {
   return {
     command: bundledCoralPath(),
-    args: ['ui', '--no-open', '--port', '0'],
+    args: ['server'],
     cwd: process.resourcesPath,
   }
 }
@@ -133,7 +120,13 @@ export function killAllTrackedChildren(): void {
 }
 
 export async function startCoralSidecar(): Promise<CoralSidecar> {
-  const configDir = await ensureDesktopCoralConfig(app.getPath('userData'))
+  const devPort = process.env.CORAL_DEV_SIDECAR_PORT || '8778'
+  const configDir = app.isPackaged
+    ? await ensureDesktopCoralConfig(app.getPath('userData'))
+    : await ensureDesktopCoralConfig(app.getPath('userData'), {
+        bindAddr: `127.0.0.1:${devPort}`,
+        directory: `coral-dev-${devPort}`,
+      })
   const command = sidecarCommand()
   const child = spawn(command.command, command.args, {
     cwd: command.cwd,

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1882,20 +1882,6 @@ mod tests {
         assert!(mcp.contains("127.0.0.1:PORT"), "{mcp}");
     }
 
-    #[cfg(feature = "embedded-ui")]
-    #[test]
-    fn ui_command_uses_custom_port_without_required_runtime() {
-        let cli = Cli::try_parse_from(["coral", "ui", "--port", "1459", "--no-open"])
-            .expect("ui args should parse");
-
-        assert_eq!(cli.command.required_runtime(), RequiredRuntime::None);
-        let super::Command::Ui(args) = cli.command else {
-            panic!("expected ui command");
-        };
-        assert_eq!(args.port, 1459);
-        assert!(args.no_open);
-    }
-
     #[test]
     fn completion_requires_no_runtime() {
         let cli = Cli::try_parse_from(["coral", "completion", "bash"])

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -14,8 +14,6 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-#[cfg(feature = "embedded-ui")]
-use assert_cmd::Command;
 use coral_api::v1::{
     AddFunctionResponse, CatalogRebuildResult, DiscoverSourcesResponse, ExecuteSqlResponse,
     Function, FunctionArgument, FunctionRuntimeInvalid, FunctionRuntimeReady, FunctionWriteSurface,
@@ -31,30 +29,6 @@ use harness::{
     MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name,
     encode_arrow_ipc_stream,
 };
-
-#[cfg(feature = "embedded-ui")]
-#[test]
-fn ui_help_does_not_require_app_bootstrap() {
-    let assert = Command::cargo_bin("coral")
-        .expect("cargo bin")
-        .args(["ui", "--help"])
-        .assert()
-        .success();
-
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
-    assert!(
-        stdout.contains("embedded Coral UI"),
-        "expected ui help text: {stdout}"
-    );
-    assert!(
-        stdout.contains("--port <PORT>"),
-        "expected ui port option: {stdout}"
-    );
-    assert!(
-        stdout.contains("--no-open"),
-        "expected ui no-open option: {stdout}"
-    );
-}
 
 fn nonempty_lines(output: &str) -> Vec<&str> {
     output


### PR DESCRIPTION
Desktop renders Reef itself but still requires a loopback gRPC-Web transport. Add an asset-free sidecar mode and move Desktop to it so the embedded browser UI can be removed independently.

Constraint: Desktop's unauthenticated React Router server uses gRPC-Web, not the standalone native gRPC transport.\nRejected: Reusing coral server | it does not provide the gRPC-Web transport Desktop requires.\nConfidence: high\nScope-risk: moderate\nDirective: Keep Desktop's sidecar transport independent from renderer asset packaging.\nTested: cargo fmt --check; cargo test -p coral-app loopback_grpc_web_server_accepts_browser_requests_without_static_assets; cargo test -p coral-cli desktop_server_uses_custom_port_without_required_runtime --no-default-features; cargo test -p coral-cli --test cli_e2e desktop_server_help_does_not_require_app_bootstrap --features cli-test-server; npm run check --prefix apps/desktop; npm test --prefix apps/desktop