### PR TITLE
feat(app)!: enforce the authorization matrix across every service

### DIFF
--- a/apps/coral-ui/app/components/runtime-features-list/runtime-features-list.tsx
+++ b/apps/coral-ui/app/components/runtime-features-list/runtime-features-list.tsx
@@ -21,6 +21,8 @@ export interface RuntimeFeatureRowProps {
   readonly feature: RuntimeFeatureListItem
   readonly onToggle: (enabled: boolean) => void
   readonly pending?: boolean
+  /** Whether this feature is somebody else's to change, leaving the row a view of it. */
+  readonly readOnly?: boolean
 }
 
 export interface RuntimeFeaturesListProps {
@@ -67,6 +69,7 @@ export function RuntimeFeatureRow({
   feature,
   onToggle,
   pending = false,
+  readOnly = false,
 }: RuntimeFeatureRowProps) {
   return (
     <Table.Row>
@@ -87,7 +90,7 @@ export function RuntimeFeatureRow({
         <Inputs.Switch
           aria-label={feature.label}
           checked={feature.enabled}
-          disabled={pending}
+          disabled={pending || readOnly}
           onCheckedChange={onToggle}
         />
       </Table.Cell>

--- a/apps/coral-ui/app/routes/settings/runtime-features.server.test.ts
+++ b/apps/coral-ui/app/routes/settings/runtime-features.server.test.ts
@@ -1,4 +1,5 @@
 import { create } from '@bufbuild/protobuf'
+import { Code, ConnectError } from '@connectrpc/connect'
 import { describe, expect, it, vi } from 'vitest'
 
 import { authRouteTestArgs } from '@/auth/server-context.test-helper'
@@ -105,6 +106,19 @@ describe('runtime features action', () => {
       expect.objectContaining({ enabled: false, key: 'feedback' }),
       expect.anything(),
     )
+  })
+
+  // Features belong to the host, so on a shared deployment every write is
+  // refused for the same reason. The page turns that into a read-only view, and
+  // it can only do so if the refusal arrives as its own outcome rather than as
+  // one more per-row error message.
+  it('reports a refused write as host-managed rather than as an error', async () => {
+    setFeature.mockRejectedValue(new ConnectError('host only', Code.PermissionDenied))
+    featureClientForRequest.mockReturnValue({ setFeature })
+
+    const result = await action(authRouteTestArgs(toggleRequest('feedback', 'true'), {}))
+
+    expect(result).toEqual({ key: 'feedback', status: 'host-managed' })
   })
 
   it('returns a write error as data rather than throwing', async () => {

--- a/apps/coral-ui/app/routes/settings/runtime-features.tsx
+++ b/apps/coral-ui/app/routes/settings/runtime-features.tsx
@@ -1,5 +1,6 @@
 import { create } from '@bufbuild/protobuf'
-import { useFetcher } from 'react-router'
+import { Code, ConnectError } from '@connectrpc/connect'
+import { useFetcher, useFetchers } from 'react-router'
 
 import type { Route } from './+types/runtime-features'
 
@@ -29,6 +30,13 @@ const RESTART_MESSAGE = isCoralDesktopBuild()
   ? 'Coral is running with different settings. Quit and reopen Coral to apply your changes.'
   : 'Coral is running with different settings. Restart the Coral server to apply your changes.'
 
+// Features belong to the machine running Coral, not to any workspace, so a
+// shared deployment lets everyone read the state and nobody change it. The
+// server is the only place that knows which of the two this is, and it says so
+// by refusing the write.
+const HOST_MANAGED_MESSAGE =
+  'Runtime features are configured on the host that runs this Coral server. You can see what is on here, but changing it has to happen on the host.'
+
 export interface RuntimeFeaturesRouteData {
   features: RuntimeFeatureListItem[]
   loadError: string | null
@@ -38,6 +46,7 @@ export interface RuntimeFeaturesRouteData {
 
 export type RuntimeFeaturesActionData =
   | { key: string; message: string; status: 'error' }
+  | { key: string; status: 'host-managed' }
   | { key: string; status: 'success' }
 
 export async function action({
@@ -56,6 +65,11 @@ export async function action({
     )
     return { key, status: 'success' }
   } catch (error) {
+    // A refused write is not a failure to report row by row: it says this
+    // whole page is a read-only view of somebody else's machine.
+    if (error instanceof ConnectError && error.code === Code.PermissionDenied) {
+      return { key, status: 'host-managed' }
+    }
     return { key, message: errorMessage(error), status: 'error' }
   }
 }
@@ -84,6 +98,7 @@ export async function loader({
 
 export default function RuntimeFeaturesRoute({ loaderData }: Route.ComponentProps) {
   const { features, loadError, restartPending } = loaderData
+  const hostManaged = useHostManaged()
 
   return (
     <SettingsPage
@@ -91,16 +106,21 @@ export default function RuntimeFeaturesRoute({ loaderData }: Route.ComponentProp
         <div className={styles.headerText}>
           <Typography.HeadingLarge as="h1">Features</Typography.HeadingLarge>
           <Typography.Body variant="secondary">
-            Turn experimental Coral capabilities on or off for this machine. Changes are saved right
-            away and apply the next time Coral starts.
+            {hostManaged
+              ? 'Experimental Coral capabilities this server is running with.'
+              : 'Turn experimental Coral capabilities on or off for this machine. Changes are saved right away and apply the next time Coral starts.'}
           </Typography.Body>
         </div>
       }
     >
+      {hostManaged && <Banner>{HOST_MANAGED_MESSAGE}</Banner>}
+
       <RuntimeFeaturesList
         error={loadError ?? undefined}
         features={features}
-        renderRow={(feature) => <RuntimeFeatureToggleRow feature={feature} />}
+        renderRow={(feature) => (
+          <RuntimeFeatureToggleRow feature={feature} readOnly={hostManaged} />
+        )}
       />
 
       {/* Below the list, so appearing after a toggle grows into empty page space
@@ -113,7 +133,13 @@ export default function RuntimeFeaturesRoute({ loaderData }: Route.ComponentProp
 // Every row writes through its own fetcher. React Router aborts the request in
 // flight when the same fetcher submits again, so one fetcher for the whole page
 // would drop the first toggle when a reader moves two switches in a row.
-function RuntimeFeatureToggleRow({ feature }: { feature: RuntimeFeatureListItem }) {
+function RuntimeFeatureToggleRow({
+  feature,
+  readOnly,
+}: {
+  feature: RuntimeFeatureListItem
+  readOnly: boolean
+}) {
   const fetcher = useFetcher<RuntimeFeaturesActionData>({ key: fetcherKey(feature.key) })
   // The switch has to move on click, but the value it settles on comes from the
   // server. Read the in-flight submission so the row does not snap back while
@@ -131,14 +157,28 @@ function RuntimeFeatureToggleRow({ feature }: { feature: RuntimeFeatureListItem 
         fetcher.submit({ enabled: String(next), key: feature.key }, { method: 'post' })
       }
       pending={fetcher.state !== 'idle'}
+      readOnly={readOnly}
     />
+  )
+}
+
+// One refused write settles the whole page: the server refuses on who is
+// asking, not on which feature was asked for. Every row writes through its own
+// fetcher, so the answer is read back out of whichever row was toggled.
+function useHostManaged(): boolean {
+  return useFetchers().some(
+    (fetcher) =>
+      fetcher.key.startsWith(FETCHER_KEY_PREFIX) &&
+      (fetcher.data as RuntimeFeaturesActionData | undefined)?.status === 'host-managed',
   )
 }
 
 // Fetcher keys are global to the app, so the feature key alone is not enough to
 // keep this page's writes apart from anyone else's.
+const FETCHER_KEY_PREFIX = 'runtime-feature:'
+
 function fetcherKey(featureKey: string): string {
-  return `runtime-feature:${featureKey}`
+  return `${FETCHER_KEY_PREFIX}${featureKey}`
 }
 
 export function toRuntimeFeature(feature: FeatureStatus): RuntimeFeatureListItem {

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -177,8 +177,46 @@ mod tests {
     use super::{AUTHORIZATION_MATRIX, Classification, HEALTH_SERVICE};
 
     /// The protobuf definitions this crate serves.
+    ///
+    /// Rooted above the version directory so a new package — a `coral/v2`, or a
+    /// service nested under `coral/v1` — is discovered rather than silently
+    /// unclassified. The walk below recurses, so anything added under here is
+    /// held to the same rule.
     fn proto_dir() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../coral-api/proto/coral/v1")
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../coral-api/proto")
+    }
+
+    /// The health RPCs this server mounts.
+    ///
+    /// These are not read from the protos. The vendored `grpc/health/v1`
+    /// copy declares only `Check`, while the `tonic_health` service actually
+    /// mounted answers `Watch` as well, so the proto would report a rule for a
+    /// live RPC as stale. What the server serves is the thing worth holding
+    /// the matrix to, and naming the methods here is what makes a misspelled
+    /// health row fail.
+    fn mounted_health_rpcs() -> [String; 2] {
+        [
+            format!("{HEALTH_SERVICE}/Check"),
+            format!("{HEALTH_SERVICE}/Watch"),
+        ]
+    }
+
+    /// Every `.proto` under `root`, including nested ones.
+    ///
+    /// The walk recurses so that a service nested under `coral/v1`, or a whole
+    /// new package beside it, is discovered rather than silently unclassified.
+    fn proto_files(root: &PathBuf) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        let entries = fs::read_dir(root).expect("proto directory is readable");
+        for entry in entries {
+            let path = entry.expect("proto directory entry").path();
+            if path.is_dir() {
+                files.extend(proto_files(&path));
+            } else if path.extension().is_some_and(|ext| ext == "proto") {
+                files.push(path);
+            }
+        }
+        files
     }
 
     /// Every RPC declared in the shipped protos, as `package.Service/Method`.
@@ -187,14 +225,9 @@ mod tests {
     /// new RPC — or a whole new service file — is discovered by the test that
     /// demands a classification for it.
     fn declared_rpcs() -> BTreeSet<String> {
-        let entries = fs::read_dir(proto_dir()).expect("proto directory is readable");
-        let mut declared = BTreeSet::new();
+        let mut declared: BTreeSet<String> = BTreeSet::new();
         let mut files = 0_usize;
-        for entry in entries {
-            let path = entry.expect("proto directory entry").path();
-            if path.extension().is_none_or(|ext| ext != "proto") {
-                continue;
-            }
+        for path in proto_files(&proto_dir()) {
             files += 1;
             let text = fs::read_to_string(&path).expect("proto file is readable");
             let mut package: Option<&str> = None;
@@ -221,6 +254,8 @@ mod tests {
             }
         }
         assert!(files > 0, "found no protos to walk under {:?}", proto_dir());
+        declared.retain(|rpc| !rpc.starts_with(HEALTH_SERVICE));
+        declared.extend(mounted_health_rpcs());
         declared
     }
 
@@ -246,10 +281,7 @@ mod tests {
     #[test]
     fn every_declared_rpc_is_classified_and_no_rule_outlives_its_rpc() {
         let declared = declared_rpcs();
-        let classified: BTreeSet<String> = classified_rpcs()
-            .into_iter()
-            .filter(|rpc| rpc.starts_with("coral.v1."))
-            .collect();
+        let classified: BTreeSet<String> = classified_rpcs().into_iter().collect();
 
         let unclassified: Vec<&String> = declared.difference(&classified).collect();
         assert!(

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -104,6 +104,19 @@ pub(crate) const AUTHORIZATION_MATRIX: &[RpcRule] = &[
     rule("coral.v1.FunctionService", "ListFunctions", Read),
     rule("coral.v1.FunctionService", "AddFunction", Manage),
     rule("coral.v1.FunctionService", "DeleteFunction", Manage),
+    // Onboarding records what a person has been shown, so it belongs to a
+    // person: an agent holding someone's credential has no onboarding of its
+    // own, and the service refuses one rather than answering for the human.
+    rule(
+        "coral.v1.GuiOnboardingService",
+        "GetGuiOnboardingState",
+        AnyHuman,
+    ),
+    rule(
+        "coral.v1.GuiOnboardingService",
+        "CompleteGuiOnboarding",
+        AnyHuman,
+    ),
     rule("coral.v1.QueryService", "ExecuteSql", Read),
     rule("coral.v1.QueryService", "ExplainSql", Read),
     // Searching reads the workspace; rebuilding, draining, and clearing the

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -134,6 +134,7 @@ pub(crate) const AUTHORIZATION_MATRIX: &[RpcRule] = &[
     // view needs a separate redacted response before it can be classified
     // Read.
     rule("coral.v1.SourceService", "DiscoverSources", Manage),
+    rule("coral.v1.SourceService", "DescribeSourceManifest", Manage),
     rule("coral.v1.SourceService", "ListSources", Manage),
     rule("coral.v1.SourceService", "GetSource", Manage),
     rule("coral.v1.SourceService", "GetSourceInfo", Manage),

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -33,9 +33,9 @@ pub(crate) enum Classification {
     /// No principal is required. Reserved for the transport's own liveness
     /// surface, which must answer before authentication exists to fail.
     Open,
-    /// Any admitted caller, answered only about themselves. The response is
-    /// filtered to the caller's own rows, so there is nothing further to
-    /// authorize.
+    /// Any admitted caller, with nothing further to authorize: either the
+    /// response is filtered to the caller's own rows, or it holds nothing that
+    /// differs between callers.
     SelfScoped,
     /// Any admitted caller that is a person rather than an agent credential.
     /// Agents are excluded because the act creates authority rather than
@@ -95,8 +95,12 @@ pub(crate) const AUTHORIZATION_MATRIX: &[RpcRule] = &[
     rule("coral.v1.CatalogService", "DescribeCatalogSurface", Read),
     rule("coral.v1.CatalogService", "ListColumns", Read),
     // Feature flags are host-global rather than workspace-scoped: there is no
-    // workspace whose owner could be entitled to them.
-    rule("coral.v1.FeatureService", "ListFeatures", LocalOnly),
+    // workspace whose owner could be entitled to them. Reading is `SelfScoped`
+    // in the sense that admission is the whole check — the listing carries the
+    // same keys, descriptions, and enabled state for every caller, and a page
+    // that cannot read it cannot say why its switches do nothing. Changing
+    // them is what stays with the host.
+    rule("coral.v1.FeatureService", "ListFeatures", SelfScoped),
     rule("coral.v1.FeatureService", "SetFeature", LocalOnly),
     rule("coral.v1.FeedbackService", "SubmitFeedback", Read),
     // Listing and using functions is reading; changing the function set
@@ -276,21 +280,27 @@ mod tests {
     }
 
     /// Feature state is host-global, and a shared deployment has no superuser
-    /// to entrust it to, so it stays with the local principal.
+    /// to entrust it to, so *changing* it stays with the local principal.
+    /// Reading it does not: the page that renders the switches has to say
+    /// which ones are on. The split is asserted rather than assumed, so
+    /// widening the mutation half would have to be written down here first.
     #[test]
-    fn every_feature_rpc_is_local_only() {
+    fn only_changing_a_feature_is_local_only() {
         let features: Vec<&super::RpcRule> = AUTHORIZATION_MATRIX
             .iter()
             .filter(|rule| rule.service == "coral.v1.FeatureService")
             .collect();
         assert!(!features.is_empty(), "the feature service lost its rules");
         for rule in features {
+            let expected = match rule.method {
+                "SetFeature" => Classification::LocalOnly,
+                "ListFeatures" => Classification::SelfScoped,
+                method => panic!("the feature service gained {method} without a decision"),
+            };
             assert_eq!(
-                rule.classification,
-                Classification::LocalOnly,
-                "{}/{} escaped the local principal",
-                rule.service,
-                rule.method
+                rule.classification, expected,
+                "{}/{} no longer answers to the rule it was split under",
+                rule.service, rule.method
             );
         }
     }

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -1,0 +1,304 @@
+//! The one written-down answer to "who may call this RPC".
+//!
+//! Access rules are enforced inside each service, where the request and its
+//! workspace are in hand. That is the right place to enforce them and the
+//! wrong place to read them: a reviewer asking whether some RPC is guarded at
+//! all would have to visit every handler and notice the one that is missing.
+//! This module states the rule for every RPC in one table, and its tests fail
+//! when an RPC exists without an entry, when an entry names an RPC that no
+//! longer exists, or when the same RPC is classified twice.
+//!
+//! The table is a declaration, not a dispatcher. Nothing routes through it;
+//! services keep enforcing their own rule, and the table is what makes the set
+//! of those rules reviewable.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the declared matrix is proved by its own tests; the enforcement paths that read it land with the per-service authorization work"
+    )
+)]
+
+use tonic_health::pb::health_server::SERVICE_NAME as HEALTH_SERVICE;
+
+use self::Classification::{AnyHuman, LocalOnly, Manage, Open, OwnerDirectory, Read, SelfScoped};
+
+/// The rule one RPC answers to.
+///
+/// [`Self::Read`] and [`Self::Manage`] are the two workspace-scoped levels and
+/// mirror `WorkspaceAction`; the other four name the shapes that have no
+/// workspace to scope to, and [`Self::Open`] names the absence of a rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Classification {
+    /// No principal is required. Reserved for the transport's own liveness
+    /// surface, which must answer before authentication exists to fail.
+    Open,
+    /// Any admitted caller, answered only about themselves. The response is
+    /// filtered to the caller's own rows, so there is nothing further to
+    /// authorize.
+    SelfScoped,
+    /// Any admitted caller that is a person rather than an agent credential.
+    /// Agents are excluded because the act creates authority rather than
+    /// exercising it.
+    AnyHuman,
+    /// Any admitted caller who owns at least one workspace. Directory
+    /// authority is ownership: the directory exists so an owner can name
+    /// somebody as a member.
+    OwnerDirectory,
+    /// Only the built-in local principal, and only on a deployment that
+    /// admits it. Host-global state has no workspace to scope to and shared
+    /// mode deliberately has no superuser, so a shared deployment exposes it
+    /// to nobody.
+    LocalOnly,
+    /// Members and owners of the named workspace.
+    Read,
+    /// Owners of the named workspace only.
+    Manage,
+}
+
+/// One RPC and the rule it answers to.
+pub(crate) struct RpcRule {
+    /// Fully qualified gRPC service name, as it appears on the wire.
+    pub(crate) service: &'static str,
+    /// Method name, as declared in the service.
+    pub(crate) method: &'static str,
+    /// What the RPC requires of its caller.
+    pub(crate) classification: Classification,
+}
+
+/// Declares one row of the matrix, short enough to keep a row on a line.
+const fn rule(
+    service: &'static str,
+    method: &'static str,
+    classification: Classification,
+) -> RpcRule {
+    RpcRule {
+        service,
+        method,
+        classification,
+    }
+}
+
+/// Every RPC this server mounts, classified exactly once.
+///
+/// The tests below hold this to the shipped protobuf definitions in both
+/// directions, so an RPC cannot be added without a decision about who may call
+/// it, and a rule cannot outlive the RPC it was written for.
+pub(crate) const AUTHORIZATION_MATRIX: &[RpcRule] = &[
+    // Liveness answers before there is a principal to answer for, so it is the
+    // only surface with no rule at all.
+    rule(HEALTH_SERVICE, "Check", Open),
+    rule(HEALTH_SERVICE, "Watch", Open),
+    // Reading a workspace's tables and columns is reading its contents.
+    rule("coral.v1.CatalogService", "ListCatalog", Read),
+    rule("coral.v1.CatalogService", "SearchCatalog", Read),
+    rule("coral.v1.CatalogService", "DescribeCatalogSurface", Read),
+    rule("coral.v1.CatalogService", "ListColumns", Read),
+    // Feature flags are host-global rather than workspace-scoped: there is no
+    // workspace whose owner could be entitled to them.
+    rule("coral.v1.FeatureService", "ListFeatures", LocalOnly),
+    rule("coral.v1.FeatureService", "SetFeature", LocalOnly),
+    rule("coral.v1.FeedbackService", "SubmitFeedback", Read),
+    // Listing and using functions is reading; changing the function set
+    // changes what every member of the workspace can run.
+    rule("coral.v1.FunctionService", "ListFunctions", Read),
+    rule("coral.v1.FunctionService", "AddFunction", Manage),
+    rule("coral.v1.FunctionService", "DeleteFunction", Manage),
+    rule("coral.v1.QueryService", "ExecuteSql", Read),
+    rule("coral.v1.QueryService", "ExplainSql", Read),
+    // Searching reads the workspace; rebuilding, draining, and clearing the
+    // index are maintenance of it.
+    rule("coral.v1.SearchService", "Search", Read),
+    rule("coral.v1.SearchService", "RebuildSearchIndex", Manage),
+    rule("coral.v1.SearchService", "DrainSearchQueue", Manage),
+    rule("coral.v1.SearchService", "ClearSearchData", Manage),
+    // Every source RPC manages, including the reads: their responses carry
+    // source configuration and credential metadata. A member-readable source
+    // view needs a separate redacted response before it can be classified
+    // Read.
+    rule("coral.v1.SourceService", "DiscoverSources", Manage),
+    rule("coral.v1.SourceService", "ListSources", Manage),
+    rule("coral.v1.SourceService", "GetSource", Manage),
+    rule("coral.v1.SourceService", "GetSourceInfo", Manage),
+    rule("coral.v1.SourceService", "CreateBundledSource", Manage),
+    rule(
+        "coral.v1.SourceService",
+        "CreateBundledSourceWithOAuth",
+        Manage,
+    ),
+    rule("coral.v1.SourceService", "ImportSource", Manage),
+    rule("coral.v1.SourceService", "DeleteSource", Manage),
+    rule("coral.v1.SourceService", "ValidateSource", Manage),
+    // Task attribution rides along with the reads it labels.
+    rule("coral.v1.TaskService", "StartTask", Read),
+    rule("coral.v1.TaskService", "EndTask", Read),
+    // Traces replay what other callers ran, including their SQL, so reading
+    // them is an owner's power rather than a member's.
+    rule("coral.v1.TraceService", "ListTraces", Manage),
+    rule("coral.v1.TraceService", "GetTrace", Manage),
+    // The caller's own identity is self-scoped; the deployment-wide directory
+    // is not, and ownership is what entitles a caller to read it.
+    rule("coral.v1.UserService", "GetCurrentUser", SelfScoped),
+    rule("coral.v1.UserService", "ListUsers", OwnerDirectory),
+    // Listing returns the caller's own memberships. Creation grants its caller
+    // ownership, which is why an agent credential may not perform it. The rest
+    // change a workspace or who may reach it.
+    rule("coral.v1.WorkspaceService", "ListWorkspaces", SelfScoped),
+    rule("coral.v1.WorkspaceService", "CreateWorkspace", AnyHuman),
+    rule("coral.v1.WorkspaceService", "DeleteWorkspace", Manage),
+    rule("coral.v1.WorkspaceService", "ListWorkspaceMembers", Manage),
+    rule("coral.v1.WorkspaceService", "AddWorkspaceMember", Manage),
+    rule("coral.v1.WorkspaceService", "RemoveWorkspaceMember", Manage),
+];
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::{AUTHORIZATION_MATRIX, Classification, HEALTH_SERVICE};
+
+    /// The protobuf definitions this crate serves.
+    fn proto_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../coral-api/proto/coral/v1")
+    }
+
+    /// Every RPC declared in the shipped protos, as `package.Service/Method`.
+    ///
+    /// This reads the `.proto` sources rather than a hand-kept list so that a
+    /// new RPC — or a whole new service file — is discovered by the test that
+    /// demands a classification for it.
+    fn declared_rpcs() -> BTreeSet<String> {
+        let entries = fs::read_dir(proto_dir()).expect("proto directory is readable");
+        let mut declared = BTreeSet::new();
+        let mut files = 0_usize;
+        for entry in entries {
+            let path = entry.expect("proto directory entry").path();
+            if path.extension().is_none_or(|ext| ext != "proto") {
+                continue;
+            }
+            files += 1;
+            let text = fs::read_to_string(&path).expect("proto file is readable");
+            let mut package: Option<&str> = None;
+            let mut service: Option<&str> = None;
+            for line in text.lines() {
+                let line = line.trim();
+                if line.starts_with("//") {
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("package ") {
+                    package = Some(rest.trim_end_matches(';').trim());
+                } else if let Some(rest) = line.strip_prefix("service ") {
+                    service = Some(rest.trim_end_matches('{').trim());
+                } else if let Some(rest) = line.strip_prefix("rpc ") {
+                    let method = rest
+                        .split('(')
+                        .next()
+                        .expect("split always yields a first part")
+                        .trim();
+                    let package = package.expect("a package precedes the rpc that uses it");
+                    let service = service.expect("a service precedes the rpcs it declares");
+                    declared.insert(format!("{package}.{service}/{method}"));
+                }
+            }
+        }
+        assert!(files > 0, "found no protos to walk under {:?}", proto_dir());
+        declared
+    }
+
+    /// The matrix's own view of the same identifiers.
+    fn classified_rpcs() -> Vec<String> {
+        AUTHORIZATION_MATRIX
+            .iter()
+            .map(|rule| format!("{}/{}", rule.service, rule.method))
+            .collect()
+    }
+
+    #[test]
+    fn no_rpc_is_classified_twice() {
+        let classified = classified_rpcs();
+        let distinct: BTreeSet<&String> = classified.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            classified.len(),
+            "the matrix classifies some RPC more than once"
+        );
+    }
+
+    #[test]
+    fn every_declared_rpc_is_classified_and_no_rule_outlives_its_rpc() {
+        let declared = declared_rpcs();
+        let classified: BTreeSet<String> = classified_rpcs()
+            .into_iter()
+            .filter(|rpc| rpc.starts_with("coral.v1."))
+            .collect();
+
+        let unclassified: Vec<&String> = declared.difference(&classified).collect();
+        assert!(
+            unclassified.is_empty(),
+            "these RPCs exist but no one decided who may call them: {unclassified:?}"
+        );
+        let stale: Vec<&String> = classified.difference(&declared).collect();
+        assert!(
+            stale.is_empty(),
+            "these matrix rules name RPCs that no longer exist: {stale:?}"
+        );
+    }
+
+    /// Liveness is the only surface that answers without a principal. Anything
+    /// else classified `Open` would be an unauthenticated hole, and a liveness
+    /// probe classified otherwise could not answer before authentication.
+    #[test]
+    fn health_and_readiness_are_the_only_open_surface() {
+        for rule in AUTHORIZATION_MATRIX {
+            assert_eq!(
+                rule.classification == Classification::Open,
+                rule.service == HEALTH_SERVICE,
+                "{}/{} disagrees with the rule that only {HEALTH_SERVICE} is open",
+                rule.service,
+                rule.method
+            );
+        }
+    }
+
+    /// Feature state is host-global, and a shared deployment has no superuser
+    /// to entrust it to, so it stays with the local principal.
+    #[test]
+    fn every_feature_rpc_is_local_only() {
+        let features: Vec<&super::RpcRule> = AUTHORIZATION_MATRIX
+            .iter()
+            .filter(|rule| rule.service == "coral.v1.FeatureService")
+            .collect();
+        assert!(!features.is_empty(), "the feature service lost its rules");
+        for rule in features {
+            assert_eq!(
+                rule.classification,
+                Classification::LocalOnly,
+                "{}/{} escaped the local principal",
+                rule.service,
+                rule.method
+            );
+        }
+    }
+
+    /// Source responses carry configuration and credential metadata, so even
+    /// their reads are owner-only until a redacted projection exists.
+    #[test]
+    fn every_source_rpc_requires_manage() {
+        let sources: Vec<&super::RpcRule> = AUTHORIZATION_MATRIX
+            .iter()
+            .filter(|rule| rule.service == "coral.v1.SourceService")
+            .collect();
+        assert!(!sources.is_empty(), "the source service lost its rules");
+        for rule in sources {
+            assert_eq!(
+                rule.classification,
+                Classification::Manage,
+                "{}/{} would expose source configuration to a member",
+                rule.service,
+                rule.method
+            );
+        }
+    }
+}

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -254,7 +254,11 @@ mod tests {
             }
         }
         assert!(files > 0, "found no protos to walk under {:?}", proto_dir());
-        declared.retain(|rpc| !rpc.starts_with(HEALTH_SERVICE));
+        // Matched to the service boundary, not the bare prefix: a future
+        // service merely named like this one would otherwise be dropped from
+        // the declared set and ship unclassified.
+        let health_prefix = format!("{HEALTH_SERVICE}/");
+        declared.retain(|rpc| !rpc.starts_with(&health_prefix));
         declared.extend(mounted_health_rpcs());
         declared
     }

--- a/crates/coral-app/src/authorization_matrix.rs
+++ b/crates/coral-app/src/authorization_matrix.rs
@@ -15,7 +15,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "the declared matrix is proved by its own tests; the enforcement paths that read it land with the per-service authorization work"
+        reason = "the matrix is a declaration proved by its own tests, not a dispatcher: by design no runtime path reads it, so every item is dead outside them"
     )
 )]
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -776,7 +776,12 @@ fn application_routes(
         None => (source, query),
     };
     let health_queries = query.clone();
-    let source_service = SourceService::new(source, query.clone(), workspace.clone());
+    let source_service = SourceService::new(
+        source,
+        query.clone(),
+        workspace.clone(),
+        workspace_authorizer.clone(),
+    );
     let workspace_service = WorkspaceService::new(workspace, workspace_authorizer.clone());
     let user_service = UserService::new(users);
     let catalog_service =

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -447,8 +447,12 @@ impl ServerBuilder {
             CatalogDiscovery::new(query_manager.clone()),
             workspace_lifecycle_lock,
         );
-        let trace_components = trace_components_for_store(active_trace_store);
         let workspace_authorizer = deployment_authorizer(&coral_db, local_principal);
+        let trace_components = trace_components_for_store(
+            active_trace_store,
+            workspace_manager.clone(),
+            workspace_authorizer.clone(),
+        );
         let mut server = start_server(
             ServerDependencies {
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
@@ -552,14 +556,17 @@ fn init_server_telemetry(
 
 fn trace_components_for_store(
     active_trace_store: Option<crate::telemetry::InstalledLocalTraceStore>,
+    workspaces: WorkspaceManager,
+    workspace_authorizer: WorkspaceAuthorizer,
 ) -> TraceServerComponents {
     active_trace_store.map_or_else(TraceServerComponents::default, |store| {
         TraceServerComponents {
             local_trace_store_dir: Some(store.dir.clone()),
-            service: Some(TraceService::new(TraceManager::new(
-                store.dir,
-                store.retention,
-            ))),
+            service: Some(TraceService::new(
+                TraceManager::new(store.dir, store.retention),
+                workspaces,
+                workspace_authorizer,
+            )),
         }
     })
 }
@@ -1837,10 +1844,11 @@ backend = "unsupported"
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
         );
-        let trace_service = TraceService::new(TraceManager::new(
-            temp.path().join("trace-store"),
-            Duration::from_mins(1),
-        ));
+        let trace_service = TraceService::new(
+            TraceManager::new(temp.path().join("trace-store"), Duration::from_mins(1)),
+            workspace_manager.clone(),
+            local_authorizer(&db),
+        );
         let server = start_server(
             ServerDependencies {
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -777,15 +777,17 @@ fn application_routes(
     };
     let health_queries = query.clone();
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
-    let workspace_service = WorkspaceService::new(workspace, workspace_authorizer);
+    let workspace_service = WorkspaceService::new(workspace, workspace_authorizer.clone());
     let user_service = UserService::new(users);
-    let catalog_service = CatalogService::new(query.clone(), task.clone());
+    let catalog_service =
+        CatalogService::new(query.clone(), task.clone(), workspace_authorizer.clone());
     let function_service = FunctionService::new(query.clone());
-    let query_service = QueryService::new(query, task.clone());
+    let query_service = QueryService::new(query, task.clone(), workspace_authorizer.clone());
     let search_service = SearchService::new(search, task.clone());
-    let feedback_service = FeedbackService::new(feedback, task.clone());
+    let feedback_service =
+        FeedbackService::new(feedback, task.clone(), workspace_authorizer.clone());
     let feature_service = FeatureService::new(feature_store, active_features);
-    let task_service = TaskService::new(task);
+    let task_service = TaskService::new(task, workspace_authorizer);
     let gui_onboarding_service = GuiOnboardingService::new(gui_onboarding);
     let mut routes = Routes::default()
         .add_service(GuiOnboardingServiceServer::new(gui_onboarding_service))
@@ -1034,6 +1036,12 @@ enabled = false
 
     fn test_user_manager(db: &Arc<CoralDb>) -> UserManager {
         UserManager::new(Arc::clone(db), WorkspaceAuthorizer::new(Arc::clone(db)))
+    }
+
+    /// The policy these fixtures run under: they serve `LocalPrincipalProvider`,
+    /// which only a single-user deployment admits.
+    fn local_authorizer(db: &Arc<CoralDb>) -> WorkspaceAuthorizer {
+        WorkspaceAuthorizer::trusting_local_principal(Arc::clone(db))
     }
 
     #[tokio::test]
@@ -1833,7 +1841,7 @@ backend = "unsupported"
                 source: source_manager,
                 workspace: workspace_manager,
                 users: test_user_manager(&db),
-                workspace_authorizer: WorkspaceAuthorizer::new(Arc::clone(&db)),
+                workspace_authorizer: local_authorizer(&db),
                 query: query_manager,
                 search: search_manager,
                 search_observations: Some(search_observations),
@@ -1992,7 +2000,7 @@ backend = "unsupported"
                 source: source_manager,
                 workspace: workspace_manager,
                 users: test_user_manager(&db),
-                workspace_authorizer: WorkspaceAuthorizer::new(Arc::clone(&db)),
+                workspace_authorizer: local_authorizer(&db),
                 query: query_manager,
                 search: search_manager,
                 search_observations: Some(search_observations),
@@ -2126,7 +2134,7 @@ tables:
                 source: source_manager,
                 workspace: workspace_manager,
                 users: test_user_manager(&db),
-                workspace_authorizer: WorkspaceAuthorizer::new(Arc::clone(&db)),
+                workspace_authorizer: local_authorizer(&db),
                 query: query_manager,
                 search: search_manager,
                 search_observations: Some(search_observations),
@@ -2260,7 +2268,7 @@ tables:
                 source: source_manager,
                 workspace: workspace_manager,
                 users: test_user_manager(&db),
-                workspace_authorizer: WorkspaceAuthorizer::new(Arc::clone(&db)),
+                workspace_authorizer: local_authorizer(&db),
                 query: query_manager,
                 search: search_manager,
                 search_observations: Some(search_observations),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -781,7 +781,7 @@ fn application_routes(
     let user_service = UserService::new(users);
     let catalog_service =
         CatalogService::new(query.clone(), task.clone(), workspace_authorizer.clone());
-    let function_service = FunctionService::new(query.clone());
+    let function_service = FunctionService::new(query.clone(), workspace_authorizer.clone());
     let query_service = QueryService::new(query, task.clone(), workspace_authorizer.clone());
     let search_service = SearchService::new(search, task.clone(), workspace_authorizer.clone());
     let feedback_service =

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -783,7 +783,7 @@ fn application_routes(
         CatalogService::new(query.clone(), task.clone(), workspace_authorizer.clone());
     let function_service = FunctionService::new(query.clone());
     let query_service = QueryService::new(query, task.clone(), workspace_authorizer.clone());
-    let search_service = SearchService::new(search, task.clone());
+    let search_service = SearchService::new(search, task.clone(), workspace_authorizer.clone());
     let feedback_service =
         FeedbackService::new(feedback, task.clone(), workspace_authorizer.clone());
     let feature_service = FeatureService::new(feature_store, active_features);

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -786,7 +786,8 @@ fn application_routes(
     let search_service = SearchService::new(search, task.clone(), workspace_authorizer.clone());
     let feedback_service =
         FeedbackService::new(feedback, task.clone(), workspace_authorizer.clone());
-    let feature_service = FeatureService::new(feature_store, active_features);
+    let feature_service =
+        FeatureService::new(feature_store, active_features, workspace_authorizer.clone());
     let task_service = TaskService::new(task, workspace_authorizer);
     let gui_onboarding_service = GuiOnboardingService::new(gui_onboarding);
     let mut routes = Routes::default()

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -63,13 +63,18 @@ impl CatalogServiceApi for CatalogService {
             let request = request.into_inner();
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = authorized_query_attribution(
-                &authorizer,
-                &tasks,
-                &workspace_name,
-                &request_context,
-            )
-            .await?;
+            // Access is settled immediately after parsing the workspace: a
+            // caller who may not reach it must not cause a task lookup or a
+            // runtime build, nor learn whether their task id exists.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
@@ -120,13 +125,15 @@ impl CatalogServiceApi for CatalogService {
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = authorized_query_attribution(
-                &authorizer,
-                &tasks,
-                &workspace_name,
-                &request_context,
-            )
-            .await?;
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
@@ -178,13 +185,15 @@ impl CatalogServiceApi for CatalogService {
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = authorized_query_attribution(
-                &authorizer,
-                &tasks,
-                &workspace_name,
-                &request_context,
-            )
-            .await?;
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let catalog_name = optional_exact(&request.catalog_name, "catalog_name")?;
             let schema_name = required_exact(&request.schema_name, "schema_name")?;
             let surface_name = required_exact(&request.surface_name, "surface_name")?;
@@ -216,13 +225,15 @@ impl CatalogServiceApi for CatalogService {
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = authorized_query_attribution(
-                &authorizer,
-                &tasks,
-                &workspace_name,
-                &request_context,
-            )
-            .await?;
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
+            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
             let catalog_name = optional_exact(&request.catalog_name, "catalog_name")?;
             let schema_name = required_exact(&request.schema_name, "schema_name")?;
             let table_name = required_exact(&request.table_name, "table_name")?;
@@ -269,24 +280,14 @@ impl CatalogServiceApi for CatalogService {
     }
 }
 
-/// Settles access to `workspace` before any discovery work, then labels the
-/// work that follows. The order is the point: every catalog RPC reaches this
-/// immediately after parsing its workspace, so a caller who may not reach the
-/// workspace never causes a task lookup or a runtime build.
-async fn authorized_query_attribution(
-    authorizer: &WorkspaceAuthorizer,
+/// Labels catalog work with the caller's task, validating the attribution
+/// against `workspace`. Callers must have already settled workspace access;
+/// this performs no authorization of its own.
+async fn query_attribution(
     tasks: &TaskManager,
     workspace: &WorkspaceName,
     request_context: &RequestContext,
 ) -> Result<QueryAttribution, Status> {
-    authorizer
-        .authorize(
-            request_context.principal(),
-            workspace,
-            WorkspaceAction::Read,
-        )
-        .await
-        .map_err(app_status)?;
     tasks
         .validate_attribution(workspace, request_context.task_id())
         .await

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -25,18 +25,25 @@ use crate::transport::{
     query_status, request_context, workspace_name_from_proto,
 };
 use crate::workspaces::WorkspaceName;
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 
 #[derive(Clone)]
 pub(crate) struct CatalogService {
     catalog: CatalogDiscovery,
     tasks: TaskManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl CatalogService {
-    pub(crate) fn new(query_manager: QueryManager, task_manager: TaskManager) -> Self {
+    pub(crate) fn new(
+        query_manager: QueryManager,
+        task_manager: TaskManager,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
         Self {
             catalog: CatalogDiscovery::new(query_manager),
             tasks: task_manager,
+            authorizer,
         }
     }
 }
@@ -50,12 +57,19 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let attribution = authorized_query_attribution(
+                &authorizer,
+                &tasks,
+                &workspace_name,
+                &request_context,
+            )
+            .await?;
             let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
@@ -101,11 +115,18 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let attribution = authorized_query_attribution(
+                &authorizer,
+                &tasks,
+                &workspace_name,
+                &request_context,
+            )
+            .await?;
             let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
@@ -152,11 +173,18 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let attribution = authorized_query_attribution(
+                &authorizer,
+                &tasks,
+                &workspace_name,
+                &request_context,
+            )
+            .await?;
             let catalog_name = optional_exact(&request.catalog_name, "catalog_name")?;
             let schema_name = required_exact(&request.schema_name, "schema_name")?;
             let surface_name = required_exact(&request.surface_name, "surface_name")?;
@@ -183,11 +211,18 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let attribution = authorized_query_attribution(
+                &authorizer,
+                &tasks,
+                &workspace_name,
+                &request_context,
+            )
+            .await?;
             let catalog_name = optional_exact(&request.catalog_name, "catalog_name")?;
             let schema_name = required_exact(&request.schema_name, "schema_name")?;
             let table_name = required_exact(&request.table_name, "table_name")?;
@@ -234,11 +269,24 @@ impl CatalogServiceApi for CatalogService {
     }
 }
 
-async fn query_attribution(
+/// Settles access to `workspace` before any discovery work, then labels the
+/// work that follows. The order is the point: every catalog RPC reaches this
+/// immediately after parsing its workspace, so a caller who may not reach the
+/// workspace never causes a task lookup or a runtime build.
+async fn authorized_query_attribution(
+    authorizer: &WorkspaceAuthorizer,
     tasks: &TaskManager,
     workspace: &WorkspaceName,
     request_context: &RequestContext,
 ) -> Result<QueryAttribution, Status> {
+    authorizer
+        .authorize(
+            request_context.principal(),
+            workspace,
+            WorkspaceAction::Read,
+        )
+        .await
+        .map_err(app_status)?;
     tasks
         .validate_attribution(workspace, request_context.task_id())
         .await

--- a/crates/coral-app/src/features/service.rs
+++ b/crates/coral-app/src/features/service.rs
@@ -8,9 +8,11 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::bootstrap::app_status;
+use crate::bootstrap::{AppError, app_status};
 use crate::features::{FeatureConfiguredState, FeatureStatus, FeatureStore, Features};
-use crate::transport::{grpc_span, instrument_grpc};
+use crate::identity::{LOCAL_PRINCIPAL_ID, Principal};
+use crate::transport::{grpc_span, instrument_grpc, request_context};
+use crate::workspaces::authorization::WorkspaceAuthorizer;
 
 /// Serves the runtime feature registry over gRPC.
 ///
@@ -22,11 +24,36 @@ use crate::transport::{grpc_span, instrument_grpc};
 pub(crate) struct FeatureService {
     store: FeatureStore,
     active: Features,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl FeatureService {
-    pub(crate) fn new(store: FeatureStore, active: Features) -> Self {
-        Self { store, active }
+    pub(crate) const fn new(
+        store: FeatureStore,
+        active: Features,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
+        Self {
+            store,
+            active,
+            authorizer,
+        }
+    }
+
+    /// Settles access to host-global feature state.
+    ///
+    /// Features configure the machine this server runs on rather than any one
+    /// workspace, so no workspace role can entitle a caller to them and a
+    /// shared deployment has no superuser to entrust them to. Only the
+    /// built-in local principal reaches them, and only where the deployment
+    /// admits that principal at all.
+    fn authorize_host_global(&self, principal: &Principal) -> Result<(), Status> {
+        if principal.id().as_str() != LOCAL_PRINCIPAL_ID {
+            return Err(app_status(AppError::PermissionDenied(
+                "runtime features are configured on the host that runs this server".to_string(),
+            )));
+        }
+        self.authorizer.admit(principal).map_err(app_status)
     }
 
     fn status_to_proto(&self, status: &FeatureStatus) -> ProtoFeatureStatus {
@@ -48,7 +75,12 @@ impl FeatureServiceApi for FeatureService {
         request: Request<ListFeaturesRequest>,
     ) -> Result<Response<ListFeaturesResponse>, Status> {
         let span = grpc_span(&request);
+        let principal = request_context(&request)?.principal().clone();
         instrument_grpc(span, async move {
+            // Settled before the feature store is read at all: a caller this
+            // deployment does not entrust with host state learns nothing from
+            // it, not even whether its config file parses.
+            self.authorize_host_global(&principal)?;
             let features = self
                 .store
                 .statuses()
@@ -66,8 +98,13 @@ impl FeatureServiceApi for FeatureService {
         request: Request<SetFeatureRequest>,
     ) -> Result<Response<SetFeatureResponse>, Status> {
         let span = grpc_span(&request);
+        let principal = request_context(&request)?.principal().clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
+            // Settled before the key is looked up, so a refused caller cannot
+            // use the registry's own complaint to enumerate feature keys, and
+            // writes nothing to the host's config file.
+            self.authorize_host_global(&principal)?;
             if request.enabled {
                 self.store.enable(&request.key).map_err(app_status)?;
             } else {
@@ -100,23 +137,62 @@ fn configured_state_to_proto(state: FeatureConfiguredState) -> ProtoFeatureConfi
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use tempfile::TempDir;
     use tonic::Code;
 
     use super::*;
     use crate::features::{Feature, FeatureOverrides};
+    use crate::identity::PrincipalKind;
+    use crate::request_context::RequestContext;
+    use crate::state::db::{CoralDb, ResolvedDatabaseConfig};
+    use crate::workspaces::authorization::LocalPrincipalPolicy;
 
-    fn service_for(config_dir: &std::path::Path, active: Features) -> FeatureService {
+    /// An authorizer over a database that was never migrated, under the policy
+    /// a single-user deployment resolves. Every membership query against it
+    /// fails, so a decision this service still reaches was reached without one.
+    async fn local_authorizer(temp: &TempDir) -> WorkspaceAuthorizer {
+        authorizer_with(temp, LocalPrincipalPolicy::ImplicitOwner).await
+    }
+
+    async fn authorizer_with(temp: &TempDir, policy: LocalPrincipalPolicy) -> WorkspaceAuthorizer {
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        WorkspaceAuthorizer::with_local_principal_policy(Arc::new(db), policy)
+    }
+
+    fn service_for(
+        config_dir: &std::path::Path,
+        active: Features,
+        authorizer: WorkspaceAuthorizer,
+    ) -> FeatureService {
         let store = FeatureStore::discover(Some(config_dir.to_path_buf())).expect("feature store");
-        FeatureService::new(store, active)
+        FeatureService::new(store, active, authorizer)
+    }
+
+    fn request<T>(message: T, principal: Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal));
+        request
+    }
+
+    fn local<T>(message: T) -> Request<T> {
+        request(message, Principal::local())
     }
 
     #[tokio::test]
     async fn list_features_reports_every_registry_entry() {
         let temp = TempDir::new().expect("temp dir");
+        let authorizer = local_authorizer(&temp).await;
 
-        let response = service_for(&temp.path().join("config"), Features::default())
-            .list_features(Request::new(ListFeaturesRequest {}))
+        let response = service_for(&temp.path().join("config"), Features::default(), authorizer)
+            .list_features(local(ListFeaturesRequest {}))
             .await
             .expect("list features")
             .into_inner();
@@ -141,11 +217,12 @@ mod tests {
     async fn set_feature_persists_the_override_and_reports_the_pending_restart() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("config");
+        let authorizer = local_authorizer(&temp).await;
         // A server that booted before the override still runs with the feature off.
-        let service = service_for(&config_dir, Features::default());
+        let service = service_for(&config_dir, Features::default(), authorizer);
 
         let response = service
-            .set_feature(Request::new(SetFeatureRequest {
+            .set_feature(local(SetFeatureRequest {
                 key: "feedback".to_string(),
                 enabled: true,
             }))
@@ -176,9 +253,10 @@ mod tests {
             "[features]\nobserved_values_search = true\n",
         )
         .expect("write config");
+        let authorizer = local_authorizer(&temp).await;
 
-        let response = service_for(&config_dir, Features::default())
-            .list_features(Request::new(ListFeaturesRequest {}))
+        let response = service_for(&config_dir, Features::default(), authorizer)
+            .list_features(local(ListFeaturesRequest {}))
             .await
             .expect("list features")
             .into_inner();
@@ -208,8 +286,8 @@ mod tests {
             .expect("boot features");
         assert!(active.enabled(Feature::Feedback));
 
-        let response = FeatureService::new(store, active)
-            .list_features(Request::new(ListFeaturesRequest {}))
+        let response = FeatureService::new(store, active, local_authorizer(&temp).await)
+            .list_features(local(ListFeaturesRequest {}))
             .await
             .expect("list features")
             .into_inner();
@@ -243,8 +321,8 @@ mod tests {
             .expect("boot features");
         assert!(!active.enabled(Feature::Feedback));
 
-        let response = FeatureService::new(store, active)
-            .list_features(Request::new(ListFeaturesRequest {}))
+        let response = FeatureService::new(store, active, local_authorizer(&temp).await)
+            .list_features(local(ListFeaturesRequest {}))
             .await
             .expect("list features")
             .into_inner();
@@ -262,9 +340,10 @@ mod tests {
     #[tokio::test]
     async fn set_feature_rejects_an_unknown_key() {
         let temp = TempDir::new().expect("temp dir");
+        let authorizer = local_authorizer(&temp).await;
 
-        let status = service_for(&temp.path().join("config"), Features::default())
-            .set_feature(Request::new(SetFeatureRequest {
+        let status = service_for(&temp.path().join("config"), Features::default(), authorizer)
+            .set_feature(local(SetFeatureRequest {
                 key: "nope".to_string(),
                 enabled: true,
             }))
@@ -273,5 +352,78 @@ mod tests {
 
         assert_eq!(status.code(), Code::InvalidArgument);
         assert!(status.message().contains("unknown feature 'nope'"));
+    }
+
+    /// Host-global state has no workspace to scope to, so it reaches only the
+    /// local principal, and only where the deployment admits it: a federated
+    /// caller is refused even under the policy that hands `coral:local`
+    /// everything, and `coral:local` itself is refused on a shared deployment.
+    ///
+    /// The probes are what make each refusal an absence rather than an error
+    /// code: the config file is unparseable, so a read would choke on it, and
+    /// `nope` is a key the registry would reject. Every refusal answers
+    /// `PermissionDenied` instead, the file keeps the bytes it started with,
+    /// and the admitted caller does hit the parse failure — which is what
+    /// proves the others never attempted the read.
+    #[tokio::test]
+    async fn feature_state_reaches_only_a_local_principal_the_deployment_admits() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let config_file = config_dir.join("config.toml");
+        std::fs::write(&config_file, "[features\n").expect("write unparseable config");
+        let someone = Principal::parse("someone", PrincipalKind::User).expect("federated user");
+        let single_user = service_for(
+            &config_dir,
+            Features::default(),
+            local_authorizer(&temp).await,
+        );
+        let shared = service_for(
+            &config_dir,
+            Features::default(),
+            authorizer_with(&temp, LocalPrincipalPolicy::NoLocalPrincipal).await,
+        );
+
+        for (service, principal) in [
+            (&single_user, someone.clone()),
+            (&shared, someone),
+            (&shared, Principal::local()),
+        ] {
+            assert_eq!(
+                service
+                    .list_features(request(ListFeaturesRequest {}, principal.clone()))
+                    .await
+                    .expect_err("this caller inspects nothing")
+                    .code(),
+                Code::PermissionDenied
+            );
+            assert_eq!(
+                service
+                    .set_feature(request(
+                        SetFeatureRequest {
+                            key: "nope".to_string(),
+                            enabled: true,
+                        },
+                        principal,
+                    ))
+                    .await
+                    .expect_err("this caller mutates nothing")
+                    .code(),
+                Code::PermissionDenied
+            );
+        }
+        assert_eq!(
+            std::fs::read_to_string(&config_file).expect("config file"),
+            "[features\n",
+            "a refused caller must not have rewritten the host's config"
+        );
+        assert_eq!(
+            single_user
+                .list_features(local(ListFeaturesRequest {}))
+                .await
+                .expect_err("the admitted local principal does reach the file")
+                .code(),
+            Code::Internal
+        );
     }
 }

--- a/crates/coral-app/src/features/service.rs
+++ b/crates/coral-app/src/features/service.rs
@@ -8,9 +8,9 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::bootstrap::{AppError, app_status};
+use crate::bootstrap::app_status;
 use crate::features::{FeatureConfiguredState, FeatureStatus, FeatureStore, Features};
-use crate::identity::{LOCAL_PRINCIPAL_ID, Principal};
+use crate::identity::Principal;
 use crate::transport::{grpc_span, instrument_grpc, request_context};
 use crate::workspaces::authorization::WorkspaceAuthorizer;
 
@@ -40,20 +40,17 @@ impl FeatureService {
         }
     }
 
-    /// Settles access to host-global feature state.
+    /// Settles who may change host-global feature state.
     ///
     /// Features configure the machine this server runs on rather than any one
-    /// workspace, so no workspace role can entitle a caller to them and a
-    /// shared deployment has no superuser to entrust them to. Only the
-    /// built-in local principal reaches them, and only where the deployment
-    /// admits that principal at all.
+    /// workspace, so no workspace role can entitle a caller to change them and
+    /// a shared deployment has no superuser to entrust them to. The rule
+    /// itself lives with its siblings on the authorizer; this is only where
+    /// its refusal becomes a gRPC status.
     fn authorize_host_global(&self, principal: &Principal) -> Result<(), Status> {
-        if principal.id().as_str() != LOCAL_PRINCIPAL_ID {
-            return Err(app_status(AppError::PermissionDenied(
-                "runtime features are configured on the host that runs this server".to_string(),
-            )));
-        }
-        self.authorizer.admit(principal).map_err(app_status)
+        self.authorizer
+            .authorize_host_global(principal)
+            .map_err(app_status)
     }
 
     fn status_to_proto(&self, status: &FeatureStatus) -> ProtoFeatureStatus {
@@ -77,10 +74,14 @@ impl FeatureServiceApi for FeatureService {
         let span = grpc_span(&request);
         let principal = request_context(&request)?.principal().clone();
         instrument_grpc(span, async move {
-            // Settled before the feature store is read at all: a caller this
-            // deployment does not entrust with host state learns nothing from
-            // it, not even whether its config file parses.
-            self.authorize_host_global(&principal)?;
+            // Reading is open to every caller this deployment admits: the
+            // response carries the same feature keys, descriptions, and
+            // enabled state for all of them, and a page that cannot read it
+            // cannot explain why its switches do nothing. Changing that state
+            // is what stays with the host. Settled before the feature store is
+            // read at all, so an unadmitted caller learns nothing from it, not
+            // even whether its config file parses.
+            self.authorizer.admit(&principal).map_err(app_status)?;
             let features = self
                 .store
                 .statuses()
@@ -354,19 +355,19 @@ mod tests {
         assert!(status.message().contains("unknown feature 'nope'"));
     }
 
-    /// Host-global state has no workspace to scope to, so it reaches only the
-    /// local principal, and only where the deployment admits it: a federated
-    /// caller is refused even under the policy that hands `coral:local`
-    /// everything, and `coral:local` itself is refused on a shared deployment.
+    /// Changing feature state has no workspace to scope to, so it reaches only
+    /// the local principal, and only where the deployment admits it: a
+    /// federated caller is refused even under the policy that hands
+    /// `coral:local` everything, and `coral:local` itself is refused on a
+    /// shared deployment.
     ///
     /// The probes are what make each refusal an absence rather than an error
-    /// code: the config file is unparseable, so a read would choke on it, and
-    /// `nope` is a key the registry would reject. Every refusal answers
-    /// `PermissionDenied` instead, the file keeps the bytes it started with,
-    /// and the admitted caller does hit the parse failure — which is what
-    /// proves the others never attempted the read.
+    /// code: `nope` is a key the registry would reject, and the config file is
+    /// unparseable, so a caller that reached the store at all would choke on
+    /// it. Every refusal answers `PermissionDenied` instead and the file keeps
+    /// the bytes it started with.
     #[tokio::test]
-    async fn feature_state_reaches_only_a_local_principal_the_deployment_admits() {
+    async fn changing_feature_state_reaches_only_a_local_principal_the_deployment_admits() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("config");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
@@ -391,14 +392,6 @@ mod tests {
         ] {
             assert_eq!(
                 service
-                    .list_features(request(ListFeaturesRequest {}, principal.clone()))
-                    .await
-                    .expect_err("this caller inspects nothing")
-                    .code(),
-                Code::PermissionDenied
-            );
-            assert_eq!(
-                service
                     .set_feature(request(
                         SetFeatureRequest {
                             key: "nope".to_string(),
@@ -417,13 +410,53 @@ mod tests {
             "[features\n",
             "a refused caller must not have rewritten the host's config"
         );
+    }
+
+    /// Reading feature state is the half that is not host-global: the page
+    /// that shows the switches has to say which ones are on, so every caller
+    /// this deployment admits reaches it. Hitting the unparseable file is what
+    /// proves the read was attempted rather than refused early — and the
+    /// principal the deployment does not admit is still turned away before it.
+    #[tokio::test]
+    async fn listing_feature_state_reaches_every_caller_the_deployment_admits() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(config_dir.join("config.toml"), "[features\n")
+            .expect("write unparseable config");
+        let someone = Principal::parse("someone", PrincipalKind::User).expect("federated user");
+        let single_user = service_for(
+            &config_dir,
+            Features::default(),
+            local_authorizer(&temp).await,
+        );
+        let shared = service_for(
+            &config_dir,
+            Features::default(),
+            authorizer_with(&temp, LocalPrincipalPolicy::NoLocalPrincipal).await,
+        );
+
+        for (service, principal) in [
+            (&single_user, someone.clone()),
+            (&single_user, Principal::local()),
+            (&shared, someone),
+        ] {
+            assert_eq!(
+                service
+                    .list_features(request(ListFeaturesRequest {}, principal))
+                    .await
+                    .expect_err("an admitted caller reaches the file")
+                    .code(),
+                Code::Internal
+            );
+        }
         assert_eq!(
-            single_user
+            shared
                 .list_features(local(ListFeaturesRequest {}))
                 .await
-                .expect_err("the admitted local principal does reach the file")
+                .expect_err("a shared deployment admits the local principal to nothing")
                 .code(),
-            Code::Internal
+            Code::PermissionDenied
         );
     }
 }

--- a/crates/coral-app/src/features/service.rs
+++ b/crates/coral-app/src/features/service.rs
@@ -414,9 +414,12 @@ mod tests {
 
     /// Reading feature state is the half that is not host-global: the page
     /// that shows the switches has to say which ones are on, so every caller
-    /// this deployment admits reaches it. Hitting the unparseable file is what
-    /// proves the read was attempted rather than refused early — and the
-    /// principal the deployment does not admit is still turned away before it.
+    /// this deployment admits reaches it. A well-formed config proves the read
+    /// answers rather than merely passing the gate, and the unparseable one
+    /// proves the read was attempted rather than refused early — a refusal and
+    /// a broken listing would otherwise be indistinguishable here. The
+    /// principal the deployment does not admit is still turned away before
+    /// either.
     #[tokio::test]
     async fn listing_feature_state_reaches_every_caller_the_deployment_admits() {
         let temp = TempDir::new().expect("temp dir");
@@ -457,6 +460,34 @@ mod tests {
                 .expect_err("a shared deployment admits the local principal to nothing")
                 .code(),
             Code::PermissionDenied
+        );
+
+        // Reaching the read is not the same as the read working: with the file
+        // readable, an admitted caller must actually be answered, or a listing
+        // broken anywhere past the gate would still satisfy everything above.
+        let readable = TempDir::new().expect("temp dir");
+        let readable_dir = readable.path().join("config");
+        std::fs::create_dir_all(&readable_dir).expect("create config dir");
+        let service = service_for(
+            &readable_dir,
+            Features::default(),
+            authorizer_with(&readable, LocalPrincipalPolicy::NoLocalPrincipal).await,
+        );
+        let listed = service
+            .list_features(request(
+                ListFeaturesRequest {},
+                Principal::parse("someone", PrincipalKind::User).expect("federated user"),
+            ))
+            .await
+            .expect("an admitted caller is answered")
+            .into_inner();
+        assert!(
+            !listed.features.is_empty(),
+            "the listing must carry the features this build ships"
+        );
+        assert!(
+            listed.features.iter().all(|status| !status.key.is_empty()),
+            "every listed feature must name itself"
         );
     }
 }

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -99,16 +99,20 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{FeedbackService, FeedbackServiceApi, SubmitFeedbackRequest};
-    use crate::identity::{Principal, PrincipalKind};
+    use crate::identity::Principal;
     use crate::request_context::RequestContext;
     use crate::state::AppStateLayout;
-    use crate::state::db::{
-        CoralDb, DbRepos as _, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
-    };
+    use crate::state::db::{CoralDb, DbRepos as _, ResolvedDatabaseConfig};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::test_support::seed_principal;
     use crate::workspaces::authorization::WorkspaceAuthorizer;
     use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// This suite's login issuer. Each suite provisions under its own, so a
+    /// subject seeded here is a different person from the same subject
+    /// seeded elsewhere.
+    const ISSUER: &str = "https://issuer.test/feedback-authorization";
 
     /// A report is filed under the workspace and published onward from it, so a
     /// caller who may not reach the workspace files nothing. The blank fields
@@ -136,9 +140,9 @@ mod tests {
         tx.commit().await.expect("commit workspace creation");
         // The workspace needs an owner before any membership in it grants
         // anything, so one is seeded beside the member under test.
-        let _owner = seed_principal(&db, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&db, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&db, "outsider", None).await;
+        let _owner = seed_principal(&db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&db, ISSUER, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&db, ISSUER, "outsider", None).await;
         let workspace = WorkspaceName::default();
         let service = FeedbackService::new(
             crate::feedback::manager::FeedbackManager::new(layout.clone()),
@@ -184,39 +188,6 @@ mod tests {
         let raw = fs::read_to_string(layout.feedback_reports_file(&workspace))
             .expect("feedback file should exist");
         assert_eq!(raw.lines().count(), 1);
-    }
-
-    /// Provisions one directory user through the production login seam and
-    /// grants it `role` on the default workspace, so the principal the
-    /// authorizer is handed is the one a real login carries.
-    async fn seed_principal(
-        db: &Arc<CoralDb>,
-        subject: &str,
-        role: Option<MemberRole>,
-    ) -> Principal {
-        let LoginProvisioning::Provisioned(user) = db
-            .user_state()
-            .provision_login(LoginIdentity {
-                issuer: "https://issuer.test/feedback-authorization",
-                subject,
-                display_name: None,
-                principal_claim: subject,
-                now_unix_nanos: 1,
-            })
-            .await
-            .expect("provision user")
-        else {
-            panic!("expected a provisioned user rather than an issuer mismatch")
-        };
-        if let Some(role) = role {
-            let mut session = db.as_ref();
-            session
-                .workspace_members()
-                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
-                .await
-                .expect("grant membership");
-        }
-        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
     }
 
     fn request<T>(message: T, principal: Principal) -> Request<T> {

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -11,18 +11,25 @@ use crate::task::service::task_manager_status;
 use crate::transport::{
     grpc_span, instrument_grpc, request_context, workspace_name_from_proto, workspace_to_proto,
 };
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 
 #[derive(Clone)]
 pub(crate) struct FeedbackService {
     feedback: FeedbackManager,
     tasks: TaskManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl FeedbackService {
-    pub(crate) fn new(feedback: FeedbackManager, task_manager: TaskManager) -> Self {
+    pub(crate) const fn new(
+        feedback: FeedbackManager,
+        task_manager: TaskManager,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
         Self {
             feedback,
             tasks: task_manager,
+            authorizer,
         }
     }
 }
@@ -36,10 +43,21 @@ impl FeedbackServiceApi for FeedbackService {
         let span = grpc_span(&request);
         let feedback = self.feedback.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            // A report is filed under the workspace and published onward from
+            // it, so a caller who may not reach the workspace files nothing.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
             let task_id = tasks
                 .validate_attribution(&workspace_name, request_context.task_id())
                 .await
@@ -69,5 +87,143 @@ fn feedback_report_to_proto(report: FeedbackReport) -> ProtoFeedbackReport {
         trying_to_do: report.trying_to_do,
         tried: report.tried,
         stuck: report.stuck,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+    use tonic::{Code, Request};
+
+    use super::{FeedbackService, FeedbackServiceApi, SubmitFeedbackRequest};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::request_context::RequestContext;
+    use crate::state::AppStateLayout;
+    use crate::state::db::{
+        CoralDb, DbRepos as _, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
+    };
+    use crate::task::manager::TaskManager;
+    use crate::task::store::TaskStore;
+    use crate::workspaces::authorization::WorkspaceAuthorizer;
+    use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// A report is filed under the workspace and published onward from it, so a
+    /// caller who may not reach the workspace files nothing. The blank fields
+    /// are the probe: reaching the manager at all would answer
+    /// `InvalidArgument` instead of the ordinary workspace miss.
+    #[tokio::test]
+    async fn submit_feedback_deny_before_read_work_publishes_nothing() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        layout.ensure().expect("ensure layout");
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+                path: temp.path().join("coral.sqlite"),
+            })
+            .await
+            .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let mut tx = db.begin().await.expect("begin workspace creation");
+        tx.workspaces()
+            .ensure(WorkspaceName::default().as_str(), 1)
+            .await
+            .expect("seed the default workspace");
+        tx.commit().await.expect("commit workspace creation");
+        // The workspace needs an owner before any membership in it grants
+        // anything, so one is seeded beside the member under test.
+        let _owner = seed_principal(&db, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&db, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&db, "outsider", None).await;
+        let workspace = WorkspaceName::default();
+        let service = FeedbackService::new(
+            crate::feedback::manager::FeedbackManager::new(layout.clone()),
+            TaskManager::new(TaskStore::new(Arc::clone(&db))),
+            WorkspaceAuthorizer::new(db),
+        );
+
+        for name in [workspace.as_str(), "absent"] {
+            let status = service
+                .submit_feedback(request(
+                    SubmitFeedbackRequest {
+                        workspace: Some(crate::transport::workspace_to_proto(
+                            &WorkspaceName::parse(name).expect("workspace name"),
+                        )),
+                        trying_to_do: " ".to_string(),
+                        tried: " ".to_string(),
+                        stuck: " ".to_string(),
+                    },
+                    outsider.clone(),
+                ))
+                .await
+                .expect_err("a non-member files nothing");
+            assert_eq!(status.code(), Code::NotFound);
+        }
+        assert!(
+            !layout.feedback_reports_file(&workspace).exists(),
+            "a denied submission must not create the workspace's report file"
+        );
+
+        service
+            .submit_feedback(request(
+                SubmitFeedbackRequest {
+                    workspace: Some(crate::transport::workspace_to_proto(&workspace)),
+                    trying_to_do: "trying".to_string(),
+                    tried: "tried".to_string(),
+                    stuck: "stuck".to_string(),
+                },
+                member,
+            ))
+            .await
+            .expect("a member files a report");
+
+        let raw = fs::read_to_string(layout.feedback_reports_file(&workspace))
+            .expect("feedback file should exist");
+        assert_eq!(raw.lines().count(), 1);
+    }
+
+    /// Provisions one directory user through the production login seam and
+    /// grants it `role` on the default workspace, so the principal the
+    /// authorizer is handed is the one a real login carries.
+    async fn seed_principal(
+        db: &Arc<CoralDb>,
+        subject: &str,
+        role: Option<MemberRole>,
+    ) -> Principal {
+        let LoginProvisioning::Provisioned(user) = db
+            .user_state()
+            .provision_login(LoginIdentity {
+                issuer: "https://issuer.test/feedback-authorization",
+                subject,
+                display_name: None,
+                principal_claim: subject,
+                now_unix_nanos: 1,
+            })
+            .await
+            .expect("provision user")
+        else {
+            panic!("expected a provisioned user rather than an issuer mismatch")
+        };
+        if let Some(role) = role {
+            let mut session = db.as_ref();
+            session
+                .workspace_members()
+                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+                .await
+                .expect("grant membership");
+        }
+        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
+    }
+
+    fn request<T>(message: T, principal: Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal));
+        request
     }
 }

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -15,19 +15,23 @@ use crate::functions::manager::{FunctionInstallMode, FunctionListing, FunctionRu
 use crate::functions::model::{FunctionName, FunctionWriteSurface};
 use crate::query::manager::QueryManager;
 use crate::transport::{
-    grpc_span, instrument_grpc, query_status, workspace_name_from_proto, workspace_to_proto,
+    grpc_span, instrument_grpc, query_status, request_context, workspace_name_from_proto,
+    workspace_to_proto,
 };
 use crate::workspaces::WorkspaceName;
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 
 #[derive(Clone)]
 pub(crate) struct FunctionService {
     queries: QueryManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl FunctionService {
-    pub(crate) fn new(query_manager: QueryManager) -> Self {
+    pub(crate) const fn new(query_manager: QueryManager, authorizer: WorkspaceAuthorizer) -> Self {
         Self {
             queries: query_manager,
+            authorizer,
         }
     }
 }
@@ -40,9 +44,23 @@ impl FunctionServiceApi for FunctionService {
     ) -> Result<Response<AddFunctionResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            // A function is installed for the whole workspace, so adding one
+            // changes what every member can run. Settled before the SQL is
+            // read: a caller who may not manage the workspace must not learn
+            // from it whether their SQL compiles against its catalog.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Manage,
+                )
+                .await
+                .map_err(app_status)?;
             let mode = if inner.fail_if_exists {
                 FunctionInstallMode::CreateOnly
             } else {
@@ -72,9 +90,20 @@ impl FunctionServiceApi for FunctionService {
     ) -> Result<Response<ListFunctionsResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            // Listing what a workspace can run is reading its contents.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
             let functions = queries
                 .list_functions(&workspace_name)
                 .await
@@ -93,9 +122,21 @@ impl FunctionServiceApi for FunctionService {
     ) -> Result<Response<DeleteFunctionResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            // Settled before the name is parsed, so the workspace's function
+            // inventory stays unreadable to a caller who may not manage it.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Manage,
+                )
+                .await
+                .map_err(app_status)?;
             let function_name = FunctionName::parse(&inner.name).map_err(app_status)?;
             queries
                 .function_manager()
@@ -195,7 +236,224 @@ fn function_table_function_publish_to_proto(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use coral_engine::QueryRuntimeContext;
+    use tempfile::TempDir;
+    use tonic::Code;
+
     use super::*;
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::request_context::RequestContext;
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
+        ResolvedDatabaseConfig, run_state_migrations,
+    };
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::manager::WorkspaceManager;
+    use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// SQL no compiler accepts. Reaching function installation with it answers
+    /// `InvalidArgument`, so a refusal that answers anything else proves the
+    /// SQL was never looked at.
+    const UNPARSEABLE_SQL: &str = "this is not sql";
+
+    struct Fixture {
+        _temp: TempDir,
+        service: FunctionService,
+        config_store: ConfigStore,
+        db: Arc<CoralDb>,
+    }
+
+    /// A shared deployment over one migrated database holding the default
+    /// workspace, so every caller's authority comes from a membership row.
+    async fn fixture() -> Fixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("the default test database is sqlite")
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("import the default workspace");
+        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let workspaces = WorkspaceManager::new_for_tests(
+            config_store.clone(),
+            credentials.clone(),
+            layout.clone(),
+            None,
+            Arc::clone(&db),
+        );
+        let queries = QueryManager::new_for_tests(
+            config_store.clone(),
+            workspaces,
+            credentials,
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+        Fixture {
+            _temp: temp,
+            service: FunctionService::new(queries, WorkspaceAuthorizer::new(Arc::clone(&db))),
+            config_store,
+            db,
+        }
+    }
+
+    /// Provisions one directory user through the production login seam and
+    /// grants it `role` on the default workspace, so the principal the
+    /// authorizer is handed is the one a real login carries.
+    async fn seed_principal(
+        db: &Arc<CoralDb>,
+        subject: &str,
+        role: Option<MemberRole>,
+    ) -> Principal {
+        let LoginProvisioning::Provisioned(user) = db
+            .user_state()
+            .provision_login(LoginIdentity {
+                issuer: "https://issuer.test/function-authorization",
+                subject,
+                display_name: None,
+                principal_claim: subject,
+                now_unix_nanos: 1,
+            })
+            .await
+            .expect("provision user")
+        else {
+            panic!("expected a provisioned user rather than an issuer mismatch")
+        };
+        if let Some(role) = role {
+            let mut session = db.as_ref();
+            session
+                .workspace_members()
+                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+                .await
+                .expect("grant membership");
+        }
+        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
+    }
+
+    fn request<T>(message: T, principal: &Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal.clone()));
+        request
+    }
+
+    fn default_workspace() -> coral_api::v1::Workspace {
+        crate::transport::workspace_to_proto(&WorkspaceName::default())
+    }
+
+    fn add_request() -> AddFunctionRequest {
+        AddFunctionRequest {
+            workspace: Some(default_workspace()),
+            sql: UNPARSEABLE_SQL.to_string(),
+            fail_if_exists: false,
+            write_surface: ProtoFunctionWriteSurface::Cli as i32,
+        }
+    }
+
+    fn delete_request() -> DeleteFunctionRequest {
+        DeleteFunctionRequest {
+            workspace: Some(default_workspace()),
+            name: "not a function name".to_string(),
+        }
+    }
+
+    fn list_request() -> ListFunctionsRequest {
+        ListFunctionsRequest {
+            workspace: Some(default_workspace()),
+        }
+    }
+
+    /// Installing a function changes what every member of the workspace can
+    /// run, so it is an owner's act while listing is a member's — and the
+    /// owner's own agent credential is not promoted by their role, so a
+    /// prompt-injected agent cannot publish SQL every member then runs.
+    ///
+    /// The unparseable SQL and the unparseable function name are what make
+    /// each refusal an absence rather than an error code: the owner reaches
+    /// the work and is told what is wrong with the request, and everyone else
+    /// is refused before the request is looked at.
+    #[tokio::test]
+    async fn only_owners_change_the_function_set_and_never_through_an_agent() {
+        let fixture = fixture().await;
+        let owner = seed_principal(&fixture.db, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, "outsider", None).await;
+        let agent = Principal::parse(owner.id().as_str(), PrincipalKind::Agent).expect("agent");
+
+        for reader in [&member, &agent] {
+            let listed = fixture
+                .service
+                .list_functions(request(list_request(), reader))
+                .await
+                .expect("a member, and a member's agent, read the function set")
+                .into_inner();
+            assert!(listed.functions.is_empty());
+        }
+        assert_eq!(
+            fixture
+                .service
+                .list_functions(request(list_request(), &outsider))
+                .await
+                .expect_err("a non-member is told nothing about the workspace")
+                .code(),
+            Code::NotFound
+        );
+
+        // A member and an owner's agent are denied; a non-member is concealed.
+        for (writer, expected) in [
+            (&member, Code::PermissionDenied),
+            (&agent, Code::PermissionDenied),
+            (&outsider, Code::NotFound),
+        ] {
+            for status in [
+                fixture
+                    .service
+                    .add_function(request(add_request(), writer))
+                    .await
+                    .expect_err("only an owner installs a function"),
+                fixture
+                    .service
+                    .delete_function(request(delete_request(), writer))
+                    .await
+                    .expect_err("only an owner removes a function"),
+            ] {
+                assert_eq!(status.code(), expected, "{status:?}");
+            }
+        }
+
+        assert_eq!(
+            fixture
+                .service
+                .add_function(request(add_request(), &owner))
+                .await
+                .expect_err("the SQL is what the owner is stopped by")
+                .code(),
+            Code::InvalidArgument
+        );
+        assert!(
+            fixture
+                .config_store
+                .list_workspace_functions(&WorkspaceName::default())
+                .expect("list installed functions")
+                .is_empty(),
+            "no refused caller may have installed a function"
+        );
+    }
 
     #[test]
     fn invalid_function_listing_keeps_inventory_identity_and_error() {

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -243,16 +243,17 @@ mod tests {
     use tonic::Code;
 
     use super::*;
-    use crate::credentials::{CredentialManager, CredentialStore};
     use crate::identity::{Principal, PrincipalKind};
     use crate::request_context::RequestContext;
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
-        ResolvedDatabaseConfig, run_state_migrations,
-    };
-    use crate::state::{AppStateLayout, ConfigStore};
-    use crate::workspaces::manager::WorkspaceManager;
+    use crate::state::ConfigStore;
+    use crate::state::db::CoralDb;
+    use crate::test_support::{migrated_deployment, seed_principal};
     use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// This suite's login issuer. Each suite provisions under its own, so a
+    /// subject seeded here is a different person from the same subject
+    /// seeded elsewhere.
+    const ISSUER: &str = "https://issuer.test/function-authorization";
 
     /// SQL no compiler accepts. Reaching function installation with it answers
     /// `InvalidArgument`, so a refusal that answers anything else proves the
@@ -269,79 +270,24 @@ mod tests {
     /// A shared deployment over one migrated database holding the default
     /// workspace, so every caller's authority comes from a membership row.
     async fn fixture() -> Fixture {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
-        else {
-            panic!("the default test database is sqlite")
-        };
-        let db = Arc::new(
-            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
-                .await
-                .expect("open sqlite"),
-        );
-        db.migrate().await.expect("migrate sqlite");
-        run_state_migrations(&db, &config_store, &layout)
-            .await
-            .expect("import the default workspace");
-        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let workspaces = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credentials.clone(),
-            layout.clone(),
-            None,
-            Arc::clone(&db),
-        );
+        let deployment = migrated_deployment().await;
         let queries = QueryManager::new_for_tests(
-            config_store.clone(),
-            workspaces,
-            credentials,
+            deployment.config_store.clone(),
+            deployment.workspaces,
+            deployment.credentials,
             QueryRuntimeContext::default(),
-            layout,
+            deployment.layout,
             Vec::new(),
         );
         Fixture {
-            _temp: temp,
-            service: FunctionService::new(queries, WorkspaceAuthorizer::new(Arc::clone(&db))),
-            config_store,
-            db,
+            _temp: deployment.temp,
+            service: FunctionService::new(
+                queries,
+                WorkspaceAuthorizer::new(Arc::clone(&deployment.db)),
+            ),
+            config_store: deployment.config_store,
+            db: deployment.db,
         }
-    }
-
-    /// Provisions one directory user through the production login seam and
-    /// grants it `role` on the default workspace, so the principal the
-    /// authorizer is handed is the one a real login carries.
-    async fn seed_principal(
-        db: &Arc<CoralDb>,
-        subject: &str,
-        role: Option<MemberRole>,
-    ) -> Principal {
-        let LoginProvisioning::Provisioned(user) = db
-            .user_state()
-            .provision_login(LoginIdentity {
-                issuer: "https://issuer.test/function-authorization",
-                subject,
-                display_name: None,
-                principal_claim: subject,
-                now_unix_nanos: 1,
-            })
-            .await
-            .expect("provision user")
-        else {
-            panic!("expected a provisioned user rather than an issuer mismatch")
-        };
-        if let Some(role) = role {
-            let mut session = db.as_ref();
-            session
-                .workspace_members()
-                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
-                .await
-                .expect("grant membership");
-        }
-        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
     }
 
     fn request<T>(message: T, principal: &Principal) -> Request<T> {
@@ -390,9 +336,9 @@ mod tests {
     #[tokio::test]
     async fn only_owners_change_the_function_set_and_never_through_an_agent() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, "outsider", None).await;
+        let owner = seed_principal(&fixture.db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, ISSUER, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, ISSUER, "outsider", None).await;
         let agent = Principal::parse(owner.id().as_str(), PrincipalKind::Agent).expect("agent");
 
         for reader in [&member, &agent] {

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -42,6 +42,7 @@
 )]
 
 mod auth;
+mod authorization_matrix;
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -68,6 +68,8 @@ mod task;
 pub mod telemetry;
 #[cfg(feature = "test-session-tokens")]
 pub mod test_session_tokens;
+#[cfg(test)]
+mod test_support;
 mod transport;
 mod users;
 mod workspaces;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1617,50 +1617,20 @@ mod tests {
     /// and an outsider does not. A separate owner is seeded because a workspace
     /// with no owner conceals its own members too.
     async fn read_access(db: &Arc<CoralDb>) -> ReadAccess {
+        use crate::test_support::seed_principal;
         use crate::workspaces::MemberRole;
 
-        let _owner = seed_principal(db, "owner", Some(MemberRole::Owner)).await;
+        /// This suite's login issuer. Each suite provisions under its own, so
+        /// a subject seeded here is a different person from the same subject
+        /// seeded elsewhere.
+        const ISSUER: &str = "https://issuer.test/read-authorization";
+
+        let _owner = seed_principal(db, ISSUER, "owner", Some(MemberRole::Owner)).await;
         ReadAccess {
-            member: seed_principal(db, "member", Some(MemberRole::Member)).await,
-            outsider: seed_principal(db, "outsider", None).await,
+            member: seed_principal(db, ISSUER, "member", Some(MemberRole::Member)).await,
+            outsider: seed_principal(db, ISSUER, "outsider", None).await,
             authorizer: WorkspaceAuthorizer::new(Arc::clone(db)),
         }
-    }
-
-    /// Provisions one directory user through the production login seam and
-    /// grants it `role` on the default workspace, so the principal the
-    /// authorizer is handed is the one a real login carries.
-    async fn seed_principal(
-        db: &Arc<CoralDb>,
-        subject: &str,
-        role: Option<crate::workspaces::MemberRole>,
-    ) -> Principal {
-        use crate::state::db::{DbRepos as _, LoginIdentity, LoginProvisioning};
-
-        let LoginProvisioning::Provisioned(user) = db
-            .user_state()
-            .provision_login(LoginIdentity {
-                issuer: "https://issuer.test/read-authorization",
-                subject,
-                display_name: None,
-                principal_claim: subject,
-                now_unix_nanos: 1,
-            })
-            .await
-            .expect("provision user")
-        else {
-            panic!("expected a provisioned user rather than an issuer mismatch")
-        };
-        if let Some(role) = role {
-            let mut session = db.as_ref();
-            session
-                .workspace_members()
-                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
-                .await
-                .expect("grant membership");
-        }
-        Principal::parse(&user.user_id, crate::identity::PrincipalKind::User)
-            .expect("federated principal")
     }
 
     fn query_span_count(exporter: &opentelemetry_sdk::trace::InMemorySpanExporter) -> usize {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1475,6 +1475,7 @@ mod tests {
     use crate::task::activity::TaskActivityRecorder;
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::workspaces::authorization::WorkspaceAuthorizer;
 
     struct QueryManagerFixture {
         _temp: TempDir,
@@ -1598,6 +1599,98 @@ mod tests {
         (task, context, task_id)
     }
 
+    /// The policy these fixtures run under: they call as `Principal::local()`,
+    /// which only a single-user deployment admits.
+    fn local_authorizer(fixture: &QueryManagerFixture) -> WorkspaceAuthorizer {
+        WorkspaceAuthorizer::trusting_local_principal(Arc::clone(&fixture.db))
+    }
+
+    /// A shared deployment over the fixture's database, with one member of the
+    /// default workspace and one authenticated caller who is not.
+    struct ReadAccess {
+        authorizer: WorkspaceAuthorizer,
+        member: Principal,
+        outsider: Principal,
+    }
+
+    /// Seeds the memberships that make `default` a workspace a member reaches
+    /// and an outsider does not. A separate owner is seeded because a workspace
+    /// with no owner conceals its own members too.
+    async fn read_access(db: &Arc<CoralDb>) -> ReadAccess {
+        use crate::workspaces::MemberRole;
+
+        let _owner = seed_principal(db, "owner", Some(MemberRole::Owner)).await;
+        ReadAccess {
+            member: seed_principal(db, "member", Some(MemberRole::Member)).await,
+            outsider: seed_principal(db, "outsider", None).await,
+            authorizer: WorkspaceAuthorizer::new(Arc::clone(db)),
+        }
+    }
+
+    /// Provisions one directory user through the production login seam and
+    /// grants it `role` on the default workspace, so the principal the
+    /// authorizer is handed is the one a real login carries.
+    async fn seed_principal(
+        db: &Arc<CoralDb>,
+        subject: &str,
+        role: Option<crate::workspaces::MemberRole>,
+    ) -> Principal {
+        use crate::state::db::{DbRepos as _, LoginIdentity, LoginProvisioning};
+
+        let LoginProvisioning::Provisioned(user) = db
+            .user_state()
+            .provision_login(LoginIdentity {
+                issuer: "https://issuer.test/read-authorization",
+                subject,
+                display_name: None,
+                principal_claim: subject,
+                now_unix_nanos: 1,
+            })
+            .await
+            .expect("provision user")
+        else {
+            panic!("expected a provisioned user rather than an issuer mismatch")
+        };
+        if let Some(role) = role {
+            let mut session = db.as_ref();
+            session
+                .workspace_members()
+                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+                .await
+                .expect("grant membership");
+        }
+        Principal::parse(&user.user_id, crate::identity::PrincipalKind::User)
+            .expect("federated principal")
+    }
+
+    fn query_span_count(exporter: &opentelemetry_sdk::trace::InMemorySpanExporter) -> usize {
+        exporter
+            .get_finished_spans()
+            .expect("finished spans")
+            .iter()
+            .filter(|span| span.name == "coral.query")
+            .count()
+    }
+
+    /// The task ids the default workspace's recorded query activity carries.
+    async fn recorded_task_ids(fixture: &QueryManagerFixture) -> Vec<String> {
+        fixture
+            .db
+            .task_query_state()
+            .list_for_workspace(WorkspaceName::default().as_str())
+            .await
+            .expect("load task query activity")
+            .into_iter()
+            .map(|record| record.task_id)
+            .collect()
+    }
+
+    /// Replaces the workspace name the caller themselves asked about, so two
+    /// answers about different names are still comparable.
+    fn normalize(message: &str, name: &str) -> String {
+        message.replace(name, "<workspace>")
+    }
+
     fn assert_workspace_not_found(error: AppError, workspace_name: &WorkspaceName) {
         match error {
             AppError::WorkspaceNotFound(actual) => assert_eq!(actual, workspace_name.as_str()),
@@ -1665,7 +1758,7 @@ mod tests {
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (task, request_context, task_id) = active_task_context(&fixture.db).await;
-        let service = QueryService::new(fixture.manager.clone(), task);
+        let service = QueryService::new(fixture.manager.clone(), task, local_authorizer(&fixture));
 
         let mut request = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
@@ -1717,7 +1810,7 @@ mod tests {
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (tasks, request_context, task_id) = active_task_context(&fixture.db).await;
-        let service = QueryService::new(fixture.manager.clone(), tasks);
+        let service = QueryService::new(fixture.manager.clone(), tasks, local_authorizer(&fixture));
         let mut request = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
                 name: WorkspaceName::default().as_str().to_string(),
@@ -1746,6 +1839,111 @@ mod tests {
         assert_eq!(record.intent, "Check renewal risk");
         assert_eq!(record.sql, "SELECT 1");
         assert_eq!(record.status, "success");
+    }
+
+    /// Access is settled before either read service does anything, so a denied
+    /// caller opens no workspace-attributed query span and records no attributed
+    /// activity — and is answered about a workspace that exists exactly as about
+    /// one that does not. The malformed SQL and task attribution are the probe:
+    /// reaching either would answer `InvalidArgument` instead of the ordinary
+    /// workspace miss. The member pass afterwards is the control that the
+    /// absences were the denial rather than a fixture that records nothing.
+    #[tokio::test(flavor = "current_thread")]
+    async fn query_and_catalog_deny_before_read_work_reach_no_runtime() {
+        use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
+        use coral_api::v1::{ExecuteSqlRequest, TaskAttribution, Workspace};
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tonic::{Code, Request};
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        use crate::catalog::service::CatalogService;
+        use crate::query::service::QueryService;
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("read-denial-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        let (tasks, task_context, task_id) = active_task_context(&fixture.db).await;
+        let access = read_access(&fixture.db).await;
+        let queries = QueryService::new(
+            fixture.manager.clone(),
+            tasks.clone(),
+            access.authorizer.clone(),
+        );
+        let catalog = CatalogService::new(fixture.manager.clone(), tasks, access.authorizer);
+        let outsider = RequestContext::new(access.outsider).with_task_id(task_context.task_id());
+        let denied_sql = |workspace: &str| {
+            let mut request = Request::new(ExecuteSqlRequest {
+                workspace: Some(Workspace {
+                    name: workspace.to_string(),
+                }),
+                sql: "SELECT FROM".to_string(),
+                guide_read_context: None,
+                task_attribution: Some(TaskAttribution {
+                    task_id: "not-a-uuid".to_string(),
+                    intent: "Probe the denied path".to_string(),
+                }),
+            });
+            request.extensions_mut().insert(outsider.clone());
+            request
+        };
+
+        let concealed = queries
+            .execute_sql(denied_sql(WorkspaceName::default().as_str()))
+            .await
+            .expect_err("a non-member reaches nothing");
+        let missing = queries
+            .execute_sql(denied_sql("absent"))
+            .await
+            .expect_err("a missing workspace reaches nothing");
+        call_catalog_tools_with_task(&catalog, &outsider).await;
+
+        assert_eq!(concealed.code(), Code::NotFound);
+        assert_eq!(concealed.code(), missing.code());
+        assert_eq!(
+            normalize(concealed.message(), WorkspaceName::default().as_str()),
+            normalize(missing.message(), "absent"),
+        );
+        provider.force_flush().expect("flush spans");
+        assert_eq!(
+            query_span_count(&exporter),
+            0,
+            "a denied call must not parse SQL or build catalog state"
+        );
+        assert!(
+            recorded_task_ids(&fixture).await.is_empty(),
+            "a denied call must record no attributed query activity"
+        );
+
+        let member = RequestContext::new(access.member).with_task_id(task_context.task_id());
+        let mut allowed = Request::new(ExecuteSqlRequest {
+            workspace: Some(Workspace {
+                name: WorkspaceName::default().as_str().to_string(),
+            }),
+            sql: "SELECT 1".to_string(),
+            guide_read_context: None,
+            task_attribution: Some(TaskAttribution {
+                task_id: task_id.clone(),
+                intent: "Check renewal risk".to_string(),
+            }),
+        });
+        allowed.extensions_mut().insert(member.clone());
+        queries.execute_sql(allowed).await.expect("a member reads");
+        call_catalog_tools_with_task(&catalog, &member).await;
+
+        provider.force_flush().expect("flush spans");
+        assert_catalog_task_spans(
+            &exporter.get_finished_spans().expect("finished spans"),
+            &task_id,
+        );
+        assert_eq!(recorded_task_ids(&fixture).await, vec![task_id]);
     }
 
     #[tokio::test]
@@ -1990,7 +2188,8 @@ mod tests {
 
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (task, request_context, task_id) = active_task_context(&fixture.db).await;
-        let service = CatalogService::new(fixture.manager.clone(), task);
+        let service =
+            CatalogService::new(fixture.manager.clone(), task, local_authorizer(&fixture));
 
         call_catalog_tools_with_task(&service, &request_context).await;
 

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -22,18 +22,25 @@ use crate::task::service::task_manager_status;
 use crate::transport::{
     grpc_span, instrument_grpc, query_status, request_context, workspace_name_from_proto,
 };
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 
 #[derive(Clone)]
 pub(crate) struct QueryService {
     queries: QueryManager,
     tasks: TaskManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl QueryService {
-    pub(crate) fn new(query_manager: QueryManager, task_manager: TaskManager) -> Self {
+    pub(crate) const fn new(
+        query_manager: QueryManager,
+        task_manager: TaskManager,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
         Self {
             queries: query_manager,
             tasks: task_manager,
+            authorizer,
         }
     }
 }
@@ -47,10 +54,23 @@ impl QueryServiceApi for QueryService {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            // Access is settled before anything else is read from the request:
+            // a caller who may not reach this workspace must not be able to
+            // learn from it whether their task id exists or their SQL parses,
+            // and must leave no attributed query behind.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
             let shown_guide_ids = shown_guide_ids(inner.guide_read_context);
             let (requested_task_id, tool_intent) = query_attribution_from_proto(
                 inner.task_attribution.as_ref(),
@@ -105,10 +125,19 @@ impl QueryServiceApi for QueryService {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
             let attribution = QueryAttribution::new(
                 tasks
                     .validate_attribution(&workspace_name, request_context.task_id())

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -30,6 +30,7 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
 use crate::query::QueryAttribution;
+use crate::request_context::RequestContext;
 use crate::search::maintenance::{
     CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult,
     ClearSearchDataRequest as DomainClearSearchDataRequest,
@@ -52,18 +53,26 @@ use crate::sources::SourceName;
 use crate::task::manager::TaskManager;
 use crate::task::service::task_manager_status;
 use crate::transport::{grpc_span, instrument_grpc, request_context, workspace_name_from_proto};
+use crate::workspaces::WorkspaceName;
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 
 #[derive(Clone)]
 pub(crate) struct SearchService {
     search: SearchManager,
     tasks: TaskManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl SearchService {
-    pub(crate) fn new(search_manager: SearchManager, task_manager: TaskManager) -> Self {
+    pub(crate) const fn new(
+        search_manager: SearchManager,
+        task_manager: TaskManager,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
         Self {
             search: search_manager,
             tasks: task_manager,
+            authorizer,
         }
     }
 }
@@ -77,10 +86,22 @@ impl SearchServiceApi for SearchService {
         let span = grpc_span(&request);
         let search = self.search.clone();
         let tasks = self.tasks.clone();
+        let authorizer = self.authorizer.clone();
         let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            // Settled before anything else is read from the request: a caller
+            // who may not reach this workspace must not be able to learn from
+            // it whether their task id exists or their query is searchable.
+            authorizer
+                .authorize(
+                    request_context.principal(),
+                    &workspace_name,
+                    WorkspaceAction::Read,
+                )
+                .await
+                .map_err(app_status)?;
             let attribution = QueryAttribution::new(
                 tasks
                     .validate_attribution(&workspace_name, request_context.task_id())
@@ -104,9 +125,12 @@ impl SearchServiceApi for SearchService {
     ) -> Result<Response<ProtoRebuildSearchIndexResponse>, Status> {
         let span = grpc_span(&request);
         let search = self.search.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_maintenance(&authorizer, &workspace_name, &request_context).await?;
             let request = DomainRebuildSearchIndexRequest {
                 workspace_name,
                 provider: index_provider_from_proto(proto_index_provider(request.provider)?),
@@ -127,9 +151,12 @@ impl SearchServiceApi for SearchService {
     ) -> Result<Response<ProtoDrainSearchQueueResponse>, Status> {
         let span = grpc_span(&request);
         let search = self.search.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_maintenance(&authorizer, &workspace_name, &request_context).await?;
             let request = DomainDrainSearchQueueRequest {
                 workspace_name,
                 budget_ms: request.budget_ms,
@@ -146,9 +173,12 @@ impl SearchServiceApi for SearchService {
     ) -> Result<Response<ProtoClearSearchDataResponse>, Status> {
         let span = grpc_span(&request);
         let search = self.search.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_maintenance(&authorizer, &workspace_name, &request_context).await?;
             let request = DomainClearSearchDataRequest {
                 workspace_name,
                 scope: data_scope_from_proto(proto_data_scope(request.scope)?)?,
@@ -159,6 +189,27 @@ impl SearchServiceApi for SearchService {
         })
         .await
     }
+}
+
+/// Settles owner access to `workspace` before any maintenance work.
+///
+/// The order is the point: rebuilding, draining, and clearing all reach this
+/// immediately after parsing their workspace, so a caller who may not manage
+/// it never causes an index to be read or a stored row to be removed, and
+/// never learns from the request's own validation that the workspace is there.
+async fn authorize_maintenance(
+    authorizer: &WorkspaceAuthorizer,
+    workspace: &WorkspaceName,
+    request_context: &RequestContext,
+) -> Result<(), Status> {
+    authorizer
+        .authorize(
+            request_context.principal(),
+            workspace,
+            WorkspaceAction::Manage,
+        )
+        .await
+        .map_err(app_status)
 }
 
 fn search_status(error: SearchManagerError) -> Status {
@@ -496,18 +547,256 @@ fn provider_coverage_to_proto(coverage: &ProviderCoverage) -> SearchProviderCove
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use coral_api::v1::{
         SearchClearTarget as ProtoSearchClearTarget,
         SearchProviderState as ProtoSearchProviderState, search_clear_target,
     };
-    use tonic::Code;
+    use coral_engine::QueryRuntimeContext;
+    use tempfile::TempDir;
+    use tonic::{Code, Request};
 
-    use super::{clear_target_from_proto, provider_status_to_proto};
+    use super::{
+        ProtoClearSearchDataRequest, ProtoDrainSearchQueueRequest, ProtoRebuildSearchIndexRequest,
+        ProtoSearchDataScope, ProtoSearchRequest, SearchService, SearchServiceApi,
+        clear_target_from_proto, provider_status_to_proto,
+    };
+    use crate::catalog::discovery::CatalogDiscovery;
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::query::manager::QueryManager;
+    use crate::request_context::RequestContext;
     use crate::search::maintenance::SearchClearTarget;
+    use crate::search::manager::SearchManager;
     use crate::search::result::{
         ProviderCoverage, ProviderStatus, SearchProviderKind,
         SearchProviderState as DomainProviderState,
     };
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
+        ResolvedDatabaseConfig, run_state_migrations,
+    };
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::task::manager::TaskManager;
+    use crate::task::store::TaskStore;
+    use crate::workspaces::authorization::WorkspaceAuthorizer;
+    use crate::workspaces::manager::WorkspaceManager;
+    use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// A provider value no enum admits. Reaching the maintenance request build
+    /// with it answers `InvalidArgument`, so a refusal that answers anything
+    /// else proves the request was never interpreted.
+    const UNDECODABLE_PROVIDER: i32 = 9_999;
+
+    struct Fixture {
+        _temp: TempDir,
+        service: SearchService,
+        db: Arc<CoralDb>,
+    }
+
+    /// A shared deployment over one migrated database holding the default
+    /// workspace, so every caller's authority comes from a membership row.
+    async fn fixture() -> Fixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("the default test database is sqlite")
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("import the default workspace");
+        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let workspaces = WorkspaceManager::new_for_tests(
+            config_store.clone(),
+            credentials.clone(),
+            layout.clone(),
+            None,
+            Arc::clone(&db),
+        );
+        let queries = QueryManager::new_for_tests(
+            config_store.clone(),
+            workspaces.clone(),
+            credentials,
+            QueryRuntimeContext::default(),
+            layout.clone(),
+            Vec::new(),
+        );
+        let lifecycle_lock = workspaces.lifecycle_lock();
+        let search = SearchManager::new(
+            layout,
+            &config_store,
+            workspaces,
+            true,
+            CatalogDiscovery::new(queries),
+            lifecycle_lock,
+        );
+        Fixture {
+            _temp: temp,
+            service: SearchService::new(
+                search,
+                TaskManager::new(TaskStore::new(Arc::clone(&db))),
+                WorkspaceAuthorizer::new(Arc::clone(&db)),
+            ),
+            db,
+        }
+    }
+
+    /// Provisions one directory user through the production login seam and
+    /// grants it `role` on the default workspace, so the principal the
+    /// authorizer is handed is the one a real login carries.
+    async fn seed_principal(
+        db: &Arc<CoralDb>,
+        subject: &str,
+        role: Option<MemberRole>,
+    ) -> Principal {
+        let LoginProvisioning::Provisioned(user) = db
+            .user_state()
+            .provision_login(LoginIdentity {
+                issuer: "https://issuer.test/search-authorization",
+                subject,
+                display_name: None,
+                principal_claim: subject,
+                now_unix_nanos: 1,
+            })
+            .await
+            .expect("provision user")
+        else {
+            panic!("expected a provisioned user rather than an issuer mismatch")
+        };
+        if let Some(role) = role {
+            let mut session = db.as_ref();
+            session
+                .workspace_members()
+                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+                .await
+                .expect("grant membership");
+        }
+        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
+    }
+
+    fn request<T>(message: T, principal: &Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal.clone()));
+        request
+    }
+
+    fn default_workspace() -> coral_api::v1::Workspace {
+        crate::transport::workspace_to_proto(&WorkspaceName::default())
+    }
+
+    /// An empty query is what search preparation rejects, so it stands as the
+    /// probe for whether preparation was reached at all.
+    fn search_request() -> ProtoSearchRequest {
+        ProtoSearchRequest {
+            workspace: Some(default_workspace()),
+            query: String::new(),
+            limit: 0,
+        }
+    }
+
+    fn rebuild_request() -> ProtoRebuildSearchIndexRequest {
+        ProtoRebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: UNDECODABLE_PROVIDER,
+            force: true,
+        }
+    }
+
+    fn clear_request() -> ProtoClearSearchDataRequest {
+        ProtoClearSearchDataRequest {
+            workspace: Some(default_workspace()),
+            scope: ProtoSearchDataScope::Unspecified as i32,
+            target: None,
+        }
+    }
+
+    /// Searching reads the workspace; rebuilding, draining, and clearing its
+    /// index are maintenance of it.
+    ///
+    /// Every request here carries input the work itself rejects, so each
+    /// refusal is an absence rather than an error code: the caller who is
+    /// allowed through is told what is wrong with the request, and the caller
+    /// who is not never gets that far.
+    #[tokio::test]
+    async fn members_search_while_only_owners_maintain_the_index() {
+        let fixture = fixture().await;
+        let owner = seed_principal(&fixture.db, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, "outsider", None).await;
+
+        assert_eq!(
+            fixture
+                .service
+                .search(request(search_request(), &member))
+                .await
+                .expect_err("the query is what the member is stopped by")
+                .code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            fixture
+                .service
+                .search(request(search_request(), &outsider))
+                .await
+                .expect_err("a non-member searches nothing")
+                .code(),
+            Code::NotFound
+        );
+
+        for status in [
+            fixture
+                .service
+                .rebuild_search_index(request(rebuild_request(), &member))
+                .await
+                .expect_err("a member rebuilds nothing"),
+            fixture
+                .service
+                .clear_search_data(request(clear_request(), &member))
+                .await
+                .expect_err("a member clears nothing"),
+            fixture
+                .service
+                .drain_search_queue(request(
+                    ProtoDrainSearchQueueRequest {
+                        workspace: Some(default_workspace()),
+                        budget_ms: 1,
+                    },
+                    &member,
+                ))
+                .await
+                .expect_err("a member drains nothing"),
+        ] {
+            assert_eq!(status.code(), Code::PermissionDenied);
+        }
+
+        for status in [
+            fixture
+                .service
+                .rebuild_search_index(request(rebuild_request(), &owner))
+                .await
+                .expect_err("the provider is what the owner is stopped by"),
+            fixture
+                .service
+                .clear_search_data(request(clear_request(), &owner))
+                .await
+                .expect_err("the scope is what the owner is stopped by"),
+        ] {
+            assert_eq!(status.code(), Code::InvalidArgument);
+        }
+    }
 
     #[test]
     fn skipped_provider_status_maps_without_coverage() {

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -563,8 +563,7 @@ mod tests {
         clear_target_from_proto, provider_status_to_proto,
     };
     use crate::catalog::discovery::CatalogDiscovery;
-    use crate::credentials::{CredentialManager, CredentialStore};
-    use crate::identity::{Principal, PrincipalKind};
+    use crate::identity::Principal;
     use crate::query::manager::QueryManager;
     use crate::request_context::RequestContext;
     use crate::search::maintenance::SearchClearTarget;
@@ -573,16 +572,17 @@ mod tests {
         ProviderCoverage, ProviderStatus, SearchProviderKind,
         SearchProviderState as DomainProviderState,
     };
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
-        ResolvedDatabaseConfig, run_state_migrations,
-    };
-    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::state::db::CoralDb;
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::test_support::{migrated_deployment, seed_principal};
     use crate::workspaces::authorization::WorkspaceAuthorizer;
-    use crate::workspaces::manager::WorkspaceManager;
     use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// This suite's login issuer. Each suite provisions under its own, so a
+    /// subject seeded here is a different person from the same subject
+    /// seeded elsewhere.
+    const ISSUER: &str = "https://issuer.test/search-authorization";
 
     /// A provider value no enum admits. Reaching the maintenance request build
     /// with it answers `InvalidArgument`, so a refusal that answers anything
@@ -598,36 +598,18 @@ mod tests {
     /// A shared deployment over one migrated database holding the default
     /// workspace, so every caller's authority comes from a membership row.
     async fn fixture() -> Fixture {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
-        else {
-            panic!("the default test database is sqlite")
-        };
-        let db = Arc::new(
-            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
-                .await
-                .expect("open sqlite"),
-        );
-        db.migrate().await.expect("migrate sqlite");
-        run_state_migrations(&db, &config_store, &layout)
-            .await
-            .expect("import the default workspace");
-        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let workspaces = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credentials.clone(),
-            layout.clone(),
-            None,
-            Arc::clone(&db),
+        let deployment = migrated_deployment().await;
+        let (temp, layout, config_store, db, workspaces) = (
+            deployment.temp,
+            deployment.layout,
+            deployment.config_store,
+            deployment.db,
+            deployment.workspaces,
         );
         let queries = QueryManager::new_for_tests(
             config_store.clone(),
             workspaces.clone(),
-            credentials,
+            deployment.credentials,
             QueryRuntimeContext::default(),
             layout.clone(),
             Vec::new(),
@@ -650,39 +632,6 @@ mod tests {
             ),
             db,
         }
-    }
-
-    /// Provisions one directory user through the production login seam and
-    /// grants it `role` on the default workspace, so the principal the
-    /// authorizer is handed is the one a real login carries.
-    async fn seed_principal(
-        db: &Arc<CoralDb>,
-        subject: &str,
-        role: Option<MemberRole>,
-    ) -> Principal {
-        let LoginProvisioning::Provisioned(user) = db
-            .user_state()
-            .provision_login(LoginIdentity {
-                issuer: "https://issuer.test/search-authorization",
-                subject,
-                display_name: None,
-                principal_claim: subject,
-                now_unix_nanos: 1,
-            })
-            .await
-            .expect("provision user")
-        else {
-            panic!("expected a provisioned user rather than an issuer mismatch")
-        };
-        if let Some(role) = role {
-            let mut session = db.as_ref();
-            session
-                .workspace_members()
-                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
-                .await
-                .expect("grant membership");
-        }
-        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
     }
 
     fn request<T>(message: T, principal: &Principal) -> Request<T> {
@@ -733,9 +682,9 @@ mod tests {
     #[tokio::test]
     async fn members_search_while_only_owners_maintain_the_index() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, "outsider", None).await;
+        let owner = seed_principal(&fixture.db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, ISSUER, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, ISSUER, "outsider", None).await;
 
         assert_eq!(
             fixture

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -37,6 +37,7 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
+use crate::request_context::RequestContext;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
@@ -46,9 +47,10 @@ use crate::sources::manager::{
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
-    grpc_span, instrument_grpc, query_status, validate_source_response_to_proto,
+    grpc_span, instrument_grpc, query_status, request_context, validate_source_response_to_proto,
     workspace_name_from_proto, workspace_to_proto,
 };
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName};
 use tokio::sync::mpsc;
 use tokio_stream::Stream;
@@ -59,18 +61,21 @@ pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
     workspaces: WorkspaceManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl SourceService {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         source_manager: SourceManager,
         query_manager: QueryManager,
         workspace_manager: WorkspaceManager,
+        authorizer: WorkspaceAuthorizer,
     ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
             workspaces: workspace_manager,
+            authorizer,
         }
     }
 }
@@ -87,9 +92,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let sources = sources
                 .discover_sources(&workspace_name)
@@ -109,9 +117,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let sources: Vec<_> = sources
                 .list_workspace_sources(&workspace_name)
@@ -131,9 +142,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let source = sources
@@ -153,9 +167,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let source = sources
@@ -175,9 +192,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
@@ -206,9 +226,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
@@ -250,9 +273,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
@@ -309,9 +335,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             sources
@@ -330,9 +359,12 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
         let workspaces = self.workspaces.clone();
+        let authorizer = self.authorizer.clone();
+        let request_context = request_context(&request)?.clone();
         Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let result = queries
@@ -370,6 +402,34 @@ impl SourceServiceApi for SourceService {
         })
         .await
     }
+}
+
+/// Settles owner access to `workspace` before any source work.
+///
+/// Every source RPC reaches this immediately after parsing its workspace, the
+/// reads included: a source response carries the variables, secret keys, and
+/// credential-setup metadata that configure a connection, so reading one is
+/// managing the workspace rather than reading its contents. A member is
+/// refused a source's configuration outright; there is deliberately no
+/// redacted projection for them to receive instead.
+///
+/// The order is the point. A refused caller must not cause a config file,
+/// credential store, manifest, or runtime package to be read, nor an import
+/// stream to start, and must not learn from the request's own validation
+/// whether a source is installed.
+async fn authorize_source_access(
+    authorizer: &WorkspaceAuthorizer,
+    workspace: &WorkspaceName,
+    request_context: &RequestContext,
+) -> Result<(), Status> {
+    authorizer
+        .authorize(
+            request_context.principal(),
+            workspace,
+            WorkspaceAction::Manage,
+        )
+        .await
+        .map_err(app_status)
 }
 
 async fn require_workspace(
@@ -801,7 +861,11 @@ mod tests {
         reason = "credential method order assertions intentionally fail loudly in tests"
     )]
 
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
     use super::*;
+    use coral_engine::QueryRuntimeContext;
     use coral_spec::{
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
         ManifestOAuthClientIdSpec, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
@@ -809,6 +873,370 @@ mod tests {
         ManifestOAuthDynamicClientRegistrationSpec, ManifestOAuthFlowKind, ManifestOAuthFlowSpec,
         ManifestOAuthPkceMode, ManifestOAuthRedirectUriPortMode,
     };
+    use tempfile::TempDir;
+    use tonic::Code;
+
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
+        ResolvedDatabaseConfig, run_state_migrations,
+    };
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::MemberRole;
+
+    /// TOML that no parse accepts. The source RPCs all read the app config on
+    /// their way to an answer, so leaving this on disk turns every read into a
+    /// loud failure — which is what lets a refusal be read as an absence.
+    const UNPARSEABLE_CONFIG: &str = "[workspaces\n";
+
+    /// A source name that is neither installed nor bundled, so a caller who
+    /// reaches the source work is stopped by the work rather than by the gate.
+    const ABSENT_SOURCE: &str = "probe";
+
+    struct Fixture {
+        _temp: TempDir,
+        service: SourceService,
+        db: Arc<CoralDb>,
+        config_file: PathBuf,
+    }
+
+    /// A shared deployment over one migrated database holding the default
+    /// workspace, so every caller's authority comes from a membership row.
+    async fn fixture() -> Fixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("the default test database is sqlite")
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("import the default workspace");
+        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let workspaces = WorkspaceManager::new_for_tests(
+            config_store.clone(),
+            credentials.clone(),
+            layout.clone(),
+            None,
+            Arc::clone(&db),
+        );
+        let sources = SourceManager::new(
+            config_store.clone(),
+            credentials.clone(),
+            layout.clone(),
+            workspaces.lifecycle_lock(),
+        );
+        let queries = QueryManager::new_for_tests(
+            config_store,
+            workspaces.clone(),
+            credentials,
+            QueryRuntimeContext::default(),
+            layout.clone(),
+            Vec::new(),
+        );
+        let config_file = layout.config_file().to_path_buf();
+        Fixture {
+            _temp: temp,
+            service: SourceService::new(
+                sources,
+                queries,
+                workspaces,
+                WorkspaceAuthorizer::new(Arc::clone(&db)),
+            ),
+            db,
+            config_file,
+        }
+    }
+
+    /// Provisions one directory user through the production login seam and
+    /// grants it `role` on the default workspace, so the principal the
+    /// authorizer is handed is the one a real login carries.
+    async fn seed_principal(
+        db: &Arc<CoralDb>,
+        subject: &str,
+        role: Option<MemberRole>,
+    ) -> Principal {
+        let LoginProvisioning::Provisioned(user) = db
+            .user_state()
+            .provision_login(LoginIdentity {
+                issuer: "https://issuer.test/source-authorization",
+                subject,
+                display_name: None,
+                principal_claim: subject,
+                now_unix_nanos: 1,
+            })
+            .await
+            .expect("provision user")
+        else {
+            panic!("expected a provisioned user rather than an issuer mismatch")
+        };
+        if let Some(role) = role {
+            let mut session = db.as_ref();
+            session
+                .workspace_members()
+                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+                .await
+                .expect("grant membership");
+        }
+        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
+    }
+
+    fn request<T>(message: T, principal: &Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal.clone()));
+        request
+    }
+
+    fn default_workspace() -> coral_api::v1::Workspace {
+        workspace_to_proto(&WorkspaceName::default())
+    }
+
+    /// The OAuth half of a request, missing the method index the conversion
+    /// requires. Reaching that conversion answers `InvalidArgument`, so a
+    /// refusal that answers anything else proves it was never reached.
+    fn incomplete_oauth_retrieval() -> Vec<OAuthCredentialRetrieval> {
+        vec![OAuthCredentialRetrieval {
+            input_key: "API_TOKEN".to_string(),
+            method_index: None,
+            credential_inputs: Vec::new(),
+        }]
+    }
+
+    /// Takes the status `rpc` refused with, and panics if it answered instead.
+    ///
+    /// For the two streaming installs that panic is itself part of the claim:
+    /// a status can only come back where no response did, so a refused caller
+    /// was never handed an import stream to read from.
+    fn status<T>(result: Result<T, Status>, rpc: &str) -> Status {
+        result.err().unwrap_or_else(|| {
+            panic!("{rpc} answered; every request here is one some layer must refuse")
+        })
+    }
+
+    /// Calls every source RPC as `principal` and returns what each answered,
+    /// in the order the authorization matrix lists them.
+    ///
+    /// Each request is one the source work itself rejects — an absent source
+    /// name, an empty manifest, an OAuth retrieval with no method index — over
+    /// state whose config file cannot be parsed. So the caller who is let
+    /// through is told what is wrong with the request or the state, and the
+    /// caller who is not never gets that far.
+    async fn every_source_rpc(service: &SourceService, principal: &Principal) -> Vec<Status> {
+        let mut statuses = source_lookup_rpcs(service, principal).await;
+        statuses.extend(source_install_rpcs(service, principal).await);
+        statuses.extend(source_removal_rpcs(service, principal).await);
+        statuses
+    }
+
+    /// Discovery and configuration reads: the four that answer with what a
+    /// source is configured with.
+    async fn source_lookup_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
+        vec![
+            status(
+                service
+                    .discover_sources(request(
+                        DiscoverSourcesRequest {
+                            workspace: Some(default_workspace()),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "DiscoverSources",
+            ),
+            status(
+                service
+                    .list_sources(request(
+                        ListSourcesRequest {
+                            workspace: Some(default_workspace()),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "ListSources",
+            ),
+            status(
+                service
+                    .get_source(request(
+                        GetSourceRequest {
+                            workspace: Some(default_workspace()),
+                            name: ABSENT_SOURCE.to_string(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "GetSource",
+            ),
+            status(
+                service
+                    .get_source_info(request(
+                        GetSourceInfoRequest {
+                            workspace: Some(default_workspace()),
+                            name: ABSENT_SOURCE.to_string(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "GetSourceInfo",
+            ),
+        ]
+    }
+
+    /// The three install paths, each of which takes credential material.
+    async fn source_install_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
+        vec![
+            status(
+                service
+                    .create_bundled_source(request(
+                        CreateBundledSourceRequest {
+                            workspace: Some(default_workspace()),
+                            name: ABSENT_SOURCE.to_string(),
+                            variables: Vec::new(),
+                            secrets: Vec::new(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "CreateBundledSource",
+            ),
+            status(
+                service
+                    .create_bundled_source_with_o_auth(request(
+                        CreateBundledSourceWithOAuthRequest {
+                            workspace: Some(default_workspace()),
+                            name: ABSENT_SOURCE.to_string(),
+                            variables: Vec::new(),
+                            secrets: Vec::new(),
+                            oauth_credential_retrievals: incomplete_oauth_retrieval(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "CreateBundledSourceWithOAuth",
+            ),
+            status(
+                service
+                    .import_source(request(
+                        ImportSourceRequest {
+                            workspace: Some(default_workspace()),
+                            manifest_yaml: String::new(),
+                            variables: Vec::new(),
+                            secrets: Vec::new(),
+                            oauth_credential_retrievals: incomplete_oauth_retrieval(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "ImportSource",
+            ),
+        ]
+    }
+
+    /// Removal and revalidation, which reach installed state and its
+    /// credentials without adding any.
+    async fn source_removal_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
+        vec![
+            status(
+                service
+                    .delete_source(request(
+                        DeleteSourceRequest {
+                            workspace: Some(default_workspace()),
+                            name: ABSENT_SOURCE.to_string(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "DeleteSource",
+            ),
+            status(
+                service
+                    .validate_source(request(
+                        ValidateSourceRequest {
+                            workspace: Some(default_workspace()),
+                            name: ABSENT_SOURCE.to_string(),
+                        },
+                        principal,
+                    ))
+                    .await,
+                "ValidateSource",
+            ),
+        ]
+    }
+
+    /// Source responses carry the variables, secret keys, and credential-setup
+    /// metadata that configure a connection, so every source RPC is an owner's
+    /// act — the reads included. A member is refused outright rather than
+    /// handed a redacted view, and a non-member is told nothing.
+    ///
+    /// The refusals are proved to be absences rather than error codes. The
+    /// config file on disk is unparseable, so any read of installed state
+    /// chokes on it, and the owner does choke on it: the four discovery and
+    /// lookup calls, the delete, and the validate all answer `Internal` from
+    /// that read, while the three install paths answer `InvalidArgument` from
+    /// the bundled catalog and the OAuth conversion they reach first. Every
+    /// refused caller answers `PermissionDenied` or `NotFound` instead, and
+    /// leaves the file with the bytes it started with.
+    #[tokio::test]
+    async fn source_configuration_reaches_only_workspace_owners() {
+        let fixture = fixture().await;
+        let owner = seed_principal(&fixture.db, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, "outsider", None).await;
+        std::fs::write(&fixture.config_file, UNPARSEABLE_CONFIG).expect("poison the app config");
+
+        for status in every_source_rpc(&fixture.service, &member).await {
+            assert_eq!(
+                status.code(),
+                Code::PermissionDenied,
+                "a member reads and changes no source configuration: {}",
+                status.message()
+            );
+        }
+        for status in every_source_rpc(&fixture.service, &outsider).await {
+            assert_eq!(
+                status.code(),
+                Code::NotFound,
+                "a non-member learns nothing about the workspace: {}",
+                status.message()
+            );
+        }
+
+        assert_eq!(
+            every_source_rpc(&fixture.service, &owner)
+                .await
+                .iter()
+                .map(Status::code)
+                .collect::<Vec<_>>(),
+            vec![
+                Code::Internal,
+                Code::Internal,
+                Code::Internal,
+                Code::Internal,
+                Code::InvalidArgument,
+                Code::InvalidArgument,
+                Code::InvalidArgument,
+                Code::Internal,
+                Code::Internal,
+            ],
+            "the owner must be stopped by the state or the request, never by the gate"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&fixture.config_file).expect("config file"),
+            UNPARSEABLE_CONFIG,
+            "a refused caller must not have rewritten installed source state"
+        );
+    }
 
     #[test]
     fn converts_credential_methods_to_source_input_spec() {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -865,6 +865,10 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::identity::Principal;
+    use crate::state::db::CoralDb;
+    use crate::test_support::{migrated_deployment, seed_principal};
+    use crate::workspaces::MemberRole;
     use coral_engine::QueryRuntimeContext;
     use coral_spec::{
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
@@ -876,14 +880,10 @@ mod tests {
     use tempfile::TempDir;
     use tonic::Code;
 
-    use crate::credentials::{CredentialManager, CredentialStore};
-    use crate::identity::{Principal, PrincipalKind};
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
-        ResolvedDatabaseConfig, run_state_migrations,
-    };
-    use crate::state::{AppStateLayout, ConfigStore};
-    use crate::workspaces::MemberRole;
+    /// This suite's login issuer. Each suite provisions under its own, so a
+    /// subject seeded here is a different person from the same subject
+    /// seeded elsewhere.
+    const ISSUER: &str = "https://issuer.test/source-authorization";
 
     /// TOML that no parse accepts. The source RPCs all read the app config on
     /// their way to an answer, so leaving this on disk turns every read into a
@@ -904,40 +904,22 @@ mod tests {
     /// A shared deployment over one migrated database holding the default
     /// workspace, so every caller's authority comes from a membership row.
     async fn fixture() -> Fixture {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
-        else {
-            panic!("the default test database is sqlite")
-        };
-        let db = Arc::new(
-            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
-                .await
-                .expect("open sqlite"),
-        );
-        db.migrate().await.expect("migrate sqlite");
-        run_state_migrations(&db, &config_store, &layout)
-            .await
-            .expect("import the default workspace");
-        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let workspaces = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credentials.clone(),
-            layout.clone(),
-            None,
-            Arc::clone(&db),
+        let deployment = migrated_deployment().await;
+        let (temp, layout, db, workspaces, credentials) = (
+            deployment.temp,
+            deployment.layout,
+            deployment.db,
+            deployment.workspaces,
+            deployment.credentials,
         );
         let sources = SourceManager::new(
-            config_store.clone(),
+            deployment.config_store.clone(),
             credentials.clone(),
             layout.clone(),
             workspaces.lifecycle_lock(),
         );
         let queries = QueryManager::new_for_tests(
-            config_store,
+            deployment.config_store,
             workspaces.clone(),
             credentials,
             QueryRuntimeContext::default(),
@@ -956,39 +938,6 @@ mod tests {
             db,
             config_file,
         }
-    }
-
-    /// Provisions one directory user through the production login seam and
-    /// grants it `role` on the default workspace, so the principal the
-    /// authorizer is handed is the one a real login carries.
-    async fn seed_principal(
-        db: &Arc<CoralDb>,
-        subject: &str,
-        role: Option<MemberRole>,
-    ) -> Principal {
-        let LoginProvisioning::Provisioned(user) = db
-            .user_state()
-            .provision_login(LoginIdentity {
-                issuer: "https://issuer.test/source-authorization",
-                subject,
-                display_name: None,
-                principal_claim: subject,
-                now_unix_nanos: 1,
-            })
-            .await
-            .expect("provision user")
-        else {
-            panic!("expected a provisioned user rather than an issuer mismatch")
-        };
-        if let Some(role) = role {
-            let mut session = db.as_ref();
-            session
-                .workspace_members()
-                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
-                .await
-                .expect("grant membership");
-        }
-        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
     }
 
     fn request<T>(message: T, principal: &Principal) -> Request<T> {
@@ -1190,9 +1139,9 @@ mod tests {
     #[tokio::test]
     async fn source_configuration_reaches_only_workspace_owners() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, "outsider", None).await;
+        let owner = seed_principal(&fixture.db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, ISSUER, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, ISSUER, "outsider", None).await;
         std::fs::write(&fixture.config_file, UNPARSEABLE_CONFIG).expect("poison the app config");
 
         for status in every_source_rpc(&fixture.service, &member).await {

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -13,15 +13,17 @@ use super::manager::{TaskManager, TaskManagerError};
 use super::store::{TaskCompletion, TaskOutcome as DomainTaskOutcome, TaskStart, TaskStoreError};
 use crate::bootstrap::app_status;
 use crate::transport::{grpc_span, instrument_grpc, request_context, workspace_name_from_proto};
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
 
 #[derive(Clone)]
 pub(crate) struct TaskService {
     task: TaskManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl TaskService {
-    pub(crate) fn new(task: TaskManager) -> Self {
-        Self { task }
+    pub(crate) const fn new(task: TaskManager, authorizer: WorkspaceAuthorizer) -> Self {
+        Self { task, authorizer }
     }
 }
 
@@ -34,9 +36,17 @@ impl TaskServiceApi for TaskService {
         let span = grpc_span(&request);
         let created_by = request_context(&request)?.principal().clone();
         let task = self.task.clone();
+        let authorizer = self.authorizer.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            // A task row is workspace-owned state, so a caller who may not
+            // reach the workspace must not create one — nor learn from a
+            // validation error that the workspace is there to create it in.
+            authorizer
+                .authorize(&created_by, &workspace, WorkspaceAction::Read)
+                .await
+                .map_err(app_status)?;
             let start = task
                 .start_task(workspace, created_by, request.intent)
                 .await
@@ -53,10 +63,16 @@ impl TaskServiceApi for TaskService {
         request: Request<EndTaskRequest>,
     ) -> Result<Response<EndTaskResponse>, Status> {
         let span = grpc_span(&request);
+        let principal = request_context(&request)?.principal().clone();
         let task = self.task.clone();
+        let authorizer = self.authorizer.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            authorizer
+                .authorize(&principal, &workspace, WorkspaceAction::Read)
+                .await
+                .map_err(app_status)?;
             let task_id = TaskId::parse(&request.task_id).map_err(app_status)?;
             let outcome = task_outcome_from_proto(request.task_status).map_err(app_status)?;
             let completion = task
@@ -140,14 +156,26 @@ mod tests {
     use super::{TaskService, TaskServiceApi};
     use crate::identity::{Principal, PrincipalKind};
     use crate::request_context::RequestContext;
-    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
+        ResolvedDatabaseConfig, run_state_migrations,
+    };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::workspaces::authorization::WorkspaceAuthorizer;
+    use crate::workspaces::{MemberRole, WorkspaceName};
 
     const UNKNOWN_TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
     async fn service() -> (TempDir, TaskService) {
+        let (dir, db) = task_database().await;
+        let task = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let service = TaskService::new(task, WorkspaceAuthorizer::trusting_local_principal(db));
+        (dir, service)
+    }
+
+    async fn task_database() -> (TempDir, Arc<CoralDb>) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
@@ -165,9 +193,7 @@ mod tests {
         run_state_migrations(&db, &config_store, &layout)
             .await
             .expect("import default workspace");
-        let task = TaskManager::new(TaskStore::new(db));
-        let service = TaskService::new(task);
-        (dir, service)
+        (dir, db)
     }
 
     fn workspace(name: &str) -> Workspace {
@@ -205,11 +231,18 @@ mod tests {
         uuid::Uuid::parse_str(&task.task_id).expect("task id is a UUID");
     }
 
+    /// The lifecycle runs under a real workspace membership rather than the
+    /// built-in local principal, so it also stands as the member half of the
+    /// read-access rule these RPCs answer to.
     #[tokio::test]
     async fn end_task_returns_success_status() {
-        let (_dir, service) = service().await;
-        let principal = Principal::parse("product:principal:saul", PrincipalKind::User)
-            .expect("user principal");
+        let (_dir, db) = task_database().await;
+        let _owner = seed_principal(&db, "owner", Some(MemberRole::Owner)).await;
+        let principal = seed_principal(&db, "member", Some(MemberRole::Member)).await;
+        let service = TaskService::new(
+            TaskManager::new(TaskStore::new(Arc::clone(&db))),
+            WorkspaceAuthorizer::new(db),
+        );
 
         let task = service
             .start_task(request_for_principal(
@@ -231,7 +264,7 @@ mod tests {
                     task_id: task.task_id.clone(),
                     task_status: TaskStatus::Success as i32,
                 },
-                principal,
+                principal.clone(),
             ))
             .await
             .expect("end task")
@@ -242,11 +275,14 @@ mod tests {
         assert_eq!(task_end.task_status, TaskStatus::Success as i32);
 
         let status = service
-            .end_task(request(EndTaskRequest {
-                workspace: Some(workspace("default")),
-                task_id: task.task_id,
-                task_status: TaskStatus::Failure as i32,
-            }))
+            .end_task(request_for_principal(
+                EndTaskRequest {
+                    workspace: Some(workspace("default")),
+                    task_id: task.task_id,
+                    task_status: TaskStatus::Failure as i32,
+                },
+                principal,
+            ))
             .await
             .expect_err("terminal task must not change status");
         assert_eq!(status.code(), Code::FailedPrecondition);
@@ -312,6 +348,106 @@ mod tests {
             .expect_err("malformed task id must be rejected");
 
         assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    /// Task rows are workspace-owned state, so a caller who may not reach the
+    /// workspace neither creates one nor ends one. The blank intent and the
+    /// malformed task id are the probe: reaching the task work at all would
+    /// answer `InvalidArgument` instead of the ordinary workspace miss.
+    #[tokio::test]
+    async fn task_lifecycle_deny_before_read_work_changes_no_task() {
+        let (_dir, db) = task_database().await;
+        let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        // The workspace needs an owner before any membership in it grants
+        // anything, so one is seeded beside the member under test.
+        let _owner = seed_principal(&db, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&db, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&db, "outsider", None).await;
+        let service = TaskService::new(tasks.clone(), WorkspaceAuthorizer::new(db));
+        let active = service
+            .start_task(request_for_principal(
+                StartTaskRequest {
+                    workspace: Some(workspace("default")),
+                    intent: "Find renewal risk".to_string(),
+                },
+                member.clone(),
+            ))
+            .await
+            .expect("a member starts a task")
+            .into_inner()
+            .task
+            .expect("task");
+        let task_id = crate::task::id::TaskId::parse(&active.task_id).expect("task id");
+
+        for (name, blank_intent) in [("default", " "), ("absent", " ")] {
+            let status = service
+                .start_task(request_for_principal(
+                    StartTaskRequest {
+                        workspace: Some(workspace(name)),
+                        intent: blank_intent.to_string(),
+                    },
+                    outsider.clone(),
+                ))
+                .await
+                .expect_err("a non-member starts nothing");
+            assert_eq!(status.code(), Code::NotFound);
+        }
+        for task in [active.task_id.as_str(), "not-a-uuid"] {
+            let status = service
+                .end_task(request_for_principal(
+                    EndTaskRequest {
+                        workspace: Some(workspace("default")),
+                        task_id: task.to_string(),
+                        task_status: TaskStatus::Success as i32,
+                    },
+                    outsider.clone(),
+                ))
+                .await
+                .expect_err("a non-member ends nothing");
+            assert_eq!(status.code(), Code::NotFound);
+        }
+
+        assert_eq!(
+            tasks
+                .validate_attribution(&WorkspaceName::default(), Some(task_id))
+                .await
+                .expect("the task is untouched"),
+            Some(task_id),
+            "the denied EndTask must leave the task active"
+        );
+    }
+
+    /// Provisions one directory user through the production login seam and
+    /// grants it `role` on the default workspace, so the principal the
+    /// authorizer is handed is the one a real login carries.
+    async fn seed_principal(
+        db: &Arc<CoralDb>,
+        subject: &str,
+        role: Option<MemberRole>,
+    ) -> Principal {
+        let LoginProvisioning::Provisioned(user) = db
+            .user_state()
+            .provision_login(LoginIdentity {
+                issuer: "https://issuer.test/task-authorization",
+                subject,
+                display_name: None,
+                principal_claim: subject,
+                now_unix_nanos: 1,
+            })
+            .await
+            .expect("provision user")
+        else {
+            panic!("expected a provisioned user rather than an issuer mismatch")
+        };
+        if let Some(role) = role {
+            let mut session = db.as_ref();
+            session
+                .workspace_members()
+                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+                .await
+                .expect("grant membership");
+        }
+        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -154,17 +154,20 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{TaskService, TaskServiceApi};
-    use crate::identity::{Principal, PrincipalKind};
+    use crate::identity::Principal;
     use crate::request_context::RequestContext;
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
-        ResolvedDatabaseConfig, run_state_migrations,
-    };
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::test_support::seed_principal;
     use crate::workspaces::authorization::WorkspaceAuthorizer;
     use crate::workspaces::{MemberRole, WorkspaceName};
+
+    /// This suite's login issuer. Each suite provisions under its own, so a
+    /// subject seeded here is a different person from the same subject
+    /// seeded elsewhere.
+    const ISSUER: &str = "https://issuer.test/task-authorization";
 
     const UNKNOWN_TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
@@ -237,8 +240,8 @@ mod tests {
     #[tokio::test]
     async fn end_task_returns_success_status() {
         let (_dir, db) = task_database().await;
-        let _owner = seed_principal(&db, "owner", Some(MemberRole::Owner)).await;
-        let principal = seed_principal(&db, "member", Some(MemberRole::Member)).await;
+        let _owner = seed_principal(&db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let principal = seed_principal(&db, ISSUER, "member", Some(MemberRole::Member)).await;
         let service = TaskService::new(
             TaskManager::new(TaskStore::new(Arc::clone(&db))),
             WorkspaceAuthorizer::new(db),
@@ -360,9 +363,9 @@ mod tests {
         let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         // The workspace needs an owner before any membership in it grants
         // anything, so one is seeded beside the member under test.
-        let _owner = seed_principal(&db, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&db, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&db, "outsider", None).await;
+        let _owner = seed_principal(&db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&db, ISSUER, "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&db, ISSUER, "outsider", None).await;
         let service = TaskService::new(tasks.clone(), WorkspaceAuthorizer::new(db));
         let active = service
             .start_task(request_for_principal(
@@ -415,39 +418,6 @@ mod tests {
             Some(task_id),
             "the denied EndTask must leave the task active"
         );
-    }
-
-    /// Provisions one directory user through the production login seam and
-    /// grants it `role` on the default workspace, so the principal the
-    /// authorizer is handed is the one a real login carries.
-    async fn seed_principal(
-        db: &Arc<CoralDb>,
-        subject: &str,
-        role: Option<MemberRole>,
-    ) -> Principal {
-        let LoginProvisioning::Provisioned(user) = db
-            .user_state()
-            .provision_login(LoginIdentity {
-                issuer: "https://issuer.test/task-authorization",
-                subject,
-                display_name: None,
-                principal_claim: subject,
-                now_unix_nanos: 1,
-            })
-            .await
-            .expect("provision user")
-        else {
-            panic!("expected a provisioned user rather than an issuer mismatch")
-        };
-        if let Some(role) = role {
-            let mut session = db.as_ref();
-            session
-                .workspace_members()
-                .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
-                .await
-                .expect("grant membership");
-        }
-        Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -407,10 +407,28 @@ impl TraceScope {
 
     /// Reports whether work whose workspace is not yet settled could still
     /// turn out to be in scope.
+    ///
+    /// A scope over no workspaces is the exception: nothing can settle into it,
+    /// so unattributed work is excluded here rather than carried until
+    /// [`Self::admits`] rejects it at the end of a scan that never had an
+    /// answer to find.
     fn may_admit(&self, workspace: Option<&str>) -> bool {
         match self {
             Self::Host => true,
+            Self::Workspaces(names) if names.is_empty() => false,
             Self::Workspaces(names) => workspace.is_none_or(|workspace| names.contains(workspace)),
+        }
+    }
+
+    /// Reports whether this scope can admit anything at all.
+    ///
+    /// A caller who owns no workspaces asks a question with no possible answer,
+    /// and reading the whole retained store to say so is work spent to learn
+    /// nothing.
+    fn admits_nothing(&self) -> bool {
+        match self {
+            Self::Host => false,
+            Self::Workspaces(names) => names.is_empty(),
         }
     }
 
@@ -750,7 +768,7 @@ impl TraceStore {
         offset: usize,
         scope: &TraceScope,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
-        if limit == 0 {
+        if limit == 0 || scope.admits_nothing() {
             return Ok(Vec::new());
         }
 

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -362,6 +362,65 @@ pub(crate) struct TraceStore {
     retention: Option<Duration>,
 }
 
+/// The spans one trace read may see.
+///
+/// Every read the store answers is scoped by one of these, and a caller is
+/// shown nothing outside it. It projects rather than admits: a trace whose
+/// spans span two workspaces is a different trace to each of their owners, and
+/// neither is handed the other's SQL because they happen to share a trace id.
+/// A read that resolves to no workspace is therefore an empty read, not a wide
+/// one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TraceScope {
+    /// Every span this host recorded, including the rows no workspace claims.
+    Host,
+    /// Only spans attributed to one of these workspaces.
+    Workspaces(HashSet<String>),
+}
+
+impl TraceScope {
+    /// Scopes a read to the workspaces `names` names.
+    pub(crate) fn workspaces<'a>(names: impl IntoIterator<Item = &'a str>) -> Self {
+        Self::Workspaces(names.into_iter().map(str::to_string).collect())
+    }
+
+    /// Reports whether work attributed to `workspace` is in scope.
+    ///
+    /// An unattributed `None` is the host's own work: no workspace claims it,
+    /// so only [`Self::Host`] sees it.
+    fn admits(&self, workspace: Option<&str>) -> bool {
+        match self {
+            Self::Host => true,
+            Self::Workspaces(names) => workspace.is_some_and(|workspace| names.contains(workspace)),
+        }
+    }
+
+    /// Reports whether a span carrying `attributes_json` is in scope.
+    fn admits_span(&self, attributes_json: &str) -> bool {
+        match self {
+            // Parsing the attributes of a span nothing can exclude is work for
+            // an answer already known.
+            Self::Host => true,
+            Self::Workspaces(_) => self.admits(workspace_attribute(attributes_json).as_deref()),
+        }
+    }
+
+    /// Reports whether work whose workspace is not yet settled could still
+    /// turn out to be in scope.
+    fn may_admit(&self, workspace: Option<&str>) -> bool {
+        match self {
+            Self::Host => true,
+            Self::Workspaces(names) => workspace.is_none_or(|workspace| names.contains(workspace)),
+        }
+    }
+
+    /// Reports whether this scope excludes nothing, which is what lets a scan
+    /// stop early without proving anything about the spans it has not read.
+    const fn admits_every_span(&self) -> bool {
+        matches!(self, Self::Host)
+    }
+}
+
 #[derive(Debug, Clone)]
 struct TraceStoreFile {
     path: PathBuf,
@@ -568,6 +627,15 @@ struct TracePrimaryCandidate {
     priority: u8,
 }
 
+/// One trace as a listing sees it, under one scope.
+///
+/// Two kinds of fact live here and must not be confused. The first four are
+/// what the caller is shown, and they count only the spans the scope admits,
+/// so a foreign span never lends this trace its SQL, its errors, or its
+/// duration. The last three describe the trace as it was stored, foreign spans
+/// included; the scan reads them to decide when it may stop opening older
+/// files, and that question is about where spans are on disk rather than about
+/// who may see them.
 #[derive(Debug, Clone)]
 struct TraceListAggregate {
     trace_id: String,
@@ -575,9 +643,12 @@ struct TraceListAggregate {
     end_time_unix_nanos: i64,
     span_count: u32,
     error_count: u32,
-    found_root_span: bool,
-    matches_workspace: bool,
     primary: Option<TracePrimaryCandidate>,
+    /// Whether any span of this trace is in scope at all.
+    in_scope: bool,
+    scan_start_unix_nanos: i64,
+    scan_end_unix_nanos: i64,
+    found_root_span: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -621,75 +692,46 @@ impl TraceStore {
         &self,
         limit: usize,
         offset: usize,
+        scope: TraceScope,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
         let traces = self.clone();
-        task::spawn_blocking(move || traces.list_traces_sync(limit, offset))
+        task::spawn_blocking(move || traces.list_traces_sync(limit, offset, &scope))
             .await
             .map_err(|source| TraceStoreError::Worker { source })?
-    }
-
-    pub(crate) async fn list_traces_for_workspace(
-        &self,
-        limit: usize,
-        offset: usize,
-        workspace_name: String,
-    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
-        let traces = self.clone();
-        task::spawn_blocking(move || {
-            traces.list_traces_for_workspace_sync(limit, offset, &workspace_name)
-        })
-        .await
-        .map_err(|source| TraceStoreError::Worker { source })?
     }
 
     pub(crate) async fn list_query_stream(
         &self,
         limit: usize,
         offset: usize,
-        workspace_name: Option<String>,
+        scope: TraceScope,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
         let traces = self.clone();
-        task::spawn_blocking(move || {
-            traces.list_query_stream_sync(limit, offset, workspace_name.as_deref())
-        })
-        .await
-        .map_err(|source| TraceStoreError::Worker { source })?
+        task::spawn_blocking(move || traces.list_query_stream_sync(limit, offset, &scope))
+            .await
+            .map_err(|source| TraceStoreError::Worker { source })?
     }
 
     pub(crate) async fn get_trace(
         &self,
         trace_id: String,
+        scope: TraceScope,
     ) -> Result<TraceDetailRecord, TraceStoreError> {
         let traces = self.clone();
-        task::spawn_blocking(move || traces.get_trace_sync(&trace_id))
+        task::spawn_blocking(move || traces.get_trace_sync(&trace_id, &scope))
             .await
             .map_err(|source| TraceStoreError::Worker { source })?
-    }
-
-    pub(crate) async fn get_trace_for_workspace(
-        &self,
-        trace_id: String,
-        workspace_name: String,
-    ) -> Result<TraceDetailRecord, TraceStoreError> {
-        let traces = self.clone();
-        task::spawn_blocking(move || {
-            traces.get_trace_for_workspace_sync(&trace_id, &workspace_name)
-        })
-        .await
-        .map_err(|source| TraceStoreError::Worker { source })?
     }
 
     pub(crate) async fn get_query_stream_trace(
         &self,
         trace_id: String,
-        workspace_name: Option<String>,
+        scope: TraceScope,
     ) -> Result<TraceDetailRecord, TraceStoreError> {
         let traces = self.clone();
-        task::spawn_blocking(move || {
-            traces.get_query_stream_trace_sync(&trace_id, workspace_name.as_deref())
-        })
-        .await
-        .map_err(|source| TraceStoreError::Worker { source })?
+        task::spawn_blocking(move || traces.get_query_stream_trace_sync(&trace_id, &scope))
+            .await
+            .map_err(|source| TraceStoreError::Worker { source })?
     }
 
     pub(crate) async fn delete_traces_for_workspace(
@@ -706,24 +748,7 @@ impl TraceStore {
         &self,
         limit: usize,
         offset: usize,
-    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
-        self.list_traces_filtered_sync(limit, offset, None)
-    }
-
-    fn list_traces_for_workspace_sync(
-        &self,
-        limit: usize,
-        offset: usize,
-        workspace_name: &str,
-    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
-        self.list_traces_filtered_sync(limit, offset, Some(workspace_name))
-    }
-
-    fn list_traces_filtered_sync(
-        &self,
-        limit: usize,
-        offset: usize,
-        workspace_name: Option<&str>,
+        scope: &TraceScope,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
         if limit == 0 {
             return Ok(Vec::new());
@@ -739,7 +764,7 @@ impl TraceStore {
         for (file_index, file) in files.iter().enumerate().rev() {
             oldest_scanned_file_index = Some(file_index);
             for span in read_list_spans_file(&file.path)? {
-                record_list_span(span, workspace_name, &mut spans_by_id, &mut traces);
+                record_list_span(span, scope, &mut spans_by_id, &mut traces);
             }
 
             let Some(newest_unscanned_file) =
@@ -751,18 +776,18 @@ impl TraceStore {
                 &traces,
                 required_trace_count,
                 newest_unscanned_file.span_end_upper_bound_unix_nanos,
-                workspace_name,
+                scope,
             ) {
                 break;
             }
         }
 
-        let page_trace_ids = trace_page_ids(&traces, offset, limit, workspace_name);
+        let page_trace_ids = trace_page_ids(&traces, offset, limit);
         complete_list_aggregates_for_page(
             &files,
             oldest_scanned_file_index,
             &page_trace_ids,
-            workspace_name,
+            scope,
             &mut spans_by_id,
             &mut traces,
         )?;
@@ -780,12 +805,16 @@ impl TraceStore {
         &self,
         limit: usize,
         offset: usize,
-        workspace_name: Option<&str>,
+        scope: &TraceScope,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
-        query_stream::list(self, limit, offset, workspace_name)
+        query_stream::list(self, limit, offset, scope)
     }
 
-    fn get_trace_sync(&self, trace_id: &str) -> Result<TraceDetailRecord, TraceStoreError> {
+    fn get_trace_sync(
+        &self,
+        trace_id: &str,
+        scope: &TraceScope,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
         let mut spans_by_id = HashMap::new();
         self.prune_expired()?;
         let files = self.jsonl_files_by_modified()?;
@@ -810,6 +839,13 @@ impl TraceStore {
             }
         }
         let mut spans = spans_by_id.into_values().collect::<Vec<_>>();
+        // The scope projects the trace rather than admitting it: a caller sees
+        // the spans their own workspaces recorded and no others, so a trace
+        // that two workspaces share carries no query text across the boundary.
+        // A trace with nothing in scope reads exactly like one that was never
+        // recorded, which is the answer a caller who may not know it exists
+        // must get.
+        spans.retain(|span| scope.admits_span(&span.attributes_json));
 
         if spans.is_empty() {
             return Err(TraceStoreError::NotFound(trace_id.to_string()));
@@ -825,30 +861,13 @@ impl TraceStore {
         Ok(TraceDetailRecord { summary, spans })
     }
 
-    fn get_trace_for_workspace_sync(
-        &self,
-        trace_id: &str,
-        workspace_name: &str,
-    ) -> Result<TraceDetailRecord, TraceStoreError> {
-        let detail = self.get_trace_sync(trace_id)?;
-        if detail
-            .spans
-            .iter()
-            .any(|span| attributes_match_workspace(&span.attributes_json, workspace_name))
-        {
-            Ok(detail)
-        } else {
-            Err(TraceStoreError::NotFound(trace_id.to_string()))
-        }
-    }
-
     fn get_query_stream_trace_sync(
         &self,
         trace_id: &str,
-        workspace_name: Option<&str>,
+        scope: &TraceScope,
     ) -> Result<TraceDetailRecord, TraceStoreError> {
-        let mut detail = self.get_trace_sync(trace_id)?;
-        let Some(summary) = query_stream::summary(&detail.spans, workspace_name) else {
+        let mut detail = self.get_trace_sync(trace_id, scope)?;
+        let Some(summary) = query_stream::summary(&detail.spans, scope) else {
             return Err(TraceStoreError::NotFound(trace_id.to_string()));
         };
         detail.summary = summary;
@@ -1038,32 +1057,45 @@ impl TracePrimaryCandidate {
 }
 
 impl TraceListAggregate {
-    fn new(span: &TraceListSpanRecord, workspace_name: Option<&str>) -> Self {
+    fn new(span: &TraceListSpanRecord, scope: &TraceScope) -> Self {
         let mut aggregate = Self {
             trace_id: span.trace_id.clone(),
-            start_time_unix_nanos: span.start_time_unix_nanos,
-            end_time_unix_nanos: span.end_time_unix_nanos,
+            // No span is in scope yet, so the shown bounds start empty rather
+            // than at this span's: `record_span` opens them only if it admits
+            // one.
+            start_time_unix_nanos: i64::MAX,
+            end_time_unix_nanos: i64::MIN,
             span_count: 0,
             error_count: 0,
-            found_root_span: false,
-            matches_workspace: false,
             primary: None,
+            in_scope: false,
+            scan_start_unix_nanos: span.start_time_unix_nanos,
+            scan_end_unix_nanos: span.end_time_unix_nanos,
+            found_root_span: false,
         };
-        aggregate.record_span(span, workspace_name);
+        aggregate.record_span(span, scope);
         aggregate
     }
 
-    fn record_span(&mut self, span: &TraceListSpanRecord, workspace_name: Option<&str>) {
+    fn record_span(&mut self, span: &TraceListSpanRecord, scope: &TraceScope) {
+        self.scan_start_unix_nanos = self.scan_start_unix_nanos.min(span.start_time_unix_nanos);
+        self.scan_end_unix_nanos = self.scan_end_unix_nanos.max(span.end_time_unix_nanos);
+        self.found_root_span |= is_root_span_parent(span.parent_span_id.as_deref());
+
+        // Everything below is what the caller is told about this trace, so a
+        // span they may not see contributes none of it — not the summary it
+        // could have been chosen for, and not the counts and times that would
+        // report its existence anyway.
+        if !scope.admits_span(&span.attributes_json) {
+            return;
+        }
+        self.in_scope = true;
         self.start_time_unix_nanos = self.start_time_unix_nanos.min(span.start_time_unix_nanos);
         self.end_time_unix_nanos = self.end_time_unix_nanos.max(span.end_time_unix_nanos);
         self.span_count = self.span_count.saturating_add(1);
         if span.status == StoredTraceStatus::Error {
             self.error_count = self.error_count.saturating_add(1);
         }
-        self.found_root_span |= is_root_span_parent(span.parent_span_id.as_deref());
-        self.matches_workspace |= workspace_name.is_some_and(|workspace_name| {
-            attributes_match_workspace(&span.attributes_json, workspace_name)
-        });
 
         let primary = TracePrimaryCandidate::from_span(span);
         if self
@@ -1089,7 +1121,7 @@ impl TraceListAggregate {
 
 fn record_list_span(
     span: TraceListSpanRecord,
-    workspace_name: Option<&str>,
+    scope: &TraceScope,
     spans_by_id: &mut HashMap<(String, String), TraceListSpanRecord>,
     traces: &mut HashMap<String, TraceListAggregate>,
 ) {
@@ -1099,8 +1131,8 @@ fn record_list_span(
         Entry::Vacant(entry) => {
             traces
                 .entry(span.trace_id.clone())
-                .and_modify(|aggregate| aggregate.record_span(&span, workspace_name))
-                .or_insert_with(|| TraceListAggregate::new(&span, workspace_name));
+                .and_modify(|aggregate| aggregate.record_span(&span, scope))
+                .or_insert_with(|| TraceListAggregate::new(&span, scope));
             entry.insert(span);
         }
     }
@@ -1110,11 +1142,10 @@ fn trace_page_ids(
     traces: &HashMap<String, TraceListAggregate>,
     offset: usize,
     limit: usize,
-    workspace_name: Option<&str>,
 ) -> HashSet<String> {
     let mut aggregates = traces
         .values()
-        .filter(|aggregate| trace_matches_workspace_filter(aggregate, workspace_name))
+        .filter(|aggregate| aggregate.in_scope)
         .collect::<Vec<_>>();
     sort_trace_aggregates(&mut aggregates);
     aggregates
@@ -1129,7 +1160,7 @@ fn complete_list_aggregates_for_page(
     files: &[TraceStoreFile],
     oldest_scanned_file_index: Option<usize>,
     page_trace_ids: &HashSet<String>,
-    workspace_name: Option<&str>,
+    scope: &TraceScope,
     spans_by_id: &mut HashMap<(String, String), TraceListSpanRecord>,
     traces: &mut HashMap<String, TraceListAggregate>,
 ) -> Result<(), TraceStoreError> {
@@ -1149,7 +1180,7 @@ fn complete_list_aggregates_for_page(
             break;
         }
         for span in read_list_spans_file_for_trace_ids(&file.path, page_trace_ids)? {
-            record_list_span(span, workspace_name, spans_by_id, traces);
+            record_list_span(span, scope, spans_by_id, traces);
         }
     }
 
@@ -1166,7 +1197,7 @@ fn page_completion_start_cutoff(
         if !aggregate.found_root_span {
             return None;
         }
-        cutoff = cutoff.min(aggregate.start_time_unix_nanos);
+        cutoff = cutoff.min(aggregate.scan_start_unix_nanos);
     }
     Some(cutoff)
 }
@@ -1175,7 +1206,7 @@ fn list_page_is_newer_than_unscanned_files(
     traces: &HashMap<String, TraceListAggregate>,
     required_trace_count: usize,
     newest_unscanned_span_end_upper_bound_unix_nanos: i64,
-    workspace_name: Option<&str>,
+    scope: &TraceScope,
 ) -> bool {
     if required_trace_count == 0 {
         return false;
@@ -1183,7 +1214,7 @@ fn list_page_is_newer_than_unscanned_files(
 
     let mut aggregates = traces
         .values()
-        .filter(|aggregate| trace_matches_workspace_filter(aggregate, workspace_name))
+        .filter(|aggregate| aggregate.in_scope)
         .collect::<Vec<_>>();
     if aggregates.len() < required_trace_count {
         return false;
@@ -1196,29 +1227,21 @@ fn list_page_is_newer_than_unscanned_files(
         return false;
     }
 
-    workspace_name.is_none_or(|_| {
-        workspace_filter_is_settled_for_page_boundary(
+    scope.admits_every_span()
+        || scope_is_settled_for_page_boundary(
             traces,
             boundary,
             newest_unscanned_span_end_upper_bound_unix_nanos,
         )
-    })
 }
 
-fn trace_matches_workspace_filter(
-    aggregate: &TraceListAggregate,
-    workspace_name: Option<&str>,
-) -> bool {
-    workspace_name.is_none_or(|_| aggregate.matches_workspace)
-}
-
-fn workspace_filter_is_settled_for_page_boundary(
+fn scope_is_settled_for_page_boundary(
     traces: &HashMap<String, TraceListAggregate>,
     boundary: &TraceListAggregate,
     newest_unscanned_span_end_upper_bound_unix_nanos: i64,
 ) -> bool {
     traces.values().all(|aggregate| {
-        aggregate.matches_workspace
+        aggregate.in_scope
             || !could_sort_before_or_at_boundary(aggregate, boundary)
             || trace_is_complete_before_unscanned_files(
                 aggregate,
@@ -1231,8 +1254,11 @@ fn could_sort_before_or_at_boundary(
     aggregate: &TraceListAggregate,
     boundary: &TraceListAggregate,
 ) -> bool {
-    aggregate.end_time_unix_nanos > boundary.end_time_unix_nanos
-        || (aggregate.end_time_unix_nanos == boundary.end_time_unix_nanos
+    // The candidate has nothing in scope yet, so the end time it would enter
+    // the page with is unknown; the latest end it has anywhere bounds it, and
+    // reading that keeps the answer conservative.
+    aggregate.scan_end_unix_nanos > boundary.end_time_unix_nanos
+        || (aggregate.scan_end_unix_nanos == boundary.end_time_unix_nanos
             && aggregate.trace_id <= boundary.trace_id)
 }
 
@@ -1241,7 +1267,7 @@ fn trace_is_complete_before_unscanned_files(
     newest_unscanned_span_end_upper_bound_unix_nanos: i64,
 ) -> bool {
     aggregate.found_root_span
-        && newest_unscanned_span_end_upper_bound_unix_nanos < aggregate.start_time_unix_nanos
+        && newest_unscanned_span_end_upper_bound_unix_nanos < aggregate.scan_start_unix_nanos
 }
 
 fn sort_trace_aggregates(aggregates: &mut [&TraceListAggregate]) {
@@ -2069,7 +2095,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        JSONL_MAX_FILE_AGE, JsonlSpanExporter, RollingJsonlWriter, StoredTraceStatus,
+        JSONL_MAX_FILE_AGE, JsonlSpanExporter, RollingJsonlWriter, StoredTraceStatus, TraceScope,
         TraceSpanRecord, TraceStore, unix_nanos,
     };
     use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
@@ -2108,13 +2134,15 @@ mod tests {
 
         let store = TraceStore::new(dir);
         let trace_id = store
-            .list_traces_sync(10, 0)
+            .list_traces_sync(10, 0, &TraceScope::Host)
             .expect("list traces")
             .into_iter()
             .next()
             .expect("trace summary")
             .trace_id;
-        let detail = store.get_trace_sync(&trace_id).expect("trace detail");
+        let detail = store
+            .get_trace_sync(&trace_id, &TraceScope::Host)
+            .expect("trace detail");
         let span = detail.spans.first().expect("trace span");
 
         assert_eq!(span.name, "coral.query");
@@ -2166,7 +2194,10 @@ mod tests {
 
         assert_eq!(jsonl_file_count(&dir), 1);
         assert_eq!(
-            TraceStore::new(dir).list_traces_sync(10, 0).unwrap().len(),
+            TraceStore::new(dir)
+                .list_traces_sync(10, 0, &TraceScope::Host)
+                .unwrap()
+                .len(),
             2
         );
     }
@@ -2194,7 +2225,9 @@ mod tests {
         provider.shutdown().expect("provider shutdown");
 
         let store = TraceStore::new(dir);
-        let summaries = store.list_traces_sync(10, 0).expect("list traces");
+        let summaries = store
+            .list_traces_sync(10, 0, &TraceScope::Host)
+            .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
         let summary = summaries.first().expect("trace summary");
@@ -2205,7 +2238,7 @@ mod tests {
         assert!(summary.row_count_recorded);
 
         let detail = store
-            .get_trace_sync(&summary.trace_id)
+            .get_trace_sync(&summary.trace_id, &TraceScope::Host)
             .expect("trace detail");
         assert_eq!(detail.summary, *summary);
         assert_eq!(detail.spans.len(), 1);
@@ -2247,12 +2280,14 @@ mod tests {
 
         let store = TraceStore::new(dir);
         let summary = store
-            .list_traces_sync(10, 0)
+            .list_traces_sync(10, 0, &TraceScope::Host)
             .expect("list traces")
             .into_iter()
             .next()
             .expect("trace summary");
-        let detail = store.get_trace_sync("mixed-batch").expect("trace detail");
+        let detail = store
+            .get_trace_sync("mixed-batch", &TraceScope::Host)
+            .expect("trace detail");
 
         assert_eq!(summary.root_span_id, "first-query");
         assert_eq!(summary.query, "SELECT 1");
@@ -2284,7 +2319,7 @@ mod tests {
         .expect("write body record");
 
         let summaries = TraceStore::new(dir)
-            .list_traces_sync(10, 0)
+            .list_traces_sync(10, 0, &TraceScope::Host)
             .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
@@ -2387,7 +2422,7 @@ mod tests {
         set_modified_time(&old_path, old_time);
 
         let summaries = TraceStore::new(dir)
-            .list_traces_sync(1, 0)
+            .list_traces_sync(1, 0, &TraceScope::Host)
             .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
@@ -2422,7 +2457,7 @@ mod tests {
         set_modified_time(&old_path, old_time);
 
         let summaries = TraceStore::new(dir)
-            .list_traces_sync(1, 1)
+            .list_traces_sync(1, 1, &TraceScope::Host)
             .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
@@ -2473,7 +2508,7 @@ mod tests {
         set_modified_time(&root_path, root_time);
 
         let summaries = TraceStore::new(dir)
-            .list_traces_sync(1, 0)
+            .list_traces_sync(1, 0, &TraceScope::Host)
             .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
@@ -2514,7 +2549,7 @@ mod tests {
         set_modified_time(&query_path, query_time);
 
         let summaries = TraceStore::new(dir)
-            .list_traces_sync(1, 0)
+            .list_traces_sync(1, 0, &TraceScope::Host)
             .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
@@ -2552,7 +2587,7 @@ mod tests {
         set_modified_time(&visible_path, visible_modified);
 
         let summaries = TraceStore::new(dir)
-            .list_traces_sync(1, 0)
+            .list_traces_sync(1, 0, &TraceScope::Host)
             .expect("list traces");
 
         assert_eq!(summaries.len(), 1);
@@ -2577,7 +2612,7 @@ mod tests {
 
         assert!(
             store
-                .list_traces_sync(10, 0)
+                .list_traces_sync(10, 0, &TraceScope::Host)
                 .expect("list traces")
                 .is_empty()
         );
@@ -2599,7 +2634,7 @@ mod tests {
         write_record_file(&target_path, &trace_record("target-trace", "target-span"));
 
         let detail = TraceStore::new(dir)
-            .get_trace_sync("target-trace")
+            .get_trace_sync("target-trace", &TraceScope::Host)
             .expect("trace detail");
 
         assert_eq!(detail.summary.trace_id, "target-trace");
@@ -2625,7 +2660,7 @@ mod tests {
         set_modified_time(&old_path, old_time);
 
         let detail = TraceStore::new(dir)
-            .get_trace_sync("target-trace")
+            .get_trace_sync("target-trace", &TraceScope::Host)
             .expect("trace detail");
 
         assert_eq!(detail.summary.trace_id, "target-trace");
@@ -2661,7 +2696,7 @@ mod tests {
         set_modified_time(&query_path, query_time);
 
         let detail = TraceStore::new(dir)
-            .get_trace_sync("nested-detail-trace")
+            .get_trace_sync("nested-detail-trace", &TraceScope::Host)
             .expect("trace detail");
 
         assert_eq!(detail.summary.root_span_id, "query-span");
@@ -2700,7 +2735,7 @@ mod tests {
         set_modified_time(&newer_path, newer_modified);
 
         let detail = TraceStore::new(dir)
-            .get_trace_sync("duplicate-trace")
+            .get_trace_sync("duplicate-trace", &TraceScope::Host)
             .expect("trace detail");
 
         assert_eq!(detail.spans.len(), 1);
@@ -2769,8 +2804,9 @@ mod tests {
         );
 
         let store = TraceStore::new(dir);
+        let alpha = TraceScope::workspaces(["alpha"]);
         let summaries = store
-            .list_traces_for_workspace_sync(10, 0, "alpha")
+            .list_traces_sync(10, 0, &alpha)
             .expect("list alpha traces");
 
         assert_eq!(
@@ -2780,27 +2816,102 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["alpha-new", "alpha-old"]
         );
-        assert_eq!(summaries.first().expect("alpha-new").span_count, 2);
+        // The child span carries no workspace, so nothing attributes it to
+        // alpha and the projection leaves it out — of the span count and of
+        // the trace's end time alike, which is what keeps a listing from
+        // reporting a span its detail will not show.
+        assert_eq!(summaries.first().expect("alpha-new").span_count, 1);
         assert_eq!(
             summaries.first().expect("alpha-new").end_time_unix_nanos,
-            20
+            15
         );
 
         let paged = store
-            .list_traces_for_workspace_sync(1, 1, "alpha")
+            .list_traces_sync(1, 1, &alpha)
             .expect("list second alpha trace");
         assert_eq!(paged.first().expect("paged alpha").trace_id, "alpha-old");
 
         let detail = store
-            .get_trace_for_workspace_sync("alpha-new", "alpha")
+            .get_trace_sync("alpha-new", &alpha)
             .expect("alpha trace detail");
-        assert_eq!(detail.spans.len(), 2);
+        assert_eq!(detail.spans.len(), 1);
+        assert_eq!(detail.summary.end_time_unix_nanos, 15);
         store
-            .get_trace_for_workspace_sync("beta-trace", "alpha")
+            .get_trace_sync("beta-trace", &alpha)
             .expect_err("beta trace must not be visible through alpha filter");
         store
-            .get_trace_for_workspace_sync("duplicate-workspace", "alpha")
+            .get_trace_sync("duplicate-workspace", &alpha)
             .expect_err("newer beta duplicate must not be visible through alpha filter");
+    }
+
+    /// A trace id is not an authorization boundary: two workspaces can end up
+    /// sharing one, through a `CORAL_TRACE_PARENT` reused across them or a
+    /// client-supplied `traceparent`. The scope therefore projects the trace
+    /// rather than admitting it — each owner is shown their own spans, and the
+    /// summary is rebuilt from those, so neither reads the other's SQL through
+    /// the trace they happen to share.
+    #[test]
+    fn a_shared_trace_shows_each_workspace_only_its_own_spans() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+
+        // Beta's span is the one a summary would reach for first: it is the
+        // earliest, so it wins the primary candidate on every tiebreak.
+        let mut beta_span = trace_record("shared-trace", "beta-span");
+        beta_span.attributes_json =
+            r#"{"workspace":"beta","sql":"SELECT beta_secret"}"#.to_string();
+        beta_span.status = StoredTraceStatus::Error;
+        beta_span.start_time_unix_nanos = 10;
+        beta_span.end_time_unix_nanos = 40;
+
+        let mut alpha_span = trace_record("shared-trace", "alpha-span");
+        alpha_span.attributes_json = r#"{"workspace":"alpha","sql":"SELECT alpha"}"#.to_string();
+        alpha_span.parent_span_id = Some("beta-span".to_string());
+        alpha_span.start_time_unix_nanos = 20;
+        alpha_span.end_time_unix_nanos = 30;
+
+        write_record_file_lines(
+            &dir.join(timestamped_jsonl_path(SystemTime::now())),
+            &[beta_span, alpha_span],
+        );
+        let store = TraceStore::new(dir);
+
+        let listed = store
+            .list_traces_sync(10, 0, &TraceScope::workspaces(["alpha"]))
+            .expect("list alpha traces");
+        let summary = listed.first().expect("the shared trace is alpha's too");
+        assert_eq!(summary.query, "SELECT alpha");
+        assert_eq!(summary.root_span_id, "alpha-span");
+        assert_eq!(summary.span_count, 1);
+        assert_eq!(summary.start_time_unix_nanos, 20);
+        assert_eq!(summary.end_time_unix_nanos, 30);
+        assert_eq!(summary.status, StoredTraceStatus::Ok);
+
+        let detail = store
+            .get_trace_sync("shared-trace", &TraceScope::workspaces(["alpha"]))
+            .expect("alpha reads the trace it took part in");
+        assert_eq!(
+            detail
+                .spans
+                .iter()
+                .map(|span| span.span_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha-span"],
+            "beta's span must not travel with the trace id it shares",
+        );
+        assert_eq!(detail.summary.query, "SELECT alpha");
+
+        // Both halves are still there for the host, which is the only reader
+        // with no workspace to be confined to.
+        let host = store
+            .get_trace_sync("shared-trace", &TraceScope::Host)
+            .expect("the host reads the whole trace");
+        assert_eq!(host.spans.len(), 2);
+        // And a caller scoped to neither workspace is told nothing exists.
+        store
+            .get_trace_sync("shared-trace", &TraceScope::workspaces(["gamma"]))
+            .expect_err("a trace with nothing in scope reads as absent");
     }
 
     #[test]
@@ -2825,13 +2936,13 @@ mod tests {
 
         let store = TraceStore::new(dir);
         let summary = store
-            .list_traces_sync(1, 0)
+            .list_traces_sync(1, 0, &TraceScope::Host)
             .expect("list traces")
             .into_iter()
             .next()
             .expect("trace summary");
         let detail = store
-            .get_trace_sync("same-file-duplicate-trace")
+            .get_trace_sync("same-file-duplicate-trace", &TraceScope::Host)
             .expect("trace detail");
 
         assert_eq!(summary.query, "SELECT 'new'");
@@ -2854,11 +2965,13 @@ mod tests {
 
         assert!(
             store
-                .list_traces_sync(10, 0)
+                .list_traces_sync(10, 0, &TraceScope::Host)
                 .expect("missing store list")
                 .is_empty()
         );
-        store.get_trace_sync("missing").unwrap_err();
+        store
+            .get_trace_sync("missing", &TraceScope::Host)
+            .unwrap_err();
     }
 
     #[test]
@@ -2904,7 +3017,9 @@ mod tests {
         );
         let store = TraceStore::with_retention(dir, TRACE_RETENTION);
 
-        let traces = store.list_traces_sync(10, 0).expect("list traces");
+        let traces = store
+            .list_traces_sync(10, 0, &TraceScope::Host)
+            .expect("list traces");
 
         assert!(!expired_path.exists());
         assert!(old_name_fresh_path.exists());

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -25,6 +25,9 @@ pub(super) fn list(
     offset: usize,
     scope: &TraceScope,
 ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+    if scope.admits_nothing() {
+        return Ok(Vec::new());
+    }
     if limit == 0 {
         return Ok(Vec::new());
     }
@@ -251,12 +254,24 @@ impl StreamingQueryStreamAggregate {
         }
     }
 
-    fn record_span(&mut self, span: &ProjectedQueryStreamSpan, depth: usize) {
+    fn record_span(&mut self, span: &ProjectedQueryStreamSpan, depth: usize, scope: &TraceScope) {
         self.span_count = self.span_count.saturating_add(1);
+        // Evidence is recorded for every span, including excluded ones: a
+        // second workspace is what makes the evidence a `Conflict`, and that
+        // conclusion is only reachable by seeing the span that conflicts.
         self.workspace_evidence.record(span.workspace.as_deref());
         let Some(metadata) = span.metadata.as_ref() else {
             return;
         };
+        // Everything below becomes what the caller is shown — the operation
+        // this summary names and the query text it carries. A span positively
+        // attributed to a workspace this scope excludes contributes none of
+        // it, or an operation admitted by its own root would report a
+        // descendant's SQL. A span carrying no workspace of its own is not
+        // excluded: it belongs to whatever operation owns it.
+        if !scope.may_admit(span.workspace.as_deref()) {
+            return;
+        }
         if depth > 0 {
             let operation = QueryStreamPrimaryOperation::new(
                 metadata.kind,
@@ -473,10 +488,11 @@ impl QueryStreamProjector {
             .or_default()
             .push(key.clone());
         self.nodes.insert(key, node);
-        if let Some((owner, depth)) = owner.zip(owner_depth)
-            && let Some(aggregate) = self.aggregates.get_mut(&owner)
-        {
-            aggregate.record_span(span, depth);
+        if let Some((owner, depth)) = owner.zip(owner_depth) {
+            let scope = &self.scope;
+            if let Some(aggregate) = self.aggregates.get_mut(&owner) {
+                aggregate.record_span(span, depth, scope);
+            }
         }
     }
 

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -11,8 +11,8 @@ use classification::{
 };
 
 use super::{
-    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceSpanRecord, TraceStore,
-    TraceStoreError, TraceSummaryRecord, attr_string, attr_u64, parse_attributes,
+    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceScope, TraceSpanRecord,
+    TraceStore, TraceStoreError, TraceSummaryRecord, attr_string, attr_u64, parse_attributes,
     read_list_spans_file, status_from_attributes, usize_to_u32,
 };
 use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
@@ -23,7 +23,7 @@ pub(super) fn list(
     store: &TraceStore,
     limit: usize,
     offset: usize,
-    workspace_name: Option<&str>,
+    scope: &TraceScope,
 ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
     if limit == 0 {
         return Ok(Vec::new());
@@ -32,7 +32,7 @@ pub(super) fn list(
     store.prune_expired()?;
     let files = store.jsonl_files_by_modified()?;
     let required_entry_count = offset.saturating_add(limit);
-    let mut projector = QueryStreamProjector::new(required_entry_count, workspace_name);
+    let mut projector = QueryStreamProjector::new(required_entry_count, scope);
     let mut scanned_all_files = true;
     let mut remaining_files = files.as_slice();
     while let Some(newest_bucket_file) = remaining_files.last() {
@@ -84,14 +84,11 @@ fn sort_and_deduplicate_query_stream_summaries(summaries: &mut Vec<TraceSummaryR
     summaries.retain(|summary| seen_trace_ids.insert(summary.trace_id.clone()));
 }
 
-pub(super) fn summary(
-    spans: &[TraceSpanRecord],
-    workspace_name: Option<&str>,
-) -> Option<TraceSummaryRecord> {
-    summaries(spans, workspace_name).into_iter().next()
+pub(super) fn summary(spans: &[TraceSpanRecord], scope: &TraceScope) -> Option<TraceSummaryRecord> {
+    summaries(spans, scope).into_iter().next()
 }
 
-fn summaries(spans: &[TraceSpanRecord], workspace_name: Option<&str>) -> Vec<TraceSummaryRecord> {
+fn summaries(spans: &[TraceSpanRecord], scope: &TraceScope) -> Vec<TraceSummaryRecord> {
     let records = spans
         .iter()
         .map(|span| TraceListSpanRecord {
@@ -107,7 +104,7 @@ fn summaries(spans: &[TraceSpanRecord], workspace_name: Option<&str>) -> Vec<Tra
         })
         .collect::<Vec<_>>();
     let required_entry_count = records.len();
-    let mut projector = QueryStreamProjector::new(required_entry_count, workspace_name);
+    let mut projector = QueryStreamProjector::new(required_entry_count, scope);
     projector.record_file(records);
     projector.finish();
     projector.into_page(0, required_entry_count)
@@ -304,11 +301,8 @@ impl StreamingQueryStreamAggregate {
             .or_else(|| self.workspace_evidence.unique())
     }
 
-    fn may_match_workspace(&self, workspace_name: Option<&str>) -> bool {
-        workspace_name.is_none_or(|workspace_name| {
-            self.workspace()
-                .is_none_or(|operation_workspace| operation_workspace == workspace_name)
-        })
+    fn may_be_in_scope(&self, scope: &TraceScope) -> bool {
+        scope.may_admit(self.workspace())
     }
 
     fn into_summary(self) -> TraceSummaryRecord {
@@ -361,7 +355,7 @@ impl StreamingQueryStreamAggregate {
 /// that would later need to be replaced by its outer operation.
 struct QueryStreamProjector {
     required_entry_count: usize,
-    workspace_name: Option<String>,
+    scope: TraceScope,
     nodes: HashMap<QueryStreamSpanKey, QueryStreamNodeState>,
     node_starts: BTreeMap<i64, Vec<QueryStreamSpanKey>>,
     aggregates: HashMap<u64, StreamingQueryStreamAggregate>,
@@ -371,10 +365,10 @@ struct QueryStreamProjector {
 }
 
 impl QueryStreamProjector {
-    fn new(required_entry_count: usize, workspace_name: Option<&str>) -> Self {
+    fn new(required_entry_count: usize, scope: &TraceScope) -> Self {
         Self {
             required_entry_count,
-            workspace_name: workspace_name.map(str::to_string),
+            scope: scope.clone(),
             nodes: HashMap::new(),
             node_starts: BTreeMap::new(),
             aggregates: HashMap::new(),
@@ -511,11 +505,7 @@ impl QueryStreamProjector {
         let Some(aggregate) = self.aggregates.remove(&operation_id) else {
             return;
         };
-        if self
-            .workspace_name
-            .as_deref()
-            .is_none_or(|workspace_name| aggregate.workspace() == Some(workspace_name))
-        {
+        if self.scope.admits(aggregate.workspace()) {
             self.finalized.push(aggregate.into_summary());
         }
     }
@@ -536,7 +526,7 @@ impl QueryStreamProjector {
             && self
                 .aggregates
                 .values()
-                .filter(|aggregate| aggregate.may_match_workspace(self.workspace_name.as_deref()))
+                .filter(|aggregate| aggregate.may_be_in_scope(&self.scope))
                 .all(|aggregate| aggregate.entry.end_time_unix_nanos < boundary.end_time_unix_nanos)
     }
 

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -255,23 +255,27 @@ impl StreamingQueryStreamAggregate {
     }
 
     fn record_span(&mut self, span: &ProjectedQueryStreamSpan, depth: usize, scope: &TraceScope) {
-        self.span_count = self.span_count.saturating_add(1);
         // Evidence is recorded for every span, including excluded ones: a
         // second workspace is what makes the evidence a `Conflict`, and that
         // conclusion is only reachable by seeing the span that conflicts.
         self.workspace_evidence.record(span.workspace.as_deref());
-        let Some(metadata) = span.metadata.as_ref() else {
-            return;
-        };
-        // Everything below becomes what the caller is shown — the operation
-        // this summary names and the query text it carries. A span positively
+
+        // Everything below is what the caller is told about this operation —
+        // the count that reports a span existed at all, the operation this
+        // summary names, and the query text it carries. A span positively
         // attributed to a workspace this scope excludes contributes none of
         // it, or an operation admitted by its own root would report a
-        // descendant's SQL. A span carrying no workspace of its own is not
-        // excluded: it belongs to whatever operation owns it.
+        // descendant's SQL and count the span that carried it. A span with no
+        // workspace of its own is not excluded: it belongs to whatever
+        // operation owns it.
         if !scope.may_admit(span.workspace.as_deref()) {
             return;
         }
+        self.span_count = self.span_count.saturating_add(1);
+
+        let Some(metadata) = span.metadata.as_ref() else {
+            return;
+        };
         if depth > 0 {
             let operation = QueryStreamPrimaryOperation::new(
                 metadata.kind,

--- a/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
@@ -492,9 +492,18 @@ fn query_stream_summary_never_enriches_across_a_workspace_boundary() {
     let summary = alpha
         .first()
         .expect("alpha owns the operation its root began");
-    assert_ne!(
-        summary.query, "SELECT beta_secret",
-        "beta's query text must not reach a caller scoped to alpha"
+    // Asserted as an absence rather than "not beta's text": a projection that
+    // mangled the leak instead of withholding it would satisfy the weaker
+    // claim. Alpha's root carries no query text of its own, so the only
+    // correct summary carries none.
+    assert!(
+        summary.query.is_empty(),
+        "alpha's root carries no query text of its own, so its summary must carry none: {:?}",
+        summary.query,
+    );
+    assert_eq!(
+        summary.span_count, 1,
+        "beta's span must not be counted into an alpha-scoped summary either"
     );
 
     // The host reads across workspaces, so the enrichment it sees is the proof

--- a/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
@@ -460,3 +460,46 @@ fn tool_operation_name_policy_bounds_identifiers() {
         UNKNOWN_TOOL_OPERATION_NAME
     );
 }
+
+/// An operation admitted by its own root must not carry a descendant's query
+/// text across a workspace boundary.
+///
+/// The root settles which workspace the operation belongs to, so alpha's owner
+/// is entitled to the operation itself. The text is a separate question: a
+/// descendant attributed to beta carries beta's SQL, and enriching alpha's
+/// summary with it would hand beta's query text to a caller who may not read
+/// beta at all.
+#[test]
+fn query_stream_summary_never_enriches_across_a_workspace_boundary() {
+    let alpha_root = span("mixed-stream", "alpha-root")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("tool", "sql", "alpha")
+        .attrs(json!({"mcp.method": "tools/call", "mcp.tool.name": "sql"}))
+        .times(10, 40)
+        .build();
+    // Attributed to beta and carrying beta's SQL, but owned by alpha's root.
+    let beta_child = span("mixed-stream", "beta-child")
+        .child_of(&alpha_root)
+        .entry("query", "sql", "beta")
+        .attrs(json!({"sql": "SELECT beta_secret", "row_count": 3}))
+        .times(20, 30)
+        .build();
+
+    let records = [alpha_root, beta_child];
+
+    let alpha = project(&records, Some("alpha"));
+    let summary = alpha
+        .first()
+        .expect("alpha owns the operation its root began");
+    assert_ne!(
+        summary.query, "SELECT beta_secret",
+        "beta's query text must not reach a caller scoped to alpha"
+    );
+
+    // The host reads across workspaces, so the enrichment it sees is the proof
+    // that the text was withheld above rather than never recorded at all.
+    let host = project(&records, None);
+    let host_summary = host.first().expect("the host reads the same operation");
+    assert_eq!(host_summary.query, "SELECT beta_secret");
+}

--- a/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
@@ -9,7 +9,7 @@ use super::super::{
     unix_nanos,
 };
 use super::QueryStreamProjector;
-use super::test_support::{TraceFiles, span};
+use super::test_support::{TraceFiles, scope, span};
 
 #[test]
 fn query_stream_resolves_equal_mtime_files_as_one_bucket() {
@@ -286,7 +286,7 @@ fn query_stream_completes_returned_operations_from_older_files() {
 
 #[test]
 fn query_stream_projector_releases_completed_discovery_trees() {
-    let mut projector = QueryStreamProjector::new(1, Some("alpha"));
+    let mut projector = QueryStreamProjector::new(1, &scope(Some("alpha")));
 
     for index in (0..128_i64).rev() {
         let base = index * 10;

--- a/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
@@ -8,7 +8,9 @@ use super::super::tests::{
     set_modified_time, timestamped_jsonl_path, trace_record, write_record_file,
     write_record_file_lines,
 };
-use super::super::{StoredTraceStatus, TraceSpanRecord, TraceStore, TraceSummaryRecord};
+use super::super::{
+    StoredTraceStatus, TraceScope, TraceSpanRecord, TraceStore, TraceSummaryRecord,
+};
 
 pub(super) fn span(trace_id: &str, span_id: &str) -> TestSpan {
     TestSpan {
@@ -79,11 +81,19 @@ impl TestSpan {
     }
 }
 
+/// The scope a workspace name stands for in these tests: naming none is the
+/// host's own unrestricted read.
+pub(super) fn scope(workspace_name: Option<&str>) -> TraceScope {
+    workspace_name.map_or(TraceScope::Host, |workspace_name| {
+        TraceScope::workspaces([workspace_name])
+    })
+}
+
 pub(super) fn project(
     records: &[TraceSpanRecord],
     workspace_name: Option<&str>,
 ) -> Vec<TraceSummaryRecord> {
-    super::summaries(records, workspace_name)
+    super::summaries(records, &scope(workspace_name))
 }
 
 pub(super) struct TraceFiles {
@@ -129,7 +139,7 @@ impl TraceFiles {
         workspace_name: Option<&str>,
     ) -> Vec<TraceSummaryRecord> {
         TraceStore::new(self.temp.path().to_path_buf())
-            .list_query_stream_sync(limit, offset, workspace_name)
+            .list_query_stream_sync(limit, offset, &scope(workspace_name))
             .expect("list query stream")
     }
 }

--- a/crates/coral-app/src/telemetry/manager.rs
+++ b/crates/coral-app/src/telemetry/manager.rs
@@ -3,8 +3,9 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use super::local_store::{TraceDetailRecord, TraceStore, TraceStoreError, TraceSummaryRecord};
-use crate::workspaces::WorkspaceName;
+use super::local_store::{
+    TraceDetailRecord, TraceScope, TraceStore, TraceStoreError, TraceSummaryRecord,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TraceListView {
@@ -15,7 +16,7 @@ pub(crate) enum TraceListView {
 #[derive(Debug)]
 pub(crate) struct ListTracesQuery {
     pub(crate) view: TraceListView,
-    pub(crate) workspace: Option<WorkspaceName>,
+    pub(crate) scope: TraceScope,
     pub(crate) page_size: usize,
     pub(crate) offset: usize,
 }
@@ -29,7 +30,7 @@ pub(crate) struct TraceListPage {
 #[derive(Debug)]
 pub(crate) struct GetTraceQuery {
     pub(crate) trace_id: String,
-    pub(crate) workspace: Option<WorkspaceName>,
+    pub(crate) scope: TraceScope,
     pub(crate) view: TraceListView,
 }
 
@@ -68,24 +69,16 @@ impl TraceManager {
     ) -> Result<TraceListPage, TraceManagerError> {
         let ListTracesQuery {
             view,
-            workspace,
+            scope,
             page_size,
             offset,
         } = query;
-        let workspace = workspace.map(|workspace| workspace.as_str().to_string());
         let fetch_limit = page_size.saturating_add(1);
         let mut traces = match view {
-            TraceListView::All => match workspace {
-                Some(workspace) => {
-                    self.traces
-                        .list_traces_for_workspace(fetch_limit, offset, workspace)
-                        .await
-                }
-                None => self.traces.list_traces(fetch_limit, offset).await,
-            },
+            TraceListView::All => self.traces.list_traces(fetch_limit, offset, scope).await,
             TraceListView::QueryStream => {
                 self.traces
-                    .list_query_stream(fetch_limit, offset, workspace)
+                    .list_query_stream(fetch_limit, offset, scope)
                     .await
             }
         }?;
@@ -105,24 +98,12 @@ impl TraceManager {
     ) -> Result<TraceDetailRecord, TraceManagerError> {
         let GetTraceQuery {
             trace_id,
-            workspace,
+            scope,
             view,
         } = query;
-        let workspace = workspace.map(|workspace| workspace.as_str().to_string());
         match view {
-            TraceListView::All => match workspace {
-                Some(workspace) => {
-                    self.traces
-                        .get_trace_for_workspace(trace_id, workspace)
-                        .await
-                }
-                None => self.traces.get_trace(trace_id).await,
-            },
-            TraceListView::QueryStream => {
-                self.traces
-                    .get_query_stream_trace(trace_id, workspace)
-                    .await
-            }
+            TraceListView::All => self.traces.get_trace(trace_id, scope).await,
+            TraceListView::QueryStream => self.traces.get_query_stream_trace(trace_id, scope).await,
         }
         .map_err(TraceManagerError::from)
     }
@@ -135,8 +116,9 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
-    use super::{GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError};
-    use crate::workspaces::WorkspaceName;
+    use super::{
+        GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError, TraceScope,
+    };
 
     #[tokio::test]
     async fn manager_scopes_and_paginates_all_trace_lists() {
@@ -150,12 +132,12 @@ mod tests {
 
     async fn assert_manager_scopes_and_paginates_trace_lists(view: TraceListView) {
         let (_temp, manager) = trace_manager_fixture();
-        let alpha = WorkspaceName::parse("alpha").expect("alpha workspace");
+        let alpha = TraceScope::workspaces(["alpha"]);
 
         let first_page = manager
             .list_traces(ListTracesQuery {
                 view,
-                workspace: Some(alpha.clone()),
+                scope: alpha.clone(),
                 page_size: 1,
                 offset: 0,
             })
@@ -171,7 +153,7 @@ mod tests {
         let second_page = manager
             .list_traces(ListTracesQuery {
                 view,
-                workspace: Some(alpha),
+                scope: alpha,
                 page_size: 1,
                 offset: 1,
             })
@@ -192,7 +174,7 @@ mod tests {
         let detail = manager
             .get_trace(GetTraceQuery {
                 trace_id: "beta".to_string(),
-                workspace: None,
+                scope: TraceScope::Host,
                 view: TraceListView::All,
             })
             .await
@@ -202,7 +184,7 @@ mod tests {
         let error = manager
             .get_trace(GetTraceQuery {
                 trace_id: "beta".to_string(),
-                workspace: Some(WorkspaceName::parse("alpha").expect("alpha workspace")),
+                scope: TraceScope::workspaces(["alpha"]),
                 view: TraceListView::All,
             })
             .await

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,5 +1,7 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
+use std::collections::HashSet;
+
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
     GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceInvocationKind,
@@ -7,30 +9,95 @@ use coral_api::v1::{
 };
 use tonic::{Code, Request, Response, Status};
 
-use crate::bootstrap::app_status;
+use crate::bootstrap::{AppError, app_status};
+use crate::identity::{LOCAL_PRINCIPAL_ID, Principal, PrincipalKind};
 use crate::telemetry::local_store::{
     StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
     TraceSpanRecord, TraceSummaryRecord,
 };
 use crate::telemetry::manager::{
-    GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError,
+    GetTraceQuery, ListTracesQuery, TraceListPage, TraceListView, TraceManager, TraceManagerError,
 };
-use crate::transport::{grpc_span, instrument_grpc};
-use crate::workspaces::WorkspaceName;
+use crate::transport::{grpc_span, instrument_grpc, request_context};
+use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
+use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
 
 const DEFAULT_TRACE_PAGE_SIZE: usize = 50;
 const MAX_TRACE_PAGE_SIZE: usize = 200;
 
+/// What one caller may read, settled before any trace leaves the store.
+enum TraceAccessScope {
+    /// One workspace the caller manages.
+    Workspace(WorkspaceName),
+    /// Every trace this host recorded, including rows no workspace claims.
+    Host,
+    /// Only the workspaces the caller owns, read one at a time.
+    Owned(Vec<WorkspaceName>),
+}
+
 #[derive(Clone)]
 pub(crate) struct TraceService {
     traces: TraceManager,
+    workspaces: WorkspaceManager,
+    authorizer: WorkspaceAuthorizer,
 }
 
 impl TraceService {
-    pub(crate) fn new(trace_manager: TraceManager) -> Self {
+    pub(crate) const fn new(
+        trace_manager: TraceManager,
+        workspaces: WorkspaceManager,
+        authorizer: WorkspaceAuthorizer,
+    ) -> Self {
         Self {
             traces: trace_manager,
+            workspaces,
+            authorizer,
         }
+    }
+
+    /// Settles what `principal` may read before any trace is fetched.
+    ///
+    /// A trace carries the query text, arguments, and errors of whoever ran it,
+    /// so reading one is an owner's act rather than a member's: a named
+    /// workspace is authorized for `Manage`, and a request that names none is
+    /// confined to the workspaces the caller owns. Only the built-in local
+    /// principal reads the host's own rows — the spans no workspace claims —
+    /// and only where the deployment admits that principal at all.
+    async fn trace_access_scope(
+        &self,
+        principal: &Principal,
+        workspace: Option<WorkspaceName>,
+    ) -> Result<TraceAccessScope, Status> {
+        if let Some(workspace) = workspace {
+            self.authorizer
+                .authorize(principal, &workspace, WorkspaceAction::Manage)
+                .await
+                .map_err(app_status)?;
+            return Ok(TraceAccessScope::Workspace(workspace));
+        }
+
+        self.authorizer.admit(principal).map_err(app_status)?;
+        if principal.id().as_str() == LOCAL_PRINCIPAL_ID {
+            return Ok(TraceAccessScope::Host);
+        }
+        // An unnamed request reads every workspace the caller owns at once, so
+        // an agent credential is refused it for the same reason `Manage`
+        // refuses it one workspace at a time.
+        if principal.kind() == PrincipalKind::Agent {
+            return Err(app_status(AppError::PermissionDenied(
+                "agent credentials cannot inspect traces".to_string(),
+            )));
+        }
+        let owned = self
+            .workspaces
+            .list_memberships_for_user(principal.id().as_str())
+            .await
+            .map_err(app_status)?
+            .into_iter()
+            .filter(|membership| membership.role == MemberRole::Owner)
+            .map(|membership| membership.workspace.name)
+            .collect();
+        Ok(TraceAccessScope::Owned(owned))
     }
 }
 
@@ -41,20 +108,19 @@ impl TraceServiceApi for TraceService {
         request: Request<ListTracesRequest>,
     ) -> Result<Response<ListTracesResponse>, Status> {
         let span = grpc_span(&request);
-        let traces = self.traces.clone();
+        let principal = request_context(&request)?.principal().clone();
+        let service = self.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
+            let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            // Settled before the rest of the request is parsed, so a caller who
+            // may not read these traces cannot learn anything from the
+            // request's own validation.
+            let scope = service.trace_access_scope(&principal, workspace).await?;
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
-            let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
             let view = trace_list_view_from_proto(request.view)?;
-            let page = traces
-                .list_traces(ListTracesQuery {
-                    view,
-                    workspace,
-                    page_size,
-                    offset,
-                })
+            let page = list_scoped_traces(&service.traces, scope, view, page_size, offset)
                 .await
                 .map_err(trace_manager_status)?;
             Ok(Response::new(ListTracesResponse {
@@ -76,29 +142,150 @@ impl TraceServiceApi for TraceService {
         request: Request<GetTraceRequest>,
     ) -> Result<Response<GetTraceResponse>, Status> {
         let span = grpc_span(&request);
-        let traces = self.traces.clone();
+        let principal = request_context(&request)?.principal().clone();
+        let service = self.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
+            let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let scope = service.trace_access_scope(&principal, workspace).await?;
             if request.trace_id.trim().is_empty() {
                 return Err(Status::new(
                     Code::InvalidArgument,
                     "invalid input: missing trace_id",
                 ));
             }
-            let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
             let view = trace_list_view_from_proto(request.view)?;
-            let trace = traces
-                .get_trace(GetTraceQuery {
-                    trace_id: request.trace_id,
-                    workspace,
-                    view,
-                })
+            let trace = get_scoped_trace(&service.traces, scope, request.trace_id, view)
                 .await
                 .map_err(trace_manager_status)?;
             Ok(Response::new(trace_detail_to_proto(trace)))
         })
         .await
     }
+}
+
+/// Reads one page of traces under `scope`.
+async fn list_scoped_traces(
+    traces: &TraceManager,
+    scope: TraceAccessScope,
+    view: TraceListView,
+    page_size: usize,
+    offset: usize,
+) -> Result<TraceListPage, TraceManagerError> {
+    let workspace = match scope {
+        TraceAccessScope::Workspace(workspace) => Some(workspace),
+        TraceAccessScope::Host => None,
+        TraceAccessScope::Owned(workspaces) => {
+            return list_owned_traces(traces, &workspaces, view, page_size, offset).await;
+        }
+    };
+    traces
+        .list_traces(ListTracesQuery {
+            view,
+            workspace,
+            page_size,
+            offset,
+        })
+        .await
+}
+
+/// Merges one page out of the workspaces the caller owns.
+///
+/// The store scopes a read to a single workspace, so an unnamed request is
+/// answered by reading each owned workspace from the top and merging. Reading
+/// `offset + page_size` from each is enough: a trace cannot rank higher in the
+/// merged page than it does in its own workspace's page, so nothing below that
+/// depth in a workspace can reach this page.
+async fn list_owned_traces(
+    traces: &TraceManager,
+    workspaces: &[WorkspaceName],
+    view: TraceListView,
+    page_size: usize,
+    offset: usize,
+) -> Result<TraceListPage, TraceManagerError> {
+    let depth = offset.saturating_add(page_size);
+    let mut merged = Vec::new();
+    let mut merged_ids = HashSet::new();
+    let mut deeper_traces_exist = false;
+    for workspace in workspaces {
+        let page = traces
+            .list_traces(ListTracesQuery {
+                view,
+                workspace: Some(workspace.clone()),
+                page_size: depth,
+                offset: 0,
+            })
+            .await?;
+        deeper_traces_exist |= page.next_offset.is_some();
+        for summary in page.traces {
+            // A trace whose spans span two owned workspaces is one trace.
+            if merged_ids.insert(summary.trace_id.clone()) {
+                merged.push(summary);
+            }
+        }
+    }
+    // Newest first, ties broken by trace id: the order each workspace's own
+    // page already arrives in, so the merge preserves it.
+    merged.sort_by(|left, right| {
+        right
+            .end_time_unix_nanos
+            .cmp(&left.end_time_unix_nanos)
+            .then_with(|| left.trace_id.cmp(&right.trace_id))
+    });
+    let next_offset = (deeper_traces_exist || merged.len() > depth).then_some(depth);
+    Ok(TraceListPage {
+        traces: merged.into_iter().skip(offset).take(page_size).collect(),
+        next_offset,
+    })
+}
+
+/// Reads one trace under `scope`.
+async fn get_scoped_trace(
+    traces: &TraceManager,
+    scope: TraceAccessScope,
+    trace_id: String,
+    view: TraceListView,
+) -> Result<TraceDetailRecord, TraceManagerError> {
+    let workspace = match scope {
+        TraceAccessScope::Workspace(workspace) => Some(workspace),
+        TraceAccessScope::Host => None,
+        TraceAccessScope::Owned(workspaces) => {
+            return get_owned_trace(traces, &workspaces, trace_id, view).await;
+        }
+    };
+    traces
+        .get_trace(GetTraceQuery {
+            trace_id,
+            workspace,
+            view,
+        })
+        .await
+}
+
+/// Looks one trace up in each workspace the caller owns.
+///
+/// A trace that belongs to none of them is reported absent rather than
+/// refused: which workspace it does belong to is not the caller's to learn.
+async fn get_owned_trace(
+    traces: &TraceManager,
+    workspaces: &[WorkspaceName],
+    trace_id: String,
+    view: TraceListView,
+) -> Result<TraceDetailRecord, TraceManagerError> {
+    for workspace in workspaces {
+        let found = traces
+            .get_trace(GetTraceQuery {
+                trace_id: trace_id.clone(),
+                workspace: Some(workspace.clone()),
+                view,
+            })
+            .await;
+        match found {
+            Err(TraceManagerError::NotFound { .. }) => {}
+            found => return found,
+        }
+    }
+    Err(TraceManagerError::NotFound { trace_id })
 }
 
 fn normalize_page_size(page_size: i32) -> usize {
@@ -232,12 +419,14 @@ fn trace_invocation_kind_to_proto(kind: StoredTraceInvocationKind) -> TraceInvoc
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
     use coral_api::v1::{
-        GetTraceRequest, ListTracesRequest, TraceInvocationKind, TraceOperationKind, TraceView,
-        Workspace,
+        GetTraceRequest, ListTracesRequest, ListTracesResponse, TraceInvocationKind,
+        TraceOperationKind, TraceView, Workspace,
     };
     use serde_json::json;
     use tempfile::TempDir;
@@ -246,7 +435,16 @@ mod tests {
     use super::{
         TraceService, normalize_page_size, parse_page_token, trace_invocation_kind_to_proto,
     };
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::request_context::RequestContext;
+    use crate::state::db::{
+        CoralDb, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
+    };
+    use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::{TraceManager, local_store::StoredTraceInvocationKind};
+    use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
+    use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -281,24 +479,19 @@ mod tests {
 
     #[tokio::test]
     async fn trace_service_scopes_list_and_get_by_workspace() {
-        let temp = TempDir::new().expect("temp dir");
-        let trace_store = temp.path().join("trace-store");
-        std::fs::create_dir_all(&trace_store).expect("trace store dir");
-        write_trace_records(
-            &trace_store,
-            &[
-                trace_record_json("alpha-trace", "alpha-span", "alpha", 10, 20),
-                trace_record_json("beta-trace", "beta-span", "beta", 30, 40),
-            ],
-        );
-        let service = TraceService::new(TraceManager::new(trace_store, Duration::from_mins(1)));
+        let deployment = Deployment::new().await;
+        deployment.write_traces(&[
+            trace_record_json("alpha-trace", "alpha-span", Some("alpha"), 10, 20),
+            trace_record_json("beta-trace", "beta-span", Some("beta"), 30, 40),
+        ]);
+        let service = deployment.service(LocalPrincipalPolicy::ImplicitOwner);
 
         let response = TraceServiceApi::list_traces(
             &service,
-            Request::new(ListTracesRequest {
+            local(ListTracesRequest {
                 page_size: 10,
                 page_token: String::new(),
-                workspace: Some(workspace("alpha")),
+                workspace: Some(workspace_proto("alpha")),
                 view: TraceView::Unspecified as i32,
             }),
         )
@@ -334,9 +527,9 @@ mod tests {
 
         let detail = TraceServiceApi::get_trace(
             &service,
-            Request::new(GetTraceRequest {
+            local(GetTraceRequest {
                 trace_id: "alpha-trace".to_string(),
-                workspace: Some(workspace("alpha")),
+                workspace: Some(workspace_proto("alpha")),
                 view: TraceView::Unspecified as i32,
             }),
         )
@@ -347,9 +540,9 @@ mod tests {
 
         let status = TraceServiceApi::get_trace(
             &service,
-            Request::new(GetTraceRequest {
+            local(GetTraceRequest {
                 trace_id: "beta-trace".to_string(),
-                workspace: Some(workspace("alpha")),
+                workspace: Some(workspace_proto("alpha")),
                 view: TraceView::Unspecified as i32,
             }),
         )
@@ -360,18 +553,16 @@ mod tests {
 
     #[tokio::test]
     async fn trace_service_projects_query_stream_entries() {
-        let temp = TempDir::new().expect("temp dir");
-        let trace_store = temp.path().join("trace-store");
-        std::fs::create_dir_all(&trace_store).expect("trace store dir");
-        write_query_stream_trace_fixture(&trace_store);
-        let service = TraceService::new(TraceManager::new(trace_store, Duration::from_mins(1)));
+        let deployment = Deployment::new().await;
+        deployment.write_query_stream_traces();
+        let service = deployment.service(LocalPrincipalPolicy::ImplicitOwner);
 
         let response = TraceServiceApi::list_traces(
             &service,
-            Request::new(ListTracesRequest {
+            local(ListTracesRequest {
                 page_size: 10,
                 page_token: String::new(),
-                workspace: Some(workspace("alpha")),
+                workspace: Some(workspace_proto("alpha")),
                 view: TraceView::QueryStream as i32,
             }),
         )
@@ -390,9 +581,9 @@ mod tests {
 
         let detail = TraceServiceApi::get_trace(
             &service,
-            Request::new(GetTraceRequest {
+            local(GetTraceRequest {
                 trace_id: "shared-trace".to_string(),
-                workspace: Some(workspace("alpha")),
+                workspace: Some(workspace_proto("alpha")),
                 view: TraceView::QueryStream as i32,
             }),
         )
@@ -405,7 +596,7 @@ mod tests {
 
         let unknown_view = TraceServiceApi::list_traces(
             &service,
-            Request::new(ListTracesRequest {
+            local(ListTracesRequest {
                 page_size: 10,
                 page_token: String::new(),
                 workspace: None,
@@ -417,7 +608,301 @@ mod tests {
         assert_eq!(unknown_view.code(), Code::InvalidArgument);
     }
 
-    fn workspace(name: &str) -> Workspace {
+    /// A named workspace is an owner's to inspect and nobody else's. The
+    /// member is the case that matters: they read the workspace's data all day
+    /// and still may not read the trace of somebody else's query in it.
+    #[tokio::test]
+    async fn named_trace_calls_require_workspace_ownership() {
+        let deployment = Deployment::new().await;
+        deployment.write_traces(&fan_out_trace_records());
+        let owner = deployment
+            .seed_member("owner", "alpha", MemberRole::Owner)
+            .await;
+        let member = deployment
+            .seed_member("member", "alpha", MemberRole::Member)
+            .await;
+        let outsider = deployment.seed_user("outsider").await;
+        let service = deployment.service(LocalPrincipalPolicy::NoLocalPrincipal);
+
+        let listed = TraceServiceApi::list_traces(&service, request(list_alpha(), owner.clone()))
+            .await
+            .expect("an owner inspects their own workspace")
+            .into_inner();
+        assert_eq!(trace_ids(&listed), vec!["alpha-new", "alpha-old"]);
+
+        // A member is denied and an outsider is concealed: the workspace they
+        // already know about stays distinguishable from the one they do not.
+        for (principal, expected) in [
+            (member, Code::PermissionDenied),
+            (outsider, Code::NotFound),
+            (as_agent(&owner), Code::PermissionDenied),
+        ] {
+            assert_eq!(
+                TraceServiceApi::list_traces(&service, request(list_alpha(), principal))
+                    .await
+                    .expect_err("only an owner inspects traces")
+                    .code(),
+                expected
+            );
+        }
+    }
+
+    /// An unnamed request is the widest read this service offers, so it is the
+    /// one that must not widen past what the caller owns: not another tenant's
+    /// workspace, and not the host rows no workspace claims.
+    #[tokio::test]
+    async fn global_listing_fans_out_across_owned_workspaces_only() {
+        let deployment = Deployment::new().await;
+        deployment.write_traces(&fan_out_trace_records());
+        let owner = deployment
+            .seed_member("owner", "alpha", MemberRole::Owner)
+            .await;
+        deployment.grant(&owner, "beta", MemberRole::Owner).await;
+        deployment.grant(&owner, "gamma", MemberRole::Member).await;
+        let member = deployment
+            .seed_member("member", "alpha", MemberRole::Member)
+            .await;
+        let service = deployment.service(LocalPrincipalPolicy::NoLocalPrincipal);
+
+        // Paged one at a time, so the merge across owned workspaces is proven
+        // to order and page as one list rather than as three.
+        let mut page_token = String::new();
+        let mut listed = Vec::new();
+        loop {
+            let page = TraceServiceApi::list_traces(
+                &service,
+                request(list_global(1, &page_token), owner.clone()),
+            )
+            .await
+            .expect("owner lists the workspaces they own")
+            .into_inner();
+            listed.extend(trace_ids(&page).into_iter().map(str::to_string));
+            page_token = page.next_page_token;
+            if page_token.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(listed, vec!["beta-trace", "alpha-new", "alpha-old"]);
+
+        for (trace_id, expected) in [
+            ("alpha-old", Code::Ok),
+            ("gamma-trace", Code::NotFound),
+            ("host-trace", Code::NotFound),
+        ] {
+            let found = TraceServiceApi::get_trace(
+                &service,
+                request(
+                    GetTraceRequest {
+                        trace_id: trace_id.to_string(),
+                        workspace: None,
+                        view: TraceView::Unspecified as i32,
+                    },
+                    owner.clone(),
+                ),
+            )
+            .await;
+            assert_eq!(
+                found.err().map_or(Code::Ok, |status| status.code()),
+                expected
+            );
+        }
+
+        let member_page =
+            TraceServiceApi::list_traces(&service, request(list_global(10, ""), member))
+                .await
+                .expect("a member owns nothing to fan out over")
+                .into_inner();
+        assert!(member_page.traces.is_empty());
+
+        for principal in [as_agent(&owner), Principal::local()] {
+            assert_eq!(
+                TraceServiceApi::list_traces(&service, request(list_global(10, ""), principal))
+                    .await
+                    .expect_err("neither an agent nor an unadmitted principal reads traces")
+                    .code(),
+                Code::PermissionDenied
+            );
+        }
+    }
+
+    /// The single-user deployment keeps the unrestricted read it has always
+    /// had, host rows included: there is nobody there to conceal them from.
+    #[tokio::test]
+    async fn the_implicit_owner_still_reads_every_trace_this_host_recorded() {
+        let deployment = Deployment::new().await;
+        deployment.write_traces(&fan_out_trace_records());
+        let service = deployment.service(LocalPrincipalPolicy::ImplicitOwner);
+
+        let response = TraceServiceApi::list_traces(&service, local(list_global(10, "")))
+            .await
+            .expect("local unrestricted traces")
+            .into_inner();
+
+        assert_eq!(
+            trace_ids(&response),
+            vec![
+                "host-trace",
+                "gamma-trace",
+                "beta-trace",
+                "alpha-new",
+                "alpha-old"
+            ]
+        );
+    }
+
+    /// A deployment fixture: one migrated database, the workspace manager over
+    /// it, and the trace store the service reads.
+    struct Deployment {
+        _temp: TempDir,
+        db: Arc<CoralDb>,
+        workspaces: WorkspaceManager,
+        trace_store: PathBuf,
+    }
+
+    impl Deployment {
+        async fn new() -> Self {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+            layout.ensure().expect("layout dirs");
+            let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+                path: temp.path().join("coral.sqlite"),
+            })
+            .await
+            .expect("open sqlite");
+            db.migrate().await.expect("migrate sqlite");
+            let db = Arc::new(db);
+            let workspaces = WorkspaceManager::new_for_tests(
+                ConfigStore::new(layout.clone()),
+                CredentialManager::new(CredentialStore::new(layout.clone())),
+                layout,
+                None,
+                Arc::clone(&db),
+            );
+            let trace_store = temp.path().join("trace-store");
+            std::fs::create_dir_all(&trace_store).expect("trace store dir");
+            Self {
+                _temp: temp,
+                db,
+                workspaces,
+                trace_store,
+            }
+        }
+
+        fn service(&self, policy: LocalPrincipalPolicy) -> TraceService {
+            TraceService::new(
+                TraceManager::new(self.trace_store.clone(), Duration::from_mins(1)),
+                self.workspaces.clone(),
+                WorkspaceAuthorizer::with_local_principal_policy(Arc::clone(&self.db), policy),
+            )
+        }
+
+        fn write_traces(&self, records: &[serde_json::Value]) {
+            write_trace_records(&self.trace_store, records);
+        }
+
+        fn write_query_stream_traces(&self) {
+            write_query_stream_trace_fixture(&self.trace_store);
+        }
+
+        /// Provisions one directory user through the production login seam, so
+        /// the `user_id` the service is handed is the one a real login carries.
+        async fn seed_user(&self, subject: &str) -> Principal {
+            let provisioned = self
+                .db
+                .user_state()
+                .provision_login(LoginIdentity {
+                    issuer: "https://issuer.test/traces",
+                    subject,
+                    display_name: None,
+                    principal_claim: subject,
+                    now_unix_nanos: 1,
+                })
+                .await
+                .expect("provision user");
+            let LoginProvisioning::Provisioned(user) = provisioned else {
+                panic!("expected a provisioned user");
+            };
+            Principal::parse(&user.user_id, PrincipalKind::User).expect("principal")
+        }
+
+        async fn seed_member(&self, subject: &str, workspace: &str, role: MemberRole) -> Principal {
+            let principal = self.seed_user(subject).await;
+            self.grant(&principal, workspace, role).await;
+            principal
+        }
+
+        async fn grant(&self, principal: &Principal, workspace: &str, role: MemberRole) {
+            let name = WorkspaceName::parse(workspace).expect("workspace name");
+            let mut session = self.db.as_ref();
+            session
+                .workspaces()
+                .ensure(name.as_str(), 1)
+                .await
+                .expect("workspace row");
+            session
+                .workspace_members()
+                .upsert(name.as_str(), principal.id().as_str(), role, 2)
+                .await
+                .expect("grant membership");
+        }
+    }
+
+    /// The traces every fan-out case reads: two workspaces the owner holds,
+    /// one they only belong to, and one host row no workspace claims.
+    fn fan_out_trace_records() -> Vec<serde_json::Value> {
+        vec![
+            trace_record_json("alpha-old", "alpha-old-span", Some("alpha"), 10, 20),
+            trace_record_json("alpha-new", "alpha-new-span", Some("alpha"), 20, 30),
+            trace_record_json("beta-trace", "beta-span", Some("beta"), 30, 40),
+            trace_record_json("gamma-trace", "gamma-span", Some("gamma"), 40, 50),
+            trace_record_json("host-trace", "host-span", None, 50, 60),
+        ]
+    }
+
+    fn list_alpha() -> ListTracesRequest {
+        ListTracesRequest {
+            page_size: 10,
+            page_token: String::new(),
+            workspace: Some(workspace_proto("alpha")),
+            view: TraceView::Unspecified as i32,
+        }
+    }
+
+    fn list_global(page_size: i32, page_token: &str) -> ListTracesRequest {
+        ListTracesRequest {
+            page_size,
+            page_token: page_token.to_string(),
+            workspace: None,
+            view: TraceView::Unspecified as i32,
+        }
+    }
+
+    fn trace_ids(response: &ListTracesResponse) -> Vec<&str> {
+        response
+            .traces
+            .iter()
+            .map(|summary| summary.trace_id.as_str())
+            .collect()
+    }
+
+    fn as_agent(principal: &Principal) -> Principal {
+        Principal::parse(principal.id().as_str(), PrincipalKind::Agent).expect("agent")
+    }
+
+    fn request<T>(message: T, principal: Principal) -> Request<T> {
+        let mut request = Request::new(message);
+        request
+            .extensions_mut()
+            .insert(RequestContext::new(principal));
+        request
+    }
+
+    fn local<T>(message: T) -> Request<T> {
+        request(message, Principal::local())
+    }
+
+    fn workspace_proto(name: &str) -> Workspace {
         Workspace {
             name: name.to_string(),
         }
@@ -433,7 +918,7 @@ mod tests {
     }
 
     fn write_query_stream_trace_fixture(trace_store: &std::path::Path) {
-        let mut tool = trace_record_json("shared-trace", "tool-span", "alpha", 10, 40);
+        let mut tool = trace_record_json("shared-trace", "tool-span", Some("alpha"), 10, 40);
         let tool_object = tool.as_object_mut().expect("tool record object");
         tool_object.insert("parent_span_id".to_string(), json!("remote-parent"));
         tool_object.insert("parent_span_is_remote".to_string(), json!(true));
@@ -454,7 +939,7 @@ mod tests {
             ),
         );
 
-        let mut nested = trace_record_json("shared-trace", "nested-query", "alpha", 20, 30);
+        let mut nested = trace_record_json("shared-trace", "nested-query", Some("alpha"), 20, 30);
         let nested_object = nested.as_object_mut().expect("nested record object");
         nested_object.insert("parent_span_id".to_string(), json!("tool-span"));
         nested_object.insert(
@@ -475,13 +960,25 @@ mod tests {
         write_trace_records(trace_store, &[tool, nested]);
     }
 
+    /// Builds one stored span. A `None` workspace is a host row: work this
+    /// server did that no workspace claims.
     fn trace_record_json(
         trace_id: &str,
         span_id: &str,
-        workspace: &str,
+        workspace: Option<&str>,
         start_time_unix_nanos: i64,
         end_time_unix_nanos: i64,
     ) -> serde_json::Value {
+        let attributes = workspace.map_or_else(
+            || json!({ "status": "ok" }),
+            |workspace| {
+                json!({
+                    "workspace": workspace,
+                    "sql": format!("SELECT {workspace}"),
+                    "status": "ok",
+                })
+            },
+        );
         json!({
             "trace_id": trace_id,
             "span_id": span_id,
@@ -494,11 +991,7 @@ mod tests {
             "start_time_unix_nanos": start_time_unix_nanos,
             "end_time_unix_nanos": end_time_unix_nanos,
             "duration_nanos": end_time_unix_nanos - start_time_unix_nanos,
-            "attributes_json": json!({
-                "workspace": workspace,
-                "sql": format!("SELECT {workspace}"),
-                "status": "ok",
-            }).to_string(),
+            "attributes_json": attributes.to_string(),
             "events_json": "[]",
             "links_json": "[]",
             "resource_json": "{}",

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,7 +1,5 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
-use std::collections::HashSet;
-
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
     GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceInvocationKind,
@@ -10,13 +8,13 @@ use coral_api::v1::{
 use tonic::{Code, Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
-use crate::identity::{LOCAL_PRINCIPAL_ID, Principal, PrincipalKind};
+use crate::identity::{Principal, PrincipalKind};
 use crate::telemetry::local_store::{
     StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
-    TraceSpanRecord, TraceSummaryRecord,
+    TraceScope, TraceSpanRecord, TraceSummaryRecord,
 };
 use crate::telemetry::manager::{
-    GetTraceQuery, ListTracesQuery, TraceListPage, TraceListView, TraceManager, TraceManagerError,
+    GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError,
 };
 use crate::transport::{grpc_span, instrument_grpc, request_context};
 use crate::workspaces::authorization::{WorkspaceAction, WorkspaceAuthorizer};
@@ -24,16 +22,14 @@ use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
 
 const DEFAULT_TRACE_PAGE_SIZE: usize = 50;
 const MAX_TRACE_PAGE_SIZE: usize = 200;
-
-/// What one caller may read, settled before any trace leaves the store.
-enum TraceAccessScope {
-    /// One workspace the caller manages.
-    Workspace(WorkspaceName),
-    /// Every trace this host recorded, including rows no workspace claims.
-    Host,
-    /// Only the workspaces the caller owns, read one at a time.
-    Owned(Vec<WorkspaceName>),
-}
+/// The deepest page `ListTraces` will serve, in traces.
+///
+/// A page token is an offset into a store that has to be re-read from the top
+/// to reach it, so an unbounded token buys unbounded work with one request.
+/// The cap is far past any real paging depth — the UI pages 50 at a time, so
+/// this is 200 pages of scrolling — and pagination stops advertising a token
+/// before it, so an honest client never meets the refusal.
+const MAX_TRACE_PAGE_OFFSET: usize = 10_000;
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
@@ -63,22 +59,25 @@ impl TraceService {
     /// confined to the workspaces the caller owns. Only the built-in local
     /// principal reads the host's own rows — the spans no workspace claims —
     /// and only where the deployment admits that principal at all.
+    ///
+    /// Authorization ends here. The scope is all that crosses into the store,
+    /// which owns the filtering and never learns who asked.
     async fn trace_access_scope(
         &self,
         principal: &Principal,
         workspace: Option<WorkspaceName>,
-    ) -> Result<TraceAccessScope, Status> {
+    ) -> Result<TraceScope, Status> {
         if let Some(workspace) = workspace {
             self.authorizer
                 .authorize(principal, &workspace, WorkspaceAction::Manage)
                 .await
                 .map_err(app_status)?;
-            return Ok(TraceAccessScope::Workspace(workspace));
+            return Ok(TraceScope::workspaces([workspace.as_str()]));
         }
 
         self.authorizer.admit(principal).map_err(app_status)?;
-        if principal.id().as_str() == LOCAL_PRINCIPAL_ID {
-            return Ok(TraceAccessScope::Host);
+        if principal.is_local() {
+            return Ok(TraceScope::Host);
         }
         // An unnamed request reads every workspace the caller owns at once, so
         // an agent credential is refused it for the same reason `Manage`
@@ -96,8 +95,12 @@ impl TraceService {
             .into_iter()
             .filter(|membership| membership.role == MemberRole::Owner)
             .map(|membership| membership.workspace.name)
-            .collect();
-        Ok(TraceAccessScope::Owned(owned))
+            .collect::<Vec<_>>();
+        // A caller who owns nothing is scoped to nothing, which is an empty
+        // read rather than a wide one.
+        Ok(TraceScope::workspaces(
+            owned.iter().map(WorkspaceName::as_str),
+        ))
     }
 }
 
@@ -120,7 +123,14 @@ impl TraceServiceApi for TraceService {
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
             let view = trace_list_view_from_proto(request.view)?;
-            let page = list_scoped_traces(&service.traces, scope, view, page_size, offset)
+            let page = service
+                .traces
+                .list_traces(ListTracesQuery {
+                    view,
+                    scope,
+                    page_size,
+                    offset,
+                })
                 .await
                 .map_err(trace_manager_status)?;
             Ok(Response::new(ListTracesResponse {
@@ -129,8 +139,11 @@ impl TraceServiceApi for TraceService {
                     .into_iter()
                     .map(trace_summary_to_proto)
                     .collect(),
+                // Paging ends at the cap rather than handing out a token the
+                // next request would refuse.
                 next_page_token: page
                     .next_offset
+                    .filter(|offset| *offset <= MAX_TRACE_PAGE_OFFSET)
                     .map_or_else(String::new, |offset| offset.to_string()),
             }))
         })
@@ -155,137 +168,19 @@ impl TraceServiceApi for TraceService {
                 ));
             }
             let view = trace_list_view_from_proto(request.view)?;
-            let trace = get_scoped_trace(&service.traces, scope, request.trace_id, view)
+            let trace = service
+                .traces
+                .get_trace(GetTraceQuery {
+                    trace_id: request.trace_id,
+                    scope,
+                    view,
+                })
                 .await
                 .map_err(trace_manager_status)?;
             Ok(Response::new(trace_detail_to_proto(trace)))
         })
         .await
     }
-}
-
-/// Reads one page of traces under `scope`.
-async fn list_scoped_traces(
-    traces: &TraceManager,
-    scope: TraceAccessScope,
-    view: TraceListView,
-    page_size: usize,
-    offset: usize,
-) -> Result<TraceListPage, TraceManagerError> {
-    let workspace = match scope {
-        TraceAccessScope::Workspace(workspace) => Some(workspace),
-        TraceAccessScope::Host => None,
-        TraceAccessScope::Owned(workspaces) => {
-            return list_owned_traces(traces, &workspaces, view, page_size, offset).await;
-        }
-    };
-    traces
-        .list_traces(ListTracesQuery {
-            view,
-            workspace,
-            page_size,
-            offset,
-        })
-        .await
-}
-
-/// Merges one page out of the workspaces the caller owns.
-///
-/// The store scopes a read to a single workspace, so an unnamed request is
-/// answered by reading each owned workspace from the top and merging. Reading
-/// `offset + page_size` from each is enough: a trace cannot rank higher in the
-/// merged page than it does in its own workspace's page, so nothing below that
-/// depth in a workspace can reach this page.
-async fn list_owned_traces(
-    traces: &TraceManager,
-    workspaces: &[WorkspaceName],
-    view: TraceListView,
-    page_size: usize,
-    offset: usize,
-) -> Result<TraceListPage, TraceManagerError> {
-    let depth = offset.saturating_add(page_size);
-    let mut merged = Vec::new();
-    let mut merged_ids = HashSet::new();
-    let mut deeper_traces_exist = false;
-    for workspace in workspaces {
-        let page = traces
-            .list_traces(ListTracesQuery {
-                view,
-                workspace: Some(workspace.clone()),
-                page_size: depth,
-                offset: 0,
-            })
-            .await?;
-        deeper_traces_exist |= page.next_offset.is_some();
-        for summary in page.traces {
-            // A trace whose spans span two owned workspaces is one trace.
-            if merged_ids.insert(summary.trace_id.clone()) {
-                merged.push(summary);
-            }
-        }
-    }
-    // Newest first, ties broken by trace id: the order each workspace's own
-    // page already arrives in, so the merge preserves it.
-    merged.sort_by(|left, right| {
-        right
-            .end_time_unix_nanos
-            .cmp(&left.end_time_unix_nanos)
-            .then_with(|| left.trace_id.cmp(&right.trace_id))
-    });
-    let next_offset = (deeper_traces_exist || merged.len() > depth).then_some(depth);
-    Ok(TraceListPage {
-        traces: merged.into_iter().skip(offset).take(page_size).collect(),
-        next_offset,
-    })
-}
-
-/// Reads one trace under `scope`.
-async fn get_scoped_trace(
-    traces: &TraceManager,
-    scope: TraceAccessScope,
-    trace_id: String,
-    view: TraceListView,
-) -> Result<TraceDetailRecord, TraceManagerError> {
-    let workspace = match scope {
-        TraceAccessScope::Workspace(workspace) => Some(workspace),
-        TraceAccessScope::Host => None,
-        TraceAccessScope::Owned(workspaces) => {
-            return get_owned_trace(traces, &workspaces, trace_id, view).await;
-        }
-    };
-    traces
-        .get_trace(GetTraceQuery {
-            trace_id,
-            workspace,
-            view,
-        })
-        .await
-}
-
-/// Looks one trace up in each workspace the caller owns.
-///
-/// A trace that belongs to none of them is reported absent rather than
-/// refused: which workspace it does belong to is not the caller's to learn.
-async fn get_owned_trace(
-    traces: &TraceManager,
-    workspaces: &[WorkspaceName],
-    trace_id: String,
-    view: TraceListView,
-) -> Result<TraceDetailRecord, TraceManagerError> {
-    for workspace in workspaces {
-        let found = traces
-            .get_trace(GetTraceQuery {
-                trace_id: trace_id.clone(),
-                workspace: Some(workspace.clone()),
-                view,
-            })
-            .await;
-        match found {
-            Err(TraceManagerError::NotFound { .. }) => {}
-            found => return found,
-        }
-    }
-    Err(TraceManagerError::NotFound { trace_id })
 }
 
 fn normalize_page_size(page_size: i32) -> usize {
@@ -302,12 +197,19 @@ fn parse_page_token(page_token: &str) -> Result<usize, Status> {
     if page_token.is_empty() {
         return Ok(0);
     }
-    page_token.parse().map_err(|_parse_error| {
+    let offset: usize = page_token.parse().map_err(|_parse_error| {
         Status::new(
             Code::InvalidArgument,
             "invalid input: page_token must be returned by ListTraces",
         )
-    })
+    })?;
+    if offset > MAX_TRACE_PAGE_OFFSET {
+        return Err(Status::new(
+            Code::InvalidArgument,
+            "invalid input: page_token is beyond the deepest page ListTraces serves",
+        ));
+    }
+    Ok(offset)
 }
 
 fn trace_list_view_from_proto(view: i32) -> Result<TraceListView, Status> {
@@ -454,11 +356,30 @@ mod tests {
         assert_eq!(normalize_page_size(10_000), super::MAX_TRACE_PAGE_SIZE);
     }
 
+    /// A token is an offset the store has to scan down to, so the depth a
+    /// caller can name is the work a caller can buy. Past the cap the request
+    /// is refused rather than served.
     #[test]
-    fn page_token_is_offset() {
+    fn page_token_is_a_bounded_offset() {
         assert_eq!(parse_page_token("").expect("empty token"), 0);
         assert_eq!(parse_page_token("25").expect("offset token"), 25);
+        assert_eq!(
+            parse_page_token(&super::MAX_TRACE_PAGE_OFFSET.to_string()).expect("the deepest page"),
+            super::MAX_TRACE_PAGE_OFFSET
+        );
         parse_page_token("not-an-offset").unwrap_err();
+        assert_eq!(
+            parse_page_token(&(super::MAX_TRACE_PAGE_OFFSET + 1).to_string())
+                .expect_err("a token past the cap buys no work")
+                .code(),
+            Code::InvalidArgument
+        );
+        assert_eq!(
+            parse_page_token("4000000000")
+                .expect_err("nor does one far past it")
+                .code(),
+            Code::InvalidArgument
+        );
     }
 
     #[test]
@@ -628,7 +549,16 @@ mod tests {
             .await
             .expect("an owner inspects their own workspace")
             .into_inner();
-        assert_eq!(trace_ids(&listed), vec!["alpha-new", "alpha-old"]);
+        assert_eq!(
+            trace_ids(&listed),
+            vec!["shared-trace", "alpha-new", "alpha-old"]
+        );
+        // The trace alpha shares with beta is summarized from alpha's span
+        // alone, so the listing never hands one workspace the other's SQL.
+        assert_eq!(
+            listed.traces.first().expect("the shared trace").query,
+            "SELECT alpha"
+        );
 
         // A member is denied and an outsider is concealed: the workspace they
         // already know about stays distinguishable from the one they do not.
@@ -682,7 +612,12 @@ mod tests {
                 break;
             }
         }
-        assert_eq!(listed, vec!["beta-trace", "alpha-new", "alpha-old"]);
+        // One entry for the shared trace, not one per owned workspace it
+        // touches: the store merges it before the page is cut.
+        assert_eq!(
+            listed,
+            vec!["shared-trace", "beta-trace", "alpha-new", "alpha-old"]
+        );
 
         for (trace_id, expected) in [
             ("alpha-old", Code::Ok),
@@ -706,6 +641,24 @@ mod tests {
                 expected
             );
         }
+
+        // Both halves of the shared trace belong to workspaces this caller
+        // owns, so the unnamed read is the one that shows the whole of it.
+        let shared = TraceServiceApi::get_trace(
+            &service,
+            request(
+                GetTraceRequest {
+                    trace_id: "shared-trace".to_string(),
+                    workspace: None,
+                    view: TraceView::Unspecified as i32,
+                },
+                owner.clone(),
+            ),
+        )
+        .await
+        .expect("the owner of both workspaces reads both halves")
+        .into_inner();
+        assert_eq!(shared.spans.len(), 2);
 
         let member_page =
             TraceServiceApi::list_traces(&service, request(list_global(10, ""), member))
@@ -741,6 +694,7 @@ mod tests {
         assert_eq!(
             trace_ids(&response),
             vec![
+                "shared-trace",
                 "host-trace",
                 "gamma-trace",
                 "beta-trace",
@@ -849,7 +803,8 @@ mod tests {
     }
 
     /// The traces every fan-out case reads: two workspaces the owner holds,
-    /// one they only belong to, and one host row no workspace claims.
+    /// one they only belong to, one host row no workspace claims, and one
+    /// trace whose spans fall in two of those workspaces at once.
     fn fan_out_trace_records() -> Vec<serde_json::Value> {
         vec![
             trace_record_json("alpha-old", "alpha-old-span", Some("alpha"), 10, 20),
@@ -857,6 +812,8 @@ mod tests {
             trace_record_json("beta-trace", "beta-span", Some("beta"), 30, 40),
             trace_record_json("gamma-trace", "gamma-span", Some("gamma"), 40, 50),
             trace_record_json("host-trace", "host-span", None, 50, 60),
+            trace_record_json("shared-trace", "shared-alpha-span", Some("alpha"), 60, 70),
+            trace_record_json("shared-trace", "shared-beta-span", Some("beta"), 65, 75),
         ]
     }
 

--- a/crates/coral-app/src/test_support.rs
+++ b/crates/coral-app/src/test_support.rs
@@ -1,0 +1,111 @@
+//! Fixtures the crate's own unit tests share.
+//!
+//! What lives here is the shape of a deployment several suites all need to
+//! stand up before they can say anything about access: a migrated database
+//! holding the default workspace, and principals provisioned through the
+//! production login seam rather than invented as strings. Kept in one place,
+//! a change to `LoginIdentity` or to membership writes is one edit rather than
+//! six, and no copy can quietly drift from the others.
+
+use std::sync::Arc;
+
+use tempfile::TempDir;
+
+use crate::credentials::{CredentialManager, CredentialStore};
+use crate::identity::{Principal, PrincipalKind};
+use crate::state::db::{
+    CoralDb, DatabaseConfig, DbRepos as _, LoginIdentity, LoginProvisioning,
+    ResolvedDatabaseConfig, run_state_migrations,
+};
+use crate::state::{AppStateLayout, ConfigStore};
+use crate::workspaces::manager::WorkspaceManager;
+use crate::workspaces::{MemberRole, WorkspaceName};
+
+/// A shared deployment over one migrated database holding the default
+/// workspace, so every caller's authority comes from a membership row.
+///
+/// It stops at the state every service needs: each suite builds its own
+/// managers on top, because that part is what the suite is about.
+pub(crate) struct MigratedDeployment {
+    /// Held so the config directory outlives the deployment built over it.
+    pub(crate) temp: TempDir,
+    pub(crate) layout: AppStateLayout,
+    pub(crate) config_store: ConfigStore,
+    pub(crate) credentials: CredentialManager,
+    pub(crate) db: Arc<CoralDb>,
+    pub(crate) workspaces: WorkspaceManager,
+}
+
+/// Opens and migrates one deployment's state.
+pub(crate) async fn migrated_deployment() -> MigratedDeployment {
+    let temp = TempDir::new().expect("temp dir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    layout.ensure().expect("ensure layout");
+    let config_store = ConfigStore::new(layout.clone());
+    let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config") else {
+        panic!("the default test database is sqlite")
+    };
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite"),
+    );
+    db.migrate().await.expect("migrate sqlite");
+    run_state_migrations(&db, &config_store, &layout)
+        .await
+        .expect("import the default workspace");
+    let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
+    let workspaces = WorkspaceManager::new_for_tests(
+        config_store.clone(),
+        credentials.clone(),
+        layout.clone(),
+        None,
+        Arc::clone(&db),
+    );
+    MigratedDeployment {
+        temp,
+        layout,
+        config_store,
+        credentials,
+        db,
+        workspaces,
+    }
+}
+
+/// Provisions one directory user through the production login seam and, when
+/// `role` names one, grants it on the default workspace.
+///
+/// The `user_id` a service is then handed is the one a real login carries,
+/// rather than an identifier a test made up. `issuer` is the only thing that
+/// differs between suites: each provisions under its own, so a subject seeded
+/// by one is a different person from the same subject seeded by another.
+pub(crate) async fn seed_principal(
+    db: &Arc<CoralDb>,
+    issuer: &str,
+    subject: &str,
+    role: Option<MemberRole>,
+) -> Principal {
+    let LoginProvisioning::Provisioned(user) = db
+        .user_state()
+        .provision_login(LoginIdentity {
+            issuer,
+            subject,
+            display_name: None,
+            principal_claim: subject,
+            now_unix_nanos: 1,
+        })
+        .await
+        .expect("provision user")
+    else {
+        panic!("expected a provisioned user rather than an issuer mismatch")
+    };
+    if let Some(role) = role {
+        let mut session = db.as_ref();
+        session
+            .workspace_members()
+            .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+            .await
+            .expect("grant membership");
+    }
+    Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
+}

--- a/crates/coral-app/src/workspaces/authorization.rs
+++ b/crates/coral-app/src/workspaces/authorization.rs
@@ -183,6 +183,29 @@ impl WorkspaceAuthorizer {
         self.decide_for_local_principal(principal).unwrap_or(Ok(()))
     }
 
+    /// Decides whether `principal` may reach host-global state.
+    ///
+    /// Host-global state configures the machine this server runs on rather
+    /// than any one workspace, so there is no workspace whose role could
+    /// entitle a caller to it and a shared deployment has no superuser to
+    /// entrust it to. Only the built-in local principal reaches it, and — as
+    /// everywhere else here — only where the deployment admits that principal
+    /// at all.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError::PermissionDenied`] for every caller but the
+    /// built-in local principal, and for that principal on a deployment that
+    /// does not admit it.
+    pub(crate) fn authorize_host_global(&self, principal: &Principal) -> Result<(), AppError> {
+        if !principal.is_local() {
+            return Err(AppError::PermissionDenied(
+                "host-global state is configured on the host that runs this server".to_string(),
+            ));
+        }
+        self.admit(principal)
+    }
+
     /// Decides whether `principal` may create a workspace at all.
     ///
     /// Creation is the one control-plane act with no workspace to check, so
@@ -372,6 +395,40 @@ mod tests {
             ),
             "the deployment decision still comes first"
         );
+    }
+
+    /// Host-global state is the one decision with neither a workspace nor a
+    /// role behind it, so the unmigrated database proves the same thing here
+    /// as above: the answer is reached without a membership row existing
+    /// anywhere to reach it from.
+    #[tokio::test]
+    async fn host_global_state_reaches_only_a_local_principal_the_deployment_admits() {
+        let (_temp, db) = unmigrated_database().await;
+        let someone = Principal::parse("someone", PrincipalKind::User).expect("user");
+
+        WorkspaceAuthorizer::trusting_local_principal(Arc::clone(&db))
+            .authorize_host_global(&Principal::local())
+            .expect("the deployment that admits the local principal admits it to host state");
+        assert!(
+            matches!(
+                WorkspaceAuthorizer::new(Arc::clone(&db))
+                    .authorize_host_global(&Principal::local()),
+                Err(AppError::PermissionDenied(_))
+            ),
+            "a shared deployment has no superuser, not even the built-in one"
+        );
+        for authorizer in [
+            WorkspaceAuthorizer::trusting_local_principal(Arc::clone(&db)),
+            WorkspaceAuthorizer::new(db),
+        ] {
+            assert!(
+                matches!(
+                    authorizer.authorize_host_global(&someone),
+                    Err(AppError::PermissionDenied(_))
+                ),
+                "no workspace role can entitle a federated caller to host state"
+            );
+        }
     }
 
     /// The directory returns the same identities the roster does, and the

--- a/crates/coral-app/src/workspaces/authorization.rs
+++ b/crates/coral-app/src/workspaces/authorization.rs
@@ -130,9 +130,12 @@ impl WorkspaceAuthorizer {
         }
 
         // The control-plane restriction is evaluated before any role, so a
-        // workspace role can never promote an agent credential: the same
-        // person's browser token manages the workspace and their MCP token
-        // does not.
+        // workspace role can never promote an agent credential. No issuance
+        // path a running server exposes mints one yet — the login token
+        // endpoint hard-codes the user kind, so an MCP client's token carries
+        // the signed-in person's full authority and never trips this gate.
+        // It is the enforcement agent-issued credentials land on once the
+        // server can mint them.
         if principal.kind() == PrincipalKind::Agent && action == WorkspaceAction::Manage {
             return Err(AppError::PermissionDenied(format!(
                 "agent credentials cannot manage workspace '{workspace}'"

--- a/crates/coral-app/src/workspaces/authorization.rs
+++ b/crates/coral-app/src/workspaces/authorization.rs
@@ -18,18 +18,6 @@ use crate::workspaces::{MemberRole, WorkspaceName};
 /// reach it. Every RPC classifies into one of them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorkspaceAction {
-    /// Every workspace-scoped RPC that exists today manages, so only
-    /// [`MemberRole::allows`] and its tests name this arm so far. The read
-    /// paths that classify into it arrive with the read-path authorization
-    /// work; the arm is declared here because the role table it feeds is
-    /// already complete.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the read paths that classify into it land after the manage RPCs"
-        )
-    )]
     Read,
     Manage,
 }

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -1040,8 +1040,14 @@ mod tests {
 
     /// Replaces the workspace name the caller themselves asked about, so two
     /// answers about different names are still comparable.
+    ///
+    /// Only the quoted occurrence is replaced. A bare substring replacement
+    /// also rewrites the name where it sits inside another identifier, which
+    /// can make two genuinely different messages compare equal — and the
+    /// comparison is the whole assertion, so that would report a concealment
+    /// that is not there.
     fn normalize(message: &str, name: &str) -> String {
-        message.replace(name, "<workspace>")
+        message.replace(&format!("'{name}'"), "'<workspace>'")
     }
 
     fn reasons(status: &Status) -> Vec<String> {

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -29,5 +29,7 @@ mod server_lifecycle_tests;
 mod session_auth;
 #[path = "grpc/source_lifecycle_tests.rs"]
 mod source_lifecycle_tests;
+#[path = "grpc/workspace_access_read_tests.rs"]
+mod workspace_access_read_tests;
 #[path = "grpc/workspace_lifecycle_tests.rs"]
 mod workspace_lifecycle_tests;

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -14,6 +14,10 @@ mod function_lifecycle_tests;
 #[path = "grpc/gui_onboarding_tests.rs"]
 mod gui_onboarding_tests;
 #[path = "grpc/harness.rs"]
+#[expect(
+    dead_code,
+    reason = "The shared harness serves several integration binaries; this one does not dial the services that need a raw credential."
+)]
 mod harness;
 #[path = "grpc/health_service_tests.rs"]
 mod health_service_tests;

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -354,15 +354,15 @@ impl SharedDeployment {
         self.connect(user_id, PrincipalKind::User).await
     }
 
-    /// Connects the same person's id, admitted as an agent rather than as
-    /// themselves.
+    /// Connects an agent, which is a principal in its own right.
     ///
-    /// Only the token's actor-kind claim separates this from [`Self::as_person`]
-    /// — same id, same audience, same issuer — so a refusal one of them meets
-    /// and the other does not is a refusal of the actor kind and of nothing
-    /// else.
-    pub(crate) async fn as_agent(&self, user_id: &str) -> AppClient {
-        self.connect(user_id, PrincipalKind::Agent).await
+    /// It carries `agent_id` rather than any person's id, because the two are
+    /// drawn from one namespace and never coincide. An agent therefore holds
+    /// only the memberships granted to `agent_id` itself, which is none until
+    /// something grants them: acting for a person is not something the identity
+    /// or the actor kind can express.
+    pub(crate) async fn as_agent(&self, agent_id: &str) -> AppClient {
+        self.connect(agent_id, PrincipalKind::Agent).await
     }
 
     /// The address to dial for a service `AppClient` does not carry, such as

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -541,10 +541,20 @@ pub(crate) async fn membership_rows(client: &AppClient) -> Vec<(String, Workspac
 /// workspace name they supplied themselves factored out, and the structured
 /// reasons. Two refusals that agree here are indistinguishable to that caller,
 /// which is what separates a concealed workspace from a denial confirming one.
+/// Reduces a refusal to what it says about a workspace, with the workspace's
+/// own name removed so two refusals can be compared.
+///
+/// Only the quoted occurrence is replaced. A bare substring replacement also
+/// rewrites the name where it sits inside another identifier, which can make
+/// two genuinely different refusals compare equal — and this comparison is the
+/// whole assertion, so a false match would report concealment that is not
+/// there.
 pub(crate) fn concealed_refusal(status: &Status, name: &str) -> (Code, String, Vec<String>) {
     (
         status.code(),
-        status.message().replace(name, "<workspace>"),
+        status
+            .message()
+            .replace(&format!("'{name}'"), "'<workspace>'"),
         status
             .get_error_details_vec()
             .iter()

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -3,15 +3,15 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use coral_api::v1::{
-    AddWorkspaceMemberRequest, CreateWorkspaceRequest, ExecuteSqlRequest, ImportSourceRequest,
-    ListCatalogRequest, ListSourcesRequest, PaginationRequest, RemoveWorkspaceMemberRequest,
-    Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, WorkspaceRole, catalog_item, import_source_response,
+    AddWorkspaceMemberRequest, AddWorkspaceMemberResponse, CreateWorkspaceRequest,
+    CreateWorkspaceResponse, ExecuteSqlRequest, ImportSourceRequest, ListCatalogRequest,
+    ListSourcesRequest, ListWorkspacesRequest, PaginationRequest, RemoveWorkspaceMemberRequest,
+    RemoveWorkspaceMemberResponse, Source, SourceSecret, SourceVariable, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, Workspace, WorkspaceRole, catalog_item,
+    import_source_response,
 };
 use coral_app::features::{Feature, FeatureOverrides};
-use coral_app::{
-    EngineExtensionsProvider, Principal, PrincipalKind, PrincipalProvider, PrincipalProviderError,
-};
+use coral_app::{EngineExtensionsProvider, PrincipalKind};
 use coral_client::{
     AppClient, BearerToken, CatalogClient, FunctionClient, QueryClient, SearchClient, SourceClient,
     WorkspaceClient, batches_to_json_rows, decode_execute_sql_response, default_workspace,
@@ -20,7 +20,10 @@ use coral_client::{
 use serde_json::{Value, json};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
-use tonic::{Request, Status};
+use tonic::{Code, Request, Response, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
+
+use crate::session_auth::{SessionAuthFixture, session_authenticated_server};
 
 pub(crate) struct GrpcHarness {
     temp_dir: TempDir,
@@ -259,42 +262,7 @@ fn ensure_file_credentials_config(config_dir: &Path) {
 
 /// Upstream issuer written into every seeded directory row, so a response that
 /// leaked one would be recognizable on the wire.
-const TEST_ISSUER: &str = "https://issuer.test/authorization";
-
-/// Authenticates a `"<kind>:<user_id>"` bearer token.
-///
-/// It stands in for the session tokens the public surfaces mint, where the
-/// audience a token was minted for decides the kind: an MCP-audience token
-/// authenticates an agent and a human surface's token a user, both carrying the
-/// same internal user id. Installing any provider is also what makes a
-/// deployment a shared one — it retires the implicit local owner, so each
-/// request arrives as a distinct person or agent rather than as the host.
-#[derive(Debug)]
-struct TokenPrincipals;
-
-#[tonic::async_trait]
-impl PrincipalProvider for TokenPrincipals {
-    async fn principal_for_metadata(
-        &self,
-        metadata: &tonic::metadata::MetadataMap,
-    ) -> Result<Principal, PrincipalProviderError> {
-        let credential = metadata
-            .get("authorization")
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.strip_prefix("Bearer "))
-            .ok_or_else(|| PrincipalProviderError::unauthenticated("missing bearer credential"))?;
-        let (kind, user_id) = credential
-            .split_once(':')
-            .ok_or_else(|| PrincipalProviderError::unauthenticated("malformed test credential"))?;
-        let kind = if kind == "agent" {
-            PrincipalKind::Agent
-        } else {
-            PrincipalKind::User
-        };
-        Principal::parse(user_id, kind)
-            .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))
-    }
-}
+pub(crate) const TEST_ISSUER: &str = "https://issuer.test/authorization";
 
 /// A running server that authenticates its callers, plus the directory rows
 /// login provisioning would have written for them.
@@ -303,6 +271,7 @@ pub(crate) struct SharedDeployment {
     config_dir: PathBuf,
     endpoint_uri: String,
     trace_store_dir: Option<PathBuf>,
+    session_auth: SessionAuthFixture,
     _server: RunningServer,
 }
 
@@ -322,11 +291,12 @@ impl SharedDeployment {
     pub(crate) async fn start() -> Self {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
-        ensure_file_credentials_config(&config_dir);
-        let server = ServerBuilder::new()
-            .with_config_dir(&config_dir)
-            .with_principal_provider(Arc::new(TokenPrincipals))
-            .start()
+        // Configuring session authentication is what makes a deployment a
+        // shared one: it retires the implicit local owner, so each request over
+        // this transport arrives as a distinct person or agent rather than as
+        // the host. The fixture writes the credentials config too.
+        let session_auth = SessionAuthFixture::write(&config_dir);
+        let server = session_authenticated_server(&session_auth)
             .await
             .expect("start an authenticated server");
         let endpoint_uri = server.endpoint_uri().to_string();
@@ -350,6 +320,7 @@ impl SharedDeployment {
             config_dir,
             endpoint_uri,
             trace_store_dir,
+            session_auth,
             _server: server,
         }
     }
@@ -380,19 +351,25 @@ impl SharedDeployment {
     }
 
     pub(crate) async fn as_person(&self, user_id: &str) -> AppClient {
-        self.connect("user", user_id).await
+        self.connect(user_id, PrincipalKind::User).await
     }
 
-    /// Connects the session an MCP-audience token authenticates: the same
-    /// person's id, admitted as an agent rather than as themselves.
+    /// Connects the same person's id, admitted as an agent rather than as
+    /// themselves.
+    ///
+    /// Only the token's actor-kind claim separates this from [`Self::as_person`]
+    /// — same id, same audience, same issuer — so a refusal one of them meets
+    /// and the other does not is a refusal of the actor kind and of nothing
+    /// else.
     pub(crate) async fn as_agent(&self, user_id: &str) -> AppClient {
-        self.connect("agent", user_id).await
+        self.connect(user_id, PrincipalKind::Agent).await
     }
 
-    async fn connect(&self, kind: &str, user_id: &str) -> AppClient {
+    async fn connect(&self, user_id: &str, principal_kind: PrincipalKind) -> AppClient {
         connect_with_loopback_bearer(
             &self.endpoint_uri,
-            BearerToken::new(format!("{kind}:{user_id}")).expect("test bearer token"),
+            BearerToken::new(self.session_auth.access_token_for(user_id, principal_kind))
+                .expect("test bearer token"),
         )
         .await
         .expect("connect a test client")
@@ -472,19 +449,20 @@ pub(crate) fn named_workspace(name: &str) -> Workspace {
     }
 }
 
-pub(crate) async fn create_workspace(client: &AppClient, name: &str) -> Result<Workspace, Status> {
+/// The workspace and membership helpers hand back the whole response rather
+/// than the one part a given caller asserts on: what the server said about a
+/// change is as much of the contract as whether it allowed it.
+pub(crate) async fn create_workspace(
+    client: &AppClient,
+    name: &str,
+) -> Result<CreateWorkspaceResponse, Status> {
     client
         .workspace_client()
         .create_workspace(Request::new(CreateWorkspaceRequest {
             workspace: Some(named_workspace(name)),
         }))
         .await
-        .map(|response| {
-            response
-                .into_inner()
-                .workspace
-                .expect("create workspace response")
-        })
+        .map(Response::into_inner)
 }
 
 pub(crate) async fn add_member(
@@ -492,7 +470,7 @@ pub(crate) async fn add_member(
     name: &str,
     user_id: &str,
     role: WorkspaceRole,
-) -> Result<(), Status> {
+) -> Result<AddWorkspaceMemberResponse, Status> {
     client
         .workspace_client()
         .add_workspace_member(Request::new(AddWorkspaceMemberRequest {
@@ -501,14 +479,14 @@ pub(crate) async fn add_member(
             role: role.into(),
         }))
         .await
-        .map(|_| ())
+        .map(Response::into_inner)
 }
 
 pub(crate) async fn remove_member(
     client: &AppClient,
     name: &str,
     user_id: &str,
-) -> Result<(), Status> {
+) -> Result<RemoveWorkspaceMemberResponse, Status> {
     client
         .workspace_client()
         .remove_workspace_member(Request::new(RemoveWorkspaceMemberRequest {
@@ -516,7 +494,48 @@ pub(crate) async fn remove_member(
             user_id: user_id.to_string(),
         }))
         .await
-        .map(|_| ())
+        .map(Response::into_inner)
+}
+
+/// Reads a listing the way a client does: workspace name beside the caller's
+/// own role, with no second request needed to learn it. A caller is always
+/// answered about their own memberships, so this asks for the rows rather than
+/// for a result.
+pub(crate) async fn membership_rows(client: &AppClient) -> Vec<(String, WorkspaceRole)> {
+    client
+        .workspace_client()
+        .list_workspaces(Request::new(ListWorkspacesRequest {}))
+        .await
+        .expect("a caller is always answered about their own memberships")
+        .into_inner()
+        .memberships
+        .into_iter()
+        .map(|membership| {
+            (
+                membership.workspace.expect("listed workspace").name,
+                membership.role.try_into().expect("listed role"),
+            )
+        })
+        .collect()
+}
+
+/// Reports only what a refused caller is told: the code, the message with the
+/// workspace name they supplied themselves factored out, and the structured
+/// reasons. Two refusals that agree here are indistinguishable to that caller,
+/// which is what separates a concealed workspace from a denial confirming one.
+pub(crate) fn concealed_refusal(status: &Status, name: &str) -> (Code, String, Vec<String>) {
+    (
+        status.code(),
+        status.message().replace(name, "<workspace>"),
+        status
+            .get_error_details_vec()
+            .iter()
+            .filter_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info.reason.clone()),
+                _ => None,
+            })
+            .collect(),
+    )
 }
 
 /// Runs one statement as `client`, discarding the rows: these tests ask whether

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -365,9 +365,21 @@ impl SharedDeployment {
         self.connect(user_id, PrincipalKind::Agent).await
     }
 
+    /// The address to dial for a service `AppClient` does not carry, such as
+    /// `TraceService` or `FeatureService`.
+    pub(crate) fn endpoint_uri(&self) -> &str {
+        &self.endpoint_uri
+    }
+
+    /// The store this deployment answers trace requests out of, for tests that
+    /// need a row on record that no request would produce.
+    pub(crate) fn trace_store_dir(&self) -> Option<&Path> {
+        self.trace_store_dir.as_deref()
+    }
+
     async fn connect(&self, user_id: &str, principal_kind: PrincipalKind) -> AppClient {
         connect_with_loopback_bearer(
-            &self.endpoint_uri,
+            self.endpoint_uri(),
             BearerToken::new(self.session_auth.access_token_for(user_id, principal_kind))
                 .expect("test bearer token"),
         )
@@ -405,7 +417,7 @@ impl SharedDeployment {
     /// deployment in the process shares one store, so the workspace name is
     /// what separates one test's spans from another's.
     fn attributed_spans(&self, workspace_name: &str) -> usize {
-        let Some(dir) = &self.trace_store_dir else {
+        let Some(dir) = self.trace_store_dir() else {
             return 0;
         };
         fs::read_dir(dir)

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -3,20 +3,24 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ImportSourceRequest, ListCatalogRequest, ListSourcesRequest,
-    PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, catalog_item, import_source_response,
+    AddWorkspaceMemberRequest, CreateWorkspaceRequest, ExecuteSqlRequest, ImportSourceRequest,
+    ListCatalogRequest, ListSourcesRequest, PaginationRequest, RemoveWorkspaceMemberRequest,
+    Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, WorkspaceRole, catalog_item, import_source_response,
 };
-use coral_app::EngineExtensionsProvider;
 use coral_app::features::{Feature, FeatureOverrides};
+use coral_app::{
+    EngineExtensionsProvider, Principal, PrincipalKind, PrincipalProvider, PrincipalProviderError,
+};
 use coral_client::{
-    AppClient, CatalogClient, FunctionClient, QueryClient, SearchClient, SourceClient,
+    AppClient, BearerToken, CatalogClient, FunctionClient, QueryClient, SearchClient, SourceClient,
     WorkspaceClient, batches_to_json_rows, decode_execute_sql_response, default_workspace,
-    local::{RunningServer, ServerBuilder},
+    local::{RunningServer, ServerBuilder, connect_with_loopback_bearer},
 };
 use serde_json::{Value, json};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
-use tonic::Request;
+use tonic::{Request, Status};
 
 pub(crate) struct GrpcHarness {
     temp_dir: TempDir,
@@ -251,6 +255,283 @@ fn ensure_file_credentials_config(config_dir: &Path) {
     };
     let updated = format!("{raw}{separator}\n[credentials]\nstorage = \"file\"\n");
     std::fs::write(config_file, updated).expect("write test credential config");
+}
+
+/// Upstream issuer written into every seeded directory row, so a response that
+/// leaked one would be recognizable on the wire.
+const TEST_ISSUER: &str = "https://issuer.test/authorization";
+
+/// Authenticates a `"<kind>:<user_id>"` bearer token.
+///
+/// It stands in for the session tokens the public surfaces mint, where the
+/// audience a token was minted for decides the kind: an MCP-audience token
+/// authenticates an agent and a human surface's token a user, both carrying the
+/// same internal user id. Installing any provider is also what makes a
+/// deployment a shared one — it retires the implicit local owner, so each
+/// request arrives as a distinct person or agent rather than as the host.
+#[derive(Debug)]
+struct TokenPrincipals;
+
+#[tonic::async_trait]
+impl PrincipalProvider for TokenPrincipals {
+    async fn principal_for_metadata(
+        &self,
+        metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<Principal, PrincipalProviderError> {
+        let credential = metadata
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .ok_or_else(|| PrincipalProviderError::unauthenticated("missing bearer credential"))?;
+        let (kind, user_id) = credential
+            .split_once(':')
+            .ok_or_else(|| PrincipalProviderError::unauthenticated("malformed test credential"))?;
+        let kind = if kind == "agent" {
+            PrincipalKind::Agent
+        } else {
+            PrincipalKind::User
+        };
+        Principal::parse(user_id, kind)
+            .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))
+    }
+}
+
+/// A running server that authenticates its callers, plus the directory rows
+/// login provisioning would have written for them.
+pub(crate) struct SharedDeployment {
+    _temp: Option<TempDir>,
+    config_dir: PathBuf,
+    endpoint_uri: String,
+    trace_store_dir: Option<PathBuf>,
+    _server: RunningServer,
+}
+
+/// What one workspace has on record from work its callers asked for.
+///
+/// A refused request must move none of these: a task row, a query recorded
+/// under one, or a span attributed to the workspace would each be a side effect
+/// of work the caller was never allowed to start.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct WorkspaceWork {
+    pub(crate) tasks: i64,
+    pub(crate) queries: i64,
+    pub(crate) attributed_spans: usize,
+}
+
+impl SharedDeployment {
+    pub(crate) async fn start() -> Self {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        ensure_file_credentials_config(&config_dir);
+        let server = ServerBuilder::new()
+            .with_config_dir(&config_dir)
+            .with_principal_provider(Arc::new(TokenPrincipals))
+            .start()
+            .await
+            .expect("start an authenticated server");
+        let endpoint_uri = server.endpoint_uri().to_string();
+        let trace_store_dir = server.local_trace_store_dir().map(Path::to_path_buf);
+        // The local trace store is installed once per process, by whichever
+        // server starts first, and the trace-history tests write into whatever
+        // directory that turned out to be. When it is this one's, the temp dir
+        // must outlive the deployment: removing it would delete the installed
+        // store out from under a concurrently running test.
+        let temp = if trace_store_dir
+            .as_ref()
+            .is_some_and(|dir| dir.starts_with(temp.path()))
+        {
+            let _installed_store_root: PathBuf = temp.keep();
+            None
+        } else {
+            Some(temp)
+        };
+        Self {
+            _temp: temp,
+            config_dir,
+            endpoint_uri,
+            trace_store_dir,
+            _server: server,
+        }
+    }
+
+    /// Writes one directory row the way a completed login would, and returns
+    /// the internal user id every credential for that person then carries.
+    ///
+    /// The login flow itself is upstream of this contract, so it is the row —
+    /// not the OIDC round trip — that these transport tests need. Authorization
+    /// never sees the upstream subject: it is stored here and nowhere else.
+    pub(crate) async fn seed_user(&self, handle: &str, display_name: &str) -> String {
+        let user_id = format!("user-{handle}");
+        let pool = self.app_database().await;
+        sqlx::query(
+            "INSERT INTO users (user_id, issuer, subject, display_name, created_at_unix_nanos, last_login_at_unix_nanos) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&user_id)
+        .bind(TEST_ISSUER)
+        .bind(format!("upstream-subject-{handle}"))
+        .bind(display_name)
+        .bind(1_i64)
+        .bind(1_i64)
+        .execute(&pool)
+        .await
+        .expect("seed a provisioned login");
+        pool.close().await;
+        user_id
+    }
+
+    pub(crate) async fn as_person(&self, user_id: &str) -> AppClient {
+        self.connect("user", user_id).await
+    }
+
+    /// Connects the session an MCP-audience token authenticates: the same
+    /// person's id, admitted as an agent rather than as themselves.
+    pub(crate) async fn as_agent(&self, user_id: &str) -> AppClient {
+        self.connect("agent", user_id).await
+    }
+
+    async fn connect(&self, kind: &str, user_id: &str) -> AppClient {
+        connect_with_loopback_bearer(
+            &self.endpoint_uri,
+            BearerToken::new(format!("{kind}:{user_id}")).expect("test bearer token"),
+        )
+        .await
+        .expect("connect a test client")
+    }
+
+    /// Reads what `workspace_name` has on record, straight from the state the
+    /// server keeps rather than from an RPC the caller under test could be
+    /// refused.
+    pub(crate) async fn workspace_work(&self, workspace_name: &str) -> WorkspaceWork {
+        let pool = self.app_database().await;
+        let tasks =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM tasks WHERE workspace_id = ?")
+                .bind(workspace_name)
+                .fetch_one(&pool)
+                .await
+                .expect("count workspace tasks");
+        let queries = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM task_queries JOIN tasks ON tasks.id = task_queries.task_id WHERE tasks.workspace_id = ?",
+        )
+        .bind(workspace_name)
+        .fetch_one(&pool)
+        .await
+        .expect("count workspace queries");
+        pool.close().await;
+        WorkspaceWork {
+            tasks,
+            queries,
+            attributed_spans: self.attributed_spans(workspace_name),
+        }
+    }
+
+    /// Counts exported spans carrying this workspace's attribution. Every
+    /// deployment in the process shares one store, so the workspace name is
+    /// what separates one test's spans from another's.
+    fn attributed_spans(&self, workspace_name: &str) -> usize {
+        let Some(dir) = &self.trace_store_dir else {
+            return 0;
+        };
+        fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.extension()
+                    .is_some_and(|extension| extension == "jsonl")
+            })
+            .filter_map(|path| fs::read_to_string(path).ok())
+            .map(|raw| {
+                raw.lines()
+                    .filter(|line| span_names_workspace(line, workspace_name))
+                    .count()
+            })
+            .sum()
+    }
+
+    async fn app_database(&self) -> sqlx::SqlitePool {
+        SqlitePoolOptions::new()
+            .connect_with(SqliteConnectOptions::new().filename(self.config_dir.join("coral.db")))
+            .await
+            .expect("open the app database")
+    }
+}
+
+fn span_names_workspace(line: &str, workspace_name: &str) -> bool {
+    serde_json::from_str::<Value>(line)
+        .ok()
+        .and_then(|span| Some(span.get("attributes_json")?.as_str()?.to_string()))
+        .and_then(|attributes| serde_json::from_str::<Value>(&attributes).ok())
+        .and_then(|attributes| Some(attributes.get("workspace")?.as_str()?.to_string()))
+        .is_some_and(|workspace| workspace == workspace_name)
+}
+
+pub(crate) fn named_workspace(name: &str) -> Workspace {
+    Workspace {
+        name: name.to_string(),
+    }
+}
+
+pub(crate) async fn create_workspace(client: &AppClient, name: &str) -> Result<Workspace, Status> {
+    client
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(named_workspace(name)),
+        }))
+        .await
+        .map(|response| {
+            response
+                .into_inner()
+                .workspace
+                .expect("create workspace response")
+        })
+}
+
+pub(crate) async fn add_member(
+    client: &AppClient,
+    name: &str,
+    user_id: &str,
+    role: WorkspaceRole,
+) -> Result<(), Status> {
+    client
+        .workspace_client()
+        .add_workspace_member(Request::new(AddWorkspaceMemberRequest {
+            workspace: Some(named_workspace(name)),
+            user_id: user_id.to_string(),
+            role: role.into(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+pub(crate) async fn remove_member(
+    client: &AppClient,
+    name: &str,
+    user_id: &str,
+) -> Result<(), Status> {
+    client
+        .workspace_client()
+        .remove_workspace_member(Request::new(RemoveWorkspaceMemberRequest {
+            workspace: Some(named_workspace(name)),
+            user_id: user_id.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Runs one statement as `client`, discarding the rows: these tests ask whether
+/// the read was allowed, not what it returned.
+pub(crate) async fn execute_sql(client: &AppClient, name: &str, sql: &str) -> Result<(), Status> {
+    client
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(named_workspace(name)),
+            sql: sql.to_string(),
+            guide_read_context: None,
+            task_attribution: None,
+        }))
+        .await
+        .map(|_| ())
 }
 
 impl FailingHttpFixture {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -377,6 +377,12 @@ impl SharedDeployment {
         self.trace_store_dir.as_deref()
     }
 
+    /// The bearer credential an actor of `principal_kind` presents for
+    /// `user_id`, for tests that dial a service `AppClient` does not carry.
+    pub(crate) fn credential(&self, user_id: &str, principal_kind: PrincipalKind) -> String {
+        self.session_auth.access_token_for(user_id, principal_kind)
+    }
+
     async fn connect(&self, user_id: &str, principal_kind: PrincipalKind) -> AppClient {
         connect_with_loopback_bearer(
             self.endpoint_uri(),

--- a/crates/coral-app/tests/grpc/session_auth.rs
+++ b/crates/coral-app/tests/grpc/session_auth.rs
@@ -81,6 +81,15 @@ redirect_uri = '{ISSUER}/auth/oidc/callback'
     /// mints through the real issuer rather than replaying the OAuth round
     /// trip: the token's wire format stays the server's own.
     pub(crate) fn access_token(&self, user_id: &str) -> String {
+        self.access_token_for(user_id, PrincipalKind::User)
+    }
+
+    /// Mints the token an actor of `principal_kind` carries for `user_id`.
+    ///
+    /// Two callers differing only in kind is the whole point: the audience is
+    /// the same either way, so a test that separates an agent from a person is
+    /// separating them by what the issuer declared and by nothing else.
+    pub(crate) fn access_token_for(&self, user_id: &str, principal_kind: PrincipalKind) -> String {
         coral_app::test_session_tokens::issue_access_token(
             ISSUER,
             &self.signing_key,
@@ -88,7 +97,7 @@ redirect_uri = '{ISSUER}/auth/oidc/callback'
             user_id,
             CLIENT_ID,
             AUDIENCE,
-            PrincipalKind::User,
+            principal_kind,
         )
         .expect("issue a session access token")
     }

--- a/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
@@ -1,9 +1,195 @@
-use coral_api::v1::WorkspaceRole;
-use tonic::Code;
+use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
+use coral_api::v1::{
+    EndTaskRequest, ExecuteSqlRequest, ListCatalogRequest, ListWorkspacesRequest,
+    PaginationRequest, StartTaskRequest, SubmitFeedbackRequest, TaskAttribution, TaskStatus,
+    WorkspaceRole,
+};
+use coral_client::AppClient;
+use tonic::{Code, Request, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::harness::{
-    SharedDeployment, WorkspaceWork, add_member, create_workspace, execute_sql, remove_member,
+    SharedDeployment, WorkspaceWork, add_member, create_workspace, execute_sql, named_workspace,
+    remove_member,
 };
+
+/// A task id that was never minted anywhere, so `EndTask` cannot be answered
+/// from a real row: the refusal it draws has to come from the workspace rule.
+const UNMINTED_TASK_ID: &str = "00000000-0000-4000-8000-000000000000";
+
+async fn list_catalog(client: &AppClient, name: &str) -> Result<usize, Status> {
+    client
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(named_workspace(name)),
+            catalog_name: String::new(),
+            schema_name: String::new(),
+            kind: 0,
+            pagination: Some(PaginationRequest {
+                limit: 0,
+                offset: 0,
+            }),
+        }))
+        .await
+        .map(|response| response.into_inner().items.len())
+}
+
+async fn start_task(client: &AppClient, name: &str) -> Result<String, Status> {
+    client
+        .task_client()
+        .start_task(Request::new(StartTaskRequest {
+            workspace: Some(named_workspace(name)),
+            intent: "prove read isolation".to_string(),
+        }))
+        .await
+        .map(|response| response.into_inner().task.expect("started task").task_id)
+}
+
+async fn end_task(client: &AppClient, name: &str, task_id: &str) -> Result<(), Status> {
+    client
+        .task_client()
+        .end_task(Request::new(EndTaskRequest {
+            workspace: Some(named_workspace(name)),
+            task_id: task_id.to_string(),
+            task_status: TaskStatus::Success.into(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn submit_feedback(client: &AppClient, name: &str) -> Result<(), Status> {
+    client
+        .feedback_client()
+        .submit_feedback(Request::new(SubmitFeedbackRequest {
+            workspace: Some(named_workspace(name)),
+            trying_to_do: "read the workspace".to_string(),
+            tried: "one statement".to_string(),
+            stuck: "nowhere".to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Runs one statement under `task_id`, which is what makes the server record
+/// the query against the task rather than only run it.
+async fn execute_sql_in_task(
+    client: &AppClient,
+    name: &str,
+    task_id: &str,
+    sql: &str,
+) -> Result<(), Status> {
+    client
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(named_workspace(name)),
+            sql: sql.to_string(),
+            guide_read_context: None,
+            task_attribution: Some(TaskAttribution {
+                task_id: task_id.to_string(),
+                intent: "prove read isolation".to_string(),
+            }),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn membership_rows(client: &AppClient) -> Vec<(String, WorkspaceRole)> {
+    client
+        .workspace_client()
+        .list_workspaces(Request::new(ListWorkspacesRequest {}))
+        .await
+        .expect("a caller is always answered about their own memberships")
+        .into_inner()
+        .memberships
+        .into_iter()
+        .map(|membership| {
+            (
+                membership.workspace.expect("listed workspace").name,
+                membership.role.try_into().expect("listed role"),
+            )
+        })
+        .collect()
+}
+
+/// Probes one workspace name across every classified read RPC and reports only
+/// what the caller is told: the surface, the code, the message with the name
+/// they supplied themselves factored out, and the structured reason. Two names
+/// that agree here are indistinguishable to that caller.
+async fn read_refusals(
+    client: &AppClient,
+    name: &str,
+) -> Vec<(&'static str, Code, String, Vec<String>)> {
+    let probes = [
+        (
+            "execute_sql",
+            execute_sql(client, name, "select 1")
+                .await
+                .expect_err("a non-member must not query the workspace"),
+        ),
+        (
+            "list_catalog",
+            list_catalog(client, name)
+                .await
+                .expect_err("a non-member must not browse the catalog"),
+        ),
+        (
+            "start_task",
+            start_task(client, name)
+                .await
+                .expect_err("a non-member must not open a task"),
+        ),
+        (
+            "end_task",
+            end_task(client, name, UNMINTED_TASK_ID)
+                .await
+                .expect_err("a non-member must not end a task"),
+        ),
+        (
+            "submit_feedback",
+            submit_feedback(client, name)
+                .await
+                .expect_err("a non-member must not file feedback"),
+        ),
+    ];
+    probes
+        .iter()
+        .map(|(surface, status)| {
+            (
+                *surface,
+                status.code(),
+                status.message().replace(name, "<workspace>"),
+                status
+                    .get_error_details_vec()
+                    .iter()
+                    .filter_map(|detail| match detail {
+                        ErrorDetail::ErrorInfo(info) => Some(info.reason.clone()),
+                        _ => None,
+                    })
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+/// Runs every classified read RPC as a caller who is expected to be allowed,
+/// so a claim about the boundary rests on both of its sides.
+async fn expect_full_read_access(client: &AppClient, name: &str) {
+    execute_sql(client, name, "select 1")
+        .await
+        .expect("a member queries the workspace");
+    list_catalog(client, name)
+        .await
+        .expect("a member browses the catalog");
+    let task_id = start_task(client, name)
+        .await
+        .expect("a member opens a task");
+    end_task(client, name, &task_id)
+        .await
+        .expect("a member ends the task they opened");
+    submit_feedback(client, name)
+        .await
+        .expect("a member files feedback");
+}
 
 /// The harness has to hold before any isolation claim can rest on it: two
 /// people who are distinct to the server, a workspace only one of them created,
@@ -64,5 +250,171 @@ async fn workspace_access_read_harness_seats_two_people_around_one_workspace() {
             .attributed_spans
             > 0,
         "permitted reads must leave the workspace attribution the refused one did not",
+    );
+}
+
+/// Two people who each created a workspace share a deployment but not a view of
+/// it: the listing shows each of them one membership, and every classified read
+/// RPC stops at the workspace they do not belong to.
+#[tokio::test]
+async fn two_creators_reach_only_the_workspace_each_of_them_made() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("read-alpha-ada", "Ada").await;
+    let bob = deployment.seed_user("read-beta-bob", "Bob").await;
+    let ada_client = deployment.as_person(&ada).await;
+    let bob_client = deployment.as_person(&bob).await;
+    create_workspace(&ada_client, "read-alpha")
+        .await
+        .expect("Ada makes her own workspace");
+    create_workspace(&bob_client, "read-beta")
+        .await
+        .expect("Bob makes his own workspace");
+
+    assert_eq!(
+        membership_rows(&ada_client).await,
+        vec![("read-alpha".to_string(), WorkspaceRole::Owner)],
+        "creating one workspace must not reveal anybody else's",
+    );
+    assert_eq!(
+        membership_rows(&bob_client).await,
+        vec![("read-beta".to_string(), WorkspaceRole::Owner)],
+    );
+
+    for (surface, code, _, _) in read_refusals(&ada_client, "read-beta").await {
+        assert_eq!(code, Code::NotFound, "Ada reached Bob's {surface}");
+    }
+    for (surface, code, _, _) in read_refusals(&bob_client, "read-alpha").await {
+        assert_eq!(code, Code::NotFound, "Bob reached Ada's {surface}");
+    }
+    expect_full_read_access(&ada_client, "read-alpha").await;
+    expect_full_read_access(&bob_client, "read-beta").await;
+}
+
+/// The read surfaces must not answer questions their caller may not ask. A
+/// workspace they hold no membership in has to read exactly like a name nobody
+/// ever created — and read as the *absent* workspace specifically, since a
+/// uniform "denied" would agree with itself while still confirming the name.
+#[tokio::test]
+async fn an_inaccessible_workspace_reads_exactly_like_an_absent_one() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("read-conceal-ada", "Ada").await;
+    let bob = deployment.seed_user("read-conceal-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let outsider = deployment.as_person(&bob).await;
+    create_workspace(&owner, "read-conceal")
+        .await
+        .expect("the creator makes their own workspace");
+
+    let existing = read_refusals(&outsider, "read-conceal").await;
+    assert_eq!(
+        existing,
+        read_refusals(&outsider, "read-ghost").await,
+        "an existing workspace must be indistinguishable from one that never existed",
+    );
+    assert!(
+        existing
+            .iter()
+            .all(|(_, code, _, reasons)| *code == Code::NotFound
+                && reasons.as_slice() == [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND]),
+        "both must read as the absent workspace, not as a denial that confirms one: {existing:?}",
+    );
+    // A probe that changed the workspace would make the two names agree only
+    // until the owner looked.
+    assert_eq!(
+        deployment.workspace_work("read-conceal").await,
+        WorkspaceWork::default(),
+    );
+
+    // `end_task` carries its share of the vector only if its refusal came from
+    // the workspace rule rather than from the task id being unknown. The owner
+    // asking the same impossible question is what separates the two: they are
+    // told about the task, and told it without a Coral reason attached.
+    let known_workspace = end_task(&owner, "read-conceal", UNMINTED_TASK_ID)
+        .await
+        .expect_err("the task id was never minted");
+    assert_eq!(known_workspace.code(), Code::NotFound);
+    assert!(
+        known_workspace.get_error_details_vec().is_empty()
+            && known_workspace.message().contains(UNMINTED_TASK_ID),
+        "a member's unknown task must not read as the absent workspace: {known_workspace:?}",
+    );
+}
+
+/// A refused read must leave the workspace with no record that it was asked
+/// for. The owner's own reads afterwards are the control: they move every
+/// counter the refusals left at zero, so the emptiness is an observation about
+/// the refusals rather than about an observer that sees nothing.
+#[tokio::test]
+async fn refused_reads_leave_the_workspace_no_record_of_them() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("read-record-ada", "Ada").await;
+    let bob = deployment.seed_user("read-record-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let outsider = deployment.as_person(&bob).await;
+    create_workspace(&owner, "read-record")
+        .await
+        .expect("the creator makes their own workspace");
+
+    let refused = read_refusals(&outsider, "read-record").await;
+    assert!(
+        refused
+            .iter()
+            .all(|(_, code, _, _)| *code == Code::NotFound),
+        "every read surface must refuse before it does anything: {refused:?}",
+    );
+    assert_eq!(
+        deployment.workspace_work("read-record").await,
+        WorkspaceWork::default(),
+        "refused work must create no task row, no recorded query, and no attributed span",
+    );
+
+    let task_id = start_task(&owner, "read-record")
+        .await
+        .expect("the owner opens a task");
+    execute_sql_in_task(&owner, "read-record", &task_id, "select 1")
+        .await
+        .expect("the owner runs a statement under it");
+    let recorded = deployment.workspace_work("read-record").await;
+    assert!(
+        recorded.tasks > 0 && recorded.queries > 0 && recorded.attributed_spans > 0,
+        "permitted work must move every counter the refusals left at zero: {recorded:?}",
+    );
+}
+
+/// Membership is the whole of the read boundary: adding a person opens every
+/// classified read RPC to them, and revoking it closes the very next request on
+/// each of those same RPCs.
+#[tokio::test]
+async fn membership_opens_every_read_surface_and_revocation_closes_it() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("read-grant-ada", "Ada").await;
+    let bob = deployment.seed_user("read-grant-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let member = deployment.as_person(&bob).await;
+    create_workspace(&owner, "read-grant")
+        .await
+        .expect("the creator makes their own workspace");
+    for (surface, code, _, _) in read_refusals(&member, "read-grant").await {
+        assert_eq!(code, Code::NotFound, "a non-member reached {surface}");
+    }
+
+    add_member(&owner, "read-grant", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+    expect_full_read_access(&member, "read-grant").await;
+    // The agent session behind the same person inherits the grant, so an MCP
+    // client is bounded by who is behind it rather than by its own audience.
+    expect_full_read_access(&deployment.as_agent(&bob).await, "read-grant").await;
+
+    remove_member(&owner, "read-grant", &bob)
+        .await
+        .expect("the owner revokes membership");
+    let after_revocation = read_refusals(&member, "read-grant").await;
+    assert!(
+        after_revocation
+            .iter()
+            .all(|(_, code, _, reasons)| *code == Code::NotFound
+                && reasons.as_slice() == [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND]),
+        "revocation must close every read surface on the next request: {after_revocation:?}",
     );
 }

--- a/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
@@ -1,7 +1,7 @@
 use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
 use coral_api::v1::{
-    EndTaskRequest, ExecuteSqlRequest, ListCatalogRequest, PaginationRequest, StartTaskRequest,
-    SubmitFeedbackRequest, TaskAttribution, TaskStatus, WorkspaceRole,
+    EndTaskRequest, ExecuteSqlRequest, ExplainSqlRequest, ListCatalogRequest, PaginationRequest,
+    StartTaskRequest, SubmitFeedbackRequest, TaskAttribution, TaskStatus, WorkspaceRole,
 };
 use coral_client::AppClient;
 use tonic::{Code, Request, Status};
@@ -14,6 +14,11 @@ use crate::harness::{
 /// A task id that was never minted anywhere, so `EndTask` cannot be answered
 /// from a real row: the refusal it draws has to come from the workspace rule.
 const UNMINTED_TASK_ID: &str = "00000000-0000-4000-8000-000000000000";
+
+/// SQL the query path itself rejects. A caller who reached the planner would
+/// be told so, which is what makes a concealing refusal on `ExplainSql` an
+/// absence rather than an error code.
+const UNPLANNABLE_SQL: &str = "this is not sql";
 
 async fn list_catalog(client: &AppClient, name: &str) -> Result<usize, Status> {
     client
@@ -30,6 +35,17 @@ async fn list_catalog(client: &AppClient, name: &str) -> Result<usize, Status> {
         }))
         .await
         .map(|response| response.into_inner().items.len())
+}
+
+async fn explain_sql(client: &AppClient, name: &str, sql: &str) -> Result<(), Status> {
+    client
+        .query_client()
+        .explain_sql(Request::new(ExplainSqlRequest {
+            workspace: Some(named_workspace(name)),
+            sql: sql.to_string(),
+        }))
+        .await
+        .map(|_| ())
 }
 
 async fn start_task(client: &AppClient, name: &str) -> Result<String, Status> {
@@ -106,6 +122,12 @@ async fn read_refusals(
                 .expect_err("a non-member must not query the workspace"),
         ),
         (
+            "explain_sql",
+            explain_sql(client, name, UNPLANNABLE_SQL)
+                .await
+                .expect_err("a non-member must not plan against the workspace"),
+        ),
+        (
             "list_catalog",
             list_catalog(client, name)
                 .await
@@ -145,6 +167,9 @@ async fn expect_full_read_access(client: &AppClient, name: &str) {
     execute_sql(client, name, "select 1")
         .await
         .expect("a member queries the workspace");
+    explain_sql(client, name, "select 1")
+        .await
+        .expect("a member plans a statement");
     list_catalog(client, name)
         .await
         .expect("a member browses the catalog");

--- a/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
@@ -1,16 +1,14 @@
 use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
 use coral_api::v1::{
-    EndTaskRequest, ExecuteSqlRequest, ListCatalogRequest, ListWorkspacesRequest,
-    PaginationRequest, StartTaskRequest, SubmitFeedbackRequest, TaskAttribution, TaskStatus,
-    WorkspaceRole,
+    EndTaskRequest, ExecuteSqlRequest, ListCatalogRequest, PaginationRequest, StartTaskRequest,
+    SubmitFeedbackRequest, TaskAttribution, TaskStatus, WorkspaceRole,
 };
 use coral_client::AppClient;
 use tonic::{Code, Request, Status};
-use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::harness::{
-    SharedDeployment, WorkspaceWork, add_member, create_workspace, execute_sql, named_workspace,
-    remove_member,
+    SharedDeployment, WorkspaceWork, add_member, concealed_refusal, create_workspace, execute_sql,
+    membership_rows, named_workspace, remove_member,
 };
 
 /// A task id that was never minted anywhere, so `EndTask` cannot be answered
@@ -93,28 +91,9 @@ async fn execute_sql_in_task(
         .map(|_| ())
 }
 
-async fn membership_rows(client: &AppClient) -> Vec<(String, WorkspaceRole)> {
-    client
-        .workspace_client()
-        .list_workspaces(Request::new(ListWorkspacesRequest {}))
-        .await
-        .expect("a caller is always answered about their own memberships")
-        .into_inner()
-        .memberships
-        .into_iter()
-        .map(|membership| {
-            (
-                membership.workspace.expect("listed workspace").name,
-                membership.role.try_into().expect("listed role"),
-            )
-        })
-        .collect()
-}
-
-/// Probes one workspace name across every classified read RPC and reports only
-/// what the caller is told: the surface, the code, the message with the name
-/// they supplied themselves factored out, and the structured reason. Two names
-/// that agree here are indistinguishable to that caller.
+/// Probes one workspace name across every classified read RPC and reports the
+/// surface beside what that surface told the caller. Two names that agree here
+/// are indistinguishable to that caller.
 async fn read_refusals(
     client: &AppClient,
     name: &str,
@@ -154,19 +133,8 @@ async fn read_refusals(
     probes
         .iter()
         .map(|(surface, status)| {
-            (
-                *surface,
-                status.code(),
-                status.message().replace(name, "<workspace>"),
-                status
-                    .get_error_details_vec()
-                    .iter()
-                    .filter_map(|detail| match detail {
-                        ErrorDetail::ErrorInfo(info) => Some(info.reason.clone()),
-                        _ => None,
-                    })
-                    .collect(),
-            )
+            let (code, message, reasons) = concealed_refusal(status, name);
+            (*surface, code, message, reasons)
         })
         .collect()
 }
@@ -205,7 +173,9 @@ async fn workspace_access_read_harness_seats_two_people_around_one_workspace() {
     let outsider = deployment.as_person(&bob).await;
     let created = create_workspace(&owner, "read-harness")
         .await
-        .expect("the creator makes their own workspace");
+        .expect("the creator makes their own workspace")
+        .workspace
+        .expect("create workspace response");
     assert_eq!(created.name, "read-harness");
 
     assert_eq!(
@@ -329,14 +299,16 @@ async fn an_inaccessible_workspace_reads_exactly_like_an_absent_one() {
     // the workspace rule rather than from the task id being unknown. The owner
     // asking the same impossible question is what separates the two: they are
     // told about the task, and told it without a Coral reason attached.
-    let known_workspace = end_task(&owner, "read-conceal", UNMINTED_TASK_ID)
-        .await
-        .expect_err("the task id was never minted");
-    assert_eq!(known_workspace.code(), Code::NotFound);
+    let (code, message, reasons) = concealed_refusal(
+        &end_task(&owner, "read-conceal", UNMINTED_TASK_ID)
+            .await
+            .expect_err("the task id was never minted"),
+        "read-conceal",
+    );
+    assert_eq!(code, Code::NotFound);
     assert!(
-        known_workspace.get_error_details_vec().is_empty()
-            && known_workspace.message().contains(UNMINTED_TASK_ID),
-        "a member's unknown task must not read as the absent workspace: {known_workspace:?}",
+        reasons.is_empty() && message.contains(UNMINTED_TASK_ID),
+        "a member's unknown task must not read as the absent workspace: {message} {reasons:?}",
     );
 }
 

--- a/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
@@ -1,0 +1,68 @@
+use coral_api::v1::WorkspaceRole;
+use tonic::Code;
+
+use crate::harness::{
+    SharedDeployment, WorkspaceWork, add_member, create_workspace, execute_sql, remove_member,
+};
+
+/// The harness has to hold before any isolation claim can rest on it: two
+/// people who are distinct to the server, a workspace only one of them created,
+/// a refusal that leaves nothing on that workspace's record, and membership as
+/// the only thing that changes either answer.
+#[tokio::test]
+async fn workspace_access_read_harness_seats_two_people_around_one_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("read-ada", "Ada").await;
+    let bob = deployment.seed_user("read-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let owner_agent = deployment.as_agent(&ada).await;
+    let outsider = deployment.as_person(&bob).await;
+    let created = create_workspace(&owner, "read-harness")
+        .await
+        .expect("the creator makes their own workspace");
+    assert_eq!(created.name, "read-harness");
+
+    assert_eq!(
+        execute_sql(&outsider, "read-harness", "select 1")
+            .await
+            .expect_err("a non-member must not read the workspace")
+            .code(),
+        Code::NotFound,
+    );
+    assert_eq!(
+        deployment.workspace_work("read-harness").await,
+        WorkspaceWork::default(),
+        "a refused read must leave behind no task, no recorded query, and no attributed span",
+    );
+
+    execute_sql(&owner_agent, "read-harness", "select 1")
+        .await
+        .expect("an agent session reads what the person behind it may read");
+    add_member(&owner, "read-harness", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+    execute_sql(&outsider, "read-harness", "select 1")
+        .await
+        .expect("membership is what opens the read");
+
+    remove_member(&owner, "read-harness", &bob)
+        .await
+        .expect("the owner revokes membership");
+    assert_eq!(
+        execute_sql(&outsider, "read-harness", "select 1")
+            .await
+            .expect_err("revocation must apply to the next request")
+            .code(),
+        Code::NotFound,
+    );
+    // The permitted reads are what prove the observer above can see anything at
+    // all: without this, an emptiness assertion would pass on a blind observer.
+    assert!(
+        deployment
+            .workspace_work("read-harness")
+            .await
+            .attributed_spans
+            > 0,
+        "permitted reads must leave the workspace attribution the refused one did not",
+    );
+}

--- a/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
@@ -169,7 +169,7 @@ async fn workspace_access_read_harness_seats_two_people_around_one_workspace() {
     let ada = deployment.seed_user("read-ada", "Ada").await;
     let bob = deployment.seed_user("read-bob", "Bob").await;
     let owner = deployment.as_person(&ada).await;
-    let owner_agent = deployment.as_agent(&ada).await;
+    let agent = deployment.as_agent("agent-read-harness").await;
     let outsider = deployment.as_person(&bob).await;
     let created = create_workspace(&owner, "read-harness")
         .await
@@ -191,9 +191,15 @@ async fn workspace_access_read_harness_seats_two_people_around_one_workspace() {
         "a refused read must leave behind no task, no recorded query, and no attributed span",
     );
 
-    execute_sql(&owner_agent, "read-harness", "select 1")
-        .await
-        .expect("an agent session reads what the person behind it may read");
+    // An agent is its own principal, so it holds no membership here and the
+    // workspace is concealed from it exactly as it is from any other outsider.
+    assert_eq!(
+        execute_sql(&agent, "read-harness", "select 1")
+            .await
+            .expect_err("an agent holds no membership of its own")
+            .code(),
+        Code::NotFound,
+    );
     add_member(&owner, "read-harness", &bob, WorkspaceRole::Member)
         .await
         .expect("the owner grants membership");
@@ -374,9 +380,13 @@ async fn membership_opens_every_read_surface_and_revocation_closes_it() {
         .await
         .expect("the owner grants membership");
     expect_full_read_access(&member, "read-grant").await;
-    // The agent session behind the same person inherits the grant, so an MCP
-    // client is bounded by who is behind it rather than by its own audience.
-    expect_full_read_access(&deployment.as_agent(&bob).await, "read-grant").await;
+    // Granting the person nothing for the agent: the two are separate
+    // principals, so a membership written for one is not readable by the other.
+    for (surface, code, _, _) in
+        read_refusals(&deployment.as_agent("agent-read-grant").await, "read-grant").await
+    {
+        assert_eq!(code, Code::NotFound, "an agent reached {surface}");
+    }
 
     remove_member(&owner, "read-grant", &bob)
         .await

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -1,34 +1,26 @@
 use std::fs;
-use std::path::PathBuf;
 
 use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
 use coral_api::v1::{
-    AddWorkspaceMemberRequest, AddWorkspaceMemberResponse, CreateWorkspaceRequest,
-    CreateWorkspaceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
-    GetCurrentUserRequest, ImportSourceRequest, ListSourcesRequest, ListUsersRequest,
-    ListWorkspaceMembersRequest, ListWorkspaceMembersResponse, ListWorkspacesRequest,
-    ListWorkspacesResponse, RemoveWorkspaceMemberRequest, RemoveWorkspaceMemberResponse, Source,
-    SourceSecret, SourceVariable, Workspace, WorkspaceRole, import_source_response,
+    CreateWorkspaceRequest, DeleteWorkspaceRequest, DeleteWorkspaceResponse, GetCurrentUserRequest,
+    ImportSourceRequest, ListSourcesRequest, ListUsersRequest, ListWorkspaceMembersRequest,
+    ListWorkspaceMembersResponse, ListWorkspacesRequest, Source, SourceSecret, SourceVariable,
+    WorkspaceRole, import_source_response,
 };
-use coral_client::local::{RunningServer, connect_with_loopback_bearer};
-use coral_client::{AppClient, BearerToken, default_workspace};
+use coral_client::{AppClient, default_workspace};
 use prost::Message as _;
 use serde_json::json;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::{Code, Request, Response, Status};
-use tonic_types::{ErrorDetail, StatusExt as _};
 
-use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
-use crate::session_auth::{SessionAuthFixture, session_authenticated_server};
+use crate::harness::{
+    GrpcHarness, SharedDeployment, TEST_ISSUER, add_member, concealed_refusal, create_workspace,
+    fixture_manifest_with_inputs_yaml, fixture_manifest_yaml, membership_rows,
+    named_workspace as workspace, remove_member,
+};
 
 static TRACE_STORE_DELETE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-fn workspace(name: &str) -> Workspace {
-    Workspace {
-        name: name.to_string(),
-    }
-}
 
 async fn workspace_names(harness: &GrpcHarness) -> Vec<String> {
     harness
@@ -744,106 +736,6 @@ async fn delete_default_workspace_returns_failed_precondition() {
     );
 }
 
-/// Upstream issuer written into every seeded directory row, so a response that
-/// leaked it would be recognizable on the wire.
-const TEST_ISSUER: &str = "https://issuer.test/authorization";
-
-/// A running server that authenticates its callers, plus the directory rows
-/// login provisioning would have written for them.
-struct SharedDeployment {
-    _temp: Option<TempDir>,
-    config_dir: PathBuf,
-    endpoint_uri: String,
-    session_auth: SessionAuthFixture,
-    _server: RunningServer,
-}
-
-impl SharedDeployment {
-    async fn start() -> Self {
-        let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("coral-config");
-        // Configuring session authentication is what makes a deployment a
-        // shared one: it retires the implicit local owner, so each request over
-        // these tests' transport arrives as a distinct person instead of as the
-        // host.
-        let session_auth = SessionAuthFixture::write(&config_dir);
-        let server = session_authenticated_server(&session_auth)
-            .await
-            .expect("start an authenticated server");
-        let endpoint_uri = server.endpoint_uri().to_string();
-        // The local trace store is installed once per process, by whichever
-        // server starts first, and the trace-history tests write into whatever
-        // directory that turned out to be. When it is this one's, the temp dir
-        // must outlive the deployment: removing it would delete the installed
-        // store out from under a concurrently running test.
-        let temp = if server
-            .local_trace_store_dir()
-            .is_some_and(|dir| dir.starts_with(temp.path()))
-        {
-            let _installed_store_root: PathBuf = temp.keep();
-            None
-        } else {
-            Some(temp)
-        };
-        Self {
-            _temp: temp,
-            config_dir,
-            endpoint_uri,
-            session_auth,
-            _server: server,
-        }
-    }
-
-    /// Writes one directory row the way a completed login would.
-    ///
-    /// The login flow itself is upstream of this contract, so it is the row —
-    /// not the OIDC round trip — that these transport tests need. Every row
-    /// shares one timestamp, leaving the directory ordered by user id.
-    async fn seed_user(&self, handle: &str, display_name: &str) -> String {
-        let user_id = format!("user-{handle}");
-        let pool = SqlitePoolOptions::new()
-            .connect_with(SqliteConnectOptions::new().filename(self.config_dir.join("coral.db")))
-            .await
-            .expect("open the app database");
-        sqlx::query(
-            "INSERT INTO users (user_id, issuer, subject, display_name, created_at_unix_nanos, last_login_at_unix_nanos) VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&user_id)
-        .bind(TEST_ISSUER)
-        .bind(format!("upstream-subject-{handle}"))
-        .bind(display_name)
-        .bind(1_i64)
-        .bind(1_i64)
-        .execute(&pool)
-        .await
-        .expect("seed a provisioned login");
-        pool.close().await;
-        user_id
-    }
-
-    async fn as_person(&self, user_id: &str) -> AppClient {
-        connect_with_loopback_bearer(
-            &self.endpoint_uri,
-            BearerToken::new(self.session_auth.access_token(user_id)).expect("test bearer token"),
-        )
-        .await
-        .expect("connect a test client")
-    }
-}
-
-async fn create_workspace(
-    client: &AppClient,
-    name: &str,
-) -> Result<CreateWorkspaceResponse, Status> {
-    client
-        .workspace_client()
-        .create_workspace(Request::new(CreateWorkspaceRequest {
-            workspace: Some(workspace(name)),
-        }))
-        .await
-        .map(Response::into_inner)
-}
-
 async fn delete_workspace(
     client: &AppClient,
     name: &str,
@@ -853,14 +745,6 @@ async fn delete_workspace(
         .delete_workspace(Request::new(DeleteWorkspaceRequest {
             workspace: Some(workspace(name)),
         }))
-        .await
-        .map(Response::into_inner)
-}
-
-async fn list_workspaces(client: &AppClient) -> Result<ListWorkspacesResponse, Status> {
-    client
-        .workspace_client()
-        .list_workspaces(Request::new(ListWorkspacesRequest {}))
         .await
         .map(Response::into_inner)
 }
@@ -878,53 +762,6 @@ async fn list_members(
         .map(Response::into_inner)
 }
 
-async fn add_member(
-    client: &AppClient,
-    name: &str,
-    user_id: &str,
-    role: WorkspaceRole,
-) -> Result<AddWorkspaceMemberResponse, Status> {
-    client
-        .workspace_client()
-        .add_workspace_member(Request::new(AddWorkspaceMemberRequest {
-            workspace: Some(workspace(name)),
-            user_id: user_id.to_string(),
-            role: role.into(),
-        }))
-        .await
-        .map(Response::into_inner)
-}
-
-async fn remove_member(
-    client: &AppClient,
-    name: &str,
-    user_id: &str,
-) -> Result<RemoveWorkspaceMemberResponse, Status> {
-    client
-        .workspace_client()
-        .remove_workspace_member(Request::new(RemoveWorkspaceMemberRequest {
-            workspace: Some(workspace(name)),
-            user_id: user_id.to_string(),
-        }))
-        .await
-        .map(Response::into_inner)
-}
-
-/// Reads a listing the way a client does: workspace name beside the caller's
-/// own role, with no second request needed to learn it.
-fn membership_rows(response: ListWorkspacesResponse) -> Vec<(String, WorkspaceRole)> {
-    response
-        .memberships
-        .into_iter()
-        .map(|membership| {
-            (
-                membership.workspace.expect("listed workspace").name,
-                membership.role.try_into().expect("listed role"),
-            )
-        })
-        .collect()
-}
-
 fn member_rows(response: ListWorkspaceMembersResponse) -> Vec<(String, WorkspaceRole, String)> {
     response
         .members
@@ -939,10 +776,9 @@ fn member_rows(response: ListWorkspaceMembersResponse) -> Vec<(String, Workspace
         .collect()
 }
 
-/// Probes one workspace name across every control-plane RPC and reports only
-/// what the caller is told: the code, the message with the name they supplied
-/// themselves factored out, and the structured reason. Two names that agree
-/// here are indistinguishable to that caller.
+/// Probes one workspace name across every control-plane RPC and reports what
+/// each of them told the caller. Two names that agree here are
+/// indistinguishable to that caller.
 async fn control_plane_refusals(
     client: &AppClient,
     name: &str,
@@ -963,20 +799,7 @@ async fn control_plane_refusals(
             .expect_err("a non-member must not revoke membership"),
     ]
     .iter()
-    .map(|status| {
-        (
-            status.code(),
-            status.message().replace(name, "<workspace>"),
-            status
-                .get_error_details_vec()
-                .iter()
-                .filter_map(|detail| match detail {
-                    ErrorDetail::ErrorInfo(info) => Some(info.reason.clone()),
-                    _ => None,
-                })
-                .collect(),
-        )
-    })
+    .map(|status| concealed_refusal(status, name))
     .collect()
 }
 
@@ -988,11 +811,7 @@ async fn a_caller_with_no_membership_is_listed_nothing_rather_than_denied() {
     let ada = deployment.seed_user("ada", "Ada").await;
     let newcomer = deployment.as_person(&ada).await;
 
-    let listing = list_workspaces(&newcomer)
-        .await
-        .expect("a caller with no membership is still answered");
-
-    assert_eq!(membership_rows(listing), Vec::new());
+    assert_eq!(membership_rows(&newcomer).await, Vec::new());
 }
 
 #[tokio::test]
@@ -1009,7 +828,7 @@ async fn creating_a_workspace_makes_its_caller_its_only_owner() {
 
     assert_eq!(created.name, "team");
     assert_eq!(
-        membership_rows(list_workspaces(&creator).await.expect("list workspaces")),
+        membership_rows(&creator).await,
         vec![("team".to_string(), WorkspaceRole::Owner)],
         "the creator reaches the workspace they asked for, as its owner"
     );
@@ -1189,7 +1008,7 @@ async fn a_non_member_cannot_tell_an_existing_workspace_from_an_absent_one() {
         "both must read as the absent workspace, not as a denial that confirms one: {existing:?}",
     );
     assert_eq!(
-        membership_rows(list_workspaces(&owner).await.expect("the owner's listing")),
+        membership_rows(&owner).await,
         vec![("team".to_string(), WorkspaceRole::Owner)],
         "a refused probe must not have changed the workspace it probed",
     );
@@ -1210,11 +1029,7 @@ async fn deleting_a_workspace_takes_its_memberships_with_it() {
         .await
         .expect("grant membership");
     assert_eq!(
-        membership_rows(
-            list_workspaces(&member)
-                .await
-                .expect("the member's listing")
-        ),
+        membership_rows(&member).await,
         vec![("team".to_string(), WorkspaceRole::Member)],
     );
 
@@ -1227,7 +1042,7 @@ async fn deleting_a_workspace_takes_its_memberships_with_it() {
     assert_eq!(deleted.name, "team");
     for (client, whose) in [(&owner, "owner"), (&member, "member")] {
         assert_eq!(
-            membership_rows(list_workspaces(client).await.expect("listing")),
+            membership_rows(client).await,
             Vec::new(),
             "the deleted workspace must leave the {whose}'s listing",
         );

--- a/crates/coral-app/tests/grpc_workspace_function_search_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_function_search_access.rs
@@ -258,6 +258,46 @@ async fn refusals(
 }
 
 /// Asserts `client` reads both families and changes neither.
+/// Both families closed to one caller, for the two different reasons that close
+/// them: the reads are concealed because the caller holds no membership, and the
+/// mutations are refused outright by the credential's kind.
+async fn reaches_neither_family(client: &AppClient, name: &str, who: &str) {
+    assert_eq!(
+        list_functions(client, name)
+            .await
+            .expect_err("a caller with no membership lists no functions")
+            .code(),
+        Code::NotFound,
+        "{who} listed the workspace's functions",
+    );
+    assert_eq!(
+        execute_sql_rows(client, name, ECHO_CALL)
+            .await
+            .expect_err("a caller with no membership calls no function")
+            .code(),
+        Code::NotFound,
+        "{who} called the installed function",
+    );
+    assert_eq!(
+        search(client, name, "echo one value")
+            .await
+            .expect_err("a caller with no membership searches nothing")
+            .code(),
+        Code::NotFound,
+        "{who} searched the workspace",
+    );
+
+    for (rpc, result) in every_mutation(client, name).await {
+        assert_eq!(
+            result
+                .expect_err("an agent credential changes nothing")
+                .code(),
+            Code::PermissionDenied,
+            "{who} changed the workspace through {rpc}",
+        );
+    }
+}
+
 async fn reads_both_and_changes_neither(client: &AppClient, name: &str, who: &str) {
     assert_eq!(
         list_functions(client, name)
@@ -385,16 +425,18 @@ async fn a_member_reads_functions_and_search_but_changes_neither() {
     );
 }
 
-/// The data plane carries the person's workspace access and the control plane
-/// does not, so an agent credential is on both sides of the same line.
+/// An agent credential reaches neither family, and the two refusals are worth
+/// separating.
 ///
-/// The owner's own agent is the half that matters: their role would make every
-/// mutation theirs to perform, and the credential is refused anyway — a
-/// prompt-injected agent cannot publish SQL every member then runs, nor clear
-/// the index every member searches. The member's agent proves the other half,
-/// that the reads were not shut off along with the writes.
+/// The mutations are the half that matters: they are refused by the credential's
+/// kind before any membership is consulted, so a prompt-injected agent cannot
+/// publish SQL every member then runs nor clear the index every member searches
+/// — and that holds whatever workspace it aims at, including one whose owner it
+/// was made for. The reads are refused for the ordinary reason instead: an agent
+/// is its own principal, and this model gives it no way to hold the memberships
+/// of the person it acts for.
 #[tokio::test]
-async fn an_agent_credential_reads_both_families_and_changes_neither() {
+async fn an_agent_credential_reaches_neither_family() {
     let deployment = SharedDeployment::start().await;
     let ada = deployment.seed_user("fs-agent-ada", "Ada").await;
     let bob = deployment.seed_user("fs-agent-bob", "Bob").await;
@@ -409,16 +451,16 @@ async fn an_agent_credential_reads_both_families_and_changes_neither() {
         .await
         .expect("the owner grants membership");
 
-    reads_both_and_changes_neither(
-        &deployment.as_agent(&bob).await,
+    reaches_neither_family(
+        &deployment.as_agent("agent-fs-one").await,
         "fs-agent",
-        "a member's agent",
+        "an agent credential",
     )
     .await;
-    reads_both_and_changes_neither(
-        &deployment.as_agent(&ada).await,
+    reaches_neither_family(
+        &deployment.as_agent("agent-fs-two").await,
         "fs-agent",
-        "the owner's own agent",
+        "a second agent credential",
     )
     .await;
 

--- a/crates/coral-app/tests/grpc_workspace_function_search_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_function_search_access.rs
@@ -1,0 +1,467 @@
+//! Public gRPC evidence that a workspace's functions and its search index are
+//! read by everyone inside it and rewritten by nobody else.
+//!
+//! These two families sit on opposite sides of the same line. Searching a
+//! workspace and listing or calling its functions are reads of what it holds,
+//! so membership is the whole requirement. Installing a function or rebuilding,
+//! draining, and clearing an index changes what every member then sees, so
+//! those are an owner's act.
+//!
+//! The agent boundary is what makes the line worth proving over the wire. A
+//! data-plane read carries the person's workspace access, so an MCP-audience
+//! credential searches and lists functions exactly as the person does — while
+//! the same credential behind the *owner* still installs nothing, because the
+//! control-plane restriction is settled before any role is read. Both halves
+//! are asserted here; a suite that only proved the denial would pass against a
+//! server that had shut agents out of reading too.
+//!
+//! Every refusal is proved to be an absence rather than an error code. Each
+//! probe request carries input the work itself rejects — SQL no compiler
+//! accepts, a function name no parser accepts, an empty query, an undecodable
+//! provider, an unspecified scope — so the caller who is let through is told
+//! what is wrong with their request and the caller who is not never gets that
+//! far.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
+)]
+
+use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
+use coral_api::v1::{
+    AddFunctionRequest, ClearSearchDataRequest, DeleteFunctionRequest, DrainSearchQueueRequest,
+    ExecuteSqlRequest, FunctionWriteSurface, ListFunctionsRequest, RebuildSearchIndexRequest,
+    SearchClearTarget, SearchDataScope, SearchIndexProvider, SearchRequest, WorkspaceRole,
+    search_clear_target,
+};
+use coral_client::{AppClient, batches_to_json_rows, decode_execute_sql_response};
+use serde_json::{Value, json};
+use tonic::{Code, Request, Status};
+
+#[path = "grpc/harness.rs"]
+#[expect(
+    dead_code,
+    reason = "The shared harness serves several integration binaries; this one exercises the shared-deployment half of it."
+)]
+mod harness;
+
+use crate::harness::{
+    SharedDeployment, add_member, concealed_refusal, create_workspace, named_workspace,
+};
+
+/// SQL no compiler accepts, so a caller who reaches function installation is
+/// told what is wrong with it and a caller who does not never gets that far.
+const UNPARSEABLE_SQL: &str = "this is not sql";
+
+/// A function name no parser accepts, for the same reason.
+const UNPARSEABLE_FUNCTION: &str = "not a function name";
+
+/// A provider number no decoder maps, so answering it is proof the rebuild
+/// request was built at all.
+const UNDECODABLE_PROVIDER: i32 = 9_999;
+
+/// The function the owner installs, published under the name its frontmatter
+/// declares so a member can call it by that name.
+const ECHO_FUNCTION_SQL: &str = r"/*
+name: echo_value
+schema: functions
+description: Echo one value
+guide: Use this function to echo a typed value.
+*/
+
+select cast($value as VARCHAR) as value
+";
+
+const ECHO_FUNCTION: &str = "echo_value";
+
+/// Calls the installed function, so a member's read of it is the function
+/// running rather than only its name being listed.
+const ECHO_CALL: &str = "select * from functions.echo_value(value => 'hello')";
+
+async fn add_function(client: &AppClient, name: &str, sql: &str) -> Result<String, Status> {
+    client
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            workspace: Some(named_workspace(name)),
+            sql: sql.to_string(),
+            fail_if_exists: false,
+            write_surface: FunctionWriteSurface::Cli as i32,
+        }))
+        .await
+        .map(|response| {
+            response
+                .into_inner()
+                .function
+                .expect("an accepted install answers with the installed function")
+                .name
+        })
+}
+
+async fn list_functions(client: &AppClient, name: &str) -> Result<Vec<String>, Status> {
+    client
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(named_workspace(name)),
+        }))
+        .await
+        .map(|response| {
+            response
+                .into_inner()
+                .functions
+                .into_iter()
+                .map(|function| function.name)
+                .collect()
+        })
+}
+
+async fn delete_function(client: &AppClient, name: &str, function: &str) -> Result<(), Status> {
+    client
+        .function_client()
+        .delete_function(Request::new(DeleteFunctionRequest {
+            workspace: Some(named_workspace(name)),
+            name: function.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn search(client: &AppClient, name: &str, query: &str) -> Result<(), Status> {
+    client
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(named_workspace(name)),
+            query: query.to_string(),
+            limit: 0,
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn rebuild_search_index(client: &AppClient, name: &str, provider: i32) -> Result<(), Status> {
+    client
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(named_workspace(name)),
+            force: true,
+            provider,
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn drain_search_queue(client: &AppClient, name: &str) -> Result<(), Status> {
+    client
+        .search_client()
+        .drain_search_queue(Request::new(DrainSearchQueueRequest {
+            workspace: Some(named_workspace(name)),
+            budget_ms: 1,
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn clear_search_data(
+    client: &AppClient,
+    name: &str,
+    scope: SearchDataScope,
+    target: Option<SearchClearTarget>,
+) -> Result<(), Status> {
+    client
+        .search_client()
+        .clear_search_data(Request::new(ClearSearchDataRequest {
+            workspace: Some(named_workspace(name)),
+            scope: scope as i32,
+            target,
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Runs one statement as `client` and hands back the rows, so calling a
+/// function proves the function ran rather than only that the statement was
+/// allowed.
+async fn execute_sql_rows(client: &AppClient, name: &str, sql: &str) -> Result<Vec<Value>, Status> {
+    let response = client
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(named_workspace(name)),
+            sql: sql.to_string(),
+            guide_read_context: None,
+            task_attribution: None,
+        }))
+        .await?
+        .into_inner();
+    let decoded = decode_execute_sql_response(&response)
+        .map_err(|error| Status::internal(error.to_string()))?;
+    batches_to_json_rows(decoded.batches()).map_err(|error| Status::internal(error.to_string()))
+}
+
+/// The five requests that change what a workspace's members can run or find.
+async fn every_mutation(client: &AppClient, name: &str) -> Vec<(&'static str, Result<(), Status>)> {
+    vec![
+        (
+            "AddFunction",
+            add_function(client, name, UNPARSEABLE_SQL)
+                .await
+                .map(|_| ()),
+        ),
+        (
+            "DeleteFunction",
+            delete_function(client, name, UNPARSEABLE_FUNCTION).await,
+        ),
+        (
+            "RebuildSearchIndex",
+            rebuild_search_index(client, name, UNDECODABLE_PROVIDER).await,
+        ),
+        ("DrainSearchQueue", drain_search_queue(client, name).await),
+        (
+            "ClearSearchData",
+            clear_search_data(client, name, SearchDataScope::Unspecified, None).await,
+        ),
+    ]
+}
+
+/// Every function and search RPC, reads first.
+async fn every_rpc(client: &AppClient, name: &str) -> Vec<(&'static str, Result<(), Status>)> {
+    let mut rpcs = vec![
+        (
+            "ListFunctions",
+            list_functions(client, name).await.map(|_| ()),
+        ),
+        ("Search", search(client, name, "").await),
+    ];
+    rpcs.extend(every_mutation(client, name).await);
+    rpcs
+}
+
+/// Reports only what a refused caller is told on each RPC: the surface beside
+/// the code, the message with the workspace name they supplied themselves
+/// factored out, and the structured reasons.
+async fn refusals(
+    client: &AppClient,
+    name: &str,
+) -> Vec<(&'static str, Code, String, Vec<String>)> {
+    let mut refused = Vec::new();
+    for (rpc, result) in every_rpc(client, name).await {
+        let status = result.expect_err("a refused caller must not be answered by these RPCs");
+        let (code, message, reasons) = concealed_refusal(&status, name);
+        refused.push((rpc, code, message, reasons));
+    }
+    refused
+}
+
+/// Asserts `client` reads both families and changes neither.
+async fn reads_both_and_changes_neither(client: &AppClient, name: &str, who: &str) {
+    assert_eq!(
+        list_functions(client, name)
+            .await
+            .unwrap_or_else(|status| panic!("{who} lists the workspace's functions: {status}")),
+        vec![ECHO_FUNCTION.to_string()],
+    );
+    assert_eq!(
+        execute_sql_rows(client, name, ECHO_CALL)
+            .await
+            .unwrap_or_else(|status| panic!("{who} calls the installed function: {status}")),
+        vec![json!({ "value": "hello" })],
+    );
+    search(client, name, "echo one value")
+        .await
+        .unwrap_or_else(|status| panic!("{who} searches the workspace: {status}"));
+
+    for (rpc, result) in every_mutation(client, name).await {
+        assert_eq!(
+            result
+                .expect_err("only an owner changes a function or a search index")
+                .code(),
+            Code::PermissionDenied,
+            "{who} reached {rpc}",
+        );
+    }
+}
+
+/// The owner reaches every function and search RPC in their own workspace: the
+/// real calls succeed, and where a probe request is refused it is the request
+/// that stopped them rather than the gate.
+#[tokio::test]
+async fn an_owner_reaches_every_function_and_search_rpc_in_their_own_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("fs-own-ada", "Ada").await;
+    let owner = deployment.as_person(&ada).await;
+    create_workspace(&owner, "fs-own")
+        .await
+        .expect("the creator makes their own workspace");
+
+    assert_eq!(
+        add_function(&owner, "fs-own", ECHO_FUNCTION_SQL)
+            .await
+            .expect("the owner installs a function"),
+        ECHO_FUNCTION,
+    );
+    assert_eq!(
+        list_functions(&owner, "fs-own")
+            .await
+            .expect("the owner lists their functions"),
+        vec![ECHO_FUNCTION.to_string()],
+    );
+    search(&owner, "fs-own", "echo one value")
+        .await
+        .expect("the owner searches their workspace");
+    rebuild_search_index(&owner, "fs-own", SearchIndexProvider::All as i32)
+        .await
+        .expect("the owner rebuilds the search index");
+    drain_search_queue(&owner, "fs-own")
+        .await
+        .expect("the owner drains the search queue");
+    clear_search_data(
+        &owner,
+        "fs-own",
+        SearchDataScope::All,
+        Some(SearchClearTarget {
+            target: Some(search_clear_target::Target::Workspace(true)),
+        }),
+    )
+    .await
+    .expect("the owner clears the workspace's search data");
+
+    for (rpc, result) in every_rpc(&owner, "fs-own").await {
+        if let Err(status) = result {
+            let (code, message, reasons) = concealed_refusal(&status, "fs-own");
+            assert!(
+                code != Code::PermissionDenied
+                    && reasons.as_slice() != [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND],
+                "the owner must be stopped by the request, never by the gate: {rpc} {code} {message}",
+            );
+        }
+    }
+
+    delete_function(&owner, "fs-own", ECHO_FUNCTION)
+        .await
+        .expect("the owner deletes the function");
+    assert_eq!(
+        list_functions(&owner, "fs-own")
+            .await
+            .expect("the owner lists their functions"),
+        Vec::<String>::new(),
+    );
+}
+
+/// Membership opens both families for reading and neither for writing: a member
+/// lists the workspace's functions, runs one, and searches it, while every
+/// request that would change what the workspace runs or finds is refused. The
+/// owner's own listing afterwards is the control that the refusals removed and
+/// installed nothing.
+#[tokio::test]
+async fn a_member_reads_functions_and_search_but_changes_neither() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("fs-member-ada", "Ada").await;
+    let bob = deployment.seed_user("fs-member-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let member = deployment.as_person(&bob).await;
+    create_workspace(&owner, "fs-member")
+        .await
+        .expect("the creator makes their own workspace");
+    add_function(&owner, "fs-member", ECHO_FUNCTION_SQL)
+        .await
+        .expect("the owner installs a function");
+    add_member(&owner, "fs-member", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+
+    reads_both_and_changes_neither(&member, "fs-member", "a member").await;
+
+    assert_eq!(
+        list_functions(&owner, "fs-member")
+            .await
+            .expect("the owner lists their functions"),
+        vec![ECHO_FUNCTION.to_string()],
+        "the refused delete removed nothing and the refused install added nothing",
+    );
+}
+
+/// The data plane carries the person's workspace access and the control plane
+/// does not, so an agent credential is on both sides of the same line.
+///
+/// The owner's own agent is the half that matters: their role would make every
+/// mutation theirs to perform, and the credential is refused anyway — a
+/// prompt-injected agent cannot publish SQL every member then runs, nor clear
+/// the index every member searches. The member's agent proves the other half,
+/// that the reads were not shut off along with the writes.
+#[tokio::test]
+async fn an_agent_credential_reads_both_families_and_changes_neither() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("fs-agent-ada", "Ada").await;
+    let bob = deployment.seed_user("fs-agent-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    create_workspace(&owner, "fs-agent")
+        .await
+        .expect("the creator makes their own workspace");
+    add_function(&owner, "fs-agent", ECHO_FUNCTION_SQL)
+        .await
+        .expect("the owner installs a function");
+    add_member(&owner, "fs-agent", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+
+    reads_both_and_changes_neither(
+        &deployment.as_agent(&bob).await,
+        "fs-agent",
+        "a member's agent",
+    )
+    .await;
+    reads_both_and_changes_neither(
+        &deployment.as_agent(&ada).await,
+        "fs-agent",
+        "the owner's own agent",
+    )
+    .await;
+
+    assert_eq!(
+        list_functions(&owner, "fs-agent")
+            .await
+            .expect("the owner lists their functions"),
+        vec![ECHO_FUNCTION.to_string()],
+        "no agent credential changed the function set",
+    );
+}
+
+/// Neither family may answer a question its caller may not ask. A workspace a
+/// non-member holds no membership in has to read exactly like a name nobody
+/// ever created — and read as the *absent* workspace specifically, since a
+/// uniform "denied" would agree with itself while still confirming the name
+/// exists.
+#[tokio::test]
+async fn a_non_members_refusals_read_exactly_like_an_absent_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("fs-conceal-ada", "Ada").await;
+    let bob = deployment.seed_user("fs-conceal-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let outsider = deployment.as_person(&bob).await;
+    create_workspace(&owner, "fs-conceal")
+        .await
+        .expect("the creator makes their own workspace");
+    add_function(&owner, "fs-conceal", ECHO_FUNCTION_SQL)
+        .await
+        .expect("the owner installs a function");
+
+    let existing = refusals(&outsider, "fs-conceal").await;
+    assert_eq!(
+        existing,
+        refusals(&outsider, "fs-ghost").await,
+        "an existing workspace must be indistinguishable from one that never existed",
+    );
+    assert!(
+        existing
+            .iter()
+            .all(|(_, code, _, reasons)| *code == Code::NotFound
+                && reasons.as_slice() == [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND]),
+        "both must read as the absent workspace, not as a denial that confirms one: {existing:?}",
+    );
+
+    assert_eq!(
+        list_functions(&owner, "fs-conceal")
+            .await
+            .expect("the owner lists their functions"),
+        vec![ECHO_FUNCTION.to_string()],
+        "the concealed refusals changed nothing behind the concealment",
+    );
+}

--- a/crates/coral-app/tests/grpc_workspace_function_search_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_function_search_access.rs
@@ -38,6 +38,13 @@ use coral_client::{AppClient, batches_to_json_rows, decode_execute_sql_response}
 use serde_json::{Value, json};
 use tonic::{Code, Request, Status};
 
+#[path = "grpc/session_auth.rs"]
+#[expect(
+    dead_code,
+    reason = "The session-auth fixture serves several integration binaries; this one uses the parts the shared harness needs."
+)]
+mod session_auth;
+
 #[path = "grpc/harness.rs"]
 #[expect(
     dead_code,

--- a/crates/coral-app/tests/grpc_workspace_membership_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_membership_access.rs
@@ -517,32 +517,34 @@ async fn concurrent_owner_changes_cannot_strand_the_workspace() {
 }
 
 /// An agent credential carries the person behind it and none of their control
-/// plane. The same user id owns this workspace through their own session, so
-/// the refusals below are about the credential's kind rather than about who is
-/// behind it — and the person's own calls afterwards say so.
-///
-/// The denial is uniform across workspaces because the rule refuses an agent
-/// every workspace alike: it is settled before any membership is read, so it
-/// reveals nothing about which workspaces exist.
+/// plane. The manage refusal is settled by the credential's kind before any
+/// membership is read, which is what makes it uniform across workspaces and
+/// therefore silent about which ones exist. The read refusal is the ordinary
+/// one: an agent is its own principal and holds no membership here.
 #[tokio::test]
-async fn an_agent_credential_is_refused_the_control_plane_of_its_own_persons_workspace() {
+async fn an_agent_credential_is_refused_every_workspace_control_plane() {
     let deployment = SharedDeployment::start().await;
     let ada = deployment.seed_user("member-agent-ada", "Ada").await;
     let person = deployment.as_person(&ada).await;
-    let agent = deployment.as_agent(&ada).await;
+    let agent = deployment.as_agent("agent-member-agent").await;
     create_workspace(&person, "member-agent")
         .await
         .expect("the creator makes their own workspace");
-    execute_sql(&agent, "member-agent", "select 1")
-        .await
-        .expect("the agent session reads what the person behind it may read");
+    assert_eq!(
+        execute_sql(&agent, "member-agent", "select 1")
+            .await
+            .expect_err("an agent holds no membership in this workspace")
+            .code(),
+        Code::NotFound,
+        "a workspace an agent does not belong to must stay concealed from it",
+    );
 
     let refusals = control_plane_refusals(&agent, "member-agent").await;
     for (rpc, code, message, _) in &refusals {
         assert_eq!(
             *code,
             Code::PermissionDenied,
-            "an agent credential manages no workspace, not even its own person's: {rpc} {message}",
+            "an agent credential manages no workspace at all: {rpc} {message}",
         );
     }
     assert_eq!(

--- a/crates/coral-app/tests/grpc_workspace_membership_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_membership_access.rs
@@ -1,0 +1,566 @@
+//! Public gRPC evidence for the control plane of a workspace: who may reach
+//! it, who may change that, and who may delete it.
+//!
+//! Membership is the access-control state itself, so reading the roster is as
+//! much an owner's act as changing it — a member works inside a workspace
+//! without learning who else holds a key to it. Deletion belongs to the same
+//! family for the same reason: it is the workspace, not its contents.
+//!
+//! The membership contract is the one place where a refusal is not the
+//! interesting half. Promotion, demotion, a second owner, a revocation, a
+//! person the directory has never seen, and a grant somebody already holds each
+//! have their own answer, and this binary pins all of them, because a contract
+//! that only says "denied" correctly would still be free to garble everything
+//! it allows.
+//!
+//! Two guarantees get their own tests. The owner floor — that no sequence of
+//! permitted changes strands a workspace with nobody able to reach it — is
+//! proved at the transaction layer against a barrier; here it is proved again
+//! over the transport, where two owners changing themselves at the same time is
+//! the only way to ask for it. And an agent credential is refused this whole
+//! family even for a workspace the person behind it owns, so an MCP session
+//! cannot manage what the person's own browser session manages.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
+)]
+
+use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
+use coral_api::v1::{
+    DeleteWorkspaceRequest, ListWorkspaceMembersRequest, WorkspaceMember, WorkspaceRole,
+};
+use coral_client::AppClient;
+use tonic::{Code, Request, Status};
+
+#[path = "grpc/harness.rs"]
+#[expect(
+    dead_code,
+    reason = "The shared harness serves several integration binaries; this one exercises the shared-deployment half of it."
+)]
+mod harness;
+
+use crate::harness::{
+    SharedDeployment, add_member, concealed_refusal, create_workspace, execute_sql,
+    membership_rows, named_workspace, remove_member,
+};
+
+/// A user id no seeded login carries, so a caller who reaches the directory is
+/// told the person is unknown and a caller who does not never gets that far.
+const ABSENT_USER: &str = "user-nobody";
+
+async fn list_members(
+    client: &AppClient,
+    name: &str,
+) -> Result<Vec<(String, WorkspaceRole)>, Status> {
+    client
+        .workspace_client()
+        .list_workspace_members(Request::new(ListWorkspaceMembersRequest {
+            workspace: Some(named_workspace(name)),
+        }))
+        .await
+        .map(|response| {
+            response
+                .into_inner()
+                .members
+                .into_iter()
+                .map(|member| (member.user_id, member.role.try_into().expect("listed role")))
+                .collect()
+        })
+}
+
+async fn delete_workspace(client: &AppClient, name: &str) -> Result<(), Status> {
+    client
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(named_workspace(name)),
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Calls every control-plane RPC one workspace has and reports what each
+/// answered.
+///
+/// The two membership changes name a person the directory has never seen, so a
+/// caller who is let through is stopped by their own request rather than by the
+/// gate — which is what makes a refusal here evidence about the gate.
+async fn every_control_plane_rpc(
+    client: &AppClient,
+    name: &str,
+) -> Vec<(&'static str, Result<(), Status>)> {
+    vec![
+        (
+            "ListWorkspaceMembers",
+            list_members(client, name).await.map(|_| ()),
+        ),
+        (
+            "AddWorkspaceMember",
+            add_member(client, name, ABSENT_USER, WorkspaceRole::Member)
+                .await
+                .map(|_| ()),
+        ),
+        (
+            "RemoveWorkspaceMember",
+            remove_member(client, name, ABSENT_USER).await.map(|_| ()),
+        ),
+        ("DeleteWorkspace", delete_workspace(client, name).await),
+    ]
+}
+
+/// Reports only what a refused caller is told on each control-plane RPC: the
+/// surface beside the code, the message with the workspace name they supplied
+/// themselves factored out, and the structured reasons.
+async fn control_plane_refusals(
+    client: &AppClient,
+    name: &str,
+) -> Vec<(&'static str, Code, String, Vec<String>)> {
+    let mut refusals = Vec::new();
+    for (rpc, result) in every_control_plane_rpc(client, name).await {
+        let status =
+            result.expect_err("a refused caller must not be answered by a control-plane RPC");
+        let (code, message, reasons) = concealed_refusal(&status, name);
+        refusals.push((rpc, code, message, reasons));
+    }
+    refusals
+}
+
+/// Membership opens a workspace's contents and nothing about who may reach it.
+/// The member's own query is the control: they are plainly inside the
+/// workspace, and it is the control plane specifically that stays shut. The
+/// owner's delete at the end is the other control — the RPC the member was
+/// refused really does destroy the workspace when the right caller sends it.
+#[tokio::test]
+async fn a_member_is_refused_the_whole_control_plane_of_their_own_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-shut-ada", "Ada").await;
+    let bob = deployment.seed_user("member-shut-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let member = deployment.as_person(&bob).await;
+    create_workspace(&owner, "member-shut")
+        .await
+        .expect("the creator makes their own workspace");
+    add_member(&owner, "member-shut", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+    execute_sql(&member, "member-shut", "select 1")
+        .await
+        .expect("a member reads the workspace's contents");
+
+    for (rpc, code, message, _) in control_plane_refusals(&member, "member-shut").await {
+        assert_eq!(
+            code,
+            Code::PermissionDenied,
+            "a member neither reads nor changes who may reach the workspace: {rpc} {message}",
+        );
+    }
+
+    assert_eq!(
+        list_members(&owner, "member-shut")
+            .await
+            .expect("the owner reads the roster"),
+        vec![
+            (ada.clone(), WorkspaceRole::Owner),
+            (bob.clone(), WorkspaceRole::Member),
+        ],
+        "the refused changes moved nobody",
+    );
+    execute_sql(&member, "member-shut", "select 1")
+        .await
+        .expect("the refused delete destroyed nothing");
+
+    delete_workspace(&owner, "member-shut")
+        .await
+        .expect("the owner deletes their own workspace");
+    assert_eq!(
+        execute_sql(&member, "member-shut", "select 1")
+            .await
+            .expect_err("a deleted workspace holds nothing to read")
+            .code(),
+        Code::NotFound,
+    );
+}
+
+/// The control plane must not answer questions its caller may not ask. A
+/// workspace a non-member holds no membership in has to read exactly like a
+/// name nobody ever created — and read as the *absent* workspace specifically,
+/// since a uniform "denied" would agree with itself while still confirming the
+/// name exists.
+#[tokio::test]
+async fn a_non_members_control_plane_refusals_read_exactly_like_an_absent_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-conceal-ada", "Ada").await;
+    let bob = deployment.seed_user("member-conceal-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let outsider = deployment.as_person(&bob).await;
+    create_workspace(&owner, "member-conceal")
+        .await
+        .expect("the creator makes their own workspace");
+
+    let existing = control_plane_refusals(&outsider, "member-conceal").await;
+    assert_eq!(
+        existing,
+        control_plane_refusals(&outsider, "member-ghost").await,
+        "an existing workspace must be indistinguishable from one that never existed",
+    );
+    assert!(
+        existing
+            .iter()
+            .all(|(_, code, _, reasons)| *code == Code::NotFound
+                && reasons.as_slice() == [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND]),
+        "both must read as the absent workspace, not as a denial that confirms one: {existing:?}",
+    );
+    assert_eq!(
+        list_members(&owner, "member-conceal")
+            .await
+            .expect("the owner reads the roster"),
+        vec![(ada, WorkspaceRole::Owner)],
+        "an outsider's refused changes moved nobody",
+    );
+}
+
+/// The two changes that are answered by a miss, and the one that is answered by
+/// nothing at all.
+///
+/// A grant somebody already holds is a success that writes nothing, so a
+/// retried invitation is indistinguishable from the first one. The other two
+/// name somebody the workspace cannot act on, and each is reported as a miss on
+/// that person rather than on the workspace: the caller already owns this
+/// workspace, so there is nothing here to conceal from them, and saying so with
+/// the workspace's own concealment reason would be a lie about which of the two
+/// was not found.
+#[tokio::test]
+async fn a_repeated_grant_writes_nothing_and_an_unknown_person_is_a_miss_on_the_directory() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-miss-ada", "Ada").await;
+    let bob = deployment.seed_user("member-miss-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    create_workspace(&owner, "member-miss")
+        .await
+        .expect("the creator makes their own workspace");
+
+    assert_eq!(
+        add_member(&owner, "member-miss", &ada, WorkspaceRole::Owner)
+            .await
+            .expect("repeating a grant somebody already holds succeeds")
+            .member,
+        Some(WorkspaceMember {
+            user_id: ada.clone(),
+            role: WorkspaceRole::Owner.into(),
+            display_name: "Ada".to_string(),
+        }),
+    );
+
+    let unknown = add_member(&owner, "member-miss", ABSENT_USER, WorkspaceRole::Member)
+        .await
+        .expect_err("nobody can be granted membership before their first sign-in");
+    assert_eq!(
+        (unknown.code(), unknown.message()),
+        (Code::NotFound, &*format!("user '{ABSENT_USER}' not found")),
+    );
+    assert_eq!(
+        concealed_refusal(&unknown, "member-miss").2,
+        Vec::<String>::new(),
+        "a directory miss must not carry the workspace's concealment reason",
+    );
+    assert_eq!(
+        remove_member(&owner, "member-miss", &bob)
+            .await
+            .expect_err("revoking a membership nobody holds is the same miss")
+            .code(),
+        Code::NotFound,
+    );
+
+    assert_eq!(
+        list_members(&owner, "member-miss")
+            .await
+            .expect("the owner reads the roster"),
+        vec![(ada, WorkspaceRole::Owner)],
+        "none of the three changed who may reach the workspace",
+    );
+}
+
+/// Promotion, demotion, and the floor they both answer to.
+///
+/// The roster is read back rather than only the responses, because the failure
+/// this guards against is a change that reports one thing and records another.
+#[tokio::test]
+async fn promotion_and_demotion_move_the_roster_and_stop_at_the_last_owner() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-contract-ada", "Ada").await;
+    let bob = deployment.seed_user("member-contract-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    create_workspace(&owner, "member-contract")
+        .await
+        .expect("the creator makes their own workspace");
+
+    // Granting and promoting are the same call, and each reports the role it
+    // was asked for rather than the one the person came in with.
+    for (step, role) in [
+        ("grants membership", WorkspaceRole::Member),
+        ("promotes a member", WorkspaceRole::Owner),
+    ] {
+        assert_eq!(
+            add_member(&owner, "member-contract", &bob, role)
+                .await
+                .unwrap_or_else(|error| panic!("the owner {step}: {error}"))
+                .member
+                .expect("the changed membership")
+                .role,
+            i32::from(role),
+        );
+    }
+    assert_eq!(
+        list_members(&owner, "member-contract")
+            .await
+            .expect("the owner reads the roster"),
+        vec![
+            (ada.clone(), WorkspaceRole::Owner),
+            (bob.clone(), WorkspaceRole::Owner),
+        ],
+        "the promotion recorded a second owner",
+    );
+
+    // Stepping an owner back down is the same call as promoting one, and it is
+    // allowed here only because the co-owner above holds the floor.
+    assert_eq!(
+        add_member(&owner, "member-contract", &ada, WorkspaceRole::Member)
+            .await
+            .expect("an owner steps back down while a co-owner holds the floor")
+            .member
+            .expect("the changed membership")
+            .role,
+        i32::from(WorkspaceRole::Member),
+    );
+
+    let last_owner = deployment.as_person(&bob).await;
+    for (change, result) in [
+        (
+            "demoted",
+            add_member(&last_owner, "member-contract", &bob, WorkspaceRole::Member)
+                .await
+                .map(|_| ()),
+        ),
+        (
+            "revoked",
+            remove_member(&last_owner, "member-contract", &bob)
+                .await
+                .map(|_| ()),
+        ),
+    ] {
+        let refused = result.expect_err("the last owner cannot strand the workspace");
+        assert_eq!(
+            (refused.code(), refused.message()),
+            (
+                Code::FailedPrecondition,
+                "workspace 'member-contract' must retain at least one owner",
+            ),
+            "the last owner was {change}",
+        );
+    }
+
+    remove_member(&last_owner, "member-contract", &ada)
+        .await
+        .expect("the owner revokes a plain member");
+    assert_eq!(
+        list_members(&last_owner, "member-contract")
+            .await
+            .expect("the owner reads the roster"),
+        vec![(bob, WorkspaceRole::Owner)],
+        "the two refusals left the floor where it was, and only the plain member's revocation moved anything",
+    );
+}
+
+/// Membership is read per request, so a change lands on the caller's very next
+/// call over the connection they already hold rather than at their next login.
+///
+/// Each step is a repeat of a call that had just succeeded, which is what makes
+/// the difference attributable to the change rather than to the request.
+#[tokio::test]
+async fn a_revoked_callers_very_next_request_is_answered_by_the_change() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-revoke-ada", "Ada").await;
+    let bob = deployment.seed_user("member-revoke-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let bob_client = deployment.as_person(&bob).await;
+    create_workspace(&owner, "member-revoke")
+        .await
+        .expect("the creator makes their own workspace");
+    add_member(&owner, "member-revoke", &bob, WorkspaceRole::Owner)
+        .await
+        .expect("the owner grants a second ownership");
+    list_members(&bob_client, "member-revoke")
+        .await
+        .expect("a co-owner reads the roster");
+
+    add_member(&owner, "member-revoke", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner steps their co-owner back down");
+    assert_eq!(
+        list_members(&bob_client, "member-revoke")
+            .await
+            .expect_err("the demoted co-owner's next request is answered as a member's")
+            .code(),
+        Code::PermissionDenied,
+    );
+    execute_sql(&bob_client, "member-revoke", "select 1")
+        .await
+        .expect("the demotion left the membership it stepped down to");
+
+    remove_member(&owner, "member-revoke", &bob)
+        .await
+        .expect("the owner revokes the membership");
+    let concealed = list_members(&bob_client, "member-revoke")
+        .await
+        .expect_err("the revoked member's next request is answered as an outsider's");
+    assert_eq!(
+        concealed_refusal(&concealed, "member-revoke"),
+        (
+            Code::NotFound,
+            "workspace '<workspace>' not found".to_string(),
+            vec![CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND.to_string()],
+        ),
+    );
+    assert_eq!(
+        execute_sql(&bob_client, "member-revoke", "select 1")
+            .await
+            .expect_err("the revocation closed the contents too")
+            .code(),
+        Code::NotFound,
+    );
+    assert!(
+        membership_rows(&bob_client).await.is_empty(),
+        "a revoked caller's own listing no longer names the workspace",
+    );
+}
+
+/// The owner floor holds when two owners change themselves at the same time.
+///
+/// Either change is permitted on its own: the workspace has two owners, so
+/// stepping one down and revoking the other each leave an owner behind. Only
+/// together do they strand it, and only if the second one decides on an owner
+/// count the first has already invalidated. Exactly one must therefore be
+/// refused, and which one is not the test's business.
+///
+/// This is the transport-level half of a guarantee the transaction layer proves
+/// against a barrier that pauses a mutation while it holds the workspace
+/// parent. That barrier is crate-internal, so what is asked here is the real
+/// question a client can ask: two requests in flight at once, on a runtime with
+/// threads to run them, against a pool with connections to serve them.
+///
+/// The race was falsified before it was trusted: replacing the parent hold with
+/// a read-only existence check fails this test on every run. The assertion that
+/// catches it is the one on *why* the loser was refused, not the one on how
+/// many changes were allowed — without the hold both writers read the same
+/// owner count, and the second one is then stopped by the database rather than
+/// by the floor. So an ownerless workspace never materializes on `SQLite`, and
+/// a test that only counted the successes would pass over the broken code.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_owner_changes_cannot_strand_the_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-race-ada", "Ada").await;
+    let bob = deployment.seed_user("member-race-bob", "Bob").await;
+    let ada_client = deployment.as_person(&ada).await;
+    let bob_client = deployment.as_person(&bob).await;
+    create_workspace(&ada_client, "member-race")
+        .await
+        .expect("the creator makes their own workspace");
+    add_member(&ada_client, "member-race", &bob, WorkspaceRole::Owner)
+        .await
+        .expect("the owner grants a second ownership");
+
+    let (demotion, revocation) = tokio::join!(
+        add_member(&ada_client, "member-race", &ada, WorkspaceRole::Member),
+        remove_member(&bob_client, "member-race", &bob),
+    );
+
+    let refused = match (demotion, revocation) {
+        (Ok(_), Err(refused)) | (Err(refused), Ok(_)) => refused,
+        (Ok(_), Ok(_)) => panic!("both changes were allowed, leaving the workspace with no owner"),
+        (Err(demotion), Err(revocation)) => {
+            panic!("neither change was allowed: {demotion}, {revocation}")
+        }
+    };
+    assert_eq!(
+        (refused.code(), refused.message()),
+        (
+            Code::FailedPrecondition,
+            "workspace 'member-race' must retain at least one owner",
+        ),
+        "the loser must be refused by the owner floor rather than by a lock or a conflict",
+    );
+
+    // Read back from each caller's own listing rather than from the roster: the
+    // roster is an owner's read, and which of the two is still an owner is
+    // exactly what is in question.
+    let mut owners = Vec::new();
+    for (client, who) in [(&ada_client, "Ada"), (&bob_client, "Bob")] {
+        if membership_rows(client)
+            .await
+            .contains(&("member-race".to_string(), WorkspaceRole::Owner))
+        {
+            owners.push(who);
+        }
+    }
+    assert_eq!(
+        owners.len(),
+        1,
+        "exactly one owner must survive the race: {owners:?}",
+    );
+}
+
+/// An agent credential carries the person behind it and none of their control
+/// plane. The same user id owns this workspace through their own session, so
+/// the refusals below are about the credential's kind rather than about who is
+/// behind it — and the person's own calls afterwards say so.
+///
+/// The denial is uniform across workspaces because the rule refuses an agent
+/// every workspace alike: it is settled before any membership is read, so it
+/// reveals nothing about which workspaces exist.
+#[tokio::test]
+async fn an_agent_credential_is_refused_the_control_plane_of_its_own_persons_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("member-agent-ada", "Ada").await;
+    let person = deployment.as_person(&ada).await;
+    let agent = deployment.as_agent(&ada).await;
+    create_workspace(&person, "member-agent")
+        .await
+        .expect("the creator makes their own workspace");
+    execute_sql(&agent, "member-agent", "select 1")
+        .await
+        .expect("the agent session reads what the person behind it may read");
+
+    let refusals = control_plane_refusals(&agent, "member-agent").await;
+    for (rpc, code, message, _) in &refusals {
+        assert_eq!(
+            *code,
+            Code::PermissionDenied,
+            "an agent credential manages no workspace, not even its own person's: {rpc} {message}",
+        );
+    }
+    assert_eq!(
+        refusals,
+        control_plane_refusals(&agent, "member-agent-ghost").await,
+        "the refusal must not tell an agent which workspaces exist",
+    );
+    assert_eq!(
+        create_workspace(&agent, "member-agent-new")
+            .await
+            .expect_err("an agent credential cannot make itself an owner")
+            .code(),
+        Code::PermissionDenied,
+    );
+
+    assert_eq!(
+        list_members(&person, "member-agent")
+            .await
+            .expect("the person's own session manages the workspace their agent could not"),
+        vec![(ada, WorkspaceRole::Owner)],
+        "nothing the agent asked for changed the roster",
+    );
+    assert_eq!(
+        membership_rows(&person).await,
+        vec![("member-agent".to_string(), WorkspaceRole::Owner)],
+        "the workspace the agent was refused was never created",
+    );
+}

--- a/crates/coral-app/tests/grpc_workspace_membership_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_membership_access.rs
@@ -33,6 +33,13 @@ use coral_api::v1::{
 use coral_client::AppClient;
 use tonic::{Code, Request, Status};
 
+#[path = "grpc/session_auth.rs"]
+#[expect(
+    dead_code,
+    reason = "The session-auth fixture serves several integration binaries; this one uses the parts the shared harness needs."
+)]
+mod session_auth;
+
 #[path = "grpc/harness.rs"]
 #[expect(
     dead_code,

--- a/crates/coral-app/tests/grpc_workspace_source_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_source_access.rs
@@ -32,6 +32,13 @@ use coral_client::AppClient;
 use tempfile::TempDir;
 use tonic::{Code, Request, Status};
 
+#[path = "grpc/session_auth.rs"]
+#[expect(
+    dead_code,
+    reason = "The session-auth fixture serves several integration binaries; this one uses the parts the shared harness needs."
+)]
+mod session_auth;
+
 #[path = "grpc/harness.rs"]
 #[expect(
     dead_code,

--- a/crates/coral-app/tests/grpc_workspace_source_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_source_access.rs
@@ -384,10 +384,13 @@ async fn a_member_is_refused_every_source_rpc() {
             "a member reads and changes no source configuration: {rpc} {message}",
         );
     }
-    // The agent session behind the same person is bounded by that person, so it
-    // gains nothing the member did not have.
-    for (rpc, code, message, _) in
-        source_refusals(&deployment.as_agent(&bob).await, "source-member").await
+    // An agent holds no membership of its own, so it is stopped before the
+    // member's ceiling is even reached.
+    for (rpc, code, message, _) in source_refusals(
+        &deployment.as_agent("agent-source-member").await,
+        "source-member",
+    )
+    .await
     {
         assert_eq!(
             code,

--- a/crates/coral-app/tests/grpc_workspace_source_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_source_access.rs
@@ -1,0 +1,530 @@
+//! Public gRPC evidence that a source's configuration reaches only the people
+//! who manage the workspace holding it.
+//!
+//! A source response is not a list of names: it carries the variables, the
+//! secret keys, and the credential-setup metadata that configure a connection.
+//! Reading one is managing the workspace rather than reading its contents, so
+//! all nine source RPCs are an owner's act. A member is refused outright — the
+//! redacted projection that would let them see a source without its setup
+//! deliberately does not exist — and a non-member is told only what they would
+//! be told about a workspace nobody ever created.
+//!
+//! Every refusal is proved to be an absence rather than an error code. Each
+//! request sent here is one the source work itself has an answer for, so the
+//! owner sending it is told about the request while the refused callers are
+//! told nothing about it; and what the workspace holds afterwards — its
+//! sources, its tasks, its recorded queries, its attributed spans — is read
+//! back to show the refusals moved none of it.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
+)]
+
+use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
+use coral_api::v1::{
+    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest, DeleteSourceRequest,
+    DiscoverSourcesRequest, ExecuteSqlRequest, GetSourceInfoRequest, GetSourceRequest,
+    ImportSourceRequest, ListSourcesRequest, OAuthCredentialRetrieval, StartTaskRequest,
+    TaskAttribution, ValidateSourceRequest, WorkspaceRole, import_source_response,
+};
+use coral_client::AppClient;
+use tempfile::TempDir;
+use tonic::{Code, Request, Status};
+
+#[path = "grpc/harness.rs"]
+#[expect(
+    dead_code,
+    reason = "The shared harness serves several integration binaries; this one exercises the shared-deployment half of it."
+)]
+mod harness;
+
+use crate::harness::{
+    SharedDeployment, add_member, concealed_refusal, create_workspace, execute_sql,
+    fixture_manifest_with_required_filter_yaml, fixture_manifest_yaml, invalid_manifest_yaml,
+    named_workspace,
+};
+
+/// A source name that is neither installed nor bundled, so a caller who
+/// reaches the source work is stopped by the work rather than by the gate.
+const ABSENT_SOURCE: &str = "probe";
+
+/// The name the fixture manifest installs under.
+const FIXTURE_SOURCE: &str = "local_messages";
+
+/// The name the second fixture manifest would install under, so its absence
+/// afterwards is an observation about the import that was refused.
+const REFUSED_IMPORT_SOURCE: &str = "filtered_messages";
+
+async fn discover_sources(client: &AppClient, name: &str) -> Result<(), Status> {
+    client
+        .source_client()
+        .discover_sources(Request::new(DiscoverSourcesRequest {
+            workspace: Some(named_workspace(name)),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn list_sources(client: &AppClient, name: &str) -> Result<Vec<String>, Status> {
+    client
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(named_workspace(name)),
+        }))
+        .await
+        .map(|response| {
+            response
+                .into_inner()
+                .sources
+                .into_iter()
+                .map(|source| source.name)
+                .collect()
+        })
+}
+
+async fn get_source(client: &AppClient, name: &str, source: &str) -> Result<(), Status> {
+    client
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(named_workspace(name)),
+            name: source.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn get_source_info(client: &AppClient, name: &str, source: &str) -> Result<(), Status> {
+    client
+        .source_client()
+        .get_source_info(Request::new(GetSourceInfoRequest {
+            workspace: Some(named_workspace(name)),
+            name: source.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn create_bundled_source(client: &AppClient, name: &str, source: &str) -> Result<(), Status> {
+    client
+        .source_client()
+        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+            workspace: Some(named_workspace(name)),
+            name: source.to_string(),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Asks for a bundled install whose OAuth half is missing the method index the
+/// credential conversion requires. Reaching that conversion is credential work,
+/// so a refusal that arrives instead proves it was never reached.
+async fn create_bundled_source_with_oauth(
+    client: &AppClient,
+    name: &str,
+    source: &str,
+) -> Result<(), Status> {
+    client
+        .source_client()
+        .create_bundled_source_with_o_auth(Request::new(CreateBundledSourceWithOAuthRequest {
+            workspace: Some(named_workspace(name)),
+            name: source.to_string(),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: vec![OAuthCredentialRetrieval {
+                input_key: "API_TOKEN".to_string(),
+                method_index: None,
+                credential_inputs: Vec::new(),
+            }],
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Imports `manifest_yaml` and returns the name it installed under.
+///
+/// The call itself is what a refused caller is answered with: a status can only
+/// come back where a stream did not, so a refusal here is also the proof that
+/// no import stream was ever handed over.
+async fn import_source(
+    client: &AppClient,
+    name: &str,
+    manifest_yaml: String,
+) -> Result<String, Status> {
+    let mut stream = client
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(named_workspace(name)),
+            manifest_yaml,
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await?
+        .into_inner();
+    stream
+        .message()
+        .await?
+        .and_then(|response| match response.event {
+            Some(import_source_response::Event::Source(source)) => Some(source.name),
+            _ => None,
+        })
+        .ok_or_else(|| Status::internal("the import stream carried no installed source"))
+}
+
+async fn delete_source(client: &AppClient, name: &str, source: &str) -> Result<(), Status> {
+    client
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(named_workspace(name)),
+            name: source.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn validate_source(client: &AppClient, name: &str, source: &str) -> Result<(), Status> {
+    client
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(named_workspace(name)),
+            name: source.to_string(),
+        }))
+        .await
+        .map(|_| ())
+}
+
+async fn start_task(client: &AppClient, name: &str) -> Result<String, Status> {
+    client
+        .task_client()
+        .start_task(Request::new(StartTaskRequest {
+            workspace: Some(named_workspace(name)),
+            intent: "prove source isolation".to_string(),
+        }))
+        .await
+        .map(|response| response.into_inner().task.expect("started task").task_id)
+}
+
+/// Runs one statement under `task_id`, which is what makes the server record
+/// the query against that task rather than only run it.
+async fn execute_sql_in_task(
+    client: &AppClient,
+    name: &str,
+    task_id: &str,
+    sql: &str,
+) -> Result<(), Status> {
+    client
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(named_workspace(name)),
+            sql: sql.to_string(),
+            guide_read_context: None,
+            task_attribution: Some(TaskAttribution {
+                task_id: task_id.to_string(),
+                intent: "prove source isolation".to_string(),
+            }),
+        }))
+        .await
+        .map(|_| ())
+}
+
+/// Calls all nine source RPCs against `name` and reports what each answered.
+///
+/// Every request here is one the source work itself has an answer for — a
+/// source name that is neither installed nor bundled, a manifest that does not
+/// parse, an OAuth retrieval with no method index — so the caller who is let
+/// through is told what is wrong with the request, and the caller who is not
+/// never gets that far.
+async fn every_source_rpc(
+    client: &AppClient,
+    name: &str,
+) -> Vec<(&'static str, Result<(), Status>)> {
+    vec![
+        ("DiscoverSources", discover_sources(client, name).await),
+        ("ListSources", list_sources(client, name).await.map(|_| ())),
+        ("GetSource", get_source(client, name, ABSENT_SOURCE).await),
+        (
+            "GetSourceInfo",
+            get_source_info(client, name, ABSENT_SOURCE).await,
+        ),
+        (
+            "CreateBundledSource",
+            create_bundled_source(client, name, ABSENT_SOURCE).await,
+        ),
+        (
+            "CreateBundledSourceWithOAuth",
+            create_bundled_source_with_oauth(client, name, ABSENT_SOURCE).await,
+        ),
+        (
+            "ImportSource",
+            import_source(client, name, invalid_manifest_yaml())
+                .await
+                .map(|_| ()),
+        ),
+        (
+            "DeleteSource",
+            delete_source(client, name, ABSENT_SOURCE).await,
+        ),
+        (
+            "ValidateSource",
+            validate_source(client, name, ABSENT_SOURCE).await,
+        ),
+    ]
+}
+
+/// Reports only what a refused caller is told on each source RPC: the surface
+/// beside the code, the message with the workspace name they supplied
+/// themselves factored out, and the structured reasons.
+async fn source_refusals(
+    client: &AppClient,
+    name: &str,
+) -> Vec<(&'static str, Code, String, Vec<String>)> {
+    let mut refusals = Vec::new();
+    for (rpc, result) in every_source_rpc(client, name).await {
+        let status = result.expect_err("a refused caller must not be answered by a source RPC");
+        let (code, message, reasons) = concealed_refusal(&status, name);
+        refusals.push((rpc, code, message, reasons));
+    }
+    refusals
+}
+
+/// The owner of a workspace reaches every source RPC in it: the seven that have
+/// something to say about an installed source say it, and the two bundled
+/// installs are stopped by the catalog they looked in rather than by the gate.
+#[tokio::test]
+async fn an_owner_reaches_every_source_rpc_in_their_own_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let fixtures = TempDir::new().expect("fixture data dir");
+    let ada = deployment.seed_user("source-own-ada", "Ada").await;
+    let owner = deployment.as_person(&ada).await;
+    create_workspace(&owner, "source-own")
+        .await
+        .expect("the creator makes their own workspace");
+
+    assert_eq!(
+        import_source(&owner, "source-own", fixture_manifest_yaml(fixtures.path()))
+            .await
+            .expect("the owner imports a source"),
+        FIXTURE_SOURCE,
+    );
+    discover_sources(&owner, "source-own")
+        .await
+        .expect("the owner discovers bundled sources");
+    assert_eq!(
+        list_sources(&owner, "source-own")
+            .await
+            .expect("the owner lists their sources"),
+        vec![FIXTURE_SOURCE.to_string()],
+    );
+    get_source(&owner, "source-own", FIXTURE_SOURCE)
+        .await
+        .expect("the owner reads the source's configuration");
+    get_source_info(&owner, "source-own", FIXTURE_SOURCE)
+        .await
+        .expect("the owner reads the source's setup metadata");
+    validate_source(&owner, "source-own", FIXTURE_SOURCE)
+        .await
+        .expect("the owner revalidates the source");
+
+    for (rpc, result) in every_source_rpc(&owner, "source-own").await {
+        if let Err(status) = result {
+            let (code, message, reasons) = concealed_refusal(&status, "source-own");
+            assert!(
+                code != Code::PermissionDenied
+                    && reasons.as_slice() != [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND],
+                "the owner must be stopped by the request, never by the gate: {rpc} {code} {message}",
+            );
+        }
+    }
+
+    delete_source(&owner, "source-own", FIXTURE_SOURCE)
+        .await
+        .expect("the owner deletes the source");
+    assert_eq!(
+        list_sources(&owner, "source-own")
+            .await
+            .expect("the owner lists their sources"),
+        Vec::<String>::new(),
+    );
+}
+
+/// Membership opens the workspace's contents and nothing about how they are
+/// configured. The member's own read is the control: they are plainly inside
+/// the workspace, and it is the source family specifically that stays shut.
+#[tokio::test]
+async fn a_member_is_refused_every_source_rpc() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("source-member-ada", "Ada").await;
+    let bob = deployment.seed_user("source-member-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let member = deployment.as_person(&bob).await;
+    create_workspace(&owner, "source-member")
+        .await
+        .expect("the creator makes their own workspace");
+    add_member(&owner, "source-member", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+    execute_sql(&member, "source-member", "select 1")
+        .await
+        .expect("a member reads the workspace's contents");
+
+    for (rpc, code, message, _) in source_refusals(&member, "source-member").await {
+        assert_eq!(
+            code,
+            Code::PermissionDenied,
+            "a member reads and changes no source configuration: {rpc} {message}",
+        );
+    }
+    // The agent session behind the same person is bounded by that person, so it
+    // gains nothing the member did not have.
+    for (rpc, code, message, _) in
+        source_refusals(&deployment.as_agent(&bob).await, "source-member").await
+    {
+        assert_eq!(
+            code,
+            Code::PermissionDenied,
+            "an agent session inherits the member's refusal: {rpc} {message}",
+        );
+    }
+}
+
+/// The source surfaces must not answer questions their caller may not ask. A
+/// workspace a non-member holds no membership in has to read exactly like a
+/// name nobody ever created — and read as the *absent* workspace specifically,
+/// since a uniform "denied" would agree with itself while still confirming the
+/// name exists.
+#[tokio::test]
+async fn a_non_members_source_refusals_read_exactly_like_an_absent_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("source-conceal-ada", "Ada").await;
+    let bob = deployment.seed_user("source-conceal-bob", "Bob").await;
+    let owner = deployment.as_person(&ada).await;
+    let outsider = deployment.as_person(&bob).await;
+    create_workspace(&owner, "source-conceal")
+        .await
+        .expect("the creator makes their own workspace");
+
+    let existing = source_refusals(&outsider, "source-conceal").await;
+    assert_eq!(
+        existing,
+        source_refusals(&outsider, "source-ghost").await,
+        "an existing workspace must be indistinguishable from one that never existed",
+    );
+    assert!(
+        existing
+            .iter()
+            .all(|(_, code, _, reasons)| *code == Code::NotFound
+                && reasons.as_slice() == [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND]),
+        "both must read as the absent workspace, not as a denial that confirms one: {existing:?}",
+    );
+}
+
+/// A refused source request must leave the workspace exactly as it found it:
+/// the installed source still installed and nothing installed beside it, and no
+/// task, recorded query, or attributed span to show it was ever asked for.
+///
+/// The attributed probe is the one that matters most. A gate placed after the
+/// work would only betray itself when the denied statement names a task that
+/// genuinely exists in the target workspace, so one refusal here carries the
+/// real task id the owner minted first. The owner's own statement under that
+/// same task afterwards is the control: it moves every counter the refusals
+/// left where they were, so the sameness is an observation about the refusals
+/// rather than about an observer that sees nothing.
+#[tokio::test]
+async fn refused_source_requests_leave_the_workspace_untouched() {
+    let deployment = SharedDeployment::start().await;
+    let fixtures = TempDir::new().expect("fixture data dir");
+    let ada = deployment.seed_user("source-record-ada", "Ada").await;
+    let bob = deployment.seed_user("source-record-bob", "Bob").await;
+    let carol = deployment.seed_user("source-record-carol", "Carol").await;
+    let owner = deployment.as_person(&ada).await;
+    let member = deployment.as_person(&bob).await;
+    let outsider = deployment.as_person(&carol).await;
+    create_workspace(&owner, "source-record")
+        .await
+        .expect("the creator makes their own workspace");
+    add_member(&owner, "source-record", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+    import_source(
+        &owner,
+        "source-record",
+        fixture_manifest_yaml(fixtures.path()),
+    )
+    .await
+    .expect("the owner imports a source");
+    let task_id = start_task(&owner, "source-record")
+        .await
+        .expect("the owner opens a task");
+    let before = deployment.workspace_work("source-record").await;
+    assert!(
+        before.tasks > 0,
+        "the attributed refusal below only probes anything if that task really is on this workspace's record: {before:?}",
+    );
+
+    for (rpc, result) in [
+        (
+            "DeleteSource",
+            delete_source(&member, "source-record", FIXTURE_SOURCE).await,
+        ),
+        (
+            "ImportSource",
+            import_source(
+                &member,
+                "source-record",
+                fixture_manifest_with_required_filter_yaml(),
+            )
+            .await
+            .map(|_| ()),
+        ),
+        (
+            "CreateBundledSourceWithOAuth",
+            create_bundled_source_with_oauth(&member, "source-record", ABSENT_SOURCE).await,
+        ),
+    ] {
+        assert_eq!(
+            result
+                .expect_err("a member must not change source configuration")
+                .code(),
+            Code::PermissionDenied,
+            "the member reached {rpc}",
+        );
+    }
+    assert_eq!(
+        execute_sql_in_task(&outsider, "source-record", &task_id, "select 1")
+            .await
+            .expect_err("a non-member must not run a statement under this workspace's task")
+            .code(),
+        Code::NotFound,
+    );
+
+    assert_eq!(
+        deployment.workspace_work("source-record").await,
+        before,
+        "refused work must add no task row, no recorded query, and no attributed span — not even when the statement names a task that really is in this workspace",
+    );
+    assert_eq!(
+        list_sources(&owner, "source-record")
+            .await
+            .expect("the owner lists their sources"),
+        vec![FIXTURE_SOURCE.to_string()],
+        "the refused delete removed nothing and the refused import installed nothing",
+    );
+    assert!(
+        get_source(&outsider, "source-record", REFUSED_IMPORT_SOURCE)
+            .await
+            .is_err(),
+        "the manifest a refused import carried must not have been installed",
+    );
+
+    execute_sql_in_task(&owner, "source-record", &task_id, "select 1")
+        .await
+        .expect("the owner runs a statement under their own task");
+    let recorded = deployment.workspace_work("source-record").await;
+    assert!(
+        recorded.queries > before.queries && recorded.attributed_spans > before.attributed_spans,
+        "permitted work must move the counters the refusals left where they were: {recorded:?} after {before:?}",
+    );
+}

--- a/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
@@ -170,12 +170,14 @@ async fn person(deployment: &SharedDeployment, user_id: &str) -> Caller {
     Caller::connect(deployment.endpoint_uri(), Some(credential)).await
 }
 
-/// The same person's id, admitted as an agent rather than as themselves.
+/// An agent, which is a principal in its own right.
 ///
-/// Only the token's actor-kind claim separates this caller from [`person`], so
-/// a refusal one meets and the other does not is a refusal of the actor kind.
-async fn agent(deployment: &SharedDeployment, user_id: &str) -> Caller {
-    let credential = deployment.credential(user_id, PrincipalKind::Agent);
+/// It carries `agent_id` rather than any person's, because the two are drawn
+/// from one namespace and never coincide — so it holds no membership until one
+/// is granted to that identifier, and acting for a person is not something this
+/// model expresses.
+async fn agent(deployment: &SharedDeployment, agent_id: &str) -> Caller {
+    let credential = deployment.credential(agent_id, PrincipalKind::Agent);
     Caller::connect(deployment.endpoint_uri(), Some(credential)).await
 }
 
@@ -370,8 +372,8 @@ async fn neither_a_member_nor_any_agent_credential_inspects_traces() {
         &[("tf-deny-trace", Some("tf-deny"))],
     );
     let member = person(&deployment, &bob).await;
-    let member_agent = agent(&deployment, &bob).await;
-    let owner_agent = agent(&deployment, &ada).await;
+    let member_agent = agent(&deployment, "agent-tf-deny-one").await;
+    let owner_agent = agent(&deployment, "agent-tf-deny-two").await;
 
     for (who, caller) in [
         ("a member", &member),
@@ -473,7 +475,7 @@ async fn no_shared_credential_configures_this_hosts_runtime_features() {
         .await
         .expect("the creator makes their own workspace");
     let owner = person(&deployment, &ada).await;
-    let owners_agent = agent(&deployment, &ada).await;
+    let owners_agent = agent(&deployment, "agent-tf-features").await;
 
     for (who, caller) in [("an owner", &owner), ("their agent", &owners_agent)] {
         assert_eq!(

--- a/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
@@ -461,8 +461,11 @@ async fn a_non_members_trace_refusals_read_exactly_like_an_absent_workspace() {
 }
 
 /// Runtime features configure the machine this server runs on, so a shared
-/// deployment has nobody to entrust them to: neither a person nor their agent
-/// reaches either RPC, whatever workspaces they own.
+/// deployment has nobody to entrust the *configuring* to: neither a person nor
+/// their agent changes one, whatever workspaces they own. Reading the same
+/// state is not host-global — the settings page has to say which features are
+/// on before it can explain that they are the host's to change — so both of
+/// them still list it.
 ///
 /// The probe key is what makes each refusal an absence rather than an error
 /// code: `nope` is a key the registry itself would reject, so a caller who
@@ -478,10 +481,11 @@ async fn no_shared_credential_configures_this_hosts_runtime_features() {
     let owners_agent = agent(&deployment, "agent-tf-features").await;
 
     for (who, caller) in [("an owner", &owner), ("their agent", &owners_agent)] {
-        assert_eq!(
-            refusal(caller.list_features().await),
-            Code::PermissionDenied,
-            "{who} listed this host's features",
+        assert!(
+            caller.list_features().await.unwrap_or_else(|status| panic!(
+                "{who} could not read the feature state: {status}"
+            )) > 0,
+            "{who} was shown an empty feature registry",
         );
         assert_eq!(
             refusal(caller.set_feature(UNKNOWN_FEATURE).await),

--- a/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
@@ -35,6 +35,7 @@ use coral_api::v1::{
     GetTraceRequest, ListFeaturesRequest, ListTracesRequest, SetFeatureRequest, TraceView,
     WorkspaceRole,
 };
+use coral_app::PrincipalKind;
 use coral_client::local::ServerBuilder;
 use serde_json::json;
 use tempfile::TempDir;
@@ -165,13 +166,17 @@ impl Caller {
 }
 
 async fn person(deployment: &SharedDeployment, user_id: &str) -> Caller {
-    Caller::connect(deployment.endpoint_uri(), Some(format!("user:{user_id}"))).await
+    let credential = deployment.credential(user_id, PrincipalKind::User);
+    Caller::connect(deployment.endpoint_uri(), Some(credential)).await
 }
 
-/// The session an MCP-audience token authenticates: the same person's id,
-/// admitted as an agent rather than as themselves.
+/// The same person's id, admitted as an agent rather than as themselves.
+///
+/// Only the token's actor-kind claim separates this caller from [`person`], so
+/// a refusal one meets and the other does not is a refusal of the actor kind.
 async fn agent(deployment: &SharedDeployment, user_id: &str) -> Caller {
-    Caller::connect(deployment.endpoint_uri(), Some(format!("agent:{user_id}"))).await
+    let credential = deployment.credential(user_id, PrincipalKind::Agent);
+    Caller::connect(deployment.endpoint_uri(), Some(credential)).await
 }
 
 /// The code a refusal answers with. A caller who may not ask must not be

--- a/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_trace_feature_access.rs
@@ -1,0 +1,552 @@
+//! Public gRPC evidence that a trace is read by the owner of the workspace it
+//! belongs to and by nobody else, and that this host's runtime features are
+//! configured from the host rather than from any credential a shared deployment
+//! issues.
+//!
+//! A trace carries the query text, arguments, and errors of whoever ran it, so
+//! reading one is an owner's act rather than a member's. The request that names
+//! no workspace is the widest read the service offers and so the widest
+//! accidental-disclosure surface in the feature: it must fan out over the
+//! workspaces the caller owns and nothing else — not one they merely belong to,
+//! and not the host's own rows, which no workspace claims.
+//!
+//! Runtime features configure the machine this server runs on, so no workspace
+//! role entitles a caller to them and a shared deployment has no superuser to
+//! entrust them to. The single-user deployment's unrestricted access is asserted
+//! here too: a change that locked the shared deployment down by locking everyone
+//! down would pass a suite that only proved the denials.
+//!
+//! Host rows are planted rather than provoked. A `TraceSummary` carries no
+//! workspace field, so without a row on record an empty answer would be
+//! indistinguishable from a host that had recorded none.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
+)]
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use coral_api::CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND;
+use coral_api::v1::feature_service_client::FeatureServiceClient;
+use coral_api::v1::trace_service_client::TraceServiceClient;
+use coral_api::v1::{
+    GetTraceRequest, ListFeaturesRequest, ListTracesRequest, SetFeatureRequest, TraceView,
+    WorkspaceRole,
+};
+use coral_client::local::ServerBuilder;
+use serde_json::json;
+use tempfile::TempDir;
+use tonic::transport::Channel;
+use tonic::{Code, Request, Status};
+
+#[path = "grpc/session_auth.rs"]
+#[expect(
+    dead_code,
+    reason = "The session-auth fixture serves several integration binaries; this one uses the parts the shared harness needs."
+)]
+mod session_auth;
+
+#[path = "grpc/harness.rs"]
+#[expect(
+    dead_code,
+    reason = "The shared harness serves several integration binaries; this one exercises the shared-deployment half of it."
+)]
+mod harness;
+
+use crate::harness::{
+    SharedDeployment, add_member, concealed_refusal, create_workspace, named_workspace,
+};
+
+/// The widest page the service serves, so a listing is never short of rows for
+/// a reason other than the scope under test.
+const WHOLE_PAGE: i32 = 200;
+
+/// A trace id nothing recorded, so a caller who reaches the store is told the
+/// trace is missing and a caller who does not never gets that far.
+const ABSENT_TRACE: &str = "probe-trace";
+
+/// A feature key the registry itself rejects, for the same reason.
+const UNKNOWN_FEATURE: &str = "nope";
+
+/// The two services this binary exercises, dialed for one credential.
+///
+/// Neither is carried by `AppClient`, so both are built straight from a raw
+/// channel; the credential rides in the same `authorization` metadata the
+/// loopback client sends, which is what the deployment's principal provider
+/// reads. A `None` credential is an anonymous call, which is what a single-user
+/// deployment resolves to its built-in local principal.
+struct Caller {
+    traces: TraceServiceClient<Channel>,
+    features: FeatureServiceClient<Channel>,
+    credential: Option<String>,
+}
+
+impl Caller {
+    async fn connect(endpoint_uri: &str, credential: Option<String>) -> Self {
+        let channel = Channel::from_shared(endpoint_uri.to_string())
+            .expect("a valid endpoint")
+            .connect()
+            .await
+            .expect("connect a raw client");
+        Self {
+            traces: TraceServiceClient::new(channel.clone()),
+            features: FeatureServiceClient::new(channel),
+            credential,
+        }
+    }
+
+    fn request<T>(&self, message: T) -> Request<T> {
+        let mut request = Request::new(message);
+        if let Some(credential) = &self.credential {
+            request.metadata_mut().insert(
+                "authorization",
+                format!("Bearer {credential}")
+                    .parse()
+                    .expect("a bearer credential is valid metadata"),
+            );
+        }
+        request
+    }
+
+    /// Lists one page of traces, either for a named workspace or for whatever
+    /// an unnamed request fans out over.
+    async fn list_traces(&self, workspace: Option<&str>) -> Result<Vec<String>, Status> {
+        self.traces
+            .clone()
+            .list_traces(self.request(ListTracesRequest {
+                page_size: WHOLE_PAGE,
+                page_token: String::new(),
+                workspace: workspace.map(named_workspace),
+                view: TraceView::Unspecified as i32,
+            }))
+            .await
+            .map(|response| {
+                response
+                    .into_inner()
+                    .traces
+                    .into_iter()
+                    .map(|summary| summary.trace_id)
+                    .collect()
+            })
+    }
+
+    async fn get_trace(&self, workspace: Option<&str>, trace_id: &str) -> Result<(), Status> {
+        self.traces
+            .clone()
+            .get_trace(self.request(GetTraceRequest {
+                trace_id: trace_id.to_string(),
+                workspace: workspace.map(named_workspace),
+                view: TraceView::Unspecified as i32,
+            }))
+            .await
+            .map(|_| ())
+    }
+
+    async fn list_features(&self) -> Result<usize, Status> {
+        self.features
+            .clone()
+            .list_features(self.request(ListFeaturesRequest {}))
+            .await
+            .map(|response| response.into_inner().features.len())
+    }
+
+    async fn set_feature(&self, key: &str) -> Result<(), Status> {
+        self.features
+            .clone()
+            .set_feature(self.request(SetFeatureRequest {
+                key: key.to_string(),
+                enabled: true,
+            }))
+            .await
+            .map(|_| ())
+    }
+}
+
+async fn person(deployment: &SharedDeployment, user_id: &str) -> Caller {
+    Caller::connect(deployment.endpoint_uri(), Some(format!("user:{user_id}"))).await
+}
+
+/// The session an MCP-audience token authenticates: the same person's id,
+/// admitted as an agent rather than as themselves.
+async fn agent(deployment: &SharedDeployment, user_id: &str) -> Caller {
+    Caller::connect(deployment.endpoint_uri(), Some(format!("agent:{user_id}"))).await
+}
+
+/// The code a refusal answers with. A caller who may not ask must not be
+/// answered at all, so being answered is the failure.
+fn refusal<T>(result: Result<T, Status>) -> Code {
+    let Err(status) = result else {
+        panic!("a caller who may not ask must not be answered");
+    };
+    status.code()
+}
+
+fn holds(listed: &[String], trace_id: &str) -> bool {
+    listed.iter().any(|found| found == trace_id)
+}
+
+/// The store every deployment in this process shares.
+fn planted_store(deployment: &SharedDeployment) -> &Path {
+    deployment
+        .trace_store_dir()
+        .expect("trace history is on by default, so the store is live")
+}
+
+/// Writes spans straight into the store the deployment reads, one file per call
+/// so concurrent tests never overwrite each other's rows.
+///
+/// A `None` workspace is a host row: work this server did that no workspace
+/// claims, and the only kind of row no request could be made to produce. The
+/// rows are dated ahead of the clock deliberately — every deployment in this
+/// process shares one store, and a row newer than anything real is on the first
+/// page of any listing no matter what the rest of the suite exported.
+fn plant_traces(dir: &Path, label: &str, rows: &[(&str, Option<&str>)]) {
+    // The store creates its directory on the first span it exports, which a
+    // deployment that has served no work yet has not reached.
+    std::fs::create_dir_all(dir).expect("the trace store directory");
+    let planted_at = unix_nanos_ahead(Duration::from_mins(1));
+    let mut lines = String::new();
+    for (trace_id, workspace) in rows {
+        let attributes = workspace.map_or_else(
+            || json!({ "status": "ok" }),
+            |workspace| json!({ "workspace": workspace, "sql": "SELECT 1", "status": "ok" }),
+        );
+        lines.push_str(
+            &json!({
+                "trace_id": trace_id,
+                "span_id": format!("{trace_id}-span"),
+                "parent_span_id": null,
+                "parent_span_is_remote": false,
+                "name": "coral.query",
+                "kind": "internal",
+                "status": "ok",
+                "status_message": null,
+                "start_time_unix_nanos": planted_at,
+                "end_time_unix_nanos": planted_at,
+                "duration_nanos": 0,
+                "attributes_json": attributes.to_string(),
+                "events_json": "[]",
+                "links_json": "[]",
+                "resource_json": "{}",
+                "scope_name": "test",
+                "scope_version": null,
+                "scope_schema_url": null,
+                "scope_attributes_json": "{}",
+                "trace_flags": 0,
+                "trace_state": "",
+                "is_remote": false
+            })
+            .to_string(),
+        );
+        lines.push('\n');
+    }
+    std::fs::write(dir.join(format!("spans-{label}.jsonl")), lines).expect("plant trace rows");
+}
+
+fn unix_nanos_ahead(ahead: Duration) -> i64 {
+    let when = SystemTime::now()
+        .checked_add(ahead)
+        .expect("a representable timestamp");
+    i64::try_from(
+        when.duration_since(UNIX_EPOCH)
+            .expect("a clock set after the epoch")
+            .as_nanos(),
+    )
+    .expect("nanoseconds that fit a trace timestamp")
+}
+
+/// Reports only what a refused caller is told on each trace RPC: the surface
+/// beside the code, the message with the workspace name they supplied
+/// themselves factored out, and the structured reasons.
+async fn refusals(caller: &Caller, name: &str) -> Vec<(&'static str, Code, String, Vec<String>)> {
+    let mut refused = Vec::new();
+    for (rpc, result) in [
+        ("ListTraces", caller.list_traces(Some(name)).await.map(drop)),
+        ("GetTrace", caller.get_trace(Some(name), ABSENT_TRACE).await),
+    ] {
+        let status = result.expect_err("a refused caller must not be answered by these RPCs");
+        let (code, message, reasons) = concealed_refusal(&status, name);
+        refused.push((rpc, code, message, reasons));
+    }
+    refused
+}
+
+/// An owner inspects the workspaces they own and only those. The fan-out is the
+/// half that carries the risk: this caller owns one workspace and merely exists
+/// alongside another, and a global request must answer with the first and say
+/// nothing at all about the second or about the host's own rows.
+#[tokio::test]
+async fn an_owner_reads_the_traces_of_the_workspaces_they_own() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("tf-own-ada", "Ada").await;
+    let bob = deployment.seed_user("tf-own-bob", "Bob").await;
+    create_workspace(&deployment.as_person(&ada).await, "tf-own-mine")
+        .await
+        .expect("the creator makes their own workspace");
+    create_workspace(&deployment.as_person(&bob).await, "tf-own-theirs")
+        .await
+        .expect("somebody else makes theirs");
+    plant_traces(
+        planted_store(&deployment),
+        "tf-own",
+        &[
+            ("tf-own-mine-trace", Some("tf-own-mine")),
+            ("tf-own-theirs-trace", Some("tf-own-theirs")),
+            ("tf-own-host-trace", None),
+        ],
+    );
+    let owner = person(&deployment, &ada).await;
+
+    let named = owner
+        .list_traces(Some("tf-own-mine"))
+        .await
+        .expect("an owner inspects their own workspace");
+    assert!(holds(&named, "tf-own-mine-trace"), "{named:?}");
+    owner
+        .get_trace(Some("tf-own-mine"), "tf-own-mine-trace")
+        .await
+        .expect("an owner reads one of their own traces");
+
+    let fanned_out = owner
+        .list_traces(None)
+        .await
+        .expect("an owner is answered about the workspaces they own");
+    assert!(
+        holds(&fanned_out, "tf-own-mine-trace")
+            && !holds(&fanned_out, "tf-own-theirs-trace")
+            && !holds(&fanned_out, "tf-own-host-trace"),
+        "the fan-out must reach the workspace the caller owns and nothing else: {fanned_out:?}",
+    );
+
+    // The control that keeps the exclusion from being vacuous: the row the
+    // fan-out did not reach is on record and does reach the person who owns it.
+    let theirs = person(&deployment, &bob)
+        .await
+        .list_traces(None)
+        .await
+        .expect("the other owner is answered about their own workspace");
+    assert!(holds(&theirs, "tf-own-theirs-trace"), "{theirs:?}");
+
+    // The same boundary one trace at a time: a trace outside what the caller
+    // owns is reported absent rather than refused, so which workspace it does
+    // belong to stays unlearnable.
+    for trace_id in ["tf-own-theirs-trace", "tf-own-host-trace"] {
+        assert_eq!(
+            refusal(owner.get_trace(None, trace_id).await),
+            Code::NotFound,
+            "{trace_id} was reachable",
+        );
+    }
+}
+
+/// Membership is not enough and an agent credential is never enough. The member
+/// is the case that matters: they read the workspace's data all day and still
+/// may not read the trace of somebody else's query in it. The owner's own agent
+/// is the other: their role would make the read theirs to perform and the
+/// credential is refused anyway, so a prompt-injected agent cannot exfiltrate
+/// the query text of everything the workspace has run.
+#[tokio::test]
+async fn neither_a_member_nor_any_agent_credential_inspects_traces() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("tf-deny-ada", "Ada").await;
+    let bob = deployment.seed_user("tf-deny-bob", "Bob").await;
+    let owner_app = deployment.as_person(&ada).await;
+    create_workspace(&owner_app, "tf-deny")
+        .await
+        .expect("the creator makes their own workspace");
+    add_member(&owner_app, "tf-deny", &bob, WorkspaceRole::Member)
+        .await
+        .expect("the owner grants membership");
+    plant_traces(
+        planted_store(&deployment),
+        "tf-deny",
+        &[("tf-deny-trace", Some("tf-deny"))],
+    );
+    let member = person(&deployment, &bob).await;
+    let member_agent = agent(&deployment, &bob).await;
+    let owner_agent = agent(&deployment, &ada).await;
+
+    for (who, caller) in [
+        ("a member", &member),
+        ("a member's agent", &member_agent),
+        ("the owner's own agent", &owner_agent),
+    ] {
+        assert_eq!(
+            refusal(caller.list_traces(Some("tf-deny")).await),
+            Code::PermissionDenied,
+            "{who} listed the workspace's traces",
+        );
+        assert_eq!(
+            refusal(caller.get_trace(Some("tf-deny"), "tf-deny-trace").await),
+            Code::PermissionDenied,
+            "{who} read one of the workspace's traces",
+        );
+    }
+
+    // An unnamed request is the same boundary reached from the other side: an
+    // agent is refused it outright, and a member owns nothing for it to reach.
+    for (who, caller) in [
+        ("a member's agent", &member_agent),
+        ("the owner's own agent", &owner_agent),
+    ] {
+        assert_eq!(
+            refusal(caller.list_traces(None).await),
+            Code::PermissionDenied,
+            "{who} fanned out",
+        );
+    }
+    let members_fan_out = member
+        .list_traces(None)
+        .await
+        .expect("a caller who owns nothing is answered with nothing");
+    assert!(
+        !holds(&members_fan_out, "tf-deny-trace"),
+        "a member's fan-out reached a workspace they only belong to: {members_fan_out:?}",
+    );
+    assert_eq!(
+        refusal(member.get_trace(None, "tf-deny-trace").await),
+        Code::NotFound,
+    );
+}
+
+/// A trace RPC may not answer a question its caller may not ask. A workspace a
+/// non-member holds no membership in has to read exactly like a name nobody ever
+/// created — and read as the *absent* workspace specifically, since a uniform
+/// "denied" would agree with itself while still confirming the name exists.
+#[tokio::test]
+async fn a_non_members_trace_refusals_read_exactly_like_an_absent_workspace() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("tf-conceal-ada", "Ada").await;
+    let bob = deployment.seed_user("tf-conceal-bob", "Bob").await;
+    create_workspace(&deployment.as_person(&ada).await, "tf-conceal")
+        .await
+        .expect("the creator makes their own workspace");
+    plant_traces(
+        planted_store(&deployment),
+        "tf-conceal",
+        &[("tf-conceal-trace", Some("tf-conceal"))],
+    );
+    let outsider = person(&deployment, &bob).await;
+
+    let existing = refusals(&outsider, "tf-conceal").await;
+    assert_eq!(
+        existing,
+        refusals(&outsider, "tf-ghost").await,
+        "an existing workspace must be indistinguishable from one that never existed",
+    );
+    assert!(
+        existing
+            .iter()
+            .all(|(_, code, _, reasons)| *code == Code::NotFound
+                && reasons.as_slice() == [CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND]),
+        "both must read as the absent workspace, not as a denial that confirms one: {existing:?}",
+    );
+    let fanned_out = outsider
+        .list_traces(None)
+        .await
+        .expect("a caller who owns nothing is answered with nothing");
+    assert!(
+        !holds(&fanned_out, "tf-conceal-trace"),
+        "the concealed workspace's traces were reachable behind the concealment: {fanned_out:?}",
+    );
+}
+
+/// Runtime features configure the machine this server runs on, so a shared
+/// deployment has nobody to entrust them to: neither a person nor their agent
+/// reaches either RPC, whatever workspaces they own.
+///
+/// The probe key is what makes each refusal an absence rather than an error
+/// code: `nope` is a key the registry itself would reject, so a caller who
+/// reached the registry would be told so.
+#[tokio::test]
+async fn no_shared_credential_configures_this_hosts_runtime_features() {
+    let deployment = SharedDeployment::start().await;
+    let ada = deployment.seed_user("tf-features-ada", "Ada").await;
+    create_workspace(&deployment.as_person(&ada).await, "tf-features")
+        .await
+        .expect("the creator makes their own workspace");
+    let owner = person(&deployment, &ada).await;
+    let owners_agent = agent(&deployment, &ada).await;
+
+    for (who, caller) in [("an owner", &owner), ("their agent", &owners_agent)] {
+        assert_eq!(
+            refusal(caller.list_features().await),
+            Code::PermissionDenied,
+            "{who} listed this host's features",
+        );
+        assert_eq!(
+            refusal(caller.set_feature(UNKNOWN_FEATURE).await),
+            Code::PermissionDenied,
+            "{who} configured this host's features",
+        );
+    }
+}
+
+/// The single-user deployment keeps the unrestricted access it has always had.
+/// Its caller reads the host's own rows and a workspace it holds no membership
+/// in, and reaches the feature registry — there is nobody there to conceal any
+/// of it from, and locking the shared deployment down must not have locked this
+/// one down with it.
+#[tokio::test]
+async fn the_implicit_owner_still_reads_host_rows_and_configures_features() {
+    let temp = TempDir::new().expect("temp dir");
+    // A builder with no principal provider is a single-user deployment: every
+    // request arrives as the built-in local principal.
+    let server = ServerBuilder::new()
+        .with_config_dir(temp.path().join("coral-config"))
+        .start()
+        .await
+        .expect("start a single-user server");
+    let store = server
+        .local_trace_store_dir()
+        .expect("trace history is on by default, so the store is live")
+        .to_path_buf();
+    // The process installs one trace store, owned by whichever server started
+    // first. When that is this one, its temp dir must outlive the deployment:
+    // removing it would delete the store out from under a concurrent test.
+    let _temp = if store.starts_with(temp.path()) {
+        let _installed_store_root: PathBuf = temp.keep();
+        None
+    } else {
+        Some(temp)
+    };
+    plant_traces(
+        &store,
+        "tf-local",
+        &[
+            ("tf-local-host-trace", None),
+            ("tf-local-workspace-trace", Some("tf-local-unknown")),
+        ],
+    );
+    let local = Caller::connect(server.endpoint_uri(), None).await;
+
+    let listed = local
+        .list_traces(None)
+        .await
+        .expect("a single-user deployment reads every trace this host recorded");
+    for trace_id in ["tf-local-host-trace", "tf-local-workspace-trace"] {
+        assert!(
+            holds(&listed, trace_id),
+            "{trace_id} was hidden: {listed:?}"
+        );
+        local
+            .get_trace(None, trace_id)
+            .await
+            .unwrap_or_else(|status| panic!("the implicit owner reads {trace_id}: {status}"));
+    }
+
+    assert!(
+        local
+            .list_features()
+            .await
+            .expect("the implicit owner inspects this host's features")
+            > 0,
+    );
+    assert_eq!(
+        refusal(local.set_feature(UNKNOWN_FEATURE).await),
+        Code::InvalidArgument,
+        "the implicit owner must be stopped by the request, never by the gate",
+    );
+}

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -73,13 +73,10 @@ fn grpc_addr(server: &RunningServer) -> SocketAddr {
         .expect("socket address")
 }
 
-async fn assert_catalog_tool(endpoint: String, bearer: Option<&str>) {
+async fn assert_catalog_tool(endpoint: String) {
     const INTENT: &str = "Exercise the composite server";
 
-    let mut config = StreamableHttpClientTransportConfig::with_uri(endpoint);
-    if let Some(bearer) = bearer {
-        config = config.auth_header(bearer);
-    }
+    let config = StreamableHttpClientTransportConfig::with_uri(endpoint);
     let client =
         ().serve(StreamableHttpClientTransport::from_config(config))
             .await
@@ -133,16 +130,38 @@ async fn assert_cli_extension_filter(endpoint: String) {
     client.cancel().await.expect("stop MCP client");
 }
 
-async fn assert_unauthorized(base: &str, authorization: &str) {
-    let rejected = reqwest::Client::new()
-        .post(format!("{base}/mcp"))
+async fn initialize_mcp(endpoint: &str, authorization: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(endpoint)
         .header("accept", "application/json, text/event-stream")
         .header("content-type", "application/json")
         .header("authorization", authorization)
         .body(INITIALIZE)
         .send()
         .await
-        .expect("MCP response");
+        .expect("MCP response")
+}
+
+/// Asserts the MCP surface admits a bearer token past authentication.
+///
+/// The mirror of [`assert_unauthorized`], and it stops at the handshake because
+/// that is where authentication is decided: everything after it is
+/// workspace-scoped — even `tools/list`, which enumerates a workspace's table
+/// functions — so a caller holding no membership is legitimately refused there
+/// while its audience was accepted here. `coral-app`'s workspace authorization
+/// tests own the boundary behind it.
+async fn assert_mcp_authenticated(endpoint: &str, token: &str) {
+    let accepted = initialize_mcp(endpoint, &format!("Bearer {token}")).await;
+    assert!(
+        accepted.status().is_success(),
+        "an accepted audience must initialize an MCP session: {}",
+        accepted.status()
+    );
+    assert!(accepted.headers().get(WWW_AUTHENTICATE).is_none());
+}
+
+async fn assert_unauthorized(base: &str, authorization: &str) {
+    let rejected = initialize_mcp(&format!("{base}/mcp"), authorization).await;
     assert_eq!(rejected.status(), reqwest::StatusCode::UNAUTHORIZED);
     assert_eq!(
         rejected.headers().get_all(WWW_AUTHENTICATE).iter().count(),
@@ -294,6 +313,13 @@ redirect_uri = 'https://auth.example/auth/oidc/callback'
     );
 }
 
+/// Asserts the private gRPC data plane admits a token past authentication.
+///
+/// The probe call is workspace-scoped, so a caller who holds no membership is
+/// legitimately refused *after* authentication has already succeeded, and that
+/// refusal still proves the audience was accepted. Only `Unauthenticated`, or a
+/// status meaning the call never reached the service, falsifies what these tests
+/// own. `coral-app`'s workspace authorization tests own the boundary itself.
 async fn assert_grpc_authenticated(server: &RunningServer, token: &str) {
     let authenticated = connect_with_loopback_bearer(
         server.endpoint_uri(),
@@ -301,16 +327,24 @@ async fn assert_grpc_authenticated(server: &RunningServer, token: &str) {
     )
     .await
     .expect("authenticated gRPC client");
-    authenticated
+    if let Err(refused) = authenticated
         .catalog_client()
         .list_catalog(Request::new(catalog_request()))
         .await
-        .expect("authenticated catalog call");
+    {
+        assert!(
+            !matches!(
+                refused.code(),
+                Code::Unauthenticated | Code::Unavailable | Code::Unknown
+            ),
+            "an accepted audience must reach the service: {refused:?}"
+        );
+    }
 }
 
-async fn assert_authenticated_data(server: &RunningServer, mcp_endpoint: &str, token: &str) {
+async fn assert_authenticated_surfaces(server: &RunningServer, mcp_endpoint: &str, token: &str) {
     assert_grpc_authenticated(server, token).await;
-    assert_catalog_tool(mcp_endpoint.to_string(), Some(token)).await;
+    assert_mcp_authenticated(mcp_endpoint, token).await;
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -439,7 +473,7 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     assert!(!server.mcp_http_authentication_enabled());
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
     assert!(server.oauth_addr().is_none());
-    assert_catalog_tool(format!("http://{mcp_addr}/mcp"), None).await;
+    assert_catalog_tool(format!("http://{mcp_addr}/mcp")).await;
     assert_cli_extension_filter(format!("http://{mcp_addr}/mcp")).await;
     server.shutdown().await.expect("shutdown composite server");
     let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC port must be released");
@@ -495,7 +529,7 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
     // Dial through loopback: the point here is that the listener started and
     // serves; reachability from other interfaces is the operator's affair.
     let dial = SocketAddr::from((Ipv4Addr::LOCALHOST, mcp_addr.port()));
-    assert_catalog_tool(format!("http://{dial}/mcp"), None).await;
+    assert_catalog_tool(format!("http://{dial}/mcp")).await;
     server.shutdown().await.expect("shutdown composite server");
 }
 
@@ -643,7 +677,7 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
     assert_grpc_rejects_unauthenticated(server.endpoint_uri()).await;
 
     let token = session_token(signing_key.as_ref(), &resource);
-    assert_authenticated_data(&server, &format!("{base}/mcp"), &token).await;
+    assert_authenticated_surfaces(&server, &format!("{base}/mcp"), &token).await;
 
     let coral_ui_token = session_token(signing_key.as_ref(), CORAL_UI_RESOURCE);
     assert_grpc_authenticated(&server, &coral_ui_token).await;
@@ -816,7 +850,7 @@ async fn session_failures_and_restart_are_fail_closed() {
     assert_eq!(expired_rejection, wrong_audience_rejection);
     assert_eq!(expired_rejection, malformed_rejection);
     assert_eq!(expired_rejection, forged_rejection);
-    assert_authenticated_data(&server, &mcp_endpoint, &valid).await;
+    assert_authenticated_surfaces(&server, &mcp_endpoint, &valid).await;
     server.shutdown().await.expect("first shutdown");
 
     let restarted = start(
@@ -832,7 +866,7 @@ async fn session_failures_and_restart_are_fail_closed() {
         "http://{}/mcp",
         restarted.mcp_http_addr().expect("restarted MCP endpoint")
     );
-    assert_authenticated_data(&restarted, &restarted_mcp, &valid).await;
+    assert_authenticated_surfaces(&restarted, &restarted_mcp, &valid).await;
     restarted.shutdown().await.expect("restarted shutdown");
 }
 


### PR DESCRIPTION
## Intent

Slice 1 established who callers are and which workspaces they belong to. This slice makes those memberships mean something everywhere: every workspace-scoped gRPC handler settles access through one authorizer before it does any work, so what a Member may read and what only an Owner may change is decided in one place rather than per-handler.

## What it enables

- Every workspace-scoped RPC authorizes through `WorkspaceAuthorizer` immediately after its workspace name is parsed and before any manager, store, parse, or task lookup runs, so a refused caller leaves no side effect behind and learns nothing from the refusal.
- `authorization_matrix.rs` is the reviewable companion to that enforcement: one table naming the rule for every RPC this server mounts. It is a declaration rather than a dispatcher — nothing routes through it — and its tests hold it to the shipped protobuf definitions in both directions, so an RPC cannot be added without a decision about who may call it, and a rule cannot outlive the RPC it was written for.
- **Breaking:** reads now require membership. Previously any authenticated caller could read any workspace's queries, feedback, tasks, and telemetry; those reads now refuse callers who are not members of the named workspace.
- Owner-only operations: source configuration, trace reads, function installation, and search mutations and maintenance require the Owner role. Trace reads being Owner-gated is deliberate — traces carry the query text, arguments, and errors of whoever ran them, so reading one is an owner's act rather than a member's. The workspace control plane (deletion and membership changes) is enforced in slice 1; this slice adds its matrix rows and the public-transport suite that proves it.
- Trace reads are projected rather than merely admitted: a caller sees the spans their own workspaces recorded and no others, so a trace that two workspaces share carries no query text across the boundary — not in the detail view, and not in the summary a listing shows. A trace with nothing in scope reads exactly like one that was never recorded.
- **Breaking:** runtime-feature settings are host-level, not workspace-level. Only the deployment's own principal may change them, so no workspace role grants that. Reading them stays open to any admitted caller: the listing carries the same keys, descriptions, and enabled state for everyone, and a settings page that cannot read it cannot explain why its switches do nothing.
- Telemetry is scoped to the workspaces the caller can see.
- Four public-transport isolation test suites (sources, traces, functions/search, membership control plane) prove the restrictions over real gRPC with two users, rather than unit-testing the policy in isolation. They authenticate the way the deployment does, with tokens the real issuer minted, so a credential the issuer would never hand out cannot make one of them pass. Separating a person from an agent acting for them is part of what they assert, resting on the actor-kind claim slice 1 carries: the suites prove an agent credential is refused the entire workspace control plane, and a unit test carries the sharper case, where an agent holding an owner's own id is still refused what that owner may do.

## Usage examples

```bash
# As a Member: reads succeed, owner-only mutations are refused
coral --workspace analytics sql "select 1"        # ok
coral --workspace analytics source add postgres…  # refused: requires Owner

# As the Owner, both succeed.
```

The refusal is a structured gRPC error naming the missing role, so clients can distinguish "not permitted" from transport failure. A workspace the caller may not know about is concealed as absent instead, so the namespace never becomes an oracle.

---
Slice 2 of 5 (milestones m3–m4; 23 commits). Builds directly on slice 1's membership model.
