### PR TITLE
feat(app): let trusted OAuth clients skip the approval page

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -269,13 +269,25 @@ impl AuthorizationServerHttpState {
         state_store: Arc<InMemoryStateStore>,
         authorization_resources: Arc<BTreeSet<String>>,
     ) -> Result<Self, AuthServerError> {
-        let client_metadata_resolver = Arc::new(
-            HttpClientMetadataResolver::new(
-                settings.authorization_server().issuer(),
-                &authorization_resources,
-            )
-            .map_err(|error| AuthServerError::ClientMetadataResolver(error.to_string()))?,
-        );
+        let client_metadata_resolver = HttpClientMetadataResolver::new(
+            settings.authorization_server().issuer(),
+            &authorization_resources,
+        )
+        .map_err(|error| AuthServerError::ClientMetadataResolver(error.to_string()))?;
+        // Config validation already held these entries to canonical spellings;
+        // only the constructed resolver knows the topology that decides
+        // whether each one can ever equal an accepted client ID.
+        for client_id in settings.authorization_server().trusted_clients() {
+            client_metadata_resolver
+                .check_trusted_client_id(client_id)
+                .map_err(|error| {
+                    AuthServerError::Config(format!(
+                        "invalid auth configuration: auth.authorization_server.trusted_clients \
+                         entry `{client_id}` cannot match a client ID this server accepts: {error}"
+                    ))
+                })?;
+        }
+        let client_metadata_resolver = Arc::new(client_metadata_resolver);
         Ok(Self {
             settings,
             session_tokens,
@@ -463,6 +475,57 @@ mod tests {
             prepared.authorization_resources,
             ["https://coral-ui.example.test".to_string()].into()
         );
+    }
+
+    /// `from_toml` holds `trusted_clients` to canonical spellings, but whether
+    /// an entry can ever equal an accepted client ID also depends on the
+    /// issuer's scheme and the loopback IDs derived from registered resources.
+    /// Every entry here passes config validation, so the topology check at
+    /// construction is the only thing standing between it and a server that
+    /// silently never skips the approval page.
+    #[tokio::test]
+    async fn trusted_clients_no_request_could_name_fail_startup() {
+        for (trusted_client, expected) in [
+            (
+                "https://client.example.test/",
+                "must include a non-root path",
+            ),
+            ("https://127.0.0.1/oauth/client.json", "host must be public"),
+            (
+                "http://127.0.0.1:9080/.well-known/oauth-client",
+                "authorized explicit-loopback HTTP endpoint",
+            ),
+        ] {
+            let dir = config(&format!(
+                "{AUTHORIZATION_SERVER}trusted_clients = ['{trusted_client}']\n{PROVIDER}"
+            ));
+            let Err(error) = server(&dir).start().await else {
+                panic!("started with dead trusted client `{trusted_client}`");
+            };
+            let error = error.to_string();
+            assert!(error.contains(trusted_client), "{error}");
+            assert!(error.contains(expected), "{error}");
+        }
+    }
+
+    /// A canonical public HTTPS entry passes with no registered resources at
+    /// all; the loopback entry rejected above is accepted once a registered
+    /// resource derives it — the topology decides, not the spelling.
+    #[tokio::test]
+    async fn trusted_clients_the_topology_can_name_start_and_serve() {
+        for (auth_fields, trusted_client) in [
+            ("", "https://client.example.test/oauth/client.json"),
+            (
+                "allowed_audiences = ['http://127.0.0.1:9080/']\n",
+                "http://127.0.0.1:9080/.well-known/oauth-client",
+            ),
+        ] {
+            let dir = config(&format!(
+                "{auth_fields}{AUTHORIZATION_SERVER}trusted_clients = ['{trusted_client}']\n{PROVIDER}"
+            ));
+            let server = server(&dir).start().await.expect("start");
+            server.shutdown().await.expect("shutdown");
+        }
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -79,6 +79,17 @@ pub(super) async fn oauth_authorize_get(
         code_challenge,
         resource,
     };
+    // A trusted client proceeds as if the user had already pressed Continue.
+    // The check sits after every validation above, so trust changes only the
+    // confirmation step — never what counts as a valid request — and the
+    // metadata document still had to resolve and name this redirect URI.
+    if state
+        .settings
+        .authorization_server()
+        .is_trusted_client(client_id)
+    {
+        return provider_sign_in(&state, approval, &trusted).await;
+    }
     let Ok(ticket) = confirmation::new_ticket() else {
         return trusted.error("server_error", "authorization failed");
     };
@@ -136,6 +147,21 @@ pub(super) async fn oauth_authorize_post(
     if decision == ApprovalDecision::Cancel {
         return trusted.error("access_denied", "authorization was denied");
     }
+    provider_sign_in(&state, approval, &trusted).await
+}
+
+/// Sends an approved authorization on to the upstream provider.
+///
+/// This is the step a Continue submission continues into and a trusted client
+/// skips to directly. The session is stored before the redirect is returned,
+/// so the callback can never arrive ahead of the state it needs, and the store
+/// hands it out once, so the callback that consumes it is the only one that
+/// can.
+async fn provider_sign_in(
+    state: &AuthorizationServerHttpState,
+    approval: OAuthAuthorizationApprovalRecord,
+    trusted: &TrustedRedirect,
+) -> Response {
     let request = match state
         .provider_client
         .authorization_request(state.settings.provider())
@@ -334,11 +360,24 @@ mod tests {
     }
 
     fn settings(issuer: &str) -> ResolvedAuthSettings {
+        settings_with_trusted_clients(issuer, &[])
+    }
+
+    fn settings_with_trusted_clients(
+        issuer: &str,
+        trusted_clients: &[&str],
+    ) -> ResolvedAuthSettings {
+        let trusted_clients = trusted_clients
+            .iter()
+            .map(|client_id| format!("'{client_id}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let settings = AuthSettings::from_toml(&format!(
             "[auth]
              [auth.session]
              [auth.authorization_server]
              issuer = '{AUTH_ISSUER}'
+             trusted_clients = [{trusted_clients}]
              [auth.provider]
              issuer = '{issuer}'
              client_id = 'provider-client'
@@ -400,6 +439,14 @@ mod tests {
         store: Arc<InMemoryStateStore>,
         resolver: Arc<dyn ClientMetadataResolver>,
     ) -> AuthorizationServerHttpState {
+        state_with_settings(settings(issuer), store, resolver)
+    }
+
+    fn state_with_settings(
+        settings: ResolvedAuthSettings,
+        store: Arc<InMemoryStateStore>,
+        resolver: Arc<dyn ClientMetadataResolver>,
+    ) -> AuthorizationServerHttpState {
         let session_tokens = SessionTokenIssuer::new(
             Some(AUTH_ISSUER),
             test_signing_key(),
@@ -407,7 +454,7 @@ mod tests {
         )
         .expect("session");
         AuthorizationServerHttpState::with_client_metadata_resolver(
-            Arc::new(settings(issuer)),
+            Arc::new(settings),
             session_tokens,
             store,
             Arc::new(BTreeSet::from([RESOURCE.into()])),
@@ -1406,6 +1453,122 @@ mod tests {
                 .expect("store")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn trusted_client_skips_the_approval_page_and_stores_a_single_use_session() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 200).await;
+        let store = Arc::new(InMemoryStateStore::new());
+        let (resolver, calls) = fake_resolver(Ok(registration(&[REDIRECT_URI])));
+        let auth_state = state_with_settings(
+            settings_with_trusted_clients(&provider.uri(), &[CLIENT_ID]),
+            store.clone(),
+            resolver,
+        );
+        let response = request(auth_state, &pairs()).await;
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_security(&response);
+        assert!(
+            response.headers().get(header::SET_COOKIE).is_none(),
+            "a skipped approval page must not set an approval cookie"
+        );
+        let provider_url = location(&response).expect("provider redirect");
+        assert!(
+            provider_url.starts_with(&provider.uri()),
+            "redirected to {provider_url}"
+        );
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        let query = Url::parse(provider_url)
+            .expect("URL")
+            .query_pairs()
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+        let oidc_state = query.get("state").expect("OIDC state");
+        let session = store
+            .take_authorization_session(oidc_state)
+            .await
+            .expect("store")
+            .expect("stored before redirect");
+        assert_eq!(session.client_id, CLIENT_ID);
+        assert_eq!(session.redirect_uri, REDIRECT_URI);
+        assert_eq!(session.client_state.as_deref(), Some(CLIENT_STATE));
+        assert_eq!(session.code_challenge, CHALLENGE);
+        assert_eq!(session.resource, RESOURCE);
+        assert!(
+            store
+                .take_authorization_session(oidc_state)
+                .await
+                .expect("store")
+                .is_none()
+        );
+    }
+
+    /// Trust skips only the approval page. Every validation the page sits
+    /// behind still runs, so a trusted client's malformed request fails exactly
+    /// like anyone else's rather than being waved through to the provider.
+    #[tokio::test]
+    async fn trusted_client_requests_are_validated_like_any_other() {
+        let store = Arc::new(InMemoryStateStore::new());
+        let trusted_state = |resolver| {
+            state_with_settings(
+                settings_with_trusted_clients("https://provider.invalid", &[CLIENT_ID]),
+                store.clone(),
+                resolver,
+            )
+        };
+
+        let (resolver, _calls) = fake_resolver(Ok(registration(&[REDIRECT_URI])));
+        let mut missing_challenge = pairs();
+        replace(&mut missing_challenge, "code_challenge", None);
+        let response = request(trusted_state(resolver), &missing_challenge).await;
+        assert_eq!(response.status(), StatusCode::FOUND);
+        let error_location = location(&response).expect("client error redirect");
+        assert!(
+            error_location.starts_with("https://client.example.test/callback"),
+            "redirected to {error_location}"
+        );
+        assert!(error_location.contains("error=invalid_request"));
+
+        let (resolver, _calls) = fake_resolver(Ok(registration(&[
+            "https://client.example.test/other-callback",
+        ])));
+        let response = request(trusted_state(resolver), &pairs()).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(location(&response).is_none());
+    }
+
+    #[tokio::test]
+    async fn only_the_listed_client_skips_the_approval_page() {
+        let (resolver, _calls) = fake_resolver(Ok(registration(&[REDIRECT_URI])));
+        let auth_state = state_with_settings(
+            settings_with_trusted_clients(
+                "https://provider.invalid",
+                &["https://other.example.test/oauth/client.json"],
+            ),
+            Arc::new(InMemoryStateStore::new()),
+            resolver,
+        );
+        let response = request(auth_state, &pairs()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response_body(response).await.contains("Approve access?"));
+    }
+
+    #[tokio::test]
+    async fn trusted_client_provider_failures_are_generic_trusted_errors() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 500).await;
+        let (resolver, _calls) = fake_resolver(Ok(registration(&[REDIRECT_URI])));
+        let auth_state = state_with_settings(
+            settings_with_trusted_clients(&provider.uri(), &[CLIENT_ID]),
+            Arc::new(InMemoryStateStore::new()),
+            resolver,
+        );
+        let response = request(auth_state, &pairs()).await;
+        let error_location = location(&response).expect("error redirect");
+        assert!(error_location.starts_with("https://client.example.test/callback"));
+        assert!(error_location.contains("error=server_error"));
+        assert!(!error_location.contains(PROVIDER_SECRET));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server/client_metadata.rs
+++ b/crates/coral-app/src/auth/authorization_server/client_metadata.rs
@@ -79,6 +79,32 @@ impl HttpClientMetadataResolver {
             fetcher,
         })
     }
+
+    /// Rejects a trusted client ID no request through this resolver could name.
+    ///
+    /// Config validation holds `trusted_clients` entries to canonical URL
+    /// spellings, but whether an entry can ever equal an accepted client ID
+    /// also depends on the served topology — the issuer's scheme and the
+    /// loopback IDs derived from registered resources — which only exists once
+    /// this resolver does. Running the entry through the same parse a request
+    /// goes through is what keeps the two answers from drifting: an entry that
+    /// fails here would otherwise pass startup and then never match, and its
+    /// runtime symptom — the approval page still appearing — points nowhere
+    /// near the config that caused it.
+    pub(super) fn check_trusted_client_id(&self, client_id: &str) -> Result<(), String> {
+        let metadata_url = EndpointUrl::<ClientMetadata>::parse(
+            client_id,
+            &self.issuer,
+            &self.allowed_loopback_client_ids,
+        )
+        .map_err(|error| error.to_string())?;
+        // Mirrors `resolve`: an accepted client ID is the canonical
+        // serialization, character for character.
+        if metadata_url.as_url().as_str() != client_id {
+            return Err("client ID must be the canonical form of the URL it names".to_string());
+        }
+        Ok(())
+    }
 }
 
 fn derive_allowed_loopback_client_ids(

--- a/crates/coral-app/src/auth/authorization_server/client_metadata.rs
+++ b/crates/coral-app/src/auth/authorization_server/client_metadata.rs
@@ -86,25 +86,70 @@ impl HttpClientMetadataResolver {
     /// spellings, but whether an entry can ever equal an accepted client ID
     /// also depends on the served topology — the issuer's scheme and the
     /// loopback IDs derived from registered resources — which only exists once
-    /// this resolver does. Running the entry through the same parse a request
-    /// goes through is what keeps the two answers from drifting: an entry that
-    /// fails here would otherwise pass startup and then never match, and its
-    /// runtime symptom — the approval page still appearing — points nowhere
-    /// near the config that caused it.
+    /// this resolver does. An entry that fails here would otherwise pass
+    /// startup and then never match, and its runtime symptom — the approval
+    /// page still appearing — points nowhere near the config that caused it.
+    ///
+    /// The rejection is rendered because an operator reading a startup failure
+    /// is the one caller entitled to know which rule the entry broke.
     pub(super) fn check_trusted_client_id(&self, client_id: &str) -> Result<(), String> {
+        self.accepted_metadata_url(client_id)
+            .map(|_metadata_url| ())
+            .map_err(|rejection| rejection.to_string())
+    }
+
+    /// Resolves `client_id` to the URL this server would fetch its metadata
+    /// from, rejecting an ID it does not accept.
+    ///
+    /// This is the single definition of an acceptable client ID. The request
+    /// path and the `trusted_clients` startup check both go through it, so the
+    /// URL policy and the canonical-identity rule cannot come to disagree
+    /// about which IDs this server honors — the divergence that otherwise lets
+    /// a configured trusted client pass startup and then silently never match.
+    fn accepted_metadata_url(
+        &self,
+        client_id: &str,
+    ) -> Result<EndpointUrl<ClientMetadata>, ClientIdRejection> {
         let metadata_url = EndpointUrl::<ClientMetadata>::parse(
             client_id,
             &self.issuer,
             &self.allowed_loopback_client_ids,
         )
-        .map_err(|error| error.to_string())?;
-        // Mirrors `resolve`: an accepted client ID is the canonical
-        // serialization, character for character.
+        .map_err(ClientIdRejection::Policy)?;
+        // A client ID must already be the URL Coral fetches, character for
+        // character. Parsing normalizes — it strips tab, CR, and LF from
+        // anywhere in the input, trims surrounding spaces, lowercases the host,
+        // and drops a default port — so without this check one document is
+        // reachable under unboundedly many client IDs that all fetch it. The ID
+        // is the client's identity: it is echoed back by the document, recorded
+        // on an approval, and compared at the token endpoint, so it has to be a
+        // single canonical string rather than a family of equivalent ones.
         if metadata_url.as_url().as_str() != client_id {
-            return Err("client ID must be the canonical form of the URL it names".to_string());
+            return Err(ClientIdRejection::NotCanonical);
         }
-        Ok(())
+        Ok(metadata_url)
     }
+}
+
+/// Why a client ID is not one this server accepts.
+///
+/// # Trust
+///
+/// Only the startup check for `trusted_clients` renders this. [`resolve`]
+/// maps every variant onto the opaque [`ClientMetadataError::InvalidClientId`]
+/// deliberately: the party that supplied the ID learns that it was rejected
+/// and nothing about which rule rejected it. Letting this detail out of
+/// `resolve` to improve its errors would hand a caller a description of the
+/// policy its input just failed, so these variants exist for an operator
+/// reading a startup error and for no one else.
+///
+/// [`resolve`]: HttpClientMetadataResolver::resolve
+#[derive(Debug, Error)]
+enum ClientIdRejection {
+    #[error("{0}")]
+    Policy(OutboundUrlPolicyError),
+    #[error("client ID must be the canonical form of the URL it names")]
+    NotCanonical,
 }
 
 fn derive_allowed_loopback_client_ids(
@@ -135,23 +180,11 @@ impl ClientMetadataResolver for HttpClientMetadataResolver {
         &self,
         client_id: &str,
     ) -> Result<OAuthClientRegistration, ClientMetadataError> {
-        let metadata_url = EndpointUrl::<ClientMetadata>::parse(
-            client_id,
-            &self.issuer,
-            &self.allowed_loopback_client_ids,
-        )
-        .map_err(|_error| ClientMetadataError::InvalidClientId)?;
-        // A client ID must already be the URL Coral fetches, character for
-        // character. Parsing normalizes — it strips tab, CR, and LF from
-        // anywhere in the input, trims surrounding spaces, lowercases the host,
-        // and drops a default port — so without this check one document is
-        // reachable under unboundedly many client IDs that all fetch it. The ID
-        // is the client's identity: it is echoed back by the document, recorded
-        // on an approval, and compared at the token endpoint, so it has to be a
-        // single canonical string rather than a family of equivalent ones.
-        if metadata_url.as_url().as_str() != client_id {
-            return Err(ClientMetadataError::InvalidClientId);
-        }
+        // Every rejection collapses into one opaque error, by design: see
+        // `ClientIdRejection`.
+        let metadata_url = self
+            .accepted_metadata_url(client_id)
+            .map_err(|_rejection| ClientMetadataError::InvalidClientId)?;
         let response = self.fetcher.fetch(&metadata_url).await?;
         registration_from_response(client_id, response).await
     }

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -278,6 +278,20 @@ impl SessionTokenSettings {
 #[serde(deny_unknown_fields)]
 pub(crate) struct AuthorizationServerSettings {
     pub(super) issuer: String,
+    /// Client IDs whose authorization requests skip the approval page.
+    ///
+    /// A listed client's sign-in redirects straight to the upstream provider
+    /// once it passes every other check — client metadata resolution, redirect
+    /// registration, PKCE, and resource validation are unchanged. What an
+    /// entry removes is the one step where a person sees who is asking before
+    /// anything else happens, so it is an operator statement that this exact
+    /// client needs no per-login confirmation. That statement should only be
+    /// made for a client whose registered redirect URIs nothing else can
+    /// serve: a loopback redirect is claimable by any local process, and the
+    /// approval page is the only thing that would have shown the user which
+    /// port the authorization code is about to be handed to.
+    #[serde(default)]
+    trusted_clients: Vec<String>,
 }
 
 impl AuthorizationServerSettings {
@@ -285,11 +299,60 @@ impl AuthorizationServerSettings {
         &self.issuer
     }
 
+    /// Reports whether `client_id` may skip the approval page.
+    ///
+    /// The comparison is exact string equality: a request's client ID is only
+    /// accepted when it is the canonical serialization of the URL it names, and
+    /// validation holds the configured entries to the same spelling, so one
+    /// string is the whole identity on both sides.
+    pub(super) fn is_trusted_client(&self, client_id: &str) -> bool {
+        self.trusted_clients
+            .iter()
+            .any(|trusted| trusted == client_id)
+    }
+
     fn validate(&mut self) -> Result<(), AuthServerError> {
         self.issuer = required("auth.authorization_server.issuer", &self.issuer)?;
         self.issuer = validate_issuer("auth.authorization_server.issuer", &self.issuer, true)?;
+        for client_id in &mut self.trusted_clients {
+            *client_id = validate_trusted_client(client_id)?;
+        }
         Ok(())
     }
+}
+
+/// Rejects a trusted-client entry that could never match a request.
+///
+/// The metadata resolver only accepts a client ID that is the canonical
+/// serialization of the URL it names, and the trusted match is exact string
+/// equality against that canonical string. An entry the URL parser would
+/// rewrite therefore cannot match any request this server accepts; failing at
+/// startup names the misspelling, where the runtime symptom — the approval
+/// page still appearing — points nowhere near it.
+fn validate_trusted_client(configured: &str) -> Result<String, AuthServerError> {
+    let entry_error = |message: String| {
+        config_error(format!(
+            "auth.authorization_server.trusted_clients {message}"
+        ))
+    };
+    let value = configured.trim();
+    if value.is_empty() {
+        return Err(entry_error("entries must not be empty".to_string()));
+    }
+    let url = Url::parse(value)
+        .map_err(|error| entry_error(format!("entry `{value}` is not a valid URL: {error}")))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(entry_error(format!(
+            "entry `{value}` must use HTTP or HTTPS"
+        )));
+    }
+    if url.as_str() != value {
+        return Err(entry_error(format!(
+            "entries must be canonical client IDs; `{value}` canonicalizes to `{}`",
+            url.as_str()
+        )));
+    }
+    Ok(value.to_string())
 }
 
 const DEFAULT_PROVIDER_SCOPES: &[&str] = &["openid", "email", "profile"];
@@ -908,6 +971,74 @@ mod tests {
         let debug = format!("{provider:?}");
         assert!(debug.contains("<redacted>"));
         assert!(!debug.contains("inline-secret"));
+    }
+
+    #[test]
+    fn trusted_clients_match_exactly_and_default_to_none() {
+        let settings = resolved(&valid(""));
+        assert!(
+            !settings
+                .authorization_server()
+                .is_trusted_client("https://client.example.test/oauth/client.json")
+        );
+
+        let raw = valid("").replace(
+            "issuer = 'http://localhost:9080/'",
+            "issuer = 'http://localhost:9080/'\ntrusted_clients = [' https://client.example.test/oauth/client.json ', 'http://127.0.0.1:1457/.well-known/oauth-client']",
+        );
+        let settings = resolved(&raw);
+        let authorization_server = settings.authorization_server();
+        assert!(
+            authorization_server.is_trusted_client("https://client.example.test/oauth/client.json")
+        );
+        assert!(
+            authorization_server
+                .is_trusted_client("http://127.0.0.1:1457/.well-known/oauth-client")
+        );
+        assert!(
+            !authorization_server.is_trusted_client("https://client.example.test/oauth/other.json")
+        );
+    }
+
+    /// A request's client ID is accepted only in its canonical spelling, so an
+    /// entry the parser would rewrite can never match one — it has to fail at
+    /// startup, where the error names the entry, rather than show the approval
+    /// page forever.
+    #[test]
+    fn rejects_trusted_clients_that_could_never_match_a_request() {
+        let with_trusted = |entry: &str| {
+            valid("").replace(
+                "issuer = 'http://localhost:9080/'",
+                &format!("issuer = 'http://localhost:9080/'\ntrusted_clients = [{entry}]"),
+            )
+        };
+        reject_all(vec![
+            (
+                with_trusted("''"),
+                "trusted_clients entries must not be empty",
+            ),
+            (with_trusted("'not a url'"), "is not a valid URL"),
+            (
+                with_trusted("'https://Client.example.test/oauth/client.json'"),
+                "canonicalizes to `https://client.example.test/oauth/client.json`",
+            ),
+            (
+                with_trusted("'https://client.example.test:443/oauth/client.json'"),
+                "canonicalizes to",
+            ),
+            (
+                with_trusted(r"'https://client.example.test/oauth\client.json'"),
+                "canonicalizes to",
+            ),
+            (
+                with_trusted("'https://client.example.test'"),
+                "canonicalizes to `https://client.example.test/`",
+            ),
+            (
+                with_trusted("'file:///oauth/client.json'"),
+                "must use HTTP or HTTPS",
+            ),
+        ]);
     }
 
     #[test]

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -311,6 +311,12 @@ impl AuthorizationServerSettings {
             .any(|trusted| trusted == client_id)
     }
 
+    /// Returns the trusted client IDs for the topology check at server
+    /// construction, which is where the full client-ID policy can first run.
+    pub(super) fn trusted_clients(&self) -> &[String] {
+        &self.trusted_clients
+    }
+
     fn validate(&mut self) -> Result<(), AuthServerError> {
         self.issuer = required("auth.authorization_server.issuer", &self.issuer)?;
         self.issuer = validate_issuer("auth.authorization_server.issuer", &self.issuer, true)?;
@@ -329,6 +335,13 @@ impl AuthorizationServerSettings {
 /// rewrite therefore cannot match any request this server accepts; failing at
 /// startup names the misspelling, where the runtime symptom — the approval
 /// page still appearing — points nowhere near it.
+///
+/// This owns only the spelling half of that guarantee. Whether a canonical
+/// entry names a client the request-time policy can accept also depends on
+/// the served topology — the issuer's scheme and the loopback IDs derived
+/// from registered resources — and the resource set only exists at server
+/// construction, so the resolver re-checks every entry under the real policy
+/// there.
 fn validate_trusted_client(configured: &str) -> Result<String, AuthServerError> {
     let entry_error = |message: String| {
         config_error(format!(


### PR DESCRIPTION
## Intent

Every browser sign-in through Coral's OAuth authorization server currently pauses on the approval page, even when the client is operated by the same party that runs the server. For a first-party client — the operator's own UI in front of their own Coral — the page asks the user to approve software the operator already vouches for, on every single login. Operators need a way to state that trust once, in configuration, instead of delegating it to each user on each sign-in.

## What it enables

`[auth.authorization_server]` gains an optional `trusted_clients` list of client-ID URLs. A listed client's authorization request redirects straight to the upstream identity provider — no approval page, no ticket, no approval cookie — once it passes every existing check. Client metadata resolution, redirect-URI registration, PKCE, and resource validation are unchanged; trust removes only the approval step, never what counts as a valid request.

Guardrails:

- Entries are validated at startup: each must be a canonical client-ID URL spelling (the only spelling a request is ever accepted with), over HTTP or HTTPS. A misspelled entry fails the server at startup with an error naming it, rather than silently matching nothing while the approval page keeps appearing.
- Matching is exact string equality against the request's already-validated client ID.
- The field's documentation warns against listing clients with loopback redirect URIs: any local process can claim a loopback port, and the approval page is the only step that would have shown the user which port the authorization code is about to be handed to.

The option defaults to empty, so existing deployments behave exactly as before.

## Usage examples

```toml
[auth.authorization_server]
issuer = "https://coral.example.com"
trusted_clients = ["https://client.example.com/oauth/client.json"]
# ... existing [auth.session] and [auth.provider] sections unchanged
```

With this added to an existing `[auth]` configuration, a sign-in started by `https://client.example.com/oauth/client.json` goes from `GET /oauth/authorize` directly to the upstream provider's login page. Any other client — and any request from the trusted client that fails validation — behaves exactly as it does today.

## Validation

- 8 new tests: config accept/reject tables for `trusted_clients`; startup rejection of entries no request could name (root path, non-public HTTPS host, undeclared loopback ID) and acceptance of a public HTTPS entry and a topology-derived loopback one; trusted skip stores a single-use session and sets no approval cookie; trusted requests still fail validation like any other; only the listed client skips; provider failures on the skip path remain generic errors.
- `cargo nextest run -p coral-app -E 'test(/^auth::/)'` — 117 tests pass.
- `cargo nextest run -p coral-cli -E 'test(/serve/)'` — 19 tests pass, covering the `serve::tests` lifecycle and auth-gating suite that consumes this config end to end.
- `cargo clippy -p coral-app --all-features --all-targets` clean; `make rust-checks` green.

Docs note: the `[auth]` section is not yet documented in `apps/docs`, so this PR adds no docs; documenting the auth config surface as a whole is a separate change.
