### PR TITLE
feat(app)!: make workspace provisioning explicit and bootstrap ownership

### DIFF
--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -15,6 +15,16 @@ Before setting up a client, make sure you have [connected at least one source](/
 
 Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`.
 
+Create a workspace first — a fresh install has none, and `coral mcp-stdio` cannot
+serve one that does not exist:
+
+```shellscript
+coral workspace create analytics
+```
+
+Name that workspace with `--workspace` in the server args of every client below.
+The examples show one workspace called `analytics`; substitute your own.
+
 <Tabs>
 <Tab title="npx add-mcp">
 
@@ -24,12 +34,12 @@ Coral uses stdio transport. If a client supports a command-based install flow, p
   <Tabs>
     <Tab title="macOS / Linux">
     ```shellscript
-    npx add-mcp -n coral -g "$(which coral) mcp-stdio"
+    npx add-mcp -n coral -g "$(which coral) mcp-stdio --workspace analytics"
     ```
     </Tab>
     <Tab title="Windows PowerShell">
     ```powershell
-    npx add-mcp -n coral -g "$((Get-Command coral).Source) mcp-stdio"
+    npx add-mcp -n coral -g "$((Get-Command coral).Source) mcp-stdio --workspace analytics"
     ```
     </Tab>
   </Tabs>

--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -239,7 +239,7 @@ If an answer needs data from multiple connected sources, ask the agent to combin
 
 ## Workspaces
 
-By default, `coral mcp-stdio` uses your default Coral workspace. If you use a named workspace, add `--workspace <name>` to the server args in your MCP config. For JSON-style clients, that looks like:
+`coral mcp-stdio` serves one workspace, which you name with `--workspace <name>` in the server args of your MCP config. With no name it falls back to a workspace called `default`, which exists only if you created it. For JSON-style clients, naming the workspace looks like:
 
 ```json
 {

--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -50,7 +50,7 @@ The examples show one workspace called `analytics`; substitute your own.
 
   <Tab title="Claude Code">
   ```shellscript
-  claude mcp add --scope user coral -- coral mcp-stdio
+  claude mcp add --scope user coral -- coral mcp-stdio --workspace analytics
   ```
 </Tab>
 
@@ -58,7 +58,7 @@ The examples show one workspace called `analytics`; substitute your own.
   **CLI**
 
   ```shellscript
-  codex mcp add coral -- coral mcp-stdio
+  codex mcp add coral -- coral mcp-stdio --workspace analytics
   ```
 
   **Manual config**
@@ -68,7 +68,7 @@ The examples show one workspace called `analytics`; substitute your own.
   ```toml
   [mcp_servers.coral]
   command = "coral"
-  args = ["mcp-stdio"]
+  args = ["mcp-stdio", "--workspace", "analytics"]
   ```
 
   Codex uses user-scoped config shared between the CLI and IDE extension, so you only need to configure it once.
@@ -93,7 +93,7 @@ The examples show one workspace called `analytics`; substitute your own.
     "mcp": {
       "coral": {
         "type": "local",
-        "command": ["coral", "mcp-stdio"],
+        "command": ["coral", "mcp-stdio", "--workspace", "analytics"],
         "enabled": true
       }
     }
@@ -118,7 +118,7 @@ The examples show one workspace called `analytics`; substitute your own.
       "coral": {
         "type": "stdio",
         "command": "coral",
-        "args": ["mcp-stdio"]
+        "args": ["mcp-stdio", "--workspace", "analytics"]
       }
     }
   }
@@ -143,7 +143,7 @@ The examples show one workspace called `analytics`; substitute your own.
       "coral": {
         "type": "stdio",
         "command": "coral",
-        "args": ["mcp-stdio"]
+        "args": ["mcp-stdio", "--workspace", "analytics"]
       }
     }
   }
@@ -167,7 +167,7 @@ The examples show one workspace called `analytics`; substitute your own.
     "mcpServers": {
       "coral": {
         "command": "coral",
-        "args": ["mcp-stdio"]
+        "args": ["mcp-stdio", "--workspace", "analytics"]
       }
     }
   }
@@ -182,7 +182,7 @@ The examples show one workspace called `analytics`; substitute your own.
 
     ```text
     command: coral
-    args: ["mcp-stdio"]
+    args: ["mcp-stdio", "--workspace", "analytics"]
     ```
 
     Consult your client's documentation for the exact config format.

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -20,8 +20,9 @@ These flags do not edit `config.toml`. Use `coral features enable <FEATURE>` or
 
 ## Global workspace selection
 
-Commands that operate on local source state target the `default` workspace
-unless you select another workspace.
+Commands that operate on local source state run against the workspace you
+select. A fresh install has no workspaces, so create one with
+`coral workspace create <NAME>` before running them.
 
 ```shellscript
 coral --workspace work source list
@@ -33,6 +34,8 @@ CORAL_WORKSPACE=work coral sql "select * from coral.tables"
 The `--workspace <NAME>` flag overrides `CORAL_WORKSPACE` for that process.
 Coral does not persist a separate active-workspace setting; set
 `CORAL_WORKSPACE` in your shell when you want a default for repeated commands.
+With neither set, commands fall back to a workspace named `default`, which is
+an ordinary workspace that exists only if you created it.
 
 ## `coral sql`
 
@@ -322,7 +325,8 @@ coral workspace list
 
 ### `coral workspace create <NAME>`
 
-Create an empty workspace.
+Create an empty workspace. The workspace belongs to whoever creates it; on a
+deployment that authenticates no one, that is the local user.
 
 ```shellscript
 coral workspace create work
@@ -339,7 +343,8 @@ workspace configured.
 coral workspace remove work
 ```
 
-The `default` workspace cannot be removed.
+No workspace name is reserved: `default` is an ordinary workspace and is
+removed like any other.
 
 ## `coral functions`
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -45,12 +45,13 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
 
 ## Workspaces
 
-Workspace metadata is stored under `[workspaces]`. Coral provisions no
-workspace of its own; workspaces are created and removed with
-`coral workspace`.
+Workspace metadata is stored under `[workspaces]`. Coral provisions no workspace
+of its own — create and remove them yourself with `coral workspace create` and
+`coral workspace remove`. `default` is an ordinary name like any other; nothing
+creates it for you and nothing protects it.
 
 ```toml
-[workspaces.default]
+[workspaces.analytics]
 
 [workspaces.work]
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -45,8 +45,8 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
 
 ## Workspaces
 
-Workspace metadata is stored under `[workspaces]`. The `default` workspace
-exists automatically, and additional workspaces can be managed with
+Workspace metadata is stored under `[workspaces]`. Coral provisions no
+workspace of its own; workspaces are created and removed with
 `coral workspace`.
 
 ```toml

--- a/crates/coral-app/src/bootstrap/health.rs
+++ b/crates/coral-app/src/bootstrap/health.rs
@@ -5,9 +5,15 @@
 //! convention for overall server health, and what off-the-shelf probers query by
 //! default — answers process liveness from a constant: a live process must not
 //! report `NotServing` just because its engine is degraded, or a liveness prober
-//! restarts the container instead of removing it from rotation. Engine readiness
-//! is a separate registered service, [`READINESS_SERVICE_NAME`], so a readiness
-//! probe can ask for it explicitly.
+//! restarts the container instead of removing it from rotation. Service
+//! readiness is a separate registered service, [`READINESS_SERVICE_NAME`], so a
+//! readiness probe can ask for it explicitly.
+//!
+//! Readiness asks whether this service can serve at all: it is up, and the
+//! database it reads and writes answers. It deliberately says nothing about any
+//! one workspace's catalog. A catalog answer would be a stronger signal, but it
+//! is a signal about a workspace and its sources rather than about this
+//! instance, and a probe that pulls a replica out of rotation cannot act on it.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -20,39 +26,30 @@ use tonic_health::pb::health_check_response::ServingStatus;
 use tonic_health::pb::health_server::Health;
 use tonic_health::pb::{HealthCheckRequest, HealthCheckResponse};
 
-use crate::catalog::discovery::CatalogDiscovery;
-use crate::query::QueryAttribution;
-use crate::query::manager::{QueryManager, QueryManagerError};
-use crate::transport::query_status;
-use crate::workspaces::WorkspaceManager;
+use crate::state::db::CoralDb;
 
-/// Health service name reporting whether the engine can answer for its catalog.
+/// Health service name reporting whether the service can reach its database.
 ///
 /// Readiness lives under its own name so the default (empty-name) check stays a
-/// constant-time liveness answer. Probes that want engine health ask for this.
+/// constant-time liveness answer. Probes that want service health ask for this.
 pub const READINESS_SERVICE_NAME: &str = "coral.readiness";
 
-/// How long one engine readiness answer is reused.
+/// How long one readiness answer is reused.
 ///
 /// The health service is unauthenticated by design, so without this every caller
-/// that can reach the port could drive a catalog resolution per request. It also
-/// keeps a normal orchestrator poll interval from doing the work every time.
+/// that can reach the port could drive a database round trip per request. It
+/// also keeps a normal orchestrator poll interval from doing the work every
+/// time.
 const READINESS_CACHE_TTL: Duration = Duration::from_secs(2);
 
 /// How long a caller waits on the running probe before answering unready.
 ///
 /// Without a deadline the health RPC hangs on exactly the fault it exists to
-/// report: catalog resolution connects to every configured source and has no
-/// bound of its own, so a wedged source would wedge the answer instead of
-/// reporting `NotServing`. This bounds only how long an answer is waited for —
-/// the resolution itself runs to completion in the background — so a slow
-/// engine converges to ready over successive polls rather than restarting a
-/// doomed resolution on every one.
-///
-/// It bounds the asynchronous part of that work. A probe stalled inside a
-/// blocking call — `load_query_sources` takes the state lock with a blocking
-/// `flock` — cannot be preempted, so it holds a runtime thread until it
-/// returns; this deadline still frees the RPC to answer.
+/// report: a database that accepts the round trip and never answers it would
+/// wedge the health answer instead of reporting `NotServing`. This bounds only
+/// how long an answer is waited for — the check itself runs to completion in
+/// the background — so a slow database converges to ready over successive polls
+/// rather than restarting a doomed check on every one.
 ///
 /// Keep it below coral-mcp's `READINESS_TIMEOUT`, the client-side deadline the
 /// authenticated `/readyz` applies to this RPC, so the answer comes from here
@@ -61,24 +58,24 @@ const READINESS_PROBE_TIMEOUT: Duration = Duration::from_millis(1_500);
 
 type ReadinessFuture = Pin<Box<dyn Future<Output = bool> + Send>>;
 
-/// Whether the server can still answer for its catalog.
+/// Whether the server can still reach the state it serves out of.
 ///
 /// The health service is the only unauthenticated RPC on the gRPC surface, which
 /// makes it the one place a readiness probe can reach without a bearer token.
-/// Answering from the engine here is what keeps an authenticated `/readyz` from
-/// degenerating into a port check: the alternative — probing a data-plane RPC
-/// from outside — either needs a token or an authentication bypass.
+/// Answering from the database here is what keeps an authenticated `/readyz`
+/// from degenerating into a port check: the alternative — probing a data-plane
+/// RPC from outside — either needs a token or an authentication bypass.
 #[derive(Clone)]
 pub(super) struct EngineReadiness {
     probe: Arc<dyn Fn() -> ReadinessFuture + Send + Sync>,
     cached: Arc<Mutex<Option<(Instant, bool)>>>,
-    /// The resolution currently running, shared by everyone waiting on it.
+    /// The check currently running, shared by everyone waiting on it.
     ///
     /// The TTL alone bounds the steady-state rate but not concurrency: every
     /// caller arriving in the instant the cache expires would otherwise launch
-    /// its own resolution, letting unauthenticated health traffic fan out into
-    /// arbitrary engine work. Occupying this slot for the length of one probe is
-    /// what collapses that burst into a single catalog resolution.
+    /// its own check, letting unauthenticated health traffic fan out into
+    /// database work. Occupying this slot for the length of one probe is what
+    /// collapses that burst into a single round trip.
     in_flight: Arc<Mutex<Option<watch::Receiver<Option<bool>>>>>,
 }
 
@@ -91,49 +88,24 @@ impl EngineReadiness {
         }
     }
 
-    /// Reports readiness by resolving one existing workspace's catalog, the
-    /// same work the auth-disabled readiness probe drives through `ListCatalog`.
+    /// Reports readiness from one round trip to the database this server serves
+    /// out of.
     ///
-    /// The workspace comes from the instance's own listing rather than a
-    /// well-known name, because no workspace is provisioned any more: naming
-    /// one would resolve a workspace that does not exist, and the missing
-    /// workspace is classified as reachable, so the probe would answer ready
-    /// without ever reaching the engine it exists to ask about.
+    /// Every RPC worth routing here reads or writes that database, so a server
+    /// that cannot reach it can answer nothing and belongs out of rotation;
+    /// one that can reach it is as ready as an instance-wide probe can
+    /// establish.
     ///
-    /// Which one it picks does not matter — readiness is instance-wide, and
-    /// every workspace's catalog runs through the same engine — so it takes the
-    /// first listed and pays for one resolution rather than one per workspace.
-    pub(super) fn from_catalog_resolution(
-        queries: QueryManager,
-        workspaces: WorkspaceManager,
-    ) -> Self {
+    /// Readiness asks nothing about a workspace. Resolving a workspace's
+    /// catalog would report more, but what it reports is a property of that
+    /// workspace and the sources it names — which workspaces exist at all is a
+    /// tenancy question, and a source outside this deployment failing is not
+    /// this replica being unfit to serve. Neither is something a probe that
+    /// empties a fleet can act on.
+    pub(super) fn from_database(database: Arc<CoralDb>) -> Self {
         Self::new(Arc::new(move || {
-            let catalog = CatalogDiscovery::new(queries.clone());
-            let workspaces = workspaces.clone();
-            Box::pin(async move {
-                let listed = match workspaces.list_workspaces().await {
-                    Ok(listed) => listed,
-                    // Classified the same way a catalog rejection is, so a
-                    // store that cannot answer reports unready under one rule.
-                    Err(error) => {
-                        return readiness_from_catalog::<()>(Err(QueryManagerError::App(error)));
-                    }
-                };
-                let Some(workspace) = listed.first() else {
-                    // An instance that owns no workspace has no catalog to fail
-                    // on. A fresh install is waiting to be given one, not
-                    // broken, so it must not be held out of rotation.
-                    return true;
-                };
-                readiness_from_catalog(
-                    catalog
-                        // Neither the catalog nor the schema is filtered: the
-                        // probe asks the same unqualified question `ListCatalog`
-                        // does.
-                        .catalog_info(&workspace.name, None, None, &QueryAttribution::new(None))
-                        .await,
-                )
-            })
+            let database = Arc::clone(&database);
+            Box::pin(async move { database.ping().await.is_ok() })
         }))
     }
 
@@ -145,15 +117,15 @@ impl EngineReadiness {
     /// Reads the cached answer while it is fresh, else waits on one probe.
     ///
     /// Exactly one probe runs at a time and every caller arriving during it
-    /// shares that one answer, so a burst of health traffic resolves the catalog
-    /// once rather than once per request.
+    /// shares that one answer, so a burst of health traffic costs one database
+    /// round trip rather than one per request.
     ///
-    /// The deadline bounds this *answer*, not the resolution behind it. A
-    /// catalog that legitimately takes longer than one poll allows keeps
-    /// resolving after this returns unready and records what it finds, so the
-    /// next poll reports ready — whereas cancelling it would discard the work
-    /// and restart from nothing every time, and an engine slower than the
-    /// deadline could never report ready at all.
+    /// The deadline bounds this *answer*, not the check behind it. A database
+    /// that legitimately takes longer than one poll allows keeps answering
+    /// after this returns unready and records what it found, so the next poll
+    /// reports ready — whereas cancelling it would discard the work and restart
+    /// from nothing every time, and a database slower than the deadline could
+    /// never report ready at all.
     async fn is_ready(&self) -> bool {
         if let Some(ready) = self.fresh_answer() {
             return ready;
@@ -165,7 +137,7 @@ impl EngineReadiness {
                     return ready;
                 }
                 // The sender is dropped without a value only if the probe task
-                // panicked, which is not an engine that can answer.
+                // panicked, which is not a service that can answer.
                 if answer.changed().await.is_err() {
                     return false;
                 }
@@ -177,16 +149,16 @@ impl EngineReadiness {
     /// Subscribes to the running probe, starting one if none is running.
     ///
     /// The probe is spawned rather than awaited in place so that neither this
-    /// caller's deadline nor its disconnection can cancel a resolution already
-    /// under way: whoever asks next still gets the answer it paid for.
+    /// caller's deadline nor its disconnection can cancel a check already under
+    /// way: whoever asks next still gets the answer it paid for.
     ///
     /// Whether to probe is decided under the slot, cache included, because a
     /// caller reads the cache before it reaches this lock. A probe finishing in
     /// between records its answer and vacates the slot, so that caller arrives
     /// to an empty slot holding a fresh answer; without re-reading the cache
-    /// here it would resolve the catalog again anyway. Deciding under the lock
+    /// here it would check the database again anyway. Deciding under the lock
     /// is what keeps the TTL a bound on how often unauthenticated health
-    /// traffic can drive a resolution, rather than only on the steady state.
+    /// traffic can drive a check, rather than only on the steady state.
     fn in_flight_probe(&self) -> watch::Receiver<Option<bool>> {
         let Ok(mut slot) = self.in_flight.lock() else {
             // A poisoned slot costs single-flight, not correctness.
@@ -231,44 +203,6 @@ impl EngineReadiness {
     }
 }
 
-/// Turns one catalog resolution into a readiness answer.
-///
-/// A rejection is not automatically an unready instance. The auth-disabled
-/// `/readyz` classifies its own answer with `catalog_rejection_is_reachable` in
-/// coral-mcp's `http` module, which deliberately reads request-shaped codes — a
-/// workspace deleted between the listing and the resolution, two sources
-/// claiming one runtime schema — as proof the engine is reachable. Those faults
-/// are instance-wide and therefore identical on every replica, so calling them
-/// unready here would pull a whole fleet out of rotation for a condition the
-/// other surface reports as reachable.
-///
-/// The two surfaces no longer ask the same question, and `/readyz` is currently
-/// the weaker one. This probe resolves the first workspace the instance
-/// actually has; `/readyz` still names the literal `default`, which nothing
-/// provisions any more, so it reads `NotFound` — a code this predicate's
-/// counterpart treats as reachable — and answers ready even for an engine that
-/// cannot resolve a real catalog. Repairing that is owned by the local
-/// MCP-resolution work, which requires readiness to stop probing a default
-/// workspace. Until then, do not read a green `/readyz` as agreement with this
-/// function.
-fn readiness_from_catalog<T>(outcome: Result<T, QueryManagerError>) -> bool {
-    match outcome {
-        Ok(_) => true,
-        // Reuse the data plane's mapping so the code classified here is the
-        // same one `/readyz` would have seen over the wire.
-        Err(error) => !matches!(
-            query_status(error).code(),
-            tonic::Code::Cancelled
-                | tonic::Code::Unknown
-                | tonic::Code::DeadlineExceeded
-                | tonic::Code::Unimplemented
-                | tonic::Code::Internal
-                | tonic::Code::Unavailable
-                | tonic::Code::DataLoss
-        ),
-    }
-}
-
 pub(super) struct AggregateHealthService {
     readiness: EngineReadiness,
 }
@@ -301,7 +235,7 @@ impl Health for AggregateHealthService {
         request: tonic::Request<HealthCheckRequest>,
     ) -> Result<tonic::Response<HealthCheckResponse>, tonic::Status> {
         let status = match request.get_ref().service.as_str() {
-            // Process liveness: answered from a constant so a degraded engine
+            // Process liveness: answered from a constant so a degraded service
             // never tells a liveness prober to restart the process.
             "" => ServingStatus::Serving,
             READINESS_SERVICE_NAME if self.readiness.is_ready().await => ServingStatus::Serving,
@@ -336,27 +270,16 @@ mod tests {
     use tonic_health::pb::health_check_response::ServingStatus;
     use tonic_health::pb::health_server::Health as _;
 
-    use coral_engine::{CoreError, QueryRuntimeContext};
-
     use super::{
         AggregateHealthService, EngineReadiness, READINESS_PROBE_TIMEOUT, READINESS_SERVICE_NAME,
-        readiness_from_catalog,
     };
-    use crate::bootstrap::AppError;
-    use crate::credentials::{CredentialManager, CredentialStore};
-    use crate::query::manager::{QueryManager, QueryManagerError};
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, run_state_migrations,
-    };
-    use crate::state::{AppStateLayout, ConfigStore};
-    use crate::workspaces::{WorkspaceManager, WorkspaceName};
+    use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
 
-    /// One instance's own state, database and managers, with the readiness
-    /// probe the server mounts over them and no workspace until a test creates
-    /// one.
+    /// One instance's own migrated database, with the readiness probe the
+    /// server mounts over it.
     struct ReadinessFixture {
         _temp: TempDir,
-        layout: AppStateLayout,
         db: Arc<CoralDb>,
         readiness: EngineReadiness,
     }
@@ -366,7 +289,6 @@ mod tests {
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
         let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
         else {
             panic!("the default test database is sqlite")
@@ -377,71 +299,34 @@ mod tests {
                 .expect("open sqlite"),
         );
         db.migrate().await.expect("migrate sqlite");
-        run_state_migrations(&db, &config_store, &layout)
-            .await
-            .expect("run state migrations");
-        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
-        let workspaces = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credentials.clone(),
-            layout.clone(),
-            None,
-            Arc::clone(&db),
-        );
-        let queries = QueryManager::new_for_tests(
-            config_store,
-            workspaces.clone(),
-            credentials,
-            QueryRuntimeContext::default(),
-            layout.clone(),
-            Vec::new(),
-        );
         ReadinessFixture {
             _temp: temp,
-            readiness: EngineReadiness::from_catalog_resolution(queries, workspaces),
-            layout,
+            readiness: EngineReadiness::from_database(Arc::clone(&db)),
             db,
         }
     }
 
-    async fn create_workspace(db: &Arc<CoralDb>, name: &str) {
-        let workspace = WorkspaceName::parse(name).expect("workspace name");
-        let mut tx = db.begin().await.expect("begin workspace creation");
-        tx.workspaces()
-            .create(workspace.as_str(), 1)
-            .await
-            .expect("create workspace");
-        tx.commit().await.expect("commit workspace creation");
-    }
-
-    /// A fresh install owns no workspace, so the probe has no catalog to
-    /// resolve. Nothing about that is a fault, and reporting unready would
-    /// hold an instance out of rotation for having nothing in it yet.
+    /// A fresh install owns no workspace and no source. Readiness is a question
+    /// about this service, not about what has been put in it, so an empty
+    /// instance whose database answers is ready to serve.
     #[tokio::test]
-    async fn an_instance_that_owns_no_workspace_reports_ready() {
+    async fn an_instance_with_a_reachable_database_reports_ready() {
         let fixture = readiness_fixture().await;
 
         assert!(fixture.readiness.is_ready().await);
     }
 
-    /// The regression that makes this probe worth having: it must resolve a
-    /// catalog the instance actually owns. Naming a workspace instead would
-    /// resolve one no install provisions any more, and a missing workspace is
-    /// deliberately classified as reachable — so an engine that cannot read
-    /// its own state would still report ready.
-    ///
-    /// The unparseable config file is that engine: catalog resolution reads it
-    /// after the workspace check, and fails with an infrastructure code.
+    /// The fault this probe exists to report: every RPC worth routing here
+    /// reads or writes the database, so a server that cannot reach it can
+    /// answer nothing and must leave the rotation.
     #[tokio::test]
-    async fn an_engine_that_cannot_answer_for_a_real_workspace_reports_unready() {
+    async fn an_unreachable_database_reports_unready() {
         let fixture = readiness_fixture().await;
-        create_workspace(&fixture.db, "work").await;
-        std::fs::write(fixture.layout.config_file(), "this is not toml")
-            .expect("write unparseable config");
+        fixture.db.close_for_tests().await;
 
         assert!(
             !fixture.readiness.is_ready().await,
-            "a catalog the instance owns and cannot resolve is an unready engine"
+            "a server that cannot reach its database is not ready to serve"
         );
     }
 
@@ -455,18 +340,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn liveness_stays_serving_while_the_engine_is_unready() {
+    async fn liveness_stays_serving_while_the_service_is_unready() {
         for ready in [true, false] {
             assert_eq!(
                 check("", ready).await.expect("liveness check"),
                 ServingStatus::Serving as i32,
-                "liveness must not follow engine readiness"
+                "liveness must not follow service readiness"
             );
         }
     }
 
     #[tokio::test]
-    async fn the_readiness_service_reports_engine_readiness() {
+    async fn the_readiness_service_reports_service_readiness() {
         assert_eq!(
             check(READINESS_SERVICE_NAME, true)
                 .await
@@ -490,7 +375,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn readiness_probes_the_engine_once_within_the_cache_window() {
+    async fn readiness_probes_the_database_once_within_the_cache_window() {
         let calls = Arc::new(AtomicUsize::new(0));
         let counted = Arc::clone(&calls);
         let readiness = EngineReadiness::new(Arc::new(move || {
@@ -505,7 +390,7 @@ mod tests {
         assert_eq!(
             calls.load(Ordering::SeqCst),
             1,
-            "the unauthenticated readiness check must not resolve the catalog per request"
+            "the unauthenticated readiness check must not hit the database per request"
         );
     }
 
@@ -533,7 +418,7 @@ mod tests {
         assert_eq!(
             calls.load(Ordering::SeqCst),
             1,
-            "losing the race to a finished probe must not buy a second catalog resolution"
+            "losing the race to a finished probe must not buy a second database round trip"
         );
     }
 
@@ -563,7 +448,7 @@ mod tests {
         assert_eq!(
             calls.load(Ordering::SeqCst),
             1,
-            "concurrent public health traffic must not fan out into parallel engine work"
+            "concurrent public health traffic must not fan out into parallel database work"
         );
     }
 
@@ -572,7 +457,7 @@ mod tests {
     async fn a_wedged_probe_answers_unready_instead_of_hanging() {
         let calls = Arc::new(AtomicUsize::new(0));
         let counted = Arc::clone(&calls);
-        // Never resolves: the catalog resolution wedging is precisely the fault
+        // Never resolves: a database that never answers is precisely the fault
         // this service exists to report, so it must not also silence it.
         let readiness = EngineReadiness::new(Arc::new(move || {
             counted.fetch_add(1, Ordering::SeqCst);
@@ -588,16 +473,16 @@ mod tests {
         assert_eq!(
             calls.load(Ordering::SeqCst),
             1,
-            "a wedged probe still occupies the slot, so polling must not pile up resolutions"
+            "a wedged probe still occupies the slot, so polling must not pile up checks"
         );
     }
 
-    /// The regression that makes a deadline dangerous: cancelling the
-    /// resolution to answer on time would discard the work, so an engine slower
-    /// than the deadline would restart from nothing every poll and never report
-    /// ready. The answer is bounded; the resolution is not.
+    /// The regression that makes a deadline dangerous: cancelling the check to
+    /// answer on time would discard the work, so a database slower than the
+    /// deadline would restart from nothing every poll and never report ready.
+    /// The answer is bounded; the check is not.
     #[tokio::test(start_paused = true)]
-    async fn a_slow_engine_reports_ready_on_a_later_poll() {
+    async fn a_slow_database_reports_ready_on_a_later_poll() {
         let calls = Arc::new(AtomicUsize::new(0));
         let counted = Arc::clone(&calls);
         let slow = READINESS_PROBE_TIMEOUT + Duration::from_millis(200);
@@ -611,15 +496,15 @@ mod tests {
 
         assert!(
             !readiness.is_ready().await,
-            "the first poll gives up waiting before the catalog finishes"
+            "the first poll gives up waiting before the check finishes"
         );
 
-        // Let the resolution the first poll walked away from finish.
+        // Let the check the first poll walked away from finish.
         tokio::time::sleep(Duration::from_millis(400)).await;
 
         assert!(
             readiness.is_ready().await,
-            "the resolution must survive the deadline and record what it found"
+            "the check must survive the deadline and record what it found"
         );
         assert_eq!(
             calls.load(Ordering::SeqCst),
@@ -628,41 +513,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_resolved_catalog_reports_ready() {
-        assert!(readiness_from_catalog(Ok(())));
-    }
-
-    #[test]
-    fn instance_wide_catalog_rejections_still_report_ready() {
-        // Each of these is identical on every replica, so reporting unready
-        // would empty the fleet for a rejection the auth-disabled `/readyz`
-        // reports as reachable.
-        for error in [
-            AppError::WorkspaceNotFound("work".to_string()),
-            AppError::InvalidInput(
-                "catalog runtime schema 'public' is owned by both 'a' and 'b'".to_string(),
-            ),
-            AppError::FailedPrecondition("source 'a' is missing credentials".to_string()),
-        ] {
-            let described = error.to_string();
-            assert!(
-                readiness_from_catalog::<()>(Err(QueryManagerError::App(error))),
-                "request-shaped rejection must not report the instance unready: {described}"
-            );
-        }
-    }
-
-    #[test]
-    fn infrastructure_faults_report_unready() {
-        assert!(
-            !readiness_from_catalog::<()>(Err(QueryManagerError::App(AppError::Internal(
-                "config store lock poisoned".to_string()
-            )))),
-            "an engine that cannot answer at all is not ready"
-        );
-        assert!(!readiness_from_catalog::<()>(Err(QueryManagerError::Core(
-            CoreError::Unavailable("backend down".to_string())
-        ))),);
-    }
 }

--- a/crates/coral-app/src/bootstrap/health.rs
+++ b/crates/coral-app/src/bootstrap/health.rs
@@ -512,5 +512,4 @@ mod tests {
             "the second poll must read the first probe's answer, not start another"
         );
     }
-
 }

--- a/crates/coral-app/src/bootstrap/health.rs
+++ b/crates/coral-app/src/bootstrap/health.rs
@@ -24,7 +24,7 @@ use crate::catalog::discovery::CatalogDiscovery;
 use crate::query::QueryAttribution;
 use crate::query::manager::{QueryManager, QueryManagerError};
 use crate::transport::query_status;
-use crate::workspaces::WorkspaceName;
+use crate::workspaces::WorkspaceManager;
 
 /// Health service name reporting whether the engine can answer for its catalog.
 ///
@@ -91,23 +91,46 @@ impl EngineReadiness {
         }
     }
 
-    /// Reports readiness by resolving the default workspace's catalog, the same
-    /// work the auth-disabled readiness probe drives through `ListCatalog`.
-    pub(super) fn from_query_manager(queries: QueryManager) -> Self {
+    /// Reports readiness by resolving one existing workspace's catalog, the
+    /// same work the auth-disabled readiness probe drives through `ListCatalog`.
+    ///
+    /// The workspace comes from the instance's own listing rather than a
+    /// well-known name, because no workspace is provisioned any more: naming
+    /// one would resolve a workspace that does not exist, and the missing
+    /// workspace is classified as reachable, so the probe would answer ready
+    /// without ever reaching the engine it exists to ask about.
+    ///
+    /// Which one it picks does not matter — readiness is instance-wide, and
+    /// every workspace's catalog runs through the same engine — so it takes the
+    /// first listed and pays for one resolution rather than one per workspace.
+    pub(super) fn from_catalog_resolution(
+        queries: QueryManager,
+        workspaces: WorkspaceManager,
+    ) -> Self {
         Self::new(Arc::new(move || {
             let catalog = CatalogDiscovery::new(queries.clone());
+            let workspaces = workspaces.clone();
             Box::pin(async move {
+                let listed = match workspaces.list_workspaces().await {
+                    Ok(listed) => listed,
+                    // Classified the same way a catalog rejection is, so a
+                    // store that cannot answer reports unready under one rule.
+                    Err(error) => {
+                        return readiness_from_catalog::<()>(Err(QueryManagerError::App(error)));
+                    }
+                };
+                let Some(workspace) = listed.first() else {
+                    // An instance that owns no workspace has no catalog to fail
+                    // on. A fresh install is waiting to be given one, not
+                    // broken, so it must not be held out of rotation.
+                    return true;
+                };
                 readiness_from_catalog(
                     catalog
                         // Neither the catalog nor the schema is filtered: the
                         // probe asks the same unqualified question `ListCatalog`
                         // does.
-                        .catalog_info(
-                            &WorkspaceName::default(),
-                            None,
-                            None,
-                            &QueryAttribution::new(None),
-                        )
+                        .catalog_info(&workspace.name, None, None, &QueryAttribution::new(None))
                         .await,
                 )
             })
@@ -213,13 +236,13 @@ impl EngineReadiness {
 /// A rejection is not automatically an unready instance. The auth-disabled
 /// `/readyz` asks the identical question through `ListCatalog` and classifies
 /// the answer with `catalog_rejection_is_reachable` in coral-mcp's `http`
-/// module, which deliberately reads request-shaped codes — a missing default
-/// workspace, two sources claiming one runtime schema — as proof the engine is
-/// reachable. Those faults are instance-wide and therefore identical on every
-/// replica, so calling them unready here would pull a whole fleet out of
-/// rotation for a condition the other surface reports as reachable. The two
-/// predicates must
-/// stay in step: change one and change the other.
+/// module, which deliberately reads request-shaped codes — a workspace deleted
+/// between the listing and the resolution, two sources claiming one runtime
+/// schema — as proof the engine is reachable. Those faults are instance-wide
+/// and therefore identical on every replica, so calling them unready here would
+/// pull a whole fleet out of rotation for a condition the other surface reports
+/// as reachable. The two predicates must stay in step: change one and change
+/// the other.
 fn readiness_from_catalog<T>(outcome: Result<T, QueryManagerError>) -> bool {
     match outcome {
         Ok(_) => true,
@@ -300,18 +323,119 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use tempfile::TempDir;
     use tonic_health::pb::HealthCheckRequest;
     use tonic_health::pb::health_check_response::ServingStatus;
     use tonic_health::pb::health_server::Health as _;
 
-    use coral_engine::CoreError;
+    use coral_engine::{CoreError, QueryRuntimeContext};
 
     use super::{
         AggregateHealthService, EngineReadiness, READINESS_PROBE_TIMEOUT, READINESS_SERVICE_NAME,
         readiness_from_catalog,
     };
     use crate::bootstrap::AppError;
-    use crate::query::manager::QueryManagerError;
+    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::query::manager::{QueryManager, QueryManagerError};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, run_state_migrations,
+    };
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::{WorkspaceManager, WorkspaceName};
+
+    /// One instance's own state, database and managers, with the readiness
+    /// probe the server mounts over them and no workspace until a test creates
+    /// one.
+    struct ReadinessFixture {
+        _temp: TempDir,
+        layout: AppStateLayout,
+        db: Arc<CoralDb>,
+        readiness: EngineReadiness,
+    }
+
+    async fn readiness_fixture() -> ReadinessFixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("the default test database is sqlite")
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("run state migrations");
+        let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let workspaces = WorkspaceManager::new_for_tests(
+            config_store.clone(),
+            credentials.clone(),
+            layout.clone(),
+            None,
+            Arc::clone(&db),
+        );
+        let queries = QueryManager::new_for_tests(
+            config_store,
+            workspaces.clone(),
+            credentials,
+            QueryRuntimeContext::default(),
+            layout.clone(),
+            Vec::new(),
+        );
+        ReadinessFixture {
+            _temp: temp,
+            readiness: EngineReadiness::from_catalog_resolution(queries, workspaces),
+            layout,
+            db,
+        }
+    }
+
+    async fn create_workspace(db: &Arc<CoralDb>, name: &str) {
+        let workspace = WorkspaceName::parse(name).expect("workspace name");
+        let mut tx = db.begin().await.expect("begin workspace creation");
+        tx.workspaces()
+            .create(workspace.as_str(), 1)
+            .await
+            .expect("create workspace");
+        tx.commit().await.expect("commit workspace creation");
+    }
+
+    /// A fresh install owns no workspace, so the probe has no catalog to
+    /// resolve. Nothing about that is a fault, and reporting unready would
+    /// hold an instance out of rotation for having nothing in it yet.
+    #[tokio::test]
+    async fn an_instance_that_owns_no_workspace_reports_ready() {
+        let fixture = readiness_fixture().await;
+
+        assert!(fixture.readiness.is_ready().await);
+    }
+
+    /// The regression that makes this probe worth having: it must resolve a
+    /// catalog the instance actually owns. Naming a workspace instead would
+    /// resolve one no install provisions any more, and a missing workspace is
+    /// deliberately classified as reachable — so an engine that cannot read
+    /// its own state would still report ready.
+    ///
+    /// The unparseable config file is that engine: catalog resolution reads it
+    /// after the workspace check, and fails with an infrastructure code.
+    #[tokio::test]
+    async fn an_engine_that_cannot_answer_for_a_real_workspace_reports_unready() {
+        let fixture = readiness_fixture().await;
+        create_workspace(&fixture.db, "work").await;
+        std::fs::write(fixture.layout.config_file(), "this is not toml")
+            .expect("write unparseable config");
+
+        assert!(
+            !fixture.readiness.is_ready().await,
+            "a catalog the instance owns and cannot resolve is an unready engine"
+        );
+    }
 
     async fn check(service: &str, ready: bool) -> Result<i32, tonic::Status> {
         AggregateHealthService::new(EngineReadiness::fixed(ready))
@@ -507,7 +631,7 @@ mod tests {
         // would empty the fleet for a rejection the auth-disabled `/readyz`
         // reports as reachable.
         for error in [
-            AppError::WorkspaceNotFound("default".to_string()),
+            AppError::WorkspaceNotFound("work".to_string()),
             AppError::InvalidInput(
                 "catalog runtime schema 'public' is owned by both 'a' and 'b'".to_string(),
             ),

--- a/crates/coral-app/src/bootstrap/health.rs
+++ b/crates/coral-app/src/bootstrap/health.rs
@@ -234,15 +234,23 @@ impl EngineReadiness {
 /// Turns one catalog resolution into a readiness answer.
 ///
 /// A rejection is not automatically an unready instance. The auth-disabled
-/// `/readyz` asks the identical question through `ListCatalog` and classifies
-/// the answer with `catalog_rejection_is_reachable` in coral-mcp's `http`
-/// module, which deliberately reads request-shaped codes — a workspace deleted
-/// between the listing and the resolution, two sources claiming one runtime
-/// schema — as proof the engine is reachable. Those faults are instance-wide
-/// and therefore identical on every replica, so calling them unready here would
-/// pull a whole fleet out of rotation for a condition the other surface reports
-/// as reachable. The two predicates must stay in step: change one and change
-/// the other.
+/// `/readyz` classifies its own answer with `catalog_rejection_is_reachable` in
+/// coral-mcp's `http` module, which deliberately reads request-shaped codes — a
+/// workspace deleted between the listing and the resolution, two sources
+/// claiming one runtime schema — as proof the engine is reachable. Those faults
+/// are instance-wide and therefore identical on every replica, so calling them
+/// unready here would pull a whole fleet out of rotation for a condition the
+/// other surface reports as reachable.
+///
+/// The two surfaces no longer ask the same question, and `/readyz` is currently
+/// the weaker one. This probe resolves the first workspace the instance
+/// actually has; `/readyz` still names the literal `default`, which nothing
+/// provisions any more, so it reads `NotFound` — a code this predicate's
+/// counterpart treats as reachable — and answers ready even for an engine that
+/// cannot resolve a real catalog. Repairing that is owned by the local
+/// MCP-resolution work, which requires readiness to stop probing a default
+/// workspace. Until then, do not read a green `/readyz` as agreement with this
+/// function.
 fn readiness_from_catalog<T>(outcome: Result<T, QueryManagerError>) -> bool {
     match outcome {
         Ok(_) => true,

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -421,7 +421,7 @@ mod tests {
     ) -> McpQueryHistoryEntry {
         let table_source = sources.first().copied().unwrap_or("source");
         McpQueryHistoryEntry {
-            workspace_name: "default".to_string(),
+            workspace_name: "work".to_string(),
             sql: sql.to_string(),
             sources: sources.iter().map(|source| (*source).to_string()).collect(),
             tables: (0..table_count)

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -562,7 +562,7 @@ fn inaccessible_workspaces_warning(report: &InaccessibleWorkspaces) -> Option<St
     }
     (!categories.is_empty()).then(|| {
         format!(
-            "these workspaces are unreachable until an operator grants ownership - {}",
+            "no authenticated caller can manage these workspaces until an operator grants ownership - {}",
             categories.join("; ")
         )
     })

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -58,7 +58,10 @@ use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
-use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+use crate::state::db::{
+    CoralDb, DatabaseConfig, InaccessibleWorkspaces, ResolvedDatabaseConfig,
+    inaccessible_workspaces, migrate_local_ownership_once, run_state_migrations,
+};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
 use crate::task::service::TaskService;
@@ -383,6 +386,7 @@ impl ServerBuilder {
             bootstrap_database(&layout, &config_store, session_auth).await?;
         let (telemetry_config, active_trace_store) =
             init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
+        apply_local_principal_policy(&coral_db, local_principal).await?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
@@ -498,6 +502,70 @@ async fn bootstrap_database(
         .map(|session_auth| build_authorization_server(*session_auth, &coral_db))
         .transpose()?;
     Ok((coral_db, authorization_server))
+}
+
+/// Settles what this deployment's local-principal policy means for the
+/// durable ownership already on disk.
+///
+/// Placed after [`bootstrap_database`] because the workspaces it reasons about
+/// only exist once the schema migration and the legacy cutover have run, and
+/// after [`init_server_telemetry`] because the shared-deployment warning is
+/// only worth emitting into an installed subscriber.
+///
+/// A shared deployment keeps serving whatever it can: workspaces nobody can
+/// reach are an operator's job to fix, not a reason to deny every other
+/// workspace its server.
+async fn apply_local_principal_policy(
+    coral_db: &CoralDb,
+    local_principal: LocalPrincipalPolicy,
+) -> Result<(), AppError> {
+    match local_principal {
+        LocalPrincipalPolicy::ImplicitOwner => {
+            let report = migrate_local_ownership_once(coral_db).await?;
+            if report.performed {
+                tracing::info!(
+                    workspaces_claimed = report.workspaces_claimed,
+                    "gave the built-in local user ownership of this install's existing workspaces"
+                );
+            }
+        }
+        LocalPrincipalPolicy::NoLocalPrincipal => {
+            if let Some(warning) =
+                inaccessible_workspaces_warning(&inaccessible_workspaces(coral_db).await?)
+            {
+                tracing::warn!("{warning}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Describes, by category, the workspaces this deployment currently serves to
+/// nobody, or `None` when every workspace has a reachable owner.
+///
+/// The two categories need different operator actions - appoint an owner
+/// versus transfer ownership off the local principal - so a single warning
+/// names both rather than collapsing them into one count.
+fn inaccessible_workspaces_warning(report: &InaccessibleWorkspaces) -> Option<String> {
+    let mut categories = Vec::new();
+    if !report.without_owner.is_empty() {
+        categories.push(format!(
+            "with no owner at all: {}",
+            report.without_owner.join(", ")
+        ));
+    }
+    if !report.local_owner_only.is_empty() {
+        categories.push(format!(
+            "owned only by the built-in local user: {}",
+            report.local_owner_only.join(", ")
+        ));
+    }
+    (!categories.is_empty()).then(|| {
+        format!(
+            "these workspaces are unreachable until an operator grants ownership - {}",
+            categories.join("; ")
+        )
+    })
 }
 
 /// Prepares the one access decision every workspace-scoped service shares.
@@ -957,7 +1025,7 @@ mod tests {
 
     use super::{
         RunningServer, ServerBuilder, ServerDependencies, ServerMode, SessionAuthSettings,
-        TraceServerComponents, start_server,
+        TraceServerComponents, inaccessible_workspaces_warning, start_server,
     };
     use crate::auth::session::test_signing_key;
     use crate::bootstrap::AppError;
@@ -966,6 +1034,7 @@ mod tests {
     use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
     use crate::feedback::manager::FeedbackManager;
     use crate::gui_onboarding::manager::GuiOnboardingManager;
+    use crate::identity::LOCAL_PRINCIPAL_ID;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
     use crate::search::observed::{
@@ -974,7 +1043,8 @@ mod tests {
     };
     use crate::sources::manager::SourceManager;
     use crate::state::db::{
-        CoralDb, DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, run_state_migrations,
+        CoralDb, DatabaseConfig, DbRepos as _, InaccessibleWorkspaces,
+        LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, ResolvedDatabaseConfig, run_state_migrations,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
@@ -983,7 +1053,7 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::users::manager::UserManager;
     use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
-    use crate::workspaces::{WorkspaceManager, WorkspaceName};
+    use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
     use crate::{
         AwsEngineExtensionsProvider, LocalPrincipalProvider, NoopEngineExtensionsProvider,
         PrincipalKind,
@@ -1435,6 +1505,168 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             policy(with_session_auth.with_session_auth(session_auth)),
             LocalPrincipalPolicy::NoLocalPrincipal,
             "session authentication is an identity system the local principal bypasses"
+        );
+    }
+
+    /// Writes a legacy config whose only workspace exists in `config.toml`, so
+    /// the workspace under test comes into being during the very startup that
+    /// is supposed to give it an owner.
+    fn configure_legacy_workspace(config_dir: &Path) {
+        std::fs::create_dir_all(config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            r"
+version = 1
+
+[trace_history]
+enabled = false
+
+[workspaces.legacy]
+",
+        )
+        .expect("write legacy workspace config");
+    }
+
+    /// Adds a legacy workspace to a config another fixture already wrote.
+    fn append_legacy_workspace(config_dir: &Path) {
+        let path = config_dir.join("config.toml");
+        let mut config = std::fs::read_to_string(&path).expect("read config");
+        config.push_str("\n[workspaces.legacy]\n");
+        std::fs::write(&path, config).expect("append legacy workspace");
+    }
+
+    /// Opens the state a server just wrote, to read what its startup did.
+    async fn open_started_state(config_dir: &Path) -> CoralDb {
+        let layout = AppStateLayout::discover(Some(config_dir.to_path_buf())).expect("layout");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default test config should be sqlite");
+        };
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite")
+    }
+
+    async fn local_role_for(db: &CoralDb, workspace_id: &str) -> Option<MemberRole> {
+        let mut session = db;
+        session
+            .workspace_members()
+            .role_for_user_id(workspace_id, LOCAL_PRINCIPAL_ID)
+            .await
+            .expect("read the local principal's role")
+    }
+
+    async fn local_ownership_migrated(db: &CoralDb) -> bool {
+        let mut session = db;
+        session
+            .state_migrations()
+            .has_completed(LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID)
+            .await
+            .expect("read the migration marker")
+    }
+
+    /// The upgrade adopts the workspaces the legacy cutover imports, which it
+    /// can only do by running after it. Ordering them the other way round
+    /// leaves this install's one workspace ownerless forever, because the
+    /// marker retires the upgrade whether or not it found anything.
+    #[tokio::test]
+    async fn local_ownership_migration_adopts_the_workspaces_cutover_just_imported() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        configure_legacy_workspace(&config_dir);
+
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir.clone())
+            .start()
+            .await
+            .expect("start a deployment with no login configured");
+        server.shutdown().await.expect("shutdown gRPC server");
+
+        let db = open_started_state(&config_dir).await;
+        assert_eq!(
+            local_role_for(&db, "legacy").await,
+            Some(MemberRole::Owner),
+            "a workspace that only existed in config.toml must come out of startup owned"
+        );
+        assert!(local_ownership_migrated(&db).await);
+    }
+
+    /// A shared deployment leaves ownership entirely alone - it neither claims
+    /// the upgrade nor provisions the local user - and keeps serving, because
+    /// workspaces awaiting an owner are an operator's task rather than grounds
+    /// to deny every other workspace its server.
+    #[tokio::test]
+    async fn local_ownership_is_untouched_by_a_shared_deployment_that_still_serves() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        configure_serve_session_auth(&config_dir);
+        append_legacy_workspace(&config_dir);
+        let (builder, session_auth) = serve_session_auth(&config_dir);
+
+        let server = builder
+            .with_session_auth(session_auth)
+            .start()
+            .await
+            .expect("an ownerless workspace must not refuse a shared server its startup");
+        server.shutdown().await.expect("shutdown gRPC server");
+
+        let db = open_started_state(&config_dir).await;
+        assert!(
+            !local_ownership_migrated(&db).await,
+            "claiming the marker here would retire the upgrade for a later single-user start"
+        );
+        assert_eq!(local_role_for(&db, "legacy").await, None);
+        let mut session = &db;
+        assert!(
+            session
+                .users()
+                .get_by_user_id(LOCAL_PRINCIPAL_ID)
+                .await
+                .expect("read the local user")
+                .is_none(),
+            "a shared deployment must not even provision the local principal"
+        );
+    }
+
+    /// The one warning has to say which of the two operator situations each
+    /// workspace is in, and stay silent when there is nothing to fix.
+    #[test]
+    fn local_ownership_warning_reports_each_inaccessible_category_separately() {
+        assert_eq!(
+            inaccessible_workspaces_warning(&InaccessibleWorkspaces::default()),
+            None,
+            "a deployment every workspace of which has a reachable owner has nothing to say"
+        );
+
+        let both = inaccessible_workspaces_warning(&InaccessibleWorkspaces {
+            without_owner: vec!["orphan".to_string()],
+            local_owner_only: vec!["adopted".to_string()],
+        })
+        .expect("a warning covering both categories");
+        assert!(both.contains("with no owner at all: orphan"), "{both}");
+        assert!(
+            both.contains("owned only by the built-in local user: adopted"),
+            "{both}"
+        );
+
+        let ownerless_only = inaccessible_workspaces_warning(&InaccessibleWorkspaces {
+            without_owner: vec!["orphan".to_string()],
+            local_owner_only: Vec::new(),
+        })
+        .expect("a warning for the category that has workspaces");
+        assert!(
+            !ownerless_only.contains("built-in local user"),
+            "an empty category must not be named: {ownerless_only}"
+        );
+
+        let local_only = inaccessible_workspaces_warning(&InaccessibleWorkspaces {
+            without_owner: Vec::new(),
+            local_owner_only: vec!["adopted".to_string()],
+        })
+        .expect("a warning for the category that has workspaces");
+        assert!(
+            !local_only.contains("no owner at all"),
+            "an empty category must not be named: {local_only}"
         );
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1054,25 +1054,15 @@ mod tests {
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
     use crate::telemetry::{TraceManager, service::TraceService};
+    use crate::test_support::{create_workspace, test_workspace};
     use crate::transport::workspace_to_proto;
     use crate::users::manager::UserManager;
     use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
-    use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
+    use crate::workspaces::{MemberRole, WorkspaceManager};
     use crate::{
         AwsEngineExtensionsProvider, LocalPrincipalProvider, NoopEngineExtensionsProvider,
         PrincipalKind,
     };
-
-    /// The workspace these fixtures run in.
-    ///
-    /// An install provisions none, so every fixture that needs one creates it:
-    /// [`test_db`] for the in-process assemblies, [`create_test_workspace_in`] for
-    /// the ones that hand a config directory to `ServerBuilder`. The name is
-    /// ordinary on purpose — a fixture that leaned on a well-known one would
-    /// prove the workspace was resolved by name rather than created.
-    fn test_workspace() -> WorkspaceName {
-        WorkspaceName::parse("work").expect("workspace name")
-    }
 
     fn workspace() -> Workspace {
         workspace_to_proto(&test_workspace())
@@ -1145,13 +1135,9 @@ enabled = false
         run_state_migrations(&db, config_store, layout)
             .await
             .expect("run state migrations");
-        let mut tx = db.begin().await.expect("begin workspace creation");
-        tx.workspaces()
-            .create(test_workspace().as_str(), 1)
-            .await
-            .expect("create workspace");
-        tx.commit().await.expect("commit workspace creation");
-        Arc::new(db)
+        let db = Arc::new(db);
+        create_workspace(&db, &test_workspace()).await;
+        db
     }
 
     fn test_user_manager(db: &Arc<CoralDb>) -> UserManager {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -755,12 +755,12 @@ struct ServerDependencies {
     active_features: Features,
 }
 
-/// Builds the gRPC routes for every application service, and returns the query
-/// manager the health service reads readiness from.
+/// Builds the gRPC routes for every application service, and returns the probe
+/// the health service reads readiness from.
 fn application_routes(
     dependencies: ServerDependencies,
     trace_service: Option<TraceService>,
-) -> (Routes, QueryManager) {
+) -> (Routes, EngineReadiness) {
     let ServerDependencies {
         gui_onboarding,
         source,
@@ -782,7 +782,7 @@ fn application_routes(
         ),
         None => (source, query),
     };
-    let health_queries = query.clone();
+    let readiness = EngineReadiness::from_catalog_resolution(query.clone(), workspace.clone());
     let source_service = SourceService::new(
         source,
         query.clone(),
@@ -833,7 +833,7 @@ fn application_routes(
                 .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE),
         );
     }
-    (routes, health_queries)
+    (routes, readiness)
 }
 
 async fn start_server(
@@ -850,7 +850,7 @@ async fn start_server(
     // `RunningServer` owns both for shutdown; the routes only borrow them.
     let search = dependencies.search.clone();
     let search_observations = dependencies.search_observations.clone();
-    let (application_routes, health_queries) = application_routes(dependencies, trace_service);
+    let (application_routes, readiness) = application_routes(dependencies, trace_service);
     let routes = Routes::from(
         application_routes
             .into_axum_router()
@@ -859,7 +859,7 @@ async fn start_server(
     // Health must not depend on principal selection: it is the readiness signal
     // an orchestrator reaches without a credential.
     .add_service(tonic_health::pb::health_server::HealthServer::new(
-        AggregateHealthService::new(EngineReadiness::from_query_manager(health_queries)),
+        AggregateHealthService::new(readiness),
     ));
 
     let listener = match grpc_listener {
@@ -973,7 +973,9 @@ mod tests {
         SqliteObservedValuesStore,
     };
     use crate::sources::manager::SourceManager;
-    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, run_state_migrations,
+    };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
@@ -987,8 +989,33 @@ mod tests {
         PrincipalKind,
     };
 
-    fn default_workspace() -> Workspace {
-        workspace_to_proto(&WorkspaceName::default())
+    /// The workspace these fixtures run in.
+    ///
+    /// An install provisions none, so every fixture that needs one creates it:
+    /// [`test_db`] for the in-process assemblies, [`create_test_workspace_in`] for
+    /// the ones that hand a config directory to `ServerBuilder`. The name is
+    /// ordinary on purpose — a fixture that leaned on a well-known one would
+    /// prove the workspace was resolved by name rather than created.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("work").expect("workspace name")
+    }
+
+    fn workspace() -> Workspace {
+        workspace_to_proto(&test_workspace())
+    }
+
+    /// Creates the workspace a `ServerBuilder` fixture runs in, in the state
+    /// the server is about to open.
+    ///
+    /// It has to happen up front: the server owns its state once it is
+    /// serving, and the RPCs under test are the ones that need the workspace
+    /// to already be there. Call it after any config file the fixture writes,
+    /// because the state migrations read that config.
+    async fn create_test_workspace_in(config_dir: &Path) {
+        let layout = AppStateLayout::discover(Some(config_dir.to_path_buf())).expect("layout");
+        layout.ensure().expect("layout dirs");
+        let config_store = ConfigStore::new(layout.clone());
+        drop(test_db(&layout, &config_store).await);
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -1044,6 +1071,12 @@ enabled = false
         run_state_migrations(&db, config_store, layout)
             .await
             .expect("run state migrations");
+        let mut tx = db.begin().await.expect("begin workspace creation");
+        tx.workspaces()
+            .create(test_workspace().as_str(), 1)
+            .await
+            .expect("create workspace");
+        tx.commit().await.expect("commit workspace creation");
         Arc::new(db)
     }
 
@@ -1095,7 +1128,7 @@ enabled = false
             CatalogDiscovery::new(query_manager),
             lifecycle_lock,
         );
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let store = SqliteObservedValuesStore::new(layout.clone());
         let generation = store
             .capture_epoch(&workspace, "github")
@@ -1666,6 +1699,7 @@ backend = "unsupported"
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         disable_internal_tracing(&config_dir);
+        create_test_workspace_in(&config_dir).await;
         let server = ServerBuilder::new()
             .with_config_dir(config_dir)
             .start()
@@ -1680,7 +1714,7 @@ backend = "unsupported"
 
         let task = task_client
             .start_task(Request::new(StartTaskRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 intent: "find the HR onboarding form".to_string(),
             }))
             .await
@@ -1692,7 +1726,7 @@ backend = "unsupported"
 
         let task_end = task_client
             .end_task(Request::new(EndTaskRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 task_id: task.task_id.clone(),
                 task_status: TaskStatus::Success as i32,
             }))
@@ -1711,9 +1745,10 @@ backend = "unsupported"
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         configure_observed_values_search(&config_dir, true);
+        create_test_workspace_in(&config_dir).await;
         let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
         layout.ensure().expect("layout dirs");
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let store = SqliteObservedValuesStore::new(layout);
         let generation = store
             .capture_epoch(&workspace, "github")
@@ -1759,9 +1794,10 @@ backend = "unsupported"
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         disable_internal_tracing(&config_dir);
+        create_test_workspace_in(&config_dir).await;
         let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
         layout.ensure().expect("layout dirs");
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let store = SqliteObservedValuesStore::new(layout);
         let generation = store
             .capture_epoch(&workspace, "github")
@@ -1926,7 +1962,7 @@ backend = "unsupported"
 
         let status = SourceServiceClient::new(channel.clone())
             .list_sources(Request::new(ListSourcesRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
             }))
             .await
             .expect_err("request should be rejected");
@@ -2042,7 +2078,7 @@ backend = "unsupported"
 
         let mut import_stream = source_client
             .import_source(Request::new(ImportSourceRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 manifest_yaml: r#"
 name: tilde_demo
 version: 0.1.0
@@ -2082,7 +2118,7 @@ tables:
 
         let response = query_client
             .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 sql: "SELECT text FROM tilde_demo.messages ORDER BY text".to_string(),
                 guide_read_context: None,
                 task_attribution: None,
@@ -2178,7 +2214,7 @@ tables:
         let sql = "SELECT repeat('x', 5000000) AS pad";
         let response = query_client
             .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 sql: sql.to_string(),
                 guide_read_context: None,
                 task_attribution: None,
@@ -2310,7 +2346,7 @@ tables:
 
         let mut import_stream = source_client
             .import_source(Request::new(ImportSourceRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 manifest_yaml: manifest,
                 variables: Vec::new(),
                 secrets: Vec::new(),
@@ -2332,7 +2368,7 @@ tables:
 
         let status = query_client
             .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace()),
                 sql: "SELECT bogus_column FROM wide_demo.wide LIMIT 0".to_string(),
                 guide_read_context: None,
                 task_attribution: None,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -459,6 +459,7 @@ impl ServerBuilder {
         );
         let mut server = start_server(
             ServerDependencies {
+                database: Arc::clone(&coral_db),
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
                 source: source_manager,
                 workspace: workspace_manager,
@@ -807,6 +808,8 @@ struct TraceServerComponents {
 }
 
 struct ServerDependencies {
+    /// The app database, which the readiness probe answers out of.
+    database: Arc<CoralDb>,
     gui_onboarding: GuiOnboardingManager,
     source: SourceManager,
     workspace: WorkspaceManager,
@@ -830,6 +833,7 @@ fn application_routes(
     trace_service: Option<TraceService>,
 ) -> (Routes, EngineReadiness) {
     let ServerDependencies {
+        database,
         gui_onboarding,
         source,
         workspace,
@@ -850,7 +854,7 @@ fn application_routes(
         ),
         None => (source, query),
     };
-    let readiness = EngineReadiness::from_catalog_resolution(query.clone(), workspace.clone());
+    let readiness = EngineReadiness::from_database(database);
     let source_service = SourceService::new(
         source,
         query.clone(),
@@ -2119,6 +2123,7 @@ backend = "unsupported"
         );
         let server = start_server(
             ServerDependencies {
+                database: Arc::clone(&db),
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
@@ -2278,6 +2283,7 @@ backend = "unsupported"
         );
         let running = start_server(
             ServerDependencies {
+                database: Arc::clone(&db),
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
@@ -2412,6 +2418,7 @@ tables:
         );
         let running = start_server(
             ServerDependencies {
+                database: Arc::clone(&db),
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
@@ -2546,6 +2553,7 @@ tables:
         );
         let running = start_server(
             ServerDependencies {
+                database: Arc::clone(&db),
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -140,9 +140,9 @@ mod tests {
         tx.commit().await.expect("commit workspace creation");
         // The workspace needs an owner before any membership in it grants
         // anything, so one is seeded beside the member under test.
-        let _owner = seed_principal(&db, ISSUER, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&db, ISSUER, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&db, ISSUER, "outsider", None).await;
+        let _owner = seed_principal(&db, ISSUER, &WorkspaceName::default(), "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&db, ISSUER, &WorkspaceName::default(), "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&db, ISSUER, &WorkspaceName::default(), "outsider", None).await;
         let workspace = WorkspaceName::default();
         let service = FeedbackService::new(
             crate::feedback::manager::FeedbackManager::new(layout.clone()),

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -140,9 +140,24 @@ mod tests {
         tx.commit().await.expect("commit workspace creation");
         // The workspace needs an owner before any membership in it grants
         // anything, so one is seeded beside the member under test.
-        let _owner = seed_principal(&db, ISSUER, &WorkspaceName::default(), "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&db, ISSUER, &WorkspaceName::default(), "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&db, ISSUER, &WorkspaceName::default(), "outsider", None).await;
+        let _owner = seed_principal(
+            &db,
+            ISSUER,
+            &WorkspaceName::default(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
+        let member = seed_principal(
+            &db,
+            ISSUER,
+            &WorkspaceName::default(),
+            "member",
+            Some(MemberRole::Member),
+        )
+        .await;
+        let outsider =
+            seed_principal(&db, ISSUER, &WorkspaceName::default(), "outsider", None).await;
         let workspace = WorkspaceName::default();
         let service = FeedbackService::new(
             crate::feedback::manager::FeedbackManager::new(layout.clone()),

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -247,8 +247,10 @@ mod tests {
     use crate::request_context::RequestContext;
     use crate::state::ConfigStore;
     use crate::state::db::CoralDb;
-    use crate::test_support::{create_workspace, migrated_deployment, seed_principal};
-    use crate::workspaces::{MemberRole, WorkspaceName};
+    use crate::test_support::{
+        create_workspace, migrated_deployment, seed_principal, test_workspace,
+    };
+    use crate::workspaces::MemberRole;
 
     /// This suite's login issuer. Each suite provisions under its own, so a
     /// subject seeded here is a different person from the same subject
@@ -265,15 +267,6 @@ mod tests {
         service: FunctionService,
         config_store: ConfigStore,
         db: Arc<CoralDb>,
-    }
-
-    /// The workspace these fixtures run in.
-    ///
-    /// An install provisions none, so [`fixture`] creates it explicitly. The
-    /// name is ordinary on purpose: a fixture that leaned on a well-known one
-    /// would prove the workspace was resolved by name rather than created.
-    fn test_workspace() -> WorkspaceName {
-        WorkspaceName::parse("work").expect("workspace name")
     }
 
     /// A shared deployment over one migrated database holding one created

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -247,7 +247,7 @@ mod tests {
     use crate::request_context::RequestContext;
     use crate::state::ConfigStore;
     use crate::state::db::CoralDb;
-    use crate::test_support::{migrated_deployment, seed_principal};
+    use crate::test_support::{create_workspace, migrated_deployment, seed_principal};
     use crate::workspaces::{MemberRole, WorkspaceName};
 
     /// This suite's login issuer. Each suite provisions under its own, so a
@@ -267,10 +267,20 @@ mod tests {
         db: Arc<CoralDb>,
     }
 
-    /// A shared deployment over one migrated database holding the default
+    /// The workspace these fixtures run in.
+    ///
+    /// An install provisions none, so [`fixture`] creates it explicitly. The
+    /// name is ordinary on purpose: a fixture that leaned on a well-known one
+    /// would prove the workspace was resolved by name rather than created.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("work").expect("workspace name")
+    }
+
+    /// A shared deployment over one migrated database holding one created
     /// workspace, so every caller's authority comes from a membership row.
     async fn fixture() -> Fixture {
         let deployment = migrated_deployment().await;
+        create_workspace(&deployment.db, &test_workspace()).await;
         let queries = QueryManager::new_for_tests(
             deployment.config_store.clone(),
             deployment.workspaces,
@@ -298,13 +308,13 @@ mod tests {
         request
     }
 
-    fn default_workspace() -> coral_api::v1::Workspace {
-        crate::transport::workspace_to_proto(&WorkspaceName::default())
+    fn workspace() -> coral_api::v1::Workspace {
+        crate::transport::workspace_to_proto(&test_workspace())
     }
 
     fn add_request() -> AddFunctionRequest {
         AddFunctionRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace()),
             sql: UNPARSEABLE_SQL.to_string(),
             fail_if_exists: false,
             write_surface: ProtoFunctionWriteSurface::Cli as i32,
@@ -313,14 +323,14 @@ mod tests {
 
     fn delete_request() -> DeleteFunctionRequest {
         DeleteFunctionRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace()),
             name: "not a function name".to_string(),
         }
     }
 
     fn list_request() -> ListFunctionsRequest {
         ListFunctionsRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace()),
         }
     }
 
@@ -336,9 +346,9 @@ mod tests {
     #[tokio::test]
     async fn only_owners_change_the_function_set_and_never_through_an_agent() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, ISSUER, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, ISSUER, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, ISSUER, "outsider", None).await;
+        let owner = seed_principal(&fixture.db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
         let agent = Principal::parse(owner.id().as_str(), PrincipalKind::Agent).expect("agent");
 
         for reader in [&member, &agent] {
@@ -394,7 +404,7 @@ mod tests {
         assert!(
             fixture
                 .config_store
-                .list_workspace_functions(&WorkspaceName::default())
+                .list_workspace_functions(&test_workspace())
                 .expect("list installed functions")
                 .is_empty(),
             "no refused caller may have installed a function"
@@ -403,7 +413,7 @@ mod tests {
 
     #[test]
     fn invalid_function_listing_keeps_inventory_identity_and_error() {
-        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let workspace = test_workspace();
         let listing = FunctionListing {
             name: FunctionName::parse("review_queue").expect("function"),
             write_surface: FunctionWriteSurface::Unknown,

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -346,9 +346,24 @@ mod tests {
     #[tokio::test]
     async fn only_owners_change_the_function_set_and_never_through_an_agent() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
+        let owner = seed_principal(
+            &fixture.db,
+            ISSUER,
+            &test_workspace(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
+        let member = seed_principal(
+            &fixture.db,
+            ISSUER,
+            &test_workspace(),
+            "member",
+            Some(MemberRole::Member),
+        )
+        .await;
+        let outsider =
+            seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
         let agent = Principal::parse(owner.id().as_str(), PrincipalKind::Agent).expect("agent");
 
         for reader in [&member, &agent] {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1641,9 +1641,23 @@ mod tests {
         /// seeded elsewhere.
         const ISSUER: &str = "https://issuer.test/read-authorization";
 
-        let _owner = seed_principal(db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
+        let _owner = seed_principal(
+            db,
+            ISSUER,
+            &test_workspace(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
         ReadAccess {
-            member: seed_principal(db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await,
+            member: seed_principal(
+                db,
+                ISSUER,
+                &test_workspace(),
+                "member",
+                Some(MemberRole::Member),
+            )
+            .await,
             outsider: seed_principal(db, ISSUER, &test_workspace(), "outsider", None).await,
             authorizer: WorkspaceAuthorizer::new(Arc::clone(db)),
         }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1475,6 +1475,7 @@ mod tests {
     use crate::task::activity::TaskActivityRecorder;
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::test_support::{create_workspace, test_workspace};
     use crate::workspaces::authorization::WorkspaceAuthorizer;
 
     struct QueryManagerFixture {
@@ -1483,18 +1484,8 @@ mod tests {
         db: Arc<CoralDb>,
     }
 
-    /// The workspace these fixtures run in.
-    ///
-    /// An install provisions none, so every fixture that needs one creates it
-    /// through [`create_test_workspace`]. The name is ordinary on purpose: a
-    /// fixture that leaned on a well-known one would prove the workspace was
-    /// resolved by name rather than by having been created.
-    fn test_workspace() -> WorkspaceName {
-        WorkspaceName::parse("work").expect("workspace name")
-    }
-
     async fn create_test_workspace(db: &Arc<CoralDb>) {
-        crate::test_support::create_workspace(db, &test_workspace()).await;
+        create_workspace(db, &test_workspace()).await;
     }
 
     async fn query_manager_with(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1483,6 +1483,20 @@ mod tests {
         db: Arc<CoralDb>,
     }
 
+    /// The workspace these fixtures run in.
+    ///
+    /// An install provisions none, so every fixture that needs one creates it
+    /// through [`create_test_workspace`]. The name is ordinary on purpose: a
+    /// fixture that leaned on a well-known one would prove the workspace was
+    /// resolved by name rather than by having been created.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("work").expect("workspace name")
+    }
+
+    async fn create_test_workspace(db: &Arc<CoralDb>) {
+        crate::test_support::create_workspace(db, &test_workspace()).await;
+    }
+
     async fn query_manager_with(
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
@@ -1493,6 +1507,7 @@ mod tests {
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let db = test_db(&layout, &config_store).await;
+        create_test_workspace(&db).await;
         let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
@@ -1524,6 +1539,7 @@ mod tests {
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let db = test_db(&layout, &config_store).await;
+        create_test_workspace(&db).await;
         let credential_store = CredentialStore::with_unavailable_keychain_for_test(
             layout.clone(),
             CredentialStoragePreference::Keychain,
@@ -1588,7 +1604,7 @@ mod tests {
         let principal = Principal::local();
         let started = task
             .start_task(
-                WorkspaceName::default(),
+                test_workspace(),
                 principal.clone(),
                 "Exercise query attribution".to_string(),
             )
@@ -1606,16 +1622,16 @@ mod tests {
     }
 
     /// A shared deployment over the fixture's database, with one member of the
-    /// default workspace and one authenticated caller who is not.
+    /// fixture's workspace and one authenticated caller who is not.
     struct ReadAccess {
         authorizer: WorkspaceAuthorizer,
         member: Principal,
         outsider: Principal,
     }
 
-    /// Seeds the memberships that make `default` a workspace a member reaches
-    /// and an outsider does not. A separate owner is seeded because a workspace
-    /// with no owner conceals its own members too.
+    /// Seeds the memberships that make the fixture's workspace one a member
+    /// reaches and an outsider does not. A separate owner is seeded because a
+    /// workspace with no owner conceals its own members too.
     async fn read_access(db: &Arc<CoralDb>) -> ReadAccess {
         use crate::test_support::seed_principal;
         use crate::workspaces::MemberRole;
@@ -1625,10 +1641,10 @@ mod tests {
         /// seeded elsewhere.
         const ISSUER: &str = "https://issuer.test/read-authorization";
 
-        let _owner = seed_principal(db, ISSUER, "owner", Some(MemberRole::Owner)).await;
+        let _owner = seed_principal(db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
         ReadAccess {
-            member: seed_principal(db, ISSUER, "member", Some(MemberRole::Member)).await,
-            outsider: seed_principal(db, ISSUER, "outsider", None).await,
+            member: seed_principal(db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await,
+            outsider: seed_principal(db, ISSUER, &test_workspace(), "outsider", None).await,
             authorizer: WorkspaceAuthorizer::new(Arc::clone(db)),
         }
     }
@@ -1642,12 +1658,12 @@ mod tests {
             .count()
     }
 
-    /// The task ids the default workspace's recorded query activity carries.
+    /// The task ids the fixture workspace's recorded query activity carries.
     async fn recorded_task_ids(fixture: &QueryManagerFixture) -> Vec<String> {
         fixture
             .db
             .task_query_state()
-            .list_for_workspace(WorkspaceName::default().as_str())
+            .list_for_workspace(test_workspace().as_str())
             .await
             .expect("load task query activity")
             .into_iter()
@@ -1657,8 +1673,12 @@ mod tests {
 
     /// Replaces the workspace name the caller themselves asked about, so two
     /// answers about different names are still comparable.
+    ///
+    /// Only the quoted occurrence is replaced: a bare replacement would also
+    /// rewrite the name where it happens to sit inside another word, and turn
+    /// two identical messages into different ones.
     fn normalize(message: &str, name: &str) -> String {
-        message.replace(name, "<workspace>")
+        message.replace(&format!("'{name}'"), "'<workspace>'")
     }
 
     fn assert_workspace_not_found(error: AppError, workspace_name: &WorkspaceName) {
@@ -1732,7 +1752,7 @@ mod tests {
 
         let mut request = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
-                name: WorkspaceName::default().as_str().to_string(),
+                name: test_workspace().as_str().to_string(),
             }),
             sql: "SELECT 1".to_string(),
             guide_read_context: None,
@@ -1783,7 +1803,7 @@ mod tests {
         let service = QueryService::new(fixture.manager.clone(), tasks, local_authorizer(&fixture));
         let mut request = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
-                name: WorkspaceName::default().as_str().to_string(),
+                name: test_workspace().as_str().to_string(),
             }),
             sql: "SELECT 1".to_string(),
             guide_read_context: None,
@@ -1801,7 +1821,7 @@ mod tests {
         let recorded = fixture
             .db
             .task_query_state()
-            .list_for_workspace(WorkspaceName::default().as_str())
+            .list_for_workspace(test_workspace().as_str())
             .await
             .expect("load task query activity");
         let record = recorded.first().expect("recorded task query");
@@ -1866,7 +1886,7 @@ mod tests {
         };
 
         let concealed = queries
-            .execute_sql(denied_sql(WorkspaceName::default().as_str()))
+            .execute_sql(denied_sql(test_workspace().as_str()))
             .await
             .expect_err("a non-member reaches nothing");
         let missing = queries
@@ -1878,7 +1898,7 @@ mod tests {
         assert_eq!(concealed.code(), Code::NotFound);
         assert_eq!(concealed.code(), missing.code());
         assert_eq!(
-            normalize(concealed.message(), WorkspaceName::default().as_str()),
+            normalize(concealed.message(), test_workspace().as_str()),
             normalize(missing.message(), "absent"),
         );
         provider.force_flush().expect("flush spans");
@@ -1895,7 +1915,7 @@ mod tests {
         let member = RequestContext::new(access.member).with_task_id(task_context.task_id());
         let mut allowed = Request::new(ExecuteSqlRequest {
             workspace: Some(Workspace {
-                name: WorkspaceName::default().as_str().to_string(),
+                name: test_workspace().as_str().to_string(),
             }),
             sql: "SELECT 1".to_string(),
             guide_read_context: None,
@@ -1920,7 +1940,7 @@ mod tests {
     async fn execute_sql_records_success_and_error_task_activity() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (tasks, request_context, task_id) = active_task_context(&fixture.db).await;
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let attribution = QueryAttribution::new(
             tasks
                 .validate_attribution(&workspace, request_context.task_id())
@@ -1973,7 +1993,7 @@ mod tests {
     async fn successful_task_activity_records_resolved_relations() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (tasks, request_context, _) = active_task_context(&fixture.db).await;
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let attribution = QueryAttribution::new(
             tasks
                 .validate_attribution(&workspace, request_context.task_id())
@@ -2047,7 +2067,7 @@ mod tests {
     #[tokio::test]
     async fn task_activity_write_failure_does_not_change_the_sql_result() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let task_id = TaskId::parse(&uuid::Uuid::new_v4().to_string()).expect("task id");
         let attribution = QueryAttribution::new(Some(task_id))
             .with_tool_intent(Some("Exercise non-fatal activity writes"));
@@ -2065,7 +2085,7 @@ mod tests {
     async fn oversized_sql_executes_without_task_activity_record() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         let (tasks, request_context, _) = active_task_context(&fixture.db).await;
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let attribution = QueryAttribution::new(
             tasks
                 .validate_attribution(&workspace, request_context.task_id())
@@ -2111,7 +2131,7 @@ mod tests {
             .with(tracing_opentelemetry::layer().with_tracer(tracer));
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let mut operation = Box::pin(run_query_operation(
             QueryOperation::ListTables,
             &workspace,
@@ -2185,7 +2205,7 @@ mod tests {
 
         let span = create_query_span(
             QueryOperation::ExecuteSql,
-            &WorkspaceName::default(),
+            &test_workspace(),
             "SELECT title FROM github.issues",
             None,
         );
@@ -2313,7 +2333,7 @@ mod tests {
 
     fn default_workspace_proto() -> coral_api::v1::Workspace {
         coral_api::v1::Workspace {
-            name: WorkspaceName::default().as_str().to_string(),
+            name: test_workspace().as_str().to_string(),
         }
     }
 
@@ -2398,7 +2418,7 @@ mod tests {
 
         let runtime = fixture
             .manager
-            .runtime_config(&WorkspaceName::default(), &[], &AppConfig::default())
+            .runtime_config(&test_workspace(), &[], &AppConfig::default())
             .expect("runtime config");
 
         let config = runtime
@@ -2411,7 +2431,7 @@ mod tests {
     #[tokio::test]
     async fn metadata_runtime_config_skips_observed_values_publishers() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let manager =
             fixture
                 .manager
@@ -2439,7 +2459,7 @@ mod tests {
     #[tokio::test]
     async fn execution_runtime_config_attaches_observed_values_publishers() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let manager =
             fixture
                 .manager
@@ -2475,7 +2495,7 @@ mod tests {
             Vec::new(),
         )
         .await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let function_sql = r"/*
 name: demo_items
@@ -2528,7 +2548,7 @@ select text from function_demo.messages
     async fn load_query_source_passes_present_optional_secrets_to_runtime() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let source_name = SourceName::parse("optional_auth").expect("source name");
         let manifest_path = fixture
             .manager
@@ -2649,7 +2669,7 @@ tables:
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
         );
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let (tasks, request_context, _) = active_task_context(&fixture.db).await;
         let attribution = QueryAttribution::new(
             tasks
@@ -2779,7 +2799,7 @@ tables:
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
         );
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
         let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
         std::fs::write(
@@ -2913,7 +2933,7 @@ surface:
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
         );
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
         let openapi_file = descriptor_temp.path().join("identity-guard-openapi.yaml");
         std::fs::write(
@@ -3008,7 +3028,7 @@ surface:
             fixture.manager.credential_manager.clone(),
             fixture.manager.layout.clone(),
         );
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
         let openapi_file = descriptor_temp.path().join("widgets-openapi.yaml");
         std::fs::write(&openapi_file, widgets_pagination_openapi(&server.uri()))
@@ -3167,7 +3187,7 @@ paths:
             Vec::new(),
         )
         .await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let calls = Arc::new(AtomicUsize::new(0));
         let config_store = fixture.manager.config_store.clone();
@@ -3236,7 +3256,7 @@ select text from function_demo.messages
             Vec::new(),
         )
         .await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let function_sql = r"/*
 name: messages_by_type
@@ -3474,7 +3494,7 @@ tables:
     async fn load_query_sources_skips_missing_v4_materialization() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let source_name =
             install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
 
@@ -3502,7 +3522,7 @@ tables:
             Vec::new(),
         )
         .await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let failed_source =
             install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
@@ -3533,7 +3553,7 @@ tables:
             Vec::new(),
         )
         .await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
 
         let summary = fixture
@@ -3589,7 +3609,7 @@ tables:
             Vec::new(),
         )
         .await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let failed_source =
             install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path());
@@ -3619,7 +3639,7 @@ tables:
     #[tokio::test]
     async fn load_query_sources_skips_unavailable_keychain_source() {
         let fixture = query_manager_with_unavailable_keychain().await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
 
         let (source_load, _) = fixture
@@ -3637,7 +3657,7 @@ tables:
     #[tokio::test]
     async fn list_functions_keeps_unrelated_function_ready_when_source_preparation_fails() {
         let fixture = query_manager_with_unavailable_keychain().await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let function_sql = r"/*
 name: constant_value
 schema: functions
@@ -3730,7 +3750,7 @@ select 1 as value
             on_first_prepare: None,
         });
         let fixture = query_manager_with(QueryRuntimeContext::default(), vec![provider]).await;
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let function_sql = r"/*
 name: constant_value
 schema: functions
@@ -3808,7 +3828,7 @@ select 1 as value
     async fn runtime_input_resolver_uses_loaded_credential_snapshot() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = test_workspace();
         let source_name = SourceName::parse("secured_messages").expect("source name");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let installed_source = InstalledSource {
@@ -3907,7 +3927,7 @@ tables:
     async fn runtime_contract_fingerprint_ignores_refreshed_credential_material() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
-        let workspace = WorkspaceName::default();
+        let workspace = test_workspace();
         let source_name = SourceName::parse("secured_messages").expect("source name");
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let installed_source = InstalledSource {
@@ -4047,7 +4067,7 @@ tables:
         let runtime = fixture
             .manager
             .runtime_config(
-                &WorkspaceName::default(),
+                &test_workspace(),
                 std::slice::from_ref(&loaded_source),
                 &AppConfig::default(),
             )

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -692,9 +692,24 @@ mod tests {
     #[tokio::test]
     async fn members_search_while_only_owners_maintain_the_index() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
+        let owner = seed_principal(
+            &fixture.db,
+            ISSUER,
+            &test_workspace(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
+        let member = seed_principal(
+            &fixture.db,
+            ISSUER,
+            &test_workspace(),
+            "member",
+            Some(MemberRole::Member),
+        )
+        .await;
+        let outsider =
+            seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
 
         assert_eq!(
             fixture

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -575,9 +575,11 @@ mod tests {
     use crate::state::db::CoralDb;
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
-    use crate::test_support::{create_workspace, migrated_deployment, seed_principal};
+    use crate::test_support::{
+        create_workspace, migrated_deployment, seed_principal, test_workspace,
+    };
+    use crate::workspaces::MemberRole;
     use crate::workspaces::authorization::WorkspaceAuthorizer;
-    use crate::workspaces::{MemberRole, WorkspaceName};
 
     /// This suite's login issuer. Each suite provisions under its own, so a
     /// subject seeded here is a different person from the same subject
@@ -593,15 +595,6 @@ mod tests {
         _temp: TempDir,
         service: SearchService,
         db: Arc<CoralDb>,
-    }
-
-    /// The workspace these fixtures run in.
-    ///
-    /// An install provisions none, so [`fixture`] creates it explicitly. The
-    /// name is ordinary on purpose: a fixture that leaned on a well-known one
-    /// would prove the workspace was resolved by name rather than created.
-    fn test_workspace() -> WorkspaceName {
-        WorkspaceName::parse("work").expect("workspace name")
     }
 
     /// A shared deployment over one migrated database holding one created

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -575,7 +575,7 @@ mod tests {
     use crate::state::db::CoralDb;
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
-    use crate::test_support::{migrated_deployment, seed_principal};
+    use crate::test_support::{create_workspace, migrated_deployment, seed_principal};
     use crate::workspaces::authorization::WorkspaceAuthorizer;
     use crate::workspaces::{MemberRole, WorkspaceName};
 
@@ -595,10 +595,20 @@ mod tests {
         db: Arc<CoralDb>,
     }
 
-    /// A shared deployment over one migrated database holding the default
+    /// The workspace these fixtures run in.
+    ///
+    /// An install provisions none, so [`fixture`] creates it explicitly. The
+    /// name is ordinary on purpose: a fixture that leaned on a well-known one
+    /// would prove the workspace was resolved by name rather than created.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("work").expect("workspace name")
+    }
+
+    /// A shared deployment over one migrated database holding one created
     /// workspace, so every caller's authority comes from a membership row.
     async fn fixture() -> Fixture {
         let deployment = migrated_deployment().await;
+        create_workspace(&deployment.db, &test_workspace()).await;
         let (temp, layout, config_store, db, workspaces) = (
             deployment.temp,
             deployment.layout,
@@ -642,15 +652,15 @@ mod tests {
         request
     }
 
-    fn default_workspace() -> coral_api::v1::Workspace {
-        crate::transport::workspace_to_proto(&WorkspaceName::default())
+    fn workspace() -> coral_api::v1::Workspace {
+        crate::transport::workspace_to_proto(&test_workspace())
     }
 
     /// An empty query is what search preparation rejects, so it stands as the
     /// probe for whether preparation was reached at all.
     fn search_request() -> ProtoSearchRequest {
         ProtoSearchRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace()),
             query: String::new(),
             limit: 0,
         }
@@ -658,7 +668,7 @@ mod tests {
 
     fn rebuild_request() -> ProtoRebuildSearchIndexRequest {
         ProtoRebuildSearchIndexRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace()),
             provider: UNDECODABLE_PROVIDER,
             force: true,
         }
@@ -666,7 +676,7 @@ mod tests {
 
     fn clear_request() -> ProtoClearSearchDataRequest {
         ProtoClearSearchDataRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace()),
             scope: ProtoSearchDataScope::Unspecified as i32,
             target: None,
         }
@@ -682,9 +692,9 @@ mod tests {
     #[tokio::test]
     async fn members_search_while_only_owners_maintain_the_index() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, ISSUER, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, ISSUER, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, ISSUER, "outsider", None).await;
+        let owner = seed_principal(&fixture.db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
 
         assert_eq!(
             fixture
@@ -720,7 +730,7 @@ mod tests {
                 .service
                 .drain_search_queue(request(
                     ProtoDrainSearchQueueRequest {
-                        workspace: Some(default_workspace()),
+                        workspace: Some(workspace()),
                         budget_ms: 1,
                     },
                     &member,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -1149,9 +1149,24 @@ mod tests {
     #[tokio::test]
     async fn source_configuration_reaches_only_workspace_owners() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
+        let owner = seed_principal(
+            &fixture.db,
+            ISSUER,
+            &test_workspace(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
+        let member = seed_principal(
+            &fixture.db,
+            ISSUER,
+            &test_workspace(),
+            "member",
+            Some(MemberRole::Member),
+        )
+        .await;
+        let outsider =
+            seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
         std::fs::write(&fixture.config_file, UNPARSEABLE_CONFIG).expect("poison the app config");
 
         for status in every_source_rpc(&fixture.service, &member).await {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -867,7 +867,9 @@ mod tests {
     use super::*;
     use crate::identity::Principal;
     use crate::state::db::CoralDb;
-    use crate::test_support::{create_workspace, migrated_deployment, seed_principal};
+    use crate::test_support::{
+        create_workspace, migrated_deployment, seed_principal, test_workspace,
+    };
     use crate::workspaces::MemberRole;
     use coral_engine::QueryRuntimeContext;
     use coral_spec::{
@@ -899,15 +901,6 @@ mod tests {
         service: SourceService,
         db: Arc<CoralDb>,
         config_file: PathBuf,
-    }
-
-    /// The workspace these fixtures run in.
-    ///
-    /// An install provisions none, so [`fixture`] creates it explicitly. The
-    /// name is ordinary on purpose: a fixture that leaned on a well-known one
-    /// would prove the workspace was resolved by name rather than created.
-    fn test_workspace() -> WorkspaceName {
-        WorkspaceName::parse("work").expect("workspace name")
     }
 
     /// A shared deployment over one migrated database holding one created

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -867,7 +867,7 @@ mod tests {
     use super::*;
     use crate::identity::Principal;
     use crate::state::db::CoralDb;
-    use crate::test_support::{migrated_deployment, seed_principal};
+    use crate::test_support::{create_workspace, migrated_deployment, seed_principal};
     use crate::workspaces::MemberRole;
     use coral_engine::QueryRuntimeContext;
     use coral_spec::{
@@ -901,10 +901,20 @@ mod tests {
         config_file: PathBuf,
     }
 
-    /// A shared deployment over one migrated database holding the default
+    /// The workspace these fixtures run in.
+    ///
+    /// An install provisions none, so [`fixture`] creates it explicitly. The
+    /// name is ordinary on purpose: a fixture that leaned on a well-known one
+    /// would prove the workspace was resolved by name rather than created.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("work").expect("workspace name")
+    }
+
+    /// A shared deployment over one migrated database holding one created
     /// workspace, so every caller's authority comes from a membership row.
     async fn fixture() -> Fixture {
         let deployment = migrated_deployment().await;
+        create_workspace(&deployment.db, &test_workspace()).await;
         let (temp, layout, db, workspaces, credentials) = (
             deployment.temp,
             deployment.layout,
@@ -948,8 +958,8 @@ mod tests {
         request
     }
 
-    fn default_workspace() -> coral_api::v1::Workspace {
-        workspace_to_proto(&WorkspaceName::default())
+    fn workspace() -> coral_api::v1::Workspace {
+        workspace_to_proto(&test_workspace())
     }
 
     /// The OAuth half of a request, missing the method index the conversion
@@ -997,7 +1007,7 @@ mod tests {
                 service
                     .discover_sources(request(
                         DiscoverSourcesRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                         },
                         principal,
                     ))
@@ -1008,7 +1018,7 @@ mod tests {
                 service
                     .list_sources(request(
                         ListSourcesRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                         },
                         principal,
                     ))
@@ -1019,7 +1029,7 @@ mod tests {
                 service
                     .get_source(request(
                         GetSourceRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             name: ABSENT_SOURCE.to_string(),
                         },
                         principal,
@@ -1031,7 +1041,7 @@ mod tests {
                 service
                     .get_source_info(request(
                         GetSourceInfoRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             name: ABSENT_SOURCE.to_string(),
                         },
                         principal,
@@ -1049,7 +1059,7 @@ mod tests {
                 service
                     .create_bundled_source(request(
                         CreateBundledSourceRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             name: ABSENT_SOURCE.to_string(),
                             variables: Vec::new(),
                             secrets: Vec::new(),
@@ -1063,7 +1073,7 @@ mod tests {
                 service
                     .create_bundled_source_with_o_auth(request(
                         CreateBundledSourceWithOAuthRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             name: ABSENT_SOURCE.to_string(),
                             variables: Vec::new(),
                             secrets: Vec::new(),
@@ -1078,7 +1088,7 @@ mod tests {
                 service
                     .import_source(request(
                         ImportSourceRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             manifest_yaml: String::new(),
                             variables: Vec::new(),
                             secrets: Vec::new(),
@@ -1100,7 +1110,7 @@ mod tests {
                 service
                     .delete_source(request(
                         DeleteSourceRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             name: ABSENT_SOURCE.to_string(),
                         },
                         principal,
@@ -1112,7 +1122,7 @@ mod tests {
                 service
                     .validate_source(request(
                         ValidateSourceRequest {
-                            workspace: Some(default_workspace()),
+                            workspace: Some(workspace()),
                             name: ABSENT_SOURCE.to_string(),
                         },
                         principal,
@@ -1139,9 +1149,9 @@ mod tests {
     #[tokio::test]
     async fn source_configuration_reaches_only_workspace_owners() {
         let fixture = fixture().await;
-        let owner = seed_principal(&fixture.db, ISSUER, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&fixture.db, ISSUER, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&fixture.db, ISSUER, "outsider", None).await;
+        let owner = seed_principal(&fixture.db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&fixture.db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&fixture.db, ISSUER, &test_workspace(), "outsider", None).await;
         std::fs::write(&fixture.config_file, UNPARSEABLE_CONFIG).expect("poison the app config");
 
         for status in every_source_rpc(&fixture.service, &member).await {

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -505,6 +505,25 @@ fn write_config_document(layout: &AppStateLayout, doc: &DocumentMut) -> Result<(
     Ok(())
 }
 
+/// Everything one workspace deletion took out of `config.toml`.
+///
+/// Held rather than dropped because the removal is the deletion's one durable
+/// step before the database commit: the material it carries is what puts the
+/// file back when a later step fails.
+#[derive(Debug, Clone)]
+pub(crate) struct RemovedWorkspaceConfig {
+    deleted: DeletedWorkspace,
+    functions: Vec<InstalledFunction>,
+}
+
+impl RemovedWorkspaceConfig {
+    /// The workspace and its sources, as post-deletion artifact cleanup reads
+    /// them. Functions own no artifacts, so they stay behind the restore.
+    pub(crate) fn into_deleted_workspace(self) -> DeletedWorkspace {
+        self.deleted
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ConfigStore {
     layout: AppStateLayout,
@@ -617,10 +636,16 @@ impl ConfigStore {
         })
     }
 
+    /// Removes one workspace's entry, sources and functions from `config.toml`.
+    ///
+    /// What comes back carries everything the removal took away, so a caller
+    /// whose next step fails can hand it to
+    /// [`Self::restore_workspace_config_entries`] rather than leave the file
+    /// disagreeing with the catalog it accompanies.
     pub(crate) fn remove_workspace_config_entries(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Option<DeletedWorkspace>, AppError> {
+    ) -> Result<Option<RemovedWorkspaceConfig>, AppError> {
         self.update_config(|config| {
             let removed = config.workspaces.remove(workspace_name);
             if removed {
@@ -630,15 +655,46 @@ impl ConfigStore {
                     .map(BTreeMap::into_values)
                     .map(Iterator::collect)
                     .unwrap_or_default();
-                config.functions.remove_workspace(workspace_name);
-                return Ok(Some(DeletedWorkspace {
-                    workspace: WorkspaceRecord {
-                        name: workspace_name.clone(),
+                let functions = config
+                    .functions
+                    .remove_workspace(workspace_name)
+                    .map(BTreeMap::into_values)
+                    .map(Iterator::collect)
+                    .unwrap_or_default();
+                return Ok(Some(RemovedWorkspaceConfig {
+                    deleted: DeletedWorkspace {
+                        workspace: WorkspaceRecord {
+                            name: workspace_name.clone(),
+                        },
+                        sources,
                     },
-                    sources,
+                    functions,
                 }));
             }
             Ok(None)
+        })
+    }
+
+    /// Puts back everything [`Self::remove_workspace_config_entries`] removed.
+    ///
+    /// The removal is durable the moment it returns while the database
+    /// transaction it accompanies is not, so a deletion that fails to commit
+    /// needs a genuine inverse here — without one the workspace stays in the
+    /// catalog with its sources and functions gone from the file.
+    pub(crate) fn restore_workspace_config_entries(
+        &self,
+        removed: RemovedWorkspaceConfig,
+    ) -> Result<(), AppError> {
+        self.update_config(|config| {
+            let workspace_name = &removed.deleted.workspace.name;
+            config.workspaces.insert(workspace_name.clone());
+            for source in removed.deleted.sources {
+                config.catalog.upsert_source(workspace_name, source);
+            }
+            for function in removed.functions {
+                config.functions.upsert_function(workspace_name, function);
+            }
+            Ok(())
         })
     }
 
@@ -1590,10 +1646,11 @@ origin = "bundled"
             .upsert_function(&workspace_name, installed_function("review_queue"))
             .expect("upsert function");
 
-        let deleted = store
+        let removed = store
             .remove_workspace_config_entries(&workspace_name)
             .expect("remove workspace config entries")
             .expect("workspace config should be removed");
+        let deleted = removed.into_deleted_workspace();
 
         assert_eq!(deleted.workspace.name, workspace_name);
         assert_eq!(deleted.sources.len(), 1);
@@ -1615,6 +1672,64 @@ origin = "bundled"
         assert!(!rendered.contains("[workspaces.work.functions.review_queue]"));
     }
 
+    /// The removal is durable before the database commit it accompanies, so
+    /// its inverse has to put back every kind of entry it took — functions
+    /// included, which nothing later in the deletion reads and which a
+    /// restore built from the deleted workspace alone would drop.
+    #[test]
+    fn restoring_removed_workspace_config_entries_puts_every_entry_back() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+
+        store
+            .create_legacy_workspace_entry_for_tests(&workspace_name)
+            .expect("create legacy workspace entry");
+        store
+            .upsert_source(&workspace_name, installed_source("github"))
+            .expect("upsert source");
+        store
+            .upsert_function(&workspace_name, installed_function("review_queue"))
+            .expect("upsert function");
+        let removed = store
+            .remove_workspace_config_entries(&workspace_name)
+            .expect("remove workspace config entries")
+            .expect("workspace config should be removed");
+
+        store
+            .restore_workspace_config_entries(removed)
+            .expect("restore workspace config entries");
+
+        assert_eq!(
+            store
+                .load_config()
+                .expect("load config")
+                .legacy_workspace_records()
+                .into_iter()
+                .map(|workspace| workspace.name)
+                .collect::<Vec<_>>(),
+            vec![workspace_name.clone()]
+        );
+        assert_eq!(
+            store
+                .list_workspace_sources(&workspace_name)
+                .expect("list source definitions")
+                .into_iter()
+                .map(|source| source.name)
+                .collect::<Vec<_>>(),
+            vec![SourceName::parse("github").expect("source")]
+        );
+        assert_eq!(
+            store
+                .list_workspace_functions(&workspace_name)
+                .expect("list function definitions")
+                .into_iter()
+                .map(|function| function.name)
+                .collect::<Vec<_>>(),
+            vec![FunctionName::parse("review_queue").expect("function")]
+        );
+    }
+
     /// Removal reads the name as data. `default` and the `default-*` shapes
     /// were the ones a reserved-name rule used to protect, so they are the ones
     /// that prove no name is protected any more.
@@ -1634,12 +1749,15 @@ origin = "bundled"
                 .create_legacy_workspace_entry_for_tests(&workspace_name)
                 .expect("create legacy workspace entry");
 
-            let deleted = store
+            let removed = store
                 .remove_workspace_config_entries(&workspace_name)
                 .expect("remove workspace config entries")
                 .unwrap_or_else(|| panic!("'{name}' should be removable"));
 
-            assert_eq!(deleted.workspace.name, workspace_name);
+            assert_eq!(
+                removed.into_deleted_workspace().workspace.name,
+                workspace_name
+            );
             assert!(
                 store
                     .remove_workspace_config_entries(&workspace_name)

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -232,14 +232,13 @@ impl From<&InstalledSource> for PersistedInstalledSource {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// The legacy workspace inventory as `config.toml` recorded it.
+///
+/// A fresh catalog is empty. Nothing is provisioned here: every entry came from
+/// an explicit creation, so a config that names no workspace describes an
+/// install that has none.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct WorkspaceCatalog(BTreeSet<WorkspaceName>);
-
-impl Default for WorkspaceCatalog {
-    fn default() -> Self {
-        Self(BTreeSet::from([WorkspaceName::default()]))
-    }
-}
 
 impl WorkspaceCatalog {
     pub(crate) fn list(&self) -> Vec<WorkspaceRecord> {
@@ -623,11 +622,6 @@ impl ConfigStore {
         workspace_name: &WorkspaceName,
     ) -> Result<Option<DeletedWorkspace>, AppError> {
         self.update_config(|config| {
-            if workspace_name.is_default() {
-                return Err(AppError::FailedPrecondition(
-                    "default workspace cannot be removed".to_string(),
-                ));
-            }
             let removed = config.workspaces.remove(workspace_name);
             if removed {
                 let sources = config
@@ -1242,8 +1236,12 @@ mod tests {
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
 
-    fn default_workspace() -> WorkspaceName {
-        WorkspaceName::default()
+    /// One ordinary, explicitly named workspace.
+    ///
+    /// These tests seed the workspace they need rather than leaning on a name
+    /// the config once provisioned on its own.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("analytics").expect("workspace")
     }
 
     fn installed_source(name: &str) -> InstalledSource {
@@ -1306,9 +1304,48 @@ mod tests {
         assert_eq!(AppConfig::default().version, 1);
     }
 
+    /// A fresh install owns no workspace at all: the first one appears when
+    /// somebody creates it, and it belongs to whoever did.
+    #[test]
+    fn fresh_config_holds_no_workspaces() {
+        assert_eq!(AppConfig::default().legacy_workspace_records(), vec![]);
+
+        let raw = render_config(&PersistedAppConfig::from(&AppConfig::default()), None);
+        assert!(
+            !raw.contains("[workspaces."),
+            "rendered fresh config: {raw}"
+        );
+    }
+
+    /// Reading legacy state must report the workspaces it actually found. An
+    /// invented `default` row would hand a legacy install a workspace nobody
+    /// created and nobody owns.
+    #[test]
+    fn loading_a_config_without_a_default_table_invents_no_workspace() {
+        let raw = r"
+version = 1
+
+[workspaces.work]
+";
+
+        let config = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("workspace config should parse"),
+        )
+        .expect("config");
+
+        assert_eq!(
+            config
+                .legacy_workspace_records()
+                .into_iter()
+                .map(|workspace| workspace.name.as_str().to_string())
+                .collect::<Vec<_>>(),
+            vec!["work".to_string()]
+        );
+    }
+
     #[test]
     fn renders_sources_under_workspace_keyed_tables() {
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut catalog = SourceCatalog::default();
         catalog.upsert_source(&workspace_name, installed_source("github"));
         let config = AppConfig {
@@ -1320,18 +1357,19 @@ mod tests {
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
-        assert!(raw.contains("[workspaces.default.sources.github]"));
+        assert!(raw.contains("[workspaces.analytics.sources.github]"));
         assert!(raw.contains("variables = { GITHUB_API_BASE = \"https://api.github.com\" }"));
         assert!(raw.contains("secrets = [\"GITHUB_TOKEN\"]"));
         assert!(raw.contains("version = \"1.1.4\""));
         assert!(!raw.contains("[[sources]]"));
-        assert!(!raw.contains("workspace = { name = \"default\" }"));
+        assert!(!raw.contains("workspace = { name = \"analytics\" }"));
         assert!(!raw.contains("manifest_file"));
     }
 
     #[test]
     fn renders_empty_workspaces_as_explicit_tables() {
         let mut workspaces = WorkspaceCatalog::default();
+        workspaces.insert(test_workspace());
         workspaces.insert(WorkspaceName::parse("work").expect("workspace"));
         let config = AppConfig {
             version: 1,
@@ -1343,7 +1381,7 @@ mod tests {
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
 
-        assert!(raw.contains("[workspaces.default]"));
+        assert!(raw.contains("[workspaces.analytics]"));
         assert!(raw.contains("[workspaces.work]"));
     }
 
@@ -1352,7 +1390,7 @@ mod tests {
         let raw = r"
 version = 1
 
-[workspaces.default]
+[workspaces.analytics]
 
 [workspaces.work]
 ";
@@ -1367,12 +1405,12 @@ version = 1
             .map(|workspace| workspace.name.as_str().to_string())
             .collect::<Vec<_>>();
 
-        assert_eq!(names, vec!["default", "work"]);
+        assert_eq!(names, vec!["analytics", "work"]);
     }
 
     #[test]
     fn renders_functions_under_workspace_keyed_tables() {
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut functions = FunctionCatalog::default();
         functions.upsert_function(&workspace_name, installed_function("review_queue"));
         let config = AppConfig {
@@ -1385,7 +1423,7 @@ version = 1
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
 
-        assert!(raw.contains("[workspaces.default.functions.review_queue]"));
+        assert!(raw.contains("[workspaces.analytics.functions.review_queue]"));
         assert!(raw.contains("write_surface = \"unknown\""));
         assert!(!raw.contains("origin = \"user\""));
         assert!(!raw.contains("enabled = true"));
@@ -1396,11 +1434,11 @@ version = 1
         let existing = r#"
 version = 1
 
-[workspaces.default.functions.review_queue]
+[workspaces.analytics.functions.review_queue]
 origin = "user"
 enabled = true
 "#;
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut functions = FunctionCatalog::default();
         functions.upsert_function(&workspace_name, installed_function("review_queue"));
         let config = AppConfig {
@@ -1413,7 +1451,7 @@ enabled = true
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
 
-        assert!(raw.contains("[workspaces.default.functions.review_queue]"));
+        assert!(raw.contains("[workspaces.analytics.functions.review_queue]"));
         assert!(raw.contains("write_surface = \"unknown\""));
         assert!(!raw.contains("origin = \"user\""));
         assert!(!raw.contains("enabled = true"));
@@ -1421,7 +1459,7 @@ enabled = true
 
     #[test]
     fn omits_empty_versions_from_rendered_source_entries() {
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut source = installed_source("github");
         source.version = None;
         source.origin = SourceOrigin::Bundled;
@@ -1445,7 +1483,7 @@ enabled = true
         let raw = r#"
 version = 1
 
-[workspaces.default.sources.github]
+[workspaces.analytics.sources.github]
 version = "1.1.4"
 variables = { GITHUB_API_BASE = "https://api.github.com" }
 secrets = ["GITHUB_TOKEN"]
@@ -1456,7 +1494,7 @@ origin = "bundled"
             toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
         )
         .expect("config");
-        let sources = config.catalog.workspace_sources(&default_workspace());
+        let sources = config.catalog.workspace_sources(&test_workspace());
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].name.as_str(), "github");
         assert_eq!(sources[0].version.as_deref(), Some("1.1.4"));
@@ -1577,19 +1615,54 @@ origin = "bundled"
         assert!(!rendered.contains("[workspaces.work.functions.review_queue]"));
     }
 
+    /// Removal reads the name as data. `default` and the `default-*` shapes
+    /// were the ones a reserved-name rule used to protect, so they are the ones
+    /// that prove no name is protected any more.
+    #[test]
+    fn removing_workspace_config_entries_protects_no_name() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = ConfigStore::new(test_layout(&temp));
+
+        for name in [
+            "default".to_string(),
+            format!("default-{}", uuid::Uuid::new_v4()),
+            "default-team".to_string(),
+            "work".to_string(),
+        ] {
+            let workspace_name = WorkspaceName::parse(&name).expect("workspace");
+            store
+                .create_legacy_workspace_entry_for_tests(&workspace_name)
+                .expect("create legacy workspace entry");
+
+            let deleted = store
+                .remove_workspace_config_entries(&workspace_name)
+                .expect("remove workspace config entries")
+                .unwrap_or_else(|| panic!("'{name}' should be removable"));
+
+            assert_eq!(deleted.workspace.name, workspace_name);
+            assert!(
+                store
+                    .remove_workspace_config_entries(&workspace_name)
+                    .expect("remove an already removed workspace")
+                    .is_none(),
+                "'{name}' must report nothing left to remove the second time"
+            );
+        }
+    }
+
     #[test]
     fn loads_functions_from_workspace_keyed_tables() {
         let raw = r"
 version = 1
 
-	[workspaces.default.functions.review_queue]
+	[workspaces.analytics.functions.review_queue]
 	";
 
         let config = AppConfig::try_from(
             toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
         )
         .expect("config");
-        let functions = config.functions.workspace_functions(&default_workspace());
+        let functions = config.functions.workspace_functions(&test_workspace());
 
         assert_eq!(functions.len(), 1);
         assert_eq!(functions[0].name.as_str(), "review_queue");
@@ -1904,7 +1977,7 @@ max_concurrency = 0
 
     #[test]
     fn round_trips_source_credential_storage() {
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut source = installed_source("github");
         source.credential_storage = Some(CredentialStorageKind::Keychain);
         let mut catalog = SourceCatalog::default();
@@ -1933,7 +2006,7 @@ max_concurrency = 0
 
     #[test]
     fn round_trips_non_nil_source_credential_revision() {
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut source = installed_source("github");
         source.credential_revision = uuid::Uuid::parse_str("c59a9c41-0e51-45d4-bfb7-f05df71eed53")
             .expect("credential revision");
@@ -1966,9 +2039,9 @@ max_concurrency = 0
         let raw = r#"
 version = 1
 
-[workspaces.default]
+[workspaces.analytics]
 
-[workspaces.default.sources.github]
+[workspaces.analytics.sources.github]
 variables = {}
 secrets = ["GITHUB_TOKEN"]
 credential_storage = "file"
@@ -1978,14 +2051,14 @@ origin = "imported"
             toml::from_str::<PersistedAppConfig>(raw).expect("legacy config should parse"),
         )
         .expect("config");
-        let sources = loaded.catalog.workspace_sources(&default_workspace());
+        let sources = loaded.catalog.workspace_sources(&test_workspace());
 
         assert!(sources[0].credential_revision.is_nil());
     }
 
     #[test]
     fn catalog_upsert_replaces_existing_workspace_source_entry() {
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut catalog = SourceCatalog::default();
         catalog.upsert_source(&workspace_name, installed_source("github"));
 
@@ -2007,26 +2080,26 @@ origin = "imported"
 
     #[test]
     fn catalog_remove_drops_empty_workspace_bucket() {
-        let default_workspace = default_workspace();
+        let workspace_name = test_workspace();
         let other_workspace_name = WorkspaceName::parse("other").expect("workspace");
         let mut catalog = SourceCatalog::default();
-        catalog.upsert_source(&default_workspace, installed_source("github"));
+        catalog.upsert_source(&workspace_name, installed_source("github"));
         catalog.upsert_source(&other_workspace_name, installed_source("slack"));
 
         catalog.remove_source(
-            &default_workspace,
+            &workspace_name,
             &SourceName::parse("github").expect("source"),
         );
 
         assert!(
             catalog
                 .get_source(
-                    &default_workspace,
+                    &workspace_name,
                     &SourceName::parse("github").expect("source")
                 )
                 .is_none()
         );
-        assert!(catalog.workspace_sources(&default_workspace).is_empty());
+        assert!(catalog.workspace_sources(&workspace_name).is_empty());
         assert!(
             catalog
                 .get_source(
@@ -2061,14 +2134,14 @@ bind_addr = "127.0.0.1:14555"
 enabled = false
 max_bindings = 250
 
-	[workspaces.default.sources.github]
+	[workspaces.analytics.sources.github]
 version = "1.0.0"
 variables = {}
 secrets = []
 origin = "bundled"
 "#;
 
-        let workspace_name = default_workspace();
+        let workspace_name = test_workspace();
         let mut catalog = SourceCatalog::default();
         catalog.upsert_source(&workspace_name, installed_source("slack"));
         let config = AppConfig {
@@ -2133,10 +2206,10 @@ origin = "bundled"
         );
 
         // The newly added source must be present.
-        assert!(raw.contains("[workspaces.default.sources.slack]"));
+        assert!(raw.contains("[workspaces.analytics.sources.slack]"));
 
         // The old source that was not in the updated catalog must be gone.
-        assert!(!raw.contains("[workspaces.default.sources.github]"));
+        assert!(!raw.contains("[workspaces.analytics.sources.github]"));
     }
 
     #[test]
@@ -2157,7 +2230,7 @@ origin = "bundled"
         let invalid_source = r#"
 version = 1
 
-[workspaces.default.sources."bad\\source"]
+[workspaces.analytics.sources."bad\\source"]
 origin = "bundled"
 "#;
         let error = AppConfig::try_from(
@@ -2170,7 +2243,7 @@ origin = "bundled"
         let invalid_function = r#"
 version = 1
 
-	[workspaces.default.functions."bad\\function"]
+	[workspaces.analytics.functions."bad\\function"]
 	"#;
         let error = AppConfig::try_from(
             toml::from_str::<PersistedAppConfig>(invalid_function)

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -30,13 +30,7 @@ impl CoralDb {
         CoralTx::begin_read_snapshot(&self.backend).await
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Phase 1 keeps an explicit database health probe for the server diagnostics wired in a later stack PR."
-        )
-    )]
+    /// Reports whether the database still answers, for the readiness probe.
     pub(crate) async fn ping(&self) -> Result<(), DbError> {
         match &self.backend {
             CoralDbBackend::Sqlite(db) => {
@@ -47,6 +41,16 @@ impl CoralDb {
             }
         }
         Ok(())
+    }
+
+    /// Closes the pool, so a test can observe a database that stopped
+    /// answering without taking a real backend away.
+    #[cfg(test)]
+    pub(crate) async fn close_for_tests(&self) {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => db.pool.close().await,
+            CoralDbBackend::Postgres(db) => db.pool.close().await,
+        }
     }
 }
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -91,26 +91,27 @@ async fn cutover_legacy_workspace_catalog_at(
 /// from there. It does not fall back to a fixed `default`: a genuinely fresh
 /// install has no workspace directory and must cut over to no workspaces.
 ///
-/// Reading a directory as a live workspace is sound because deletion moves the
-/// directory out of the workspaces root before it commits anything, so this
-/// root holds live workspaces only. That holds for deletions this version
-/// performed. A directory an older Coral orphaned — it staged the deletion
-/// beside the live workspaces and failed to remove it, or failed to stage it
-/// at all after committing — carries no evidence of being deleted, and this
-/// scan does resurrect it. Nothing on disk can tell the two apart after the
-/// fact; the residue is bounded by installs that hit that failure before
-/// upgrading.
+/// Every entry here is read as a live workspace, and one class of them is
+/// not: a deletion stages the workspace directory into its own root, outside
+/// this one, but only after the deletion has committed, and staging that fails
+/// only warns. A directory such a deletion left behind — or an older Coral
+/// staged beside the live workspaces and failed to remove — carries no
+/// evidence that it was deleted, so this scan resurrects it. That window is
+/// deliberately open rather than closed: staging before the commit would shut
+/// it, at the price of a crash between the rename and the commit leaving a
+/// live workspace whose directory is already gone, which is worse than a
+/// directory that outlives its workspace. Nothing on disk can tell the two
+/// apart after the fact.
 ///
 /// Deliberately a fallback and not a union with the config's own names, which
 /// leaves one residual open. A config that named `analytics` and nothing else
 /// could still have had a live implicit workspace beside it, and that one is
 /// orphaned for good because the cutover marker never re-runs. Closing it by
-/// unioning would resurrect exactly the older-Coral orphans described above,
-/// and `cuts_over_legacy_workspaces_into_database` pins that a leftover
-/// directory must not come back beside a config that names workspaces. The
-/// exposed population is narrow: every config Coral itself persisted
-/// serializes its workspaces back, so only a hand-edited config reaches this
-/// shape.
+/// unioning would resurrect exactly the orphans described above, and
+/// `cuts_over_legacy_workspaces_into_database` pins that a leftover directory
+/// must not come back beside a config that names workspaces. The exposed
+/// population is narrow: every config Coral itself persisted serializes its
+/// workspaces back, so only a hand-edited config reaches this shape.
 fn implicitly_provisioned_workspaces(
     layout: &AppStateLayout,
 ) -> Result<Vec<WorkspaceRecord>, AppError> {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -4,7 +4,6 @@ use super::session::DbRepos;
 use super::{CoralDb, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
 use crate::state::{AppStateLayout, ConfigStore};
-use crate::storage::fs::is_deletion_backup;
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
@@ -92,17 +91,26 @@ async fn cutover_legacy_workspace_catalog_at(
 /// from there. It does not fall back to a fixed `default`: a genuinely fresh
 /// install has no workspace directory and must cut over to no workspaces.
 ///
+/// Reading a directory as a live workspace is sound because deletion moves the
+/// directory out of the workspaces root before it commits anything, so this
+/// root holds live workspaces only. That holds for deletions this version
+/// performed. A directory an older Coral orphaned — it staged the deletion
+/// beside the live workspaces and failed to remove it, or failed to stage it
+/// at all after committing — carries no evidence of being deleted, and this
+/// scan does resurrect it. Nothing on disk can tell the two apart after the
+/// fact; the residue is bounded by installs that hit that failure before
+/// upgrading.
+///
 /// Deliberately a fallback and not a union with the config's own names, which
 /// leaves one residual open. A config that named `analytics` and nothing else
 /// could still have had a live implicit workspace beside it, and that one is
 /// orphaned for good because the cutover marker never re-runs. Closing it by
-/// unioning is not safe from here: a directory alone cannot distinguish a
-/// workspace that was implicitly provisioned from one a user deleted, and
-/// `cuts_over_legacy_workspaces_into_database` pins that a leftover directory
-/// must not come back — resurrecting deleted content is the worse failure. Any
-/// real fix needs evidence a directory scan does not carry. The exposed
-/// population is narrow: every config Coral itself persisted serializes its
-/// workspaces back, so only a hand-edited config reaches this shape.
+/// unioning would resurrect exactly the older-Coral orphans described above,
+/// and `cuts_over_legacy_workspaces_into_database` pins that a leftover
+/// directory must not come back beside a config that names workspaces. The
+/// exposed population is narrow: every config Coral itself persisted
+/// serializes its workspaces back, so only a hand-edited config reaches this
+/// shape.
 fn implicitly_provisioned_workspaces(
     layout: &AppStateLayout,
 ) -> Result<Vec<WorkspaceRecord>, AppError> {
@@ -130,7 +138,6 @@ fn implicitly_provisioned_workspaces(
         let directory_name = entry.file_name();
         let Some(name) = directory_name
             .to_str()
-            .filter(|name| !is_deletion_backup(name))
             .and_then(|name| WorkspaceName::parse(name).ok())
         else {
             continue;
@@ -318,11 +325,12 @@ mod tests {
         layout.ensure().expect("ensure layout");
         // An install that has held a workspace and lost it looks the same as
         // one that never had one: an emptied root, and at most a directory a
-        // deletion staged aside and failed to remove.
-        std::fs::create_dir_all(layout.workspaces_root().join(format!(
+        // deletion staged aside — into its own root — and failed to remove.
+        std::fs::create_dir_all(layout.workspaces_root()).expect("create workspaces root");
+        std::fs::create_dir_all(layout.deleted_workspaces_root().join(format!(
             "default{DELETION_BACKUP_INFIX}{STAGED_DELETION_SUFFIX}"
         )))
-        .expect("create workspaces root");
+        .expect("stage a deletion that was never removed");
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
@@ -454,24 +462,25 @@ mod tests {
         assert_eq!(workspace_ids(&db).await, vec!["analytics".to_string()]);
     }
 
-    /// Workspace names may contain the infix a staged deletion is spelled with,
-    /// and one that does is an ordinary workspace: only the full staged shape
-    /// is excluded from the import.
+    /// A workspace name is free to look exactly like a staged deletion, so a
+    /// name can never say which of the two a directory is. Location can: the
+    /// live workspace stays in the workspaces root and the staged deletion
+    /// sits in its own, and only the former is imported.
     #[tokio::test]
-    async fn cutover_preserves_a_workspace_named_like_a_staged_deletion() {
+    async fn cutover_separates_a_staged_deletion_from_a_workspace_named_like_one() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
-        let named_like_a_backup = format!("analytics{DELETION_BACKUP_INFIX}archive");
+        let named_like_a_backup =
+            format!("analytics{DELETION_BACKUP_INFIX}{STAGED_DELETION_SUFFIX}");
         let implicit_workspace = WorkspaceName::parse(&named_like_a_backup).expect("workspace");
         std::fs::create_dir_all(layout.workspace_dir(&implicit_workspace))
             .expect("create the legacy workspace dir");
-        let staged = WorkspaceName::parse(&format!(
-            "analytics{DELETION_BACKUP_INFIX}{STAGED_DELETION_SUFFIX}"
-        ))
-        .expect("workspace");
-        std::fs::create_dir_all(layout.workspace_dir(&staged)).expect("stage a deletion beside it");
+        std::fs::create_dir_all(layout.deleted_workspaces_root().join(format!(
+            "work{DELETION_BACKUP_INFIX}{STAGED_DELETION_SUFFIX}"
+        )))
+        .expect("stage a deletion outside the workspaces root");
         let db = open_sqlite(&layout).await;
 
         cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -4,17 +4,10 @@ use super::session::DbRepos;
 use super::{CoralDb, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
 use crate::state::{AppStateLayout, ConfigStore};
+use crate::storage::fs::is_deletion_backup;
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
-
-/// Marks the directory a workspace deletion moved aside before removing it.
-///
-/// Deletion stages the workspace directory under this name and only then
-/// removes it, so a leftover is a workspace on its way out rather than one to
-/// carry into the database. It is spelled here because the cutover reads the
-/// directory layout a `DirectoryBackup` leaves behind, not the type itself.
-const DELETION_BACKUP_MARKER: &str = ".delete.rollback.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceCatalogCutoverReport {
@@ -128,7 +121,7 @@ fn implicitly_provisioned_workspaces(
         let directory_name = entry.file_name();
         let Some(name) = directory_name
             .to_str()
-            .filter(|name| !name.contains(DELETION_BACKUP_MARKER))
+            .filter(|name| !is_deletion_backup(name))
             .and_then(|name| WorkspaceName::parse(name).ok())
         else {
             continue;
@@ -194,6 +187,7 @@ mod tests {
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
     use crate::state::{AppStateLayout, ConfigStore};
+    use crate::storage::fs::DELETION_BACKUP_INFIX;
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
@@ -314,7 +308,7 @@ mod tests {
         std::fs::create_dir_all(
             layout
                 .workspaces_root()
-                .join("default.delete.rollback.7f1c5a4e"),
+                .join(format!("default{DELETION_BACKUP_INFIX}7f1c5a4e")),
         )
         .expect("create workspaces root");
         let config_store = ConfigStore::new(layout.clone());

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(
             report,
             WorkspaceCatalogCutoverReport {
-                workspace_count: 2,
+                workspace_count: 1,
                 cutover_performed: true
             }
         );
@@ -166,10 +166,8 @@ mod tests {
                 .into_iter()
                 .map(|workspace| workspace.id)
                 .collect::<Vec<_>>(),
-            vec![
-                "analytics".to_string(),
-                WorkspaceName::default().as_str().to_string(),
-            ]
+            vec!["analytics".to_string()],
+            "the cutover carries the legacy names across and invents none"
         );
         assert!(
             session
@@ -212,10 +210,7 @@ mod tests {
                 .into_iter()
                 .map(|workspace| workspace.id)
                 .collect::<Vec<_>>(),
-            vec![
-                "analytics".to_string(),
-                WorkspaceName::default().as_str().to_string(),
-            ]
+            vec!["analytics".to_string()]
         );
     }
 
@@ -239,9 +234,41 @@ mod tests {
         assert_eq!(
             report,
             WorkspaceCatalogCutoverReport {
-                workspace_count: 1,
+                workspace_count: 0,
                 cutover_performed: false
             }
+        );
+    }
+
+    /// A legacy config that never named a workspace describes an install with
+    /// none, so the cutover must not seed one on its way into the database.
+    #[tokio::test]
+    async fn cutover_without_legacy_workspaces_creates_none() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = open_sqlite(&layout).await;
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 0,
+                cutover_performed: true
+            }
+        );
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .list()
+                .await
+                .expect("list workspaces")
+                .is_empty()
         );
     }
 
@@ -256,12 +283,13 @@ mod tests {
         second_layout.ensure().expect("ensure second layout");
         let first_config_store = ConfigStore::new(first_layout.clone());
         let second_config_store = ConfigStore::new(second_layout.clone());
+        let legacy_workspace = WorkspaceName::parse("analytics").expect("workspace");
         let first_legacy_file = first_layout
-            .workspace_dir(&WorkspaceName::default())
+            .workspace_dir(&legacy_workspace)
             .join("tasks")
             .join("tasks.jsonl");
         let second_legacy_file = second_layout
-            .workspace_dir(&WorkspaceName::default())
+            .workspace_dir(&legacy_workspace)
             .join("tasks")
             .join("tasks.jsonl");
         for path in [&first_legacy_file, &second_legacy_file] {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -4,9 +4,17 @@ use super::session::DbRepos;
 use super::{CoralDb, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
 use crate::state::{AppStateLayout, ConfigStore};
-use crate::workspaces::WorkspaceRecord;
+use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
+
+/// Marks the directory a workspace deletion moved aside before removing it.
+///
+/// Deletion stages the workspace directory under this name and only then
+/// removes it, so a leftover is a workspace on its way out rather than one to
+/// carry into the database. It is spelled here because the cutover reads the
+/// directory layout a `DirectoryBackup` leaves behind, not the type itself.
+const DELETION_BACKUP_MARKER: &str = ".delete.rollback.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceCatalogCutoverReport {
@@ -19,7 +27,7 @@ pub(crate) async fn run_state_migrations(
     config_store: &ConfigStore,
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
-    cutover_legacy_workspace_catalog(db, config_store).await?;
+    cutover_legacy_workspace_catalog(db, config_store, layout).await?;
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
 }
@@ -36,13 +44,15 @@ fn remove_legacy_task_jsonl(
 async fn cutover_legacy_workspace_catalog(
     db: &CoralDb,
     config_store: &ConfigStore,
+    layout: &AppStateLayout,
 ) -> Result<WorkspaceCatalogCutoverReport, AppError> {
-    cutover_legacy_workspace_catalog_at(db, config_store, now_unix_nanos_i64()?).await
+    cutover_legacy_workspace_catalog_at(db, config_store, layout, now_unix_nanos_i64()?).await
 }
 
 async fn cutover_legacy_workspace_catalog_at(
     db: &CoralDb,
     config_store: &ConfigStore,
+    layout: &AppStateLayout,
     now_unix_nanos: i64,
 ) -> Result<WorkspaceCatalogCutoverReport, AppError> {
     let _state_lock = config_store.state_lock_exclusive()?;
@@ -60,9 +70,12 @@ async fn cutover_legacy_workspace_catalog_at(
         });
     }
 
-    let workspaces = config_store
+    let mut workspaces = config_store
         .load_config_unlocked()?
         .legacy_workspace_records();
+    if workspaces.is_empty() {
+        workspaces = implicitly_provisioned_workspaces(layout)?;
+    }
     let workspace_count = workspaces.len();
 
     tx.workspaces().delete_all().await?;
@@ -74,6 +87,44 @@ async fn cutover_legacy_workspace_catalog_at(
         workspace_count,
         cutover_performed: true,
     })
+}
+
+/// Lists the workspaces on-disk state proves an install had, for a legacy
+/// config that names none itself.
+///
+/// Workspaces were once implicit: the catalog seeded one, so a `config.toml`
+/// with no workspace tables still described an install that had a workspace,
+/// with sources, tasks, and search state under its directory. Nothing records
+/// that name any more except the directory itself, so the cutover reads it
+/// from there. It does not fall back to a fixed `default`: a genuinely fresh
+/// install has no workspace directory and must cut over to no workspaces.
+fn implicitly_provisioned_workspaces(
+    layout: &AppStateLayout,
+) -> Result<Vec<WorkspaceRecord>, AppError> {
+    let entries = match std::fs::read_dir(layout.workspaces_root()) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error.into()),
+    };
+
+    let mut workspaces = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let directory_name = entry.file_name();
+        let Some(name) = directory_name
+            .to_str()
+            .filter(|name| !name.contains(DELETION_BACKUP_MARKER))
+            .and_then(|name| WorkspaceName::parse(name).ok())
+        else {
+            continue;
+        };
+        workspaces.push(WorkspaceRecord { name });
+    }
+    workspaces.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(workspaces)
 }
 
 async fn import_legacy_workspaces<S>(
@@ -143,9 +194,14 @@ mod tests {
         config_store
             .create_legacy_workspace_entry_for_tests(&analytics_workspace)
             .expect("create legacy workspace entry");
+        // A config that names workspaces is authoritative, so a directory left
+        // behind by a deleted workspace must not come back beside them.
+        let deleted_workspace = WorkspaceName::parse("removed").expect("workspace");
+        std::fs::create_dir_all(layout.workspace_dir(&deleted_workspace))
+            .expect("create leftover workspace dir");
         let db = open_sqlite(&layout).await;
 
-        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
             .await
             .expect("cut over legacy workspace catalog");
 
@@ -156,19 +212,12 @@ mod tests {
                 cutover_performed: true
             }
         );
-        let mut session = &db;
         assert_eq!(
-            session
-                .workspaces()
-                .list()
-                .await
-                .expect("list workspaces")
-                .into_iter()
-                .map(|workspace| workspace.id)
-                .collect::<Vec<_>>(),
+            workspace_ids(&db).await,
             vec!["analytics".to_string()],
             "the cutover carries the legacy names across and invents none"
         );
+        let mut session = &db;
         assert!(
             session
                 .state_migrations()
@@ -196,7 +245,7 @@ mod tests {
             .expect("seed stale workspace");
         tx.commit().await.expect("commit stale seed tx");
 
-        cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
             .await
             .expect("cut over legacy workspace catalog");
 
@@ -222,12 +271,12 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
-        cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
             .await
             .expect("initial cutover");
         std::fs::write(layout.config_file(), "[[workspaces]\n").expect("corrupt config");
 
-        let report = cutover_legacy_workspace_catalog(&db, &config_store)
+        let report = cutover_legacy_workspace_catalog(&db, &config_store, &layout)
             .await
             .expect("marker should skip legacy config reload");
 
@@ -240,17 +289,26 @@ mod tests {
         );
     }
 
-    /// A legacy config that never named a workspace describes an install with
-    /// none, so the cutover must not seed one on its way into the database.
+    /// A fresh install names no workspace and holds none on disk, so the
+    /// cutover must not seed one on its way into the database.
     #[tokio::test]
     async fn cutover_without_legacy_workspaces_creates_none() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
+        // An install that has held a workspace and lost it looks the same as
+        // one that never had one: an emptied root, and at most a directory a
+        // deletion staged aside and failed to remove.
+        std::fs::create_dir_all(
+            layout
+                .workspaces_root()
+                .join("default.delete.rollback.7f1c5a4e"),
+        )
+        .expect("create workspaces root");
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
-        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
             .await
             .expect("cut over legacy workspace catalog");
 
@@ -270,6 +328,56 @@ mod tests {
                 .expect("list workspaces")
                 .is_empty()
         );
+    }
+
+    /// Workspaces were once implicit, so an older install can hold one whose
+    /// name only its directory records. The cutover happens once and marks
+    /// itself done, so a workspace it drops is orphaned for good: its name and
+    /// its contents have to come across.
+    #[tokio::test]
+    async fn cutover_preserves_an_implicitly_provisioned_legacy_workspace() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let implicit_workspace = WorkspaceName::parse("default").expect("workspace");
+        let installed_source = layout
+            .sources_root(&implicit_workspace)
+            .join("github")
+            .join("manifest.yaml");
+        std::fs::create_dir_all(installed_source.parent().expect("source dir"))
+            .expect("create legacy source dir");
+        std::fs::write(&installed_source, "name: github").expect("write legacy manifest");
+        let db = open_sqlite(&layout).await;
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 1,
+                cutover_performed: true
+            }
+        );
+        assert_eq!(workspace_ids(&db).await, vec!["default".to_string()]);
+        assert!(
+            installed_source.exists(),
+            "the preserved workspace keeps its contents"
+        );
+    }
+
+    async fn workspace_ids(db: &CoralDb) -> Vec<String> {
+        let mut session = db;
+        session
+            .workspaces()
+            .list()
+            .await
+            .expect("list workspaces")
+            .into_iter()
+            .map(|workspace| workspace.id)
+            .collect()
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -115,7 +115,10 @@ fn implicitly_provisioned_workspaces(
     let mut workspaces = Vec::new();
     for entry in entries {
         let entry = entry?;
-        if !entry.file_type()?.is_dir() {
+        // Metadata, not `file_type`: a workspace directory may be a symlink to
+        // another volume, and skipping it here would orphan it for good once
+        // the cutover marker commits.
+        if !std::fs::metadata(entry.path())?.is_dir() {
             continue;
         }
         let directory_name = entry.file_name();
@@ -372,6 +375,38 @@ mod tests {
             installed_source.exists(),
             "the preserved workspace keeps its contents"
         );
+    }
+
+    /// A workspace directory can be a symlink — relocated to another volume by
+    /// hand, say. The cutover runs once, so reading only the link itself and
+    /// not what it points at would orphan that workspace for good.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cutover_preserves_a_symlinked_legacy_workspace() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let implicit_workspace = WorkspaceName::parse("default").expect("workspace");
+        let relocated = temp.path().join("other-volume").join("default");
+        std::fs::create_dir_all(&relocated).expect("create relocated workspace dir");
+        std::fs::create_dir_all(layout.workspaces_root()).expect("create workspaces root");
+        std::os::unix::fs::symlink(&relocated, layout.workspace_dir(&implicit_workspace))
+            .expect("link the relocated workspace into place");
+        let db = open_sqlite(&layout).await;
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 1,
+                cutover_performed: true
+            }
+        );
+        assert_eq!(workspace_ids(&db).await, vec!["default".to_string()]);
     }
 
     async fn workspace_ids(db: &CoralDb) -> Vec<String> {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -193,6 +193,11 @@ mod tests {
     use crate::storage::fs::DELETION_BACKUP_INFIX;
     use crate::workspaces::WorkspaceName;
 
+    /// The unique suffix a staged deletion carries, fixed so the directories
+    /// these tests plant read exactly as `move_for_delete` would have written
+    /// them.
+    const STAGED_DELETION_SUFFIX: &str = "7f1c5a4e-1d29-4f3a-9f2b-2c6d0f9a1b34";
+
     #[tokio::test]
     async fn cuts_over_legacy_workspaces_into_database() {
         let temp = tempdir().expect("temp dir");
@@ -308,11 +313,9 @@ mod tests {
         // An install that has held a workspace and lost it looks the same as
         // one that never had one: an emptied root, and at most a directory a
         // deletion staged aside and failed to remove.
-        std::fs::create_dir_all(
-            layout
-                .workspaces_root()
-                .join(format!("default{DELETION_BACKUP_INFIX}7f1c5a4e")),
-        )
+        std::fs::create_dir_all(layout.workspaces_root().join(format!(
+            "default{DELETION_BACKUP_INFIX}{STAGED_DELETION_SUFFIX}"
+        )))
         .expect("create workspaces root");
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
@@ -407,6 +410,33 @@ mod tests {
             }
         );
         assert_eq!(workspace_ids(&db).await, vec!["default".to_string()]);
+    }
+
+    /// Workspace names may contain the infix a staged deletion is spelled with,
+    /// and one that does is an ordinary workspace: only the full staged shape
+    /// is excluded from the import.
+    #[tokio::test]
+    async fn cutover_preserves_a_workspace_named_like_a_staged_deletion() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let named_like_a_backup = format!("analytics{DELETION_BACKUP_INFIX}archive");
+        let implicit_workspace = WorkspaceName::parse(&named_like_a_backup).expect("workspace");
+        std::fs::create_dir_all(layout.workspace_dir(&implicit_workspace))
+            .expect("create the legacy workspace dir");
+        let staged = WorkspaceName::parse(&format!(
+            "analytics{DELETION_BACKUP_INFIX}{STAGED_DELETION_SUFFIX}"
+        ))
+        .expect("workspace");
+        std::fs::create_dir_all(layout.workspace_dir(&staged)).expect("stage a deletion beside it");
+        let db = open_sqlite(&layout).await;
+
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        assert_eq!(workspace_ids(&db).await, vec![named_like_a_backup]);
     }
 
     async fn workspace_ids(db: &CoralDb) -> Vec<String> {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -117,9 +117,15 @@ fn implicitly_provisioned_workspaces(
         let entry = entry?;
         // Metadata, not `file_type`: a workspace directory may be a symlink to
         // another volume, and skipping it here would orphan it for good once
-        // the cutover marker commits.
-        if !std::fs::metadata(entry.path())?.is_dir() {
-            continue;
+        // the cutover marker commits. Following the link means a dangling one
+        // reports `NotFound`, which is this scan's answer for "not a workspace
+        // directory" rather than a reason to fail startup; every other io error
+        // still surfaces.
+        match std::fs::metadata(entry.path()) {
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
         }
         let directory_name = entry.file_name();
         let Some(name) = directory_name
@@ -410,6 +416,42 @@ mod tests {
             }
         );
         assert_eq!(workspace_ids(&db).await, vec!["default".to_string()]);
+    }
+
+    /// Following the link is what carries a relocated workspace across, and a
+    /// link whose target is gone is the cost of that. It names no workspace, so
+    /// the cutover skips it — refusing to start over a broken link would strand
+    /// the whole install.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cutover_skips_a_dangling_workspace_symlink() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let live_workspace = WorkspaceName::parse("analytics").expect("workspace");
+        let dangling_workspace = WorkspaceName::parse("relocated").expect("workspace");
+        std::fs::create_dir_all(layout.workspace_dir(&live_workspace))
+            .expect("create the live workspace dir");
+        std::os::unix::fs::symlink(
+            temp.path().join("other-volume").join("relocated"),
+            layout.workspace_dir(&dangling_workspace),
+        )
+        .expect("link a workspace that is no longer there");
+        let db = open_sqlite(&layout).await;
+
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        assert_eq!(
+            report,
+            WorkspaceCatalogCutoverReport {
+                workspace_count: 1,
+                cutover_performed: true
+            }
+        );
+        assert_eq!(workspace_ids(&db).await, vec!["analytics".to_string()]);
     }
 
     /// Workspace names may contain the infix a staged deletion is spelled with,

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -98,6 +98,18 @@ async fn cutover_legacy_workspace_catalog_at(
 /// that name any more except the directory itself, so the cutover reads it
 /// from there. It does not fall back to a fixed `default`: a genuinely fresh
 /// install has no workspace directory and must cut over to no workspaces.
+///
+/// Deliberately a fallback and not a union with the config's own names, which
+/// leaves one residual open. A config that named `analytics` and nothing else
+/// could still have had a live implicit workspace beside it, and that one is
+/// orphaned for good because the cutover marker never re-runs. Closing it by
+/// unioning is not safe from here: a directory alone cannot distinguish a
+/// workspace that was implicitly provisioned from one a user deleted, and
+/// `cuts_over_legacy_workspaces_into_database` pins that a leftover directory
+/// must not come back — resurrecting deleted content is the worse failure. Any
+/// real fix needs evidence a directory scan does not carry. The exposed
+/// population is narrow: every config Coral itself persisted serializes its
+/// workspaces back, so only a hand-edited config reaches this shape.
 fn implicitly_provisioned_workspaces(
     layout: &AppStateLayout,
 ) -> Result<Vec<WorkspaceRecord>, AppError> {

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -42,5 +42,6 @@ pub(crate) use task_state::{TaskCreation, TaskCreationResult};
 pub(crate) use transaction::CoralTx;
 pub(crate) use user_state::{LoginIdentity, LoginProvisioning};
 pub(crate) use workspace_state::{
-    AddMemberOutcome, CreateWorkspaceOutcome, RemoveMemberOutcome, WorkspaceMemberRecord,
+    AddMemberOutcome, CreateWorkspaceOutcome, RemoveMemberOutcome, WorkspaceDeletion,
+    WorkspaceMemberRecord,
 };

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -23,11 +23,15 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
+pub(crate) use ownership_bootstrap::{inaccessible_workspaces, migrate_local_ownership_once};
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
     IdentitySpecScope,
 };
+#[cfg(test)]
+pub(crate) use repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
+pub(crate) use repositories::workspaces::InaccessibleWorkspaces;
 pub(crate) use session::{DbRepos, DbSession};
 #[cfg(test)]
 pub(crate) use task_query_state::TaskQueryRelationRecord;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -7,6 +7,7 @@ mod coral_db;
 mod error;
 mod import;
 mod migrations;
+mod ownership_bootstrap;
 mod repositories;
 mod schema;
 mod session;

--- a/crates/coral-app/src/state/db/ownership_bootstrap.rs
+++ b/crates/coral-app/src/state/db/ownership_bootstrap.rs
@@ -1,0 +1,418 @@
+//! The one-time upgrade that gives legacy ownerless workspaces a local owner.
+
+use super::repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
+use super::session::DbRepos;
+use super::{CoralDb, CoralTx, now_unix_nanos_i64};
+use crate::bootstrap::AppError;
+use crate::identity::LOCAL_PRINCIPAL_ID;
+
+/// What one attempt at the local ownership migration did.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the single-user composition root logs this after the deployment policy lands"
+    )
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LocalOwnershipMigrationReport {
+    /// Whether this process was the one that claimed and ran the migration.
+    pub(crate) performed: bool,
+    /// How many workspaces this run gave the local principal ownership of.
+    pub(crate) workspaces_claimed: usize,
+}
+
+/// Gives the built-in local user ownership of every legacy ownerless
+/// workspace, exactly once for the lifetime of a state directory.
+///
+/// Only single-user deployments may call this: a shared deployment leaves its
+/// legacy workspaces ownerless and concealed until an operator appoints real
+/// owners. Every write lands in one transaction with the migration marker, so
+/// a failed upgrade leaves no half-migrated state and the next start retries
+/// the whole thing. Workspaces that already have an owner are untouched, and
+/// nothing here creates, renames, or deletes a workspace.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the single-user composition root runs this after the deployment policy lands"
+    )
+)]
+pub(crate) async fn migrate_local_ownership_once(
+    db: &CoralDb,
+) -> Result<LocalOwnershipMigrationReport, AppError> {
+    migrate_local_ownership_once_at(db, now_unix_nanos_i64()?).await
+}
+
+async fn migrate_local_ownership_once_at(
+    db: &CoralDb,
+    now_unix_nanos: i64,
+) -> Result<LocalOwnershipMigrationReport, AppError> {
+    let mut tx = db.begin().await?;
+    if !tx
+        .state_migrations()
+        .try_claim(LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, now_unix_nanos)
+        .await?
+    {
+        tx.rollback().await?;
+        return Ok(LocalOwnershipMigrationReport {
+            performed: false,
+            workspaces_claimed: 0,
+        });
+    }
+
+    match claim_ownerless_workspaces(&mut tx, now_unix_nanos).await {
+        Ok(workspaces_claimed) => {
+            tx.commit().await?;
+            Ok(LocalOwnershipMigrationReport {
+                performed: true,
+                workspaces_claimed,
+            })
+        }
+        Err(error) => {
+            tx.rollback().await?;
+            Err(error)
+        }
+    }
+}
+
+/// Holds each workspace in turn and gives the local principal the ones that
+/// still have no owner, reporting how many it wrote.
+///
+/// A workspace that disappears between the listing and its hold is skipped:
+/// it no longer exists to be given an owner.
+async fn claim_ownerless_workspaces(
+    tx: &mut CoralTx<'_>,
+    now_unix_nanos: i64,
+) -> Result<usize, AppError> {
+    tx.users().ensure_local(now_unix_nanos).await?;
+
+    let workspaces = tx.workspaces().list().await?;
+    let mut workspaces_claimed = 0;
+    for workspace in workspaces {
+        if tx
+            .workspaces()
+            .hold_for_child_mutation(&workspace.id)
+            .await?
+            && tx
+                .workspace_members()
+                .claim_ownership_if_unowned(&workspace.id, LOCAL_PRINCIPAL_ID, now_unix_nanos)
+                .await?
+        {
+            workspaces_claimed += 1;
+        }
+    }
+    Ok(workspaces_claimed)
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_query::{Expr, ExprTrait, Query};
+    use tempfile::{TempDir, tempdir};
+
+    use super::{
+        LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, LocalOwnershipMigrationReport,
+        migrate_local_ownership_once, migrate_local_ownership_once_at,
+    };
+    use crate::identity::LOCAL_PRINCIPAL_ID;
+    use crate::state::db::repositories::users::{UpsertLoginOutcome, UserRecord};
+    use crate::state::db::schema::Users;
+    use crate::state::db::{CoralDb, DbRepos, DbSession, ResolvedDatabaseConfig};
+    use crate::workspaces::MemberRole;
+
+    /// The upgrade gives the local principal every ownerless workspace, leaves
+    /// an already-owned one alone, and never runs a second time.
+    #[tokio::test]
+    async fn migrates_every_ownerless_workspace_exactly_once() {
+        let (db, _temp) = open_sqlite().await;
+        let human = seed_user(&db, "human").await;
+        seed_workspaces(&db, &["unowned", "local_member", "owned"]).await;
+        // An older single-user install could already hold a plain local
+        // membership, which the upgrade has to promote rather than duplicate.
+        seed_local_user(&db).await;
+        grant(
+            &db,
+            "local_member",
+            LOCAL_PRINCIPAL_ID,
+            MemberRole::Member,
+            30,
+        )
+        .await;
+        grant(&db, "owned", &human, MemberRole::Owner, 40).await;
+
+        let report = migrate_local_ownership_once(&db)
+            .await
+            .expect("migrate local ownership");
+
+        assert_eq!(
+            report,
+            LocalOwnershipMigrationReport {
+                performed: true,
+                workspaces_claimed: 2,
+            }
+        );
+        assert_eq!(
+            role_for(&db, "unowned", LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner)
+        );
+        assert_eq!(
+            role_for(&db, "local_member", LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner),
+            "an existing local member is promoted rather than duplicated"
+        );
+        assert_eq!(
+            role_for(&db, "owned", LOCAL_PRINCIPAL_ID).await,
+            None,
+            "an already-owned workspace must be left completely untouched"
+        );
+        assert_eq!(
+            role_for(&db, "owned", &human).await,
+            Some(MemberRole::Owner)
+        );
+        assert!(marker_completed(&db).await);
+
+        // A workspace that loses its owner after the upgrade stays ownerless:
+        // the marker retires the migration for good.
+        revoke(&db, "unowned", LOCAL_PRINCIPAL_ID).await;
+        let second = migrate_local_ownership_once(&db)
+            .await
+            .expect("re-run the completed migration");
+
+        assert_eq!(
+            second,
+            LocalOwnershipMigrationReport {
+                performed: false,
+                workspaces_claimed: 0,
+            }
+        );
+        assert_eq!(role_for(&db, "unowned", LOCAL_PRINCIPAL_ID).await, None);
+    }
+
+    /// A marker another process committed stops this one before it scans, so a
+    /// workspace it would otherwise have claimed is left exactly as it was.
+    #[tokio::test]
+    async fn a_completed_marker_skips_workspace_scanning() {
+        let (db, _temp) = open_sqlite().await;
+        seed_workspaces(&db, &["unowned"]).await;
+        let mut tx = db.begin().await.expect("begin foreign claim");
+        assert!(
+            tx.state_migrations()
+                .try_claim(LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID, 5)
+                .await
+                .expect("claim the migration elsewhere")
+        );
+        tx.commit().await.expect("commit foreign claim");
+
+        let report = migrate_local_ownership_once_at(&db, 70)
+            .await
+            .expect("skip the completed migration");
+
+        assert_eq!(
+            report,
+            LocalOwnershipMigrationReport {
+                performed: false,
+                workspaces_claimed: 0,
+            }
+        );
+        assert_eq!(role_for(&db, "unowned", LOCAL_PRINCIPAL_ID).await, None);
+        let mut session = &db;
+        assert!(
+            session
+                .users()
+                .get_by_user_id(LOCAL_PRINCIPAL_ID)
+                .await
+                .expect("read the local user")
+                .is_none(),
+            "a skipped migration writes nothing at all"
+        );
+    }
+
+    /// A fresh single-user install has no workspaces. The upgrade still records
+    /// itself and the local user, and must not invent a workspace to own.
+    #[tokio::test]
+    async fn fresh_state_records_the_marker_and_local_user_without_a_workspace() {
+        let (db, _temp) = open_sqlite().await;
+
+        let report = migrate_local_ownership_once_at(&db, 70)
+            .await
+            .expect("migrate empty state");
+
+        assert_eq!(
+            report,
+            LocalOwnershipMigrationReport {
+                performed: true,
+                workspaces_claimed: 0,
+            }
+        );
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .list()
+                .await
+                .expect("list workspaces")
+                .is_empty(),
+            "the upgrade must not create a workspace"
+        );
+        let local_user = local_user(&db).await;
+        assert_eq!(local_user.user_id, LOCAL_PRINCIPAL_ID);
+        assert_eq!(local_user.created_at_unix_nanos, 70);
+        assert!(marker_completed(&db).await);
+    }
+
+    /// A row squatting on the local user's unique empty subject makes
+    /// `ensure_local` a no-op, so the membership insert fails its user foreign
+    /// key after the upgrade has already claimed its marker. That claim must
+    /// not survive, or no later start could ever retry the upgrade. The
+    /// repository contract covers the sibling direction — an ownership row
+    /// that was written before a rollback disappears with it.
+    #[tokio::test]
+    async fn a_failure_part_way_through_rolls_back_every_write_and_retries_later() {
+        let (db, _temp) = open_sqlite().await;
+        seed_workspaces(&db, &["first", "second"]).await;
+        // A verified identity always carries a non-empty `sub`, so only a
+        // corrupted directory can hold the local user's empty subject.
+        let squatter = seed_user(&db, "").await;
+
+        let error = migrate_local_ownership_once_at(&db, 70)
+            .await
+            .expect_err("the membership insert must fail its user foreign key");
+
+        assert!(
+            error.to_string().contains("FOREIGN KEY constraint failed"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !marker_completed(&db).await,
+            "a failed upgrade must leave no marker behind, so a later start retries"
+        );
+        for workspace_id in ["first", "second"] {
+            assert_eq!(
+                role_for(&db, workspace_id, LOCAL_PRINCIPAL_ID).await,
+                None,
+                "{workspace_id} kept an ownership write from a rolled-back upgrade"
+            );
+        }
+
+        remove_user(&db, &squatter).await;
+        let retry = migrate_local_ownership_once_at(&db, 80)
+            .await
+            .expect("retry the upgrade");
+
+        assert_eq!(
+            retry,
+            LocalOwnershipMigrationReport {
+                performed: true,
+                workspaces_claimed: 2,
+            }
+        );
+        assert_eq!(
+            role_for(&db, "first", LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner)
+        );
+        assert_eq!(
+            role_for(&db, "second", LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner)
+        );
+    }
+
+    async fn seed_workspaces(db: &CoralDb, workspace_ids: &[&str]) {
+        let mut tx = db.begin().await.expect("begin workspace seed");
+        for workspace_id in workspace_ids {
+            tx.workspaces()
+                .create(workspace_id, 1)
+                .await
+                .expect("create legacy workspace");
+        }
+        tx.commit().await.expect("commit workspace seed");
+    }
+
+    async fn seed_local_user(db: &CoralDb) {
+        let mut tx = db.begin().await.expect("begin local user seed");
+        tx.users().ensure_local(5).await.expect("ensure local user");
+        tx.commit().await.expect("commit local user seed");
+    }
+
+    async fn seed_user(db: &CoralDb, subject: &str) -> String {
+        let mut session = db;
+        match session
+            .users()
+            .upsert_login("https://issuer.test/members", subject, None, 1)
+            .await
+            .expect("provision user")
+        {
+            UpsertLoginOutcome::Upserted(user) => user.user_id,
+            UpsertLoginOutcome::IssuerMismatch { stored_issuer } => {
+                panic!("expected a provisioned user, got a mismatch with issuer {stored_issuer}")
+            }
+        }
+    }
+
+    async fn remove_user(db: &CoralDb, user_id: &str) {
+        let mut session = db;
+        let statement = Query::delete()
+            .from_table(Users::Table)
+            .and_where(Expr::col(Users::UserId).eq(user_id))
+            .to_owned();
+        session.execute(statement).await.expect("remove user");
+    }
+
+    async fn local_user(db: &CoralDb) -> UserRecord {
+        let mut session = db;
+        session
+            .users()
+            .get_by_user_id(LOCAL_PRINCIPAL_ID)
+            .await
+            .expect("read the local user")
+            .expect("the local user row exists")
+    }
+
+    async fn marker_completed(db: &CoralDb) -> bool {
+        let mut session = db;
+        session
+            .state_migrations()
+            .has_completed(LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID)
+            .await
+            .expect("read the migration marker")
+    }
+
+    async fn grant(db: &CoralDb, workspace_id: &str, user_id: &str, role: MemberRole, at: i64) {
+        let mut session = db;
+        session
+            .workspace_members()
+            .upsert(workspace_id, user_id, role, at)
+            .await
+            .expect("grant membership");
+    }
+
+    async fn revoke(db: &CoralDb, workspace_id: &str, user_id: &str) {
+        let mut session = db;
+        assert!(
+            session
+                .workspace_members()
+                .remove(workspace_id, user_id)
+                .await
+                .expect("revoke membership")
+        );
+    }
+
+    async fn role_for(db: &CoralDb, workspace_id: &str, user_id: &str) -> Option<MemberRole> {
+        let mut session = db;
+        session
+            .workspace_members()
+            .role_for_user_id(workspace_id, user_id)
+            .await
+            .expect("read role")
+    }
+
+    async fn open_sqlite() -> (CoralDb, TempDir) {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        (db, temp)
+    }
+}

--- a/crates/coral-app/src/state/db/ownership_bootstrap.rs
+++ b/crates/coral-app/src/state/db/ownership_bootstrap.rs
@@ -1,19 +1,13 @@
 //! The one-time upgrade that gives legacy ownerless workspaces a local owner.
 
 use super::repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
+use super::repositories::workspaces::InaccessibleWorkspaces;
 use super::session::DbRepos;
 use super::{CoralDb, CoralTx, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
 use crate::identity::LOCAL_PRINCIPAL_ID;
 
 /// What one attempt at the local ownership migration did.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the single-user composition root logs this after the deployment policy lands"
-    )
-)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct LocalOwnershipMigrationReport {
     /// Whether this process was the one that claimed and ran the migration.
@@ -31,17 +25,22 @@ pub(crate) struct LocalOwnershipMigrationReport {
 /// a failed upgrade leaves no half-migrated state and the next start retries
 /// the whole thing. Workspaces that already have an owner are untouched, and
 /// nothing here creates, renames, or deletes a workspace.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the single-user composition root runs this after the deployment policy lands"
-    )
-)]
 pub(crate) async fn migrate_local_ownership_once(
     db: &CoralDb,
 ) -> Result<LocalOwnershipMigrationReport, AppError> {
     migrate_local_ownership_once_at(db, now_unix_nanos_i64()?).await
+}
+
+/// Reports the workspaces a shared deployment currently serves to nobody.
+///
+/// This is the counterpart of the migration above, for the deployments that
+/// must not run it: the workspaces stay in place and the server keeps serving
+/// the rest, so an operator needs to be told which ones await an owner.
+pub(crate) async fn inaccessible_workspaces(
+    db: &CoralDb,
+) -> Result<InaccessibleWorkspaces, AppError> {
+    let mut session = db;
+    Ok(session.workspaces().inaccessible().await?)
 }
 
 async fn migrate_local_ownership_once_at(

--- a/crates/coral-app/src/state/db/ownership_bootstrap.rs
+++ b/crates/coral-app/src/state/db/ownership_bootstrap.rs
@@ -259,12 +259,12 @@ mod tests {
         assert!(marker_completed(&db).await);
     }
 
-    /// A row squatting on the local user's unique empty subject makes
-    /// `ensure_local` a no-op, so the membership insert fails its user foreign
-    /// key after the upgrade has already claimed its marker. That claim must
-    /// not survive, or no later start could ever retry the upgrade. The
-    /// repository contract covers the sibling direction — an ownership row
-    /// that was written before a rollback disappears with it.
+    /// A row squatting on the local user's unique empty subject swallows the
+    /// `ensure_local` insert, which fails the upgrade after it has already
+    /// claimed its marker. That claim must not survive, or no later start
+    /// could ever retry the upgrade. The repository contract covers the
+    /// sibling direction — an ownership row that was written before a rollback
+    /// disappears with it.
     #[tokio::test]
     async fn a_failure_part_way_through_rolls_back_every_write_and_retries_later() {
         let (db, _temp) = open_sqlite().await;
@@ -275,10 +275,10 @@ mod tests {
 
         let error = migrate_local_ownership_once_at(&db, 70)
             .await
-            .expect_err("the membership insert must fail its user foreign key");
+            .expect_err("a swallowed local user insert must fail the upgrade");
 
         assert!(
-            error.to_string().contains("FOREIGN KEY constraint failed"),
+            error.to_string().contains("the local user row is absent"),
             "unexpected error: {error}"
         );
         assert!(
@@ -313,6 +313,44 @@ mod tests {
             role_for(&db, "second", LOCAL_PRINCIPAL_ID).await,
             Some(MemberRole::Owner)
         );
+    }
+
+    /// The same squatter on an instance that holds no workspace at all. No
+    /// membership is written, so nothing else references the local user and
+    /// only `ensure_local` proving its own row keeps the marker from retiring
+    /// an upgrade that never happened — which would leave `workspace create`
+    /// failing on a missing creator for good.
+    #[tokio::test]
+    async fn a_squatted_local_row_fails_the_upgrade_even_with_no_workspaces() {
+        let (db, _temp) = open_sqlite().await;
+        let squatter = seed_user(&db, "").await;
+
+        let error = migrate_local_ownership_once_at(&db, 70)
+            .await
+            .expect_err("a swallowed local user insert must fail the upgrade");
+
+        assert!(
+            error.to_string().contains("the local user row is absent"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !marker_completed(&db).await,
+            "the marker must not retire an upgrade that never wrote the local user"
+        );
+
+        remove_user(&db, &squatter).await;
+        let retry = migrate_local_ownership_once_at(&db, 80)
+            .await
+            .expect("retry the upgrade");
+
+        assert_eq!(
+            retry,
+            LocalOwnershipMigrationReport {
+                performed: true,
+                workspaces_claimed: 0,
+            }
+        );
+        assert_eq!(local_user(&db).await.user_id, LOCAL_PRINCIPAL_ID);
     }
 
     async fn seed_workspaces(db: &CoralDb, workspace_ids: &[&str]) {

--- a/crates/coral-app/src/state/db/repositories/state_migrations.rs
+++ b/crates/coral-app/src/state/db/repositories/state_migrations.rs
@@ -5,6 +5,17 @@ use sea_query::{Expr, OnConflict, Query};
 use crate::state::db::schema::AppStateMigrations;
 use crate::state::db::{CoralTx, DbError, DbSession};
 
+/// Identifies the one-time migration that gives legacy ownerless workspaces
+/// their local owner.
+///
+/// The id is part of the on-disk contract: it is what an already-upgraded
+/// state directory matches against, so it must never change.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "the one-time local ownership migration claims it")
+)]
+pub(crate) const LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID: &str = "local_workspace_ownership_v1";
+
 #[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub(crate) struct StateMigrationRecord {

--- a/crates/coral-app/src/state/db/repositories/state_migrations.rs
+++ b/crates/coral-app/src/state/db/repositories/state_migrations.rs
@@ -10,10 +10,6 @@ use crate::state::db::{CoralTx, DbError, DbSession};
 ///
 /// The id is part of the on-disk contract: it is what an already-upgraded
 /// state directory matches against, so it must never change.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "the one-time local ownership migration claims it")
-)]
 pub(crate) const LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID: &str = "local_workspace_ownership_v1";
 
 #[cfg(test)]

--- a/crates/coral-app/src/state/db/repositories/users.rs
+++ b/crates/coral-app/src/state/db/repositories/users.rs
@@ -110,6 +110,12 @@ where
     /// though `users.subject` is unique. Re-running leaves an existing row
     /// exactly as it stands, so a retried migration never rewrites the local
     /// user's timestamps.
+    ///
+    /// Returning `Ok` means the row is there. The insert alone cannot promise
+    /// that — a corrupted directory row squatting on the empty subject
+    /// swallows it — and a caller that writes nothing referencing the local
+    /// user would otherwise take a silent no-op for success and commit a
+    /// migration marker that retires itself without the row ever existing.
     pub(crate) async fn ensure_local(&mut self, now_unix_nanos: i64) -> Result<(), DbError> {
         let statement = Query::insert()
             .into_table(Users::Table)
@@ -127,7 +133,15 @@ where
             // re-run trips instead of guessing which arbiter fires first.
             .on_conflict(OnConflict::new().do_nothing().to_owned())
             .to_owned();
-        self.session.execute(statement).await
+        self.session.execute(statement).await?;
+
+        if self.get_by_user_id(LOCAL_PRINCIPAL_ID).await?.is_none() {
+            return Err(DbError::CorruptData(
+                "the local user row is absent after its upsert; another directory row holds its identity"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 
     pub(crate) async fn get_by_user_id(

--- a/crates/coral-app/src/state/db/repositories/users.rs
+++ b/crates/coral-app/src/state/db/repositories/users.rs
@@ -1,9 +1,13 @@
 use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query, SelectStatement};
 use uuid::Uuid;
 
+use crate::identity::LOCAL_PRINCIPAL_ID;
 use crate::state::db::DbError;
 use crate::state::db::schema::Users;
 use crate::state::db::session::DbSession;
+
+/// The display name the synthetic local directory row carries.
+const LOCAL_USER_DISPLAY_NAME: &str = "Local";
 
 /// One directory row for an authenticated upstream identity.
 ///
@@ -95,6 +99,42 @@ where
                 stored_issuer: record.issuer,
             })
         }
+    }
+
+    /// Ensures the synthetic directory row a single-user deployment owns its
+    /// workspaces through.
+    ///
+    /// The row's `user_id` and `issuer` are both `coral:local` and its subject
+    /// is empty. A verified upstream identity always carries a non-empty
+    /// `sub`, so the empty subject cannot collide with a real login even
+    /// though `users.subject` is unique. Re-running leaves an existing row
+    /// exactly as it stands, so a retried migration never rewrites the local
+    /// user's timestamps.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the one-time local ownership migration writes the row"
+        )
+    )]
+    pub(crate) async fn ensure_local(&mut self, now_unix_nanos: i64) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Users::Table)
+            .columns(user_columns())
+            .values_panic([
+                Expr::val(LOCAL_PRINCIPAL_ID),
+                Expr::val(LOCAL_PRINCIPAL_ID),
+                Expr::val(""),
+                Expr::val(LOCAL_USER_DISPLAY_NAME),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            // The primary key and the unique subject both identify this same
+            // one row, so the untargeted form absorbs whichever of the two a
+            // re-run trips instead of guessing which arbiter fires first.
+            .on_conflict(OnConflict::new().do_nothing().to_owned())
+            .to_owned();
+        self.session.execute(statement).await
     }
 
     pub(crate) async fn get_by_user_id(

--- a/crates/coral-app/src/state/db/repositories/users.rs
+++ b/crates/coral-app/src/state/db/repositories/users.rs
@@ -110,13 +110,6 @@ where
     /// though `users.subject` is unique. Re-running leaves an existing row
     /// exactly as it stands, so a retried migration never rewrites the local
     /// user's timestamps.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the one-time local ownership migration writes the row"
-        )
-    )]
     pub(crate) async fn ensure_local(&mut self, now_unix_nanos: i64) -> Result<(), DbError> {
         let statement = Query::insert()
             .into_table(Users::Table)

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -485,6 +485,10 @@ mod tests {
         local_member: String,
         owned: String,
         human: String,
+        /// What the singleton local row already said before the migration ran.
+        /// The row cannot be suffixed per run, so the only stable claim about
+        /// it is that re-ensuring leaves whatever was there untouched.
+        local_last_login_at_unix_nanos: i64,
     }
 
     /// Drives the whole one-time local ownership migration through the
@@ -542,7 +546,7 @@ mod tests {
 
     async fn seed_legacy_ownership(db: &CoralDb) -> LegacyOwnership {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
-        let legacy = LegacyOwnership {
+        let mut legacy = LegacyOwnership {
             // The real marker id would stay claimed in the shared Postgres
             // test database and fail every later run, so the shape is
             // exercised under a per-run id derived from it.
@@ -551,6 +555,8 @@ mod tests {
             local_member: format!("workspace_local_member_{suffix}"),
             owned: format!("workspace_owned_{suffix}"),
             human: seed_user(db, &format!("human_{suffix}"), None).await,
+            // Read back below, once the seed has ensured the row exists.
+            local_last_login_at_unix_nanos: 0,
         };
 
         let mut tx = db.begin().await.expect("begin legacy seed");
@@ -592,6 +598,7 @@ mod tests {
             ),
             (LOCAL_PRINCIPAL_ID, LOCAL_PRINCIPAL_ID, "", Some("Local"))
         );
+        legacy.local_last_login_at_unix_nanos = local.last_login_at_unix_nanos;
         legacy
     }
 
@@ -695,7 +702,7 @@ mod tests {
         );
         assert_eq!(
             local_user(db).await.last_login_at_unix_nanos,
-            5,
+            legacy.local_last_login_at_unix_nanos,
             "re-ensuring the local user must not rewrite the stored row"
         );
     }

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -190,13 +190,6 @@ impl WorkspaceMembersRepo<'_, CoralTx<'_>> {
     /// place rather than duplicated.
     ///
     /// [`hold_for_child_mutation`]: super::workspaces::WorkspacesRepo::hold_for_child_mutation
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the one-time local ownership migration writes the memberships"
-        )
-    )]
     pub(crate) async fn claim_ownership_if_unowned(
         &mut self,
         workspace_id: &str,

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -576,16 +576,21 @@ mod tests {
             .expect("seed a human owner");
         tx.commit().await.expect("commit legacy seed");
 
+        // The local principal is a singleton row, so unlike the ids above it
+        // cannot be suffixed per run: a shared Postgres database may already
+        // hold it, written by an earlier run at its own timestamps, and
+        // `ensure_local` leaves such a row alone. Its identity is what the
+        // helper guarantees on every database, so assert that and not when it
+        // was first written.
+        let local = local_user(db).await;
         assert_eq!(
-            local_user(db).await,
-            UserRecord {
-                user_id: LOCAL_PRINCIPAL_ID.to_string(),
-                issuer: LOCAL_PRINCIPAL_ID.to_string(),
-                subject: String::new(),
-                display_name: Some("Local".to_string()),
-                created_at_unix_nanos: 5,
-                last_login_at_unix_nanos: 5,
-            }
+            (
+                local.user_id.as_str(),
+                local.issuer.as_str(),
+                local.subject.as_str(),
+                local.display_name.as_deref()
+            ),
+            (LOCAL_PRINCIPAL_ID, LOCAL_PRINCIPAL_ID, "", Some("Local"))
         );
         legacy
     }

--- a/crates/coral-app/src/state/db/repositories/workspace_members.rs
+++ b/crates/coral-app/src/state/db/repositories/workspace_members.rs
@@ -2,9 +2,10 @@ use sea_query::{
     Alias, Expr, ExprTrait, Func, OnConflict, Order, Query, SelectStatement, SimpleExpr,
 };
 
-use crate::state::db::DbError;
+use crate::identity::LOCAL_PRINCIPAL_ID;
 use crate::state::db::schema::{Users, WorkspaceMembers};
 use crate::state::db::session::DbSession;
+use crate::state::db::{CoralTx, DbError};
 use crate::workspaces::MemberRole;
 
 pub(crate) struct WorkspaceMembersRepo<'a, S> {
@@ -176,6 +177,58 @@ where
     }
 }
 
+impl WorkspaceMembersRepo<'_, CoralTx<'_>> {
+    /// Grants `user_id` ownership of `workspace_id`, but only while that
+    /// workspace has no owner at all, reporting whether it wrote.
+    ///
+    /// The caller must already hold the workspace parent row through
+    /// [`hold_for_child_mutation`]: that hold is the one serialization point
+    /// for owner-floor writes, and without it this count and write could
+    /// straddle a concurrent membership mutation. A workspace that already has
+    /// any owner is left completely untouched — no row is added for `user_id`
+    /// there — while an existing non-owner row for `user_id` is promoted in
+    /// place rather than duplicated.
+    ///
+    /// [`hold_for_child_mutation`]: super::workspaces::WorkspacesRepo::hold_for_child_mutation
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the one-time local ownership migration writes the memberships"
+        )
+    )]
+    pub(crate) async fn claim_ownership_if_unowned(
+        &mut self,
+        workspace_id: &str,
+        user_id: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<bool, DbError> {
+        if self.owner_count(workspace_id).await? > 0 {
+            return Ok(false);
+        }
+        self.upsert(
+            workspace_id,
+            user_id,
+            MemberRole::Owner,
+            created_at_unix_nanos,
+        )
+        .await?;
+        Ok(true)
+    }
+}
+
+/// Selects every workspace id that still has at least one owner.
+///
+/// The set form, for callers that need the whole list — `NOT IN` cannot be
+/// correlated away. The per-row question has its own helper below.
+pub(super) fn owner_bearing_workspaces() -> SelectStatement {
+    Query::select()
+        .column(WorkspaceMembers::WorkspaceId)
+        .from(WorkspaceMembers::Table)
+        .and_where(Expr::col(WorkspaceMembers::Role).eq(MemberRole::Owner.as_storage_str()))
+        .to_owned()
+}
+
 /// Table alias the ownership probe reads under, so its predicates cannot be
 /// mistaken for the outer row's.
 fn owner_probe() -> Alias {
@@ -204,6 +257,15 @@ fn owner_bearing_workspace(workspace_id: SimpleExpr) -> SelectStatement {
         .to_owned()
 }
 
+/// Selects every workspace id owned by someone other than the synthetic local
+/// principal — that is, every workspace an authenticated caller can still
+/// reach through an owner.
+pub(super) fn non_local_owner_bearing_workspaces() -> SelectStatement {
+    owner_bearing_workspaces()
+        .and_where(Expr::col(WorkspaceMembers::UserId).ne(LOCAL_PRINCIPAL_ID))
+        .to_owned()
+}
+
 /// Decodes one stored role, failing closed on anything unrecognized.
 fn decode_role(value: &str) -> Result<MemberRole, DbError> {
     MemberRole::from_storage_str(value).ok_or_else(|| {
@@ -220,7 +282,10 @@ mod tests {
 
     use super::decode_role;
     use crate::bootstrap;
-    use crate::state::db::repositories::users::UpsertLoginOutcome;
+    use crate::identity::LOCAL_PRINCIPAL_ID;
+    use crate::state::db::repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
+    use crate::state::db::repositories::users::{UpsertLoginOutcome, UserRecord};
+    use crate::state::db::repositories::workspaces::InaccessibleWorkspaces;
     use crate::state::db::schema::WorkspaceMembers;
     use crate::state::db::{CoralDb, DbError, DbRepos, DbSession, ResolvedDatabaseConfig};
     use crate::workspaces::MemberRole;
@@ -268,6 +333,21 @@ mod tests {
             return;
         };
         assert_identical_adds_converge(&db).await;
+    }
+
+    #[tokio::test]
+    async fn local_ownership_repository_contract_holds_against_sqlite() {
+        let (db, _temp) = open_sqlite().await;
+        assert_local_ownership_contract(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
+    async fn local_ownership_repository_contract_on_postgres() {
+        let Some(db) = open_postgres().await else {
+            return;
+        };
+        assert_local_ownership_contract(&db).await;
     }
 
     #[test]
@@ -402,6 +482,243 @@ mod tests {
             1,
             "revoking a member must not touch the owner floor"
         );
+    }
+
+    /// One legacy state per test run: a workspace with nothing, one whose only
+    /// local row is a plain membership, and one an authenticated person owns.
+    struct LegacyOwnership {
+        migration_id: String,
+        unowned: String,
+        local_member: String,
+        owned: String,
+        human: String,
+    }
+
+    /// Drives the whole one-time local ownership migration through the
+    /// primitives it is built from, inside the caller's own transaction.
+    async fn assert_local_ownership_contract(db: &CoralDb) {
+        let legacy = seed_legacy_ownership(db).await;
+
+        let before = inaccessible(db).await;
+        assert!(before.without_owner.contains(&legacy.unowned));
+        assert!(
+            before.without_owner.contains(&legacy.local_member),
+            "a workspace whose only member is not an owner has no owner"
+        );
+        assert!(!before.without_owner.contains(&legacy.owned));
+        assert!(!before.local_owner_only.contains(&legacy.owned));
+
+        assert_rolled_back_migration_writes_nothing(db, &legacy).await;
+        migrate_local_ownership(db, &legacy).await;
+        assert_migration_wrote_only_where_unowned(db, &legacy).await;
+
+        let after = inaccessible(db).await;
+        assert!(!after.without_owner.contains(&legacy.unowned));
+        assert!(!after.without_owner.contains(&legacy.local_member));
+        assert!(after.local_owner_only.contains(&legacy.unowned));
+        assert!(after.local_owner_only.contains(&legacy.local_member));
+        assert!(!after.local_owner_only.contains(&legacy.owned));
+
+        // A workspace an authenticated owner shares with the local principal
+        // is reachable, so holding a local owner is not on its own enough to
+        // report it.
+        grant(
+            db,
+            &legacy.local_member,
+            &legacy.human,
+            MemberRole::Owner,
+            110,
+        )
+        .await;
+        let shared = inaccessible(db).await;
+        assert!(!shared.local_owner_only.contains(&legacy.local_member));
+        assert!(!shared.without_owner.contains(&legacy.local_member));
+
+        let mut tx = db.begin().await.expect("begin duplicate migration");
+        assert!(
+            !tx.state_migrations()
+                .try_claim(&legacy.migration_id, 100)
+                .await
+                .expect("reject a completed migration"),
+            "a completed marker must stop the migration before it scans"
+        );
+        tx.rollback()
+            .await
+            .expect("roll back the duplicate migration");
+    }
+
+    async fn seed_legacy_ownership(db: &CoralDb) -> LegacyOwnership {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let legacy = LegacyOwnership {
+            // The real marker id would stay claimed in the shared Postgres
+            // test database and fail every later run, so the shape is
+            // exercised under a per-run id derived from it.
+            migration_id: format!("{LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID}_{suffix}"),
+            unowned: format!("workspace_unowned_{suffix}"),
+            local_member: format!("workspace_local_member_{suffix}"),
+            owned: format!("workspace_owned_{suffix}"),
+            human: seed_user(db, &format!("human_{suffix}"), None).await,
+        };
+
+        let mut tx = db.begin().await.expect("begin legacy seed");
+        for workspace_id in [&legacy.unowned, &legacy.local_member, &legacy.owned] {
+            tx.workspaces()
+                .create(workspace_id, 1)
+                .await
+                .expect("create legacy workspace");
+        }
+        tx.users().ensure_local(5).await.expect("ensure local user");
+        tx.workspace_members()
+            .upsert(
+                &legacy.local_member,
+                LOCAL_PRINCIPAL_ID,
+                MemberRole::Member,
+                30,
+            )
+            .await
+            .expect("seed a local member");
+        tx.workspace_members()
+            .upsert(&legacy.owned, &legacy.human, MemberRole::Owner, 40)
+            .await
+            .expect("seed a human owner");
+        tx.commit().await.expect("commit legacy seed");
+
+        assert_eq!(
+            local_user(db).await,
+            UserRecord {
+                user_id: LOCAL_PRINCIPAL_ID.to_string(),
+                issuer: LOCAL_PRINCIPAL_ID.to_string(),
+                subject: String::new(),
+                display_name: Some("Local".to_string()),
+                created_at_unix_nanos: 5,
+                last_login_at_unix_nanos: 5,
+            }
+        );
+        legacy
+    }
+
+    /// A failed migration must leave neither its marker nor its ownership
+    /// writes behind, so the next startup can retry the whole thing.
+    async fn assert_rolled_back_migration_writes_nothing(db: &CoralDb, legacy: &LegacyOwnership) {
+        let mut tx = db.begin().await.expect("begin rolled-back migration");
+        assert!(
+            tx.state_migrations()
+                .try_claim(&legacy.migration_id, 50)
+                .await
+                .expect("claim the migration")
+        );
+        assert!(
+            tx.workspaces()
+                .hold_for_child_mutation(&legacy.unowned)
+                .await
+                .expect("hold the workspace parent")
+        );
+        assert!(
+            tx.workspace_members()
+                .claim_ownership_if_unowned(&legacy.unowned, LOCAL_PRINCIPAL_ID, 60)
+                .await
+                .expect("claim ownership")
+        );
+        tx.rollback().await.expect("roll back the migration");
+
+        assert_eq!(
+            role_for(db, &legacy.unowned, LOCAL_PRINCIPAL_ID).await,
+            None,
+            "a rolled-back migration must leave no ownership behind"
+        );
+    }
+
+    /// Runs the migration shape once: one claim, one local user, and one
+    /// hold-then-conditional-write per workspace, all in one transaction.
+    async fn migrate_local_ownership(db: &CoralDb, legacy: &LegacyOwnership) {
+        let mut tx = db.begin().await.expect("begin migration");
+        assert!(
+            tx.state_migrations()
+                .try_claim(&legacy.migration_id, 70)
+                .await
+                .expect("claim the migration after a rollback")
+        );
+        tx.users()
+            .ensure_local(80)
+            .await
+            .expect("ensure local user again");
+        for (workspace_id, claimed) in [
+            (&legacy.unowned, true),
+            (&legacy.local_member, true),
+            (&legacy.owned, false),
+        ] {
+            assert!(
+                tx.workspaces()
+                    .hold_for_child_mutation(workspace_id)
+                    .await
+                    .expect("hold the workspace parent")
+            );
+            assert_eq!(
+                tx.workspace_members()
+                    .claim_ownership_if_unowned(workspace_id, LOCAL_PRINCIPAL_ID, 90)
+                    .await
+                    .expect("claim ownership"),
+                claimed,
+                "{workspace_id} took the wrong conditional ownership decision"
+            );
+        }
+        assert!(
+            !tx.workspaces()
+                .hold_for_child_mutation(&format!("{}_missing", legacy.unowned))
+                .await
+                .expect("hold a missing workspace")
+        );
+        tx.commit().await.expect("commit migration");
+    }
+
+    async fn assert_migration_wrote_only_where_unowned(db: &CoralDb, legacy: &LegacyOwnership) {
+        assert_eq!(
+            role_for(db, &legacy.unowned, LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner)
+        );
+        assert_eq!(
+            role_for(db, &legacy.local_member, LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner),
+            "an existing local member must be promoted rather than duplicated"
+        );
+        assert_eq!(
+            granted_at(db, &legacy.local_member, LOCAL_PRINCIPAL_ID).await,
+            30,
+            "a promotion must keep recording the first grant"
+        );
+        assert_eq!(
+            role_for(db, &legacy.owned, LOCAL_PRINCIPAL_ID).await,
+            None,
+            "an already-owned workspace must be left completely untouched"
+        );
+        assert_eq!(
+            role_for(db, &legacy.owned, &legacy.human).await,
+            Some(MemberRole::Owner)
+        );
+        assert_eq!(
+            local_user(db).await.last_login_at_unix_nanos,
+            5,
+            "re-ensuring the local user must not rewrite the stored row"
+        );
+    }
+
+    async fn local_user(db: &CoralDb) -> UserRecord {
+        let mut session = db;
+        session
+            .users()
+            .get_by_user_id(LOCAL_PRINCIPAL_ID)
+            .await
+            .expect("read the local user")
+            .expect("the local user row exists")
+    }
+
+    async fn inaccessible(db: &CoralDb) -> InaccessibleWorkspaces {
+        let mut session = db;
+        session
+            .workspaces()
+            .inaccessible()
+            .await
+            .expect("report inaccessible workspaces")
     }
 
     async fn assert_identical_adds_converge(db: &CoralDb) {

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -16,13 +16,6 @@ pub(crate) struct WorkspaceRecord {
 /// The two categories are different operator situations — one needs an owner
 /// appointed, the other needs ownership moved off the local principal — so
 /// they are reported apart rather than merged into one list.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "shared startup warns with this after telemetry is installed"
-    )
-)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct InaccessibleWorkspaces {
     /// Ids with no owner at all, concealed from every caller including their
@@ -105,13 +98,6 @@ where
     }
 
     /// Reports the workspaces an authenticated caller cannot reach.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "shared startup warns with this after telemetry is installed"
-        )
-    )]
     pub(crate) async fn inaccessible(&mut self) -> Result<InaccessibleWorkspaces, DbError> {
         let without_owner = self
             .ids(

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -1,5 +1,6 @@
-use sea_query::{Expr, ExprTrait, OnConflict, Query};
+use sea_query::{Expr, ExprTrait, OnConflict, Order, Query, SelectStatement};
 
+use super::workspace_members::{non_local_owner_bearing_workspaces, owner_bearing_workspaces};
 use crate::state::db::schema::Workspaces;
 use crate::state::db::session::DbSession;
 use crate::state::db::{CoralTx, DbError};
@@ -8,6 +9,29 @@ use crate::state::db::{CoralTx, DbError};
 pub(crate) struct WorkspaceRecord {
     pub(crate) id: String,
     pub(crate) created_at_unix_nanos: i64,
+}
+
+/// The workspaces no authenticated caller can reach, split by why.
+///
+/// The two categories are different operator situations — one needs an owner
+/// appointed, the other needs ownership moved off the local principal — so
+/// they are reported apart rather than merged into one list.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "shared startup warns with this after telemetry is installed"
+    )
+)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct InaccessibleWorkspaces {
+    /// Ids with no owner at all, concealed from every caller including their
+    /// own members.
+    pub(crate) without_owner: Vec<String>,
+    /// Ids whose only owner is the synthetic local principal. Storage-wise
+    /// these are validly owned and preserve the owner floor, but no
+    /// authenticated caller can reach them until ownership is transferred.
+    pub(crate) local_owner_only: Vec<String>,
 }
 
 pub(crate) struct WorkspacesRepo<'a, S> {
@@ -79,6 +103,54 @@ where
         let statement = Query::delete().from_table(Workspaces::Table).to_owned();
         self.session.execute(statement).await
     }
+
+    /// Reports the workspaces an authenticated caller cannot reach.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "shared startup warns with this after telemetry is installed"
+        )
+    )]
+    pub(crate) async fn inaccessible(&mut self) -> Result<InaccessibleWorkspaces, DbError> {
+        let without_owner = self
+            .ids(
+                select_workspace_ids()
+                    .and_where(
+                        Expr::col(Workspaces::Id).not_in_subquery(owner_bearing_workspaces()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        let local_owner_only = self
+            .ids(
+                select_workspace_ids()
+                    .and_where(Expr::col(Workspaces::Id).in_subquery(owner_bearing_workspaces()))
+                    .and_where(
+                        Expr::col(Workspaces::Id)
+                            .not_in_subquery(non_local_owner_bearing_workspaces()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(InaccessibleWorkspaces {
+            without_owner,
+            local_owner_only,
+        })
+    }
+
+    async fn ids(&mut self, statement: SelectStatement) -> Result<Vec<String>, DbError> {
+        let rows: Vec<(String,)> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+}
+
+fn select_workspace_ids() -> SelectStatement {
+    Query::select()
+        .column(Workspaces::Id)
+        .from(Workspaces::Table)
+        .order_by(Workspaces::Id, Order::Asc)
+        .to_owned()
 }
 
 impl WorkspacesRepo<'_, CoralTx<'_>> {

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -11,19 +11,28 @@ pub(crate) struct WorkspaceRecord {
     pub(crate) created_at_unix_nanos: i64,
 }
 
-/// The workspaces no authenticated caller can reach, split by why.
+/// The workspaces no authenticated caller can *own*, split by why.
 ///
 /// The two categories are different operator situations — one needs an owner
 /// appointed, the other needs ownership moved off the local principal — so
 /// they are reported apart rather than merged into one list.
+///
+/// Deliberately about owners, not reachability. The classifying query looks
+/// only at owner rows, so a workspace can appear here while a Member still
+/// reads and queries it — a local host can grant membership to a directory
+/// user before the install is switched to shared mode. What both categories
+/// prove is that nobody left can *manage* the workspace, which is what makes
+/// operator action necessary.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct InaccessibleWorkspaces {
-    /// Ids with no owner at all, concealed from every caller including their
-    /// own members.
+    /// Ids with no owner at all. These are concealed from every caller,
+    /// members included, because concealment treats ownerless exactly as it
+    /// treats nonexistent.
     pub(crate) without_owner: Vec<String>,
     /// Ids whose only owner is the synthetic local principal. Storage-wise
     /// these are validly owned and preserve the owner floor, but no
-    /// authenticated caller can reach them until ownership is transferred.
+    /// authenticated caller can manage them until ownership is transferred.
+    /// Any member they already have keeps its read access.
     pub(crate) local_owner_only: Vec<String>,
 }
 

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -106,7 +106,14 @@ where
         self.session.execute(statement).await
     }
 
-    /// Reports the workspaces an authenticated caller cannot reach.
+    /// Reports the workspaces no authenticated caller can manage.
+    ///
+    /// Neither half has a reachable owner, which is what management needs:
+    /// [`InaccessibleWorkspaces::without_owner`] has no owner at all and is
+    /// concealed from every caller, while
+    /// [`InaccessibleWorkspaces::local_owner_only`] is owned solely by the
+    /// synthetic local principal and stays unmanageable until ownership is
+    /// transferred — the members it already has keep their read access.
     pub(crate) async fn inaccessible(&mut self) -> Result<InaccessibleWorkspaces, DbError> {
         let without_owner = self
             .ids(

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -103,6 +103,18 @@ impl AppStateLayout {
         self.config_dir.join("workspaces")
     }
 
+    /// Where a workspace directory waits between the deletion committing and
+    /// its contents being removed.
+    ///
+    /// A sibling of [`Self::workspaces_root`] rather than a directory inside
+    /// it, so the rename stays on one filesystem while every entry a scan of
+    /// the workspaces root finds is a live workspace. A workspace name is free
+    /// to look like anything, staging included, so the location is the only
+    /// evidence that separates the two.
+    pub(crate) fn deleted_workspaces_root(&self) -> PathBuf {
+        self.config_dir.join("deleted-workspaces")
+    }
+
     pub(crate) fn remove_legacy_task_event_logs(&self) -> Result<(), std::io::Error> {
         let workspace_entries = match std::fs::read_dir(self.workspaces_root()) {
             Ok(entries) => entries,
@@ -307,6 +319,10 @@ impl AppStateLayout {
 impl WorkspacePaths for AppStateLayout {
     fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         AppStateLayout::workspace_dir(self, workspace_name)
+    }
+
+    fn deleted_workspaces_root(&self) -> PathBuf {
+        AppStateLayout::deleted_workspaces_root(self)
     }
 }
 

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -17,6 +17,9 @@ pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_FUNCTION_FILE_NAME: &str = "function.sql";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
 
+/// Names the per-workspace directory holding installed source state.
+const SOURCES_DIR_NAME: &str = "sources";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum V4ProjectionCatalogOrigin {
     Materialized,
@@ -136,7 +139,25 @@ impl AppStateLayout {
     }
 
     pub(crate) fn sources_root(&self, workspace_name: &WorkspaceName) -> PathBuf {
-        self.workspace_dir(workspace_name).join("sources")
+        self.workspace_dir(workspace_name).join(SOURCES_DIR_NAME)
+    }
+
+    /// The secret file for `source_name` inside a workspace directory that has
+    /// already been staged for deletion.
+    ///
+    /// Deletion moves the directory out of the workspaces root before it
+    /// commits, so the live layout no longer reaches the material and asking it
+    /// to erase one would find nothing and report success. Cleanup addresses
+    /// the staged copy through here instead, and composes it from the same
+    /// pieces [`Self::secret_file`] does so the two cannot drift.
+    pub(crate) fn staged_secret_file(
+        staged_workspace_dir: &Path,
+        source_name: &SourceName,
+    ) -> PathBuf {
+        staged_workspace_dir
+            .join(SOURCES_DIR_NAME)
+            .join(source_name.as_str())
+            .join(INSTALLED_SECRETS_FILE_NAME)
     }
 
     pub(crate) fn feedback_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
@@ -486,6 +507,31 @@ mod tests {
         assert_eq!(
             overridden_metadata.origin,
             super::V4OperationMetadataOrigin::Override
+        );
+    }
+    /// The staged path must stay the live path's tail, or deletion cleanup
+    /// would erase nothing while reporting success.
+    #[test]
+    fn the_staged_secret_path_mirrors_the_live_one() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("work").expect("workspace name");
+        let source = SourceName::parse("secured_messages").expect("source name");
+
+        let live = layout.secret_file(&workspace, &source);
+        let staged_root = temp.path().join("deleted-workspaces").join("work.staged");
+        let staged = AppStateLayout::staged_secret_file(&staged_root, &source);
+
+        let live_tail = live
+            .strip_prefix(layout.workspace_dir(&workspace))
+            .expect("live secret sits under the workspace dir");
+        let staged_tail = staged
+            .strip_prefix(&staged_root)
+            .expect("staged secret sits under the staged dir");
+        assert_eq!(
+            live_tail, staged_tail,
+            "the staged secret must sit at the same place inside the directory as the live one"
         );
     }
 }

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -142,24 +142,6 @@ impl AppStateLayout {
         self.workspace_dir(workspace_name).join(SOURCES_DIR_NAME)
     }
 
-    /// The secret file for `source_name` inside a workspace directory that has
-    /// already been staged for deletion.
-    ///
-    /// Deletion moves the directory out of the workspaces root before it
-    /// commits, so the live layout no longer reaches the material and asking it
-    /// to erase one would find nothing and report success. Cleanup addresses
-    /// the staged copy through here instead, and composes it from the same
-    /// pieces [`Self::secret_file`] does so the two cannot drift.
-    pub(crate) fn staged_secret_file(
-        staged_workspace_dir: &Path,
-        source_name: &SourceName,
-    ) -> PathBuf {
-        staged_workspace_dir
-            .join(SOURCES_DIR_NAME)
-            .join(source_name.as_str())
-            .join(INSTALLED_SECRETS_FILE_NAME)
-    }
-
     pub(crate) fn feedback_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name).join("feedback")
     }
@@ -507,31 +489,6 @@ mod tests {
         assert_eq!(
             overridden_metadata.origin,
             super::V4OperationMetadataOrigin::Override
-        );
-    }
-    /// The staged path must stay the live path's tail, or deletion cleanup
-    /// would erase nothing while reporting success.
-    #[test]
-    fn the_staged_secret_path_mirrors_the_live_one() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let workspace = WorkspaceName::parse("work").expect("workspace name");
-        let source = SourceName::parse("secured_messages").expect("source name");
-
-        let live = layout.secret_file(&workspace, &source);
-        let staged_root = temp.path().join("deleted-workspaces").join("work.staged");
-        let staged = AppStateLayout::staged_secret_file(&staged_root, &source);
-
-        let live_tail = live
-            .strip_prefix(layout.workspace_dir(&workspace))
-            .expect("live secret sits under the workspace dir");
-        let staged_tail = staged
-            .strip_prefix(&staged_root)
-            .expect("staged secret sits under the staged dir");
-        assert_eq!(
-            live_tail, staged_tail,
-            "the staged secret must sit at the same place inside the directory as the live one"
         );
     }
 }

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -4,7 +4,7 @@ mod config;
 pub(crate) mod db;
 mod layout;
 
-pub(crate) use config::{AppConfig, ConfigStore};
+pub(crate) use config::{AppConfig, ConfigStore, RemovedWorkspaceConfig};
 pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -112,20 +112,6 @@ pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
 /// [`DirectoryBackup::move_for_delete`] stages a deletion under.
 pub(crate) const DELETION_BACKUP_INFIX: &str = ".delete.rollback.";
 
-/// Reports whether `name` is a directory staged aside for deletion.
-///
-/// Callers that walk a directory listing rather than hold a [`DirectoryBackup`]
-/// ask here, so the staging spelling lives in one place. The whole shape
-/// [`DirectoryBackup::move_for_delete`] writes has to match — the infix
-/// followed by the unique suffix — because a workspace name may legitimately
-/// contain the infix, and reading such a name as staged would drop a live
-/// workspace from a directory scan. The last occurrence is the one that counts,
-/// so a name containing the infix cannot mask the staged suffix after it.
-pub(crate) fn is_deletion_backup(name: &str) -> bool {
-    name.rsplit_once(DELETION_BACKUP_INFIX)
-        .is_some_and(|(_, unique_suffix)| Uuid::try_parse(unique_suffix).is_ok())
-}
-
 #[derive(Debug)]
 pub(crate) struct DirectoryBackup {
     original: PathBuf,
@@ -134,15 +120,44 @@ pub(crate) struct DirectoryBackup {
 }
 
 impl DirectoryBackup {
+    /// Stages `path` aside for deletion beside itself.
+    ///
+    /// Only for callers whose parent directory nothing enumerates for live
+    /// entries — the staged directory sits in it, and a name carries no
+    /// evidence of which of the two it is. Callers whose parent *is* scanned
+    /// take [`DirectoryBackup::move_for_delete_into`] instead.
     pub(crate) fn move_for_delete(path: &Path, name: impl fmt::Display) -> io::Result<Self> {
         let backup =
             path.with_file_name(format!("{name}{DELETION_BACKUP_INFIX}{}", Uuid::new_v4()));
+        Self::stage(path, backup)
+    }
+
+    /// Stages `path` aside for deletion inside `staging_dir`, which is created
+    /// if it is not there yet.
+    ///
+    /// Keeping the staged directory out of the original's parent is what lets
+    /// a scan of that parent read every entry it finds as live. Pass a
+    /// `staging_dir` on the same filesystem as `path`, so the move stays a
+    /// rename.
+    pub(crate) fn move_for_delete_into(
+        path: &Path,
+        staging_dir: &Path,
+        name: impl fmt::Display,
+    ) -> io::Result<Self> {
+        let backup = staging_dir.join(format!("{name}{DELETION_BACKUP_INFIX}{}", Uuid::new_v4()));
+        Self::stage(path, backup)
+    }
+
+    fn stage(path: &Path, backup: PathBuf) -> io::Result<Self> {
         if !path.try_exists()? {
             return Ok(Self {
                 original: path.to_path_buf(),
                 backup,
                 moved: false,
             });
+        }
+        if let Some(parent) = backup.parent() {
+            ensure_dir(parent)?;
         }
         if backup.try_exists()? {
             fs::remove_dir_all(&backup)?;
@@ -315,34 +330,7 @@ fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DELETION_BACKUP_INFIX, DirectoryBackup, Uuid, ensure_file_private, is_deletion_backup,
-        remove_file_if_exists,
-    };
-
-    /// The infix alone is not the staging spelling, and a workspace name is
-    /// free to contain it, so only the full staged shape may be read as one.
-    #[test]
-    fn only_the_staged_shape_reads_as_a_deletion_backup() {
-        assert!(is_deletion_backup(&format!(
-            "workspace{DELETION_BACKUP_INFIX}{}",
-            Uuid::new_v4()
-        )));
-        assert!(
-            is_deletion_backup(&format!(
-                "workspace{DELETION_BACKUP_INFIX}stale{DELETION_BACKUP_INFIX}{}",
-                Uuid::new_v4()
-            )),
-            "the last occurrence is the staged one"
-        );
-        assert!(!is_deletion_backup(&format!(
-            "left{DELETION_BACKUP_INFIX}right"
-        )));
-        assert!(!is_deletion_backup(&format!(
-            "workspace{DELETION_BACKUP_INFIX}7f1c5a4e"
-        )));
-        assert!(!is_deletion_backup("workspace"));
-    }
+    use super::{DirectoryBackup, ensure_file_private, remove_file_if_exists};
 
     #[test]
     fn ensure_file_private_rejects_existing_directory() {
@@ -411,6 +399,35 @@ mod tests {
 
         assert!(source_dir.join("manifest.yaml").exists());
         assert!(!backup.backup_path().exists());
+    }
+
+    /// Staging into a separate root is what keeps the original's parent
+    /// holding live entries only, so the staged directory has to land outside
+    /// it — and a root that is not there yet must not fail the staging.
+    #[test]
+    fn directory_backup_stages_into_a_separate_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspaces_root = temp.path().join("workspaces");
+        let workspace_dir = workspaces_root.join("work");
+        std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
+        std::fs::write(workspace_dir.join("marker"), "live").expect("write file");
+        let staging_root = temp.path().join("deleted-workspaces");
+
+        let backup = DirectoryBackup::move_for_delete_into(&workspace_dir, &staging_root, "work")
+            .expect("move backup");
+
+        assert_eq!(backup.backup_path().parent(), Some(staging_root.as_path()));
+        assert!(
+            std::fs::read_dir(&workspaces_root)
+                .expect("read workspaces root")
+                .next()
+                .is_none(),
+            "a scan of the original parent must see nothing left behind"
+        );
+
+        backup.restore().expect("restore backup");
+
+        assert!(workspace_dir.join("marker").exists());
     }
 
     #[test]

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -108,6 +108,18 @@ pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Separates the original directory name from the unique suffix that
+/// [`DirectoryBackup::move_for_delete`] stages a deletion under.
+pub(crate) const DELETION_BACKUP_INFIX: &str = ".delete.rollback.";
+
+/// Reports whether `name` is a directory staged aside for deletion.
+///
+/// Callers that walk a directory listing rather than hold a [`DirectoryBackup`]
+/// ask here, so the staging spelling lives in one place.
+pub(crate) fn is_deletion_backup(name: &str) -> bool {
+    name.contains(DELETION_BACKUP_INFIX)
+}
+
 #[derive(Debug)]
 pub(crate) struct DirectoryBackup {
     original: PathBuf,
@@ -117,7 +129,10 @@ pub(crate) struct DirectoryBackup {
 
 impl DirectoryBackup {
     pub(crate) fn move_for_delete(path: &Path, name: impl fmt::Display) -> io::Result<Self> {
-        let backup = path.with_file_name(format!("{name}.delete.rollback.{}", Uuid::new_v4()));
+        let backup = path.with_file_name(format!(
+            "{name}{DELETION_BACKUP_INFIX}{}",
+            Uuid::new_v4()
+        ));
         if !path.try_exists()? {
             return Ok(Self {
                 original: path.to_path_buf(),

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -129,10 +129,8 @@ pub(crate) struct DirectoryBackup {
 
 impl DirectoryBackup {
     pub(crate) fn move_for_delete(path: &Path, name: impl fmt::Display) -> io::Result<Self> {
-        let backup = path.with_file_name(format!(
-            "{name}{DELETION_BACKUP_INFIX}{}",
-            Uuid::new_v4()
-        ));
+        let backup =
+            path.with_file_name(format!("{name}{DELETION_BACKUP_INFIX}{}", Uuid::new_v4()));
         if !path.try_exists()? {
             return Ok(Self {
                 original: path.to_path_buf(),

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -133,12 +133,17 @@ impl DirectoryBackup {
     }
 
     /// Stages `path` aside for deletion inside `staging_dir`, which is created
-    /// if it is not there yet.
+    /// when there is something to move into it.
     ///
     /// Keeping the staged directory out of the original's parent is what lets
     /// a scan of that parent read every entry it finds as live. Pass a
     /// `staging_dir` on the same filesystem as `path`, so the move stays a
     /// rename.
+    ///
+    /// A `path` that is not there stages nothing and creates no directory: the
+    /// backup it returns names a place inside `staging_dir` that both
+    /// [`Self::restore`] and [`Self::commit`] then leave alone, so making the
+    /// root for it would be work with nothing behind it.
     pub(crate) fn move_for_delete_into(
         path: &Path,
         staging_dir: &Path,
@@ -428,6 +433,26 @@ mod tests {
         backup.restore().expect("restore backup");
 
         assert!(workspace_dir.join("marker").exists());
+    }
+
+    /// A workspace that never wrote a directory still gets staged for
+    /// deletion, and staging nothing must neither fail nor leave a staging
+    /// root behind for a caller that has nothing to put in it.
+    #[test]
+    fn staging_a_missing_directory_creates_no_staging_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join("workspaces").join("work");
+        let staging_root = temp.path().join("deleted-workspaces");
+
+        let backup = DirectoryBackup::move_for_delete_into(&workspace_dir, &staging_root, "work")
+            .expect("staging a missing directory should succeed");
+
+        assert_eq!(backup.backup_path().parent(), Some(staging_root.as_path()));
+        assert!(!staging_root.exists());
+        backup.restore().expect("restore a backup of nothing");
+        backup.commit().expect("commit a backup of nothing");
+        assert!(!staging_root.exists());
+        assert!(!workspace_dir.exists());
     }
 
     #[test]

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -115,9 +115,15 @@ pub(crate) const DELETION_BACKUP_INFIX: &str = ".delete.rollback.";
 /// Reports whether `name` is a directory staged aside for deletion.
 ///
 /// Callers that walk a directory listing rather than hold a [`DirectoryBackup`]
-/// ask here, so the staging spelling lives in one place.
+/// ask here, so the staging spelling lives in one place. The whole shape
+/// [`DirectoryBackup::move_for_delete`] writes has to match — the infix
+/// followed by the unique suffix — because a workspace name may legitimately
+/// contain the infix, and reading such a name as staged would drop a live
+/// workspace from a directory scan. The last occurrence is the one that counts,
+/// so a name containing the infix cannot mask the staged suffix after it.
 pub(crate) fn is_deletion_backup(name: &str) -> bool {
-    name.contains(DELETION_BACKUP_INFIX)
+    name.rsplit_once(DELETION_BACKUP_INFIX)
+        .is_some_and(|(_, unique_suffix)| Uuid::try_parse(unique_suffix).is_ok())
 }
 
 #[derive(Debug)]
@@ -309,7 +315,34 @@ fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DirectoryBackup, ensure_file_private, remove_file_if_exists};
+    use super::{
+        DELETION_BACKUP_INFIX, DirectoryBackup, Uuid, ensure_file_private, is_deletion_backup,
+        remove_file_if_exists,
+    };
+
+    /// The infix alone is not the staging spelling, and a workspace name is
+    /// free to contain it, so only the full staged shape may be read as one.
+    #[test]
+    fn only_the_staged_shape_reads_as_a_deletion_backup() {
+        assert!(is_deletion_backup(&format!(
+            "workspace{DELETION_BACKUP_INFIX}{}",
+            Uuid::new_v4()
+        )));
+        assert!(
+            is_deletion_backup(&format!(
+                "workspace{DELETION_BACKUP_INFIX}stale{DELETION_BACKUP_INFIX}{}",
+                Uuid::new_v4()
+            )),
+            "the last occurrence is the staged one"
+        );
+        assert!(!is_deletion_backup(&format!(
+            "left{DELETION_BACKUP_INFIX}right"
+        )));
+        assert!(!is_deletion_backup(&format!(
+            "workspace{DELETION_BACKUP_INFIX}7f1c5a4e"
+        )));
+        assert!(!is_deletion_backup("workspace"));
+    }
 
     #[test]
     fn ensure_file_private_rejects_existing_directory() {

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -160,9 +160,9 @@ mod tests {
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
-    use crate::test_support::{create_workspace, seed_principal};
+    use crate::test_support::{create_workspace, seed_principal, test_workspace};
+    use crate::workspaces::MemberRole;
     use crate::workspaces::authorization::WorkspaceAuthorizer;
-    use crate::workspaces::{MemberRole, WorkspaceName};
 
     /// This suite's login issuer. Each suite provisions under its own, so a
     /// subject seeded here is a different person from the same subject
@@ -198,15 +198,6 @@ mod tests {
             .expect("run state migrations");
         create_workspace(&db, &test_workspace()).await;
         (dir, db)
-    }
-
-    /// The workspace these fixtures run in.
-    ///
-    /// An install provisions none, so [`task_database`] creates it explicitly.
-    /// The name is ordinary on purpose: a fixture that leaned on a well-known
-    /// one would prove the workspace was resolved by name rather than created.
-    fn test_workspace() -> WorkspaceName {
-        WorkspaceName::parse("work").expect("workspace name")
     }
 
     fn workspace(name: &str) -> Workspace {

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -250,8 +250,22 @@ mod tests {
     #[tokio::test]
     async fn end_task_returns_success_status() {
         let (_dir, db) = task_database().await;
-        let _owner = seed_principal(&db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
-        let principal = seed_principal(&db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
+        let _owner = seed_principal(
+            &db,
+            ISSUER,
+            &test_workspace(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
+        let principal = seed_principal(
+            &db,
+            ISSUER,
+            &test_workspace(),
+            "member",
+            Some(MemberRole::Member),
+        )
+        .await;
         let service = TaskService::new(
             TaskManager::new(TaskStore::new(Arc::clone(&db))),
             WorkspaceAuthorizer::new(db),
@@ -373,8 +387,22 @@ mod tests {
         let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         // The workspace needs an owner before any membership in it grants
         // anything, so one is seeded beside the member under test.
-        let _owner = seed_principal(&db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
+        let _owner = seed_principal(
+            &db,
+            ISSUER,
+            &test_workspace(),
+            "owner",
+            Some(MemberRole::Owner),
+        )
+        .await;
+        let member = seed_principal(
+            &db,
+            ISSUER,
+            &test_workspace(),
+            "member",
+            Some(MemberRole::Member),
+        )
+        .await;
         let outsider = seed_principal(&db, ISSUER, &test_workspace(), "outsider", None).await;
         let service = TaskService::new(tasks.clone(), WorkspaceAuthorizer::new(db));
         let active = service

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -160,7 +160,7 @@ mod tests {
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
-    use crate::test_support::seed_principal;
+    use crate::test_support::{create_workspace, seed_principal};
     use crate::workspaces::authorization::WorkspaceAuthorizer;
     use crate::workspaces::{MemberRole, WorkspaceName};
 
@@ -195,8 +195,18 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&db, &config_store, &layout)
             .await
-            .expect("import default workspace");
+            .expect("run state migrations");
+        create_workspace(&db, &test_workspace()).await;
         (dir, db)
+    }
+
+    /// The workspace these fixtures run in.
+    ///
+    /// An install provisions none, so [`task_database`] creates it explicitly.
+    /// The name is ordinary on purpose: a fixture that leaned on a well-known
+    /// one would prove the workspace was resolved by name rather than created.
+    fn test_workspace() -> WorkspaceName {
+        WorkspaceName::parse("work").expect("workspace name")
     }
 
     fn workspace(name: &str) -> Workspace {
@@ -223,7 +233,7 @@ mod tests {
 
         let response = service
             .start_task(request(StartTaskRequest {
-                workspace: Some(workspace("default")),
+                workspace: Some(workspace(test_workspace().as_str())),
                 intent: "Find renewal risk".to_string(),
             }))
             .await
@@ -240,8 +250,8 @@ mod tests {
     #[tokio::test]
     async fn end_task_returns_success_status() {
         let (_dir, db) = task_database().await;
-        let _owner = seed_principal(&db, ISSUER, "owner", Some(MemberRole::Owner)).await;
-        let principal = seed_principal(&db, ISSUER, "member", Some(MemberRole::Member)).await;
+        let _owner = seed_principal(&db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
+        let principal = seed_principal(&db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
         let service = TaskService::new(
             TaskManager::new(TaskStore::new(Arc::clone(&db))),
             WorkspaceAuthorizer::new(db),
@@ -250,7 +260,7 @@ mod tests {
         let task = service
             .start_task(request_for_principal(
                 StartTaskRequest {
-                    workspace: Some(workspace("default")),
+                    workspace: Some(workspace(test_workspace().as_str())),
                     intent: "Find renewal risk".to_string(),
                 },
                 principal.clone(),
@@ -263,7 +273,7 @@ mod tests {
         let response = service
             .end_task(request_for_principal(
                 EndTaskRequest {
-                    workspace: Some(workspace("default")),
+                    workspace: Some(workspace(test_workspace().as_str())),
                     task_id: task.task_id.clone(),
                     task_status: TaskStatus::Success as i32,
                 },
@@ -280,7 +290,7 @@ mod tests {
         let status = service
             .end_task(request_for_principal(
                 EndTaskRequest {
-                    workspace: Some(workspace("default")),
+                    workspace: Some(workspace(test_workspace().as_str())),
                     task_id: task.task_id,
                     task_status: TaskStatus::Failure as i32,
                 },
@@ -312,7 +322,7 @@ mod tests {
 
         let status = service
             .start_task(request(StartTaskRequest {
-                workspace: Some(workspace("default")),
+                workspace: Some(workspace(test_workspace().as_str())),
                 intent: " ".to_string(),
             }))
             .await
@@ -327,7 +337,7 @@ mod tests {
 
         let status = service
             .end_task(request(EndTaskRequest {
-                workspace: Some(workspace("default")),
+                workspace: Some(workspace(test_workspace().as_str())),
                 task_id: UNKNOWN_TASK_ID.to_string(),
                 task_status: TaskStatus::Success as i32,
             }))
@@ -343,7 +353,7 @@ mod tests {
 
         let status = service
             .end_task(request(EndTaskRequest {
-                workspace: Some(workspace("default")),
+                workspace: Some(workspace(test_workspace().as_str())),
                 task_id: "not-a-uuid".to_string(),
                 task_status: TaskStatus::Success as i32,
             }))
@@ -363,14 +373,14 @@ mod tests {
         let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         // The workspace needs an owner before any membership in it grants
         // anything, so one is seeded beside the member under test.
-        let _owner = seed_principal(&db, ISSUER, "owner", Some(MemberRole::Owner)).await;
-        let member = seed_principal(&db, ISSUER, "member", Some(MemberRole::Member)).await;
-        let outsider = seed_principal(&db, ISSUER, "outsider", None).await;
+        let _owner = seed_principal(&db, ISSUER, &test_workspace(), "owner", Some(MemberRole::Owner)).await;
+        let member = seed_principal(&db, ISSUER, &test_workspace(), "member", Some(MemberRole::Member)).await;
+        let outsider = seed_principal(&db, ISSUER, &test_workspace(), "outsider", None).await;
         let service = TaskService::new(tasks.clone(), WorkspaceAuthorizer::new(db));
         let active = service
             .start_task(request_for_principal(
                 StartTaskRequest {
-                    workspace: Some(workspace("default")),
+                    workspace: Some(workspace(test_workspace().as_str())),
                     intent: "Find renewal risk".to_string(),
                 },
                 member.clone(),
@@ -382,11 +392,14 @@ mod tests {
             .expect("task");
         let task_id = crate::task::id::TaskId::parse(&active.task_id).expect("task id");
 
-        for (name, blank_intent) in [("default", " "), ("absent", " ")] {
+        for (target, blank_intent) in [
+            (workspace(test_workspace().as_str()), " "),
+            (workspace("absent"), " "),
+        ] {
             let status = service
                 .start_task(request_for_principal(
                     StartTaskRequest {
-                        workspace: Some(workspace(name)),
+                        workspace: Some(target),
                         intent: blank_intent.to_string(),
                     },
                     outsider.clone(),
@@ -399,7 +412,7 @@ mod tests {
             let status = service
                 .end_task(request_for_principal(
                     EndTaskRequest {
-                        workspace: Some(workspace("default")),
+                        workspace: Some(workspace(test_workspace().as_str())),
                         task_id: task.to_string(),
                         task_status: TaskStatus::Success as i32,
                     },
@@ -412,7 +425,7 @@ mod tests {
 
         assert_eq!(
             tasks
-                .validate_attribution(&WorkspaceName::default(), Some(task_id))
+                .validate_attribution(&test_workspace(), Some(task_id))
                 .await
                 .expect("the task is untouched"),
             Some(task_id),
@@ -425,7 +438,7 @@ mod tests {
         let (_dir, service) = service().await;
         let task = service
             .start_task(request(StartTaskRequest {
-                workspace: Some(workspace("default")),
+                workspace: Some(workspace(test_workspace().as_str())),
                 intent: "Find renewal risk".to_string(),
             }))
             .await
@@ -436,7 +449,7 @@ mod tests {
 
         let status = service
             .end_task(request(EndTaskRequest {
-                workspace: Some(workspace("default")),
+                workspace: Some(workspace(test_workspace().as_str())),
                 task_id: task.task_id,
                 task_status: TaskStatus::Unspecified as i32,
             }))

--- a/crates/coral-app/src/test_support.rs
+++ b/crates/coral-app/src/test_support.rs
@@ -1,8 +1,8 @@
 //! Fixtures the crate's own unit tests share.
 //!
 //! What lives here is the shape of a deployment several suites all need to
-//! stand up before they can say anything about access: a migrated database
-//! holding the default workspace, and principals provisioned through the
+//! stand up before they can say anything about access: a migrated database,
+//! the workspace a suite runs in, and principals provisioned through the
 //! production login seam rather than invented as strings. Kept in one place,
 //! a change to `LoginIdentity` or to membership writes is one edit rather than
 //! six, and no copy can quietly drift from the others.
@@ -21,11 +21,13 @@ use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::manager::WorkspaceManager;
 use crate::workspaces::{MemberRole, WorkspaceName};
 
-/// A shared deployment over one migrated database holding the default
-/// workspace, so every caller's authority comes from a membership row.
+/// A shared deployment over one migrated database, so every caller's
+/// authority comes from a membership row.
 ///
-/// It stops at the state every service needs: each suite builds its own
-/// managers on top, because that part is what the suite is about.
+/// It stops at the state every service needs: each suite creates the
+/// workspace it runs in and builds its own managers on top, because that part
+/// is what the suite is about. An install provisions no workspace, so there is
+/// none here to inherit.
 pub(crate) struct MigratedDeployment {
     /// Held so the config directory outlives the deployment built over it.
     pub(crate) temp: TempDir,
@@ -53,7 +55,7 @@ pub(crate) async fn migrated_deployment() -> MigratedDeployment {
     db.migrate().await.expect("migrate sqlite");
     run_state_migrations(&db, &config_store, &layout)
         .await
-        .expect("import the default workspace");
+        .expect("run state migrations");
     let credentials = CredentialManager::new(CredentialStore::new(layout.clone()));
     let workspaces = WorkspaceManager::new_for_tests(
         config_store.clone(),
@@ -73,15 +75,19 @@ pub(crate) async fn migrated_deployment() -> MigratedDeployment {
 }
 
 /// Provisions one directory user through the production login seam and, when
-/// `role` names one, grants it on the default workspace.
+/// `role` names one, grants it on `workspace`.
 ///
 /// The `user_id` a service is then handed is the one a real login carries,
 /// rather than an identifier a test made up. `issuer` is the only thing that
 /// differs between suites: each provisions under its own, so a subject seeded
-/// by one is a different person from the same subject seeded by another.
+/// by one is a different person from the same subject seeded by another. The
+/// workspace is named rather than assumed, because a fixture that spelled a
+/// well-known name would prove a workspace is resolved by being well known
+/// instead of by having been created.
 pub(crate) async fn seed_principal(
     db: &Arc<CoralDb>,
     issuer: &str,
+    workspace: &WorkspaceName,
     subject: &str,
     role: Option<MemberRole>,
 ) -> Principal {
@@ -103,9 +109,22 @@ pub(crate) async fn seed_principal(
         let mut session = db.as_ref();
         session
             .workspace_members()
-            .upsert(WorkspaceName::default().as_str(), &user.user_id, role, 2)
+            .upsert(workspace.as_str(), &user.user_id, role, 2)
             .await
             .expect("grant membership");
     }
     Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
+}
+
+/// Creates one ordinary workspace for a suite to run in.
+///
+/// An install provisions none, so a fixture that needs one creates it the way
+/// a caller would rather than relying on a name that happens to be there.
+pub(crate) async fn create_workspace(db: &Arc<CoralDb>, workspace: &WorkspaceName) {
+    let mut tx = db.begin().await.expect("begin workspace creation");
+    tx.workspaces()
+        .create(workspace.as_str(), 1)
+        .await
+        .expect("create workspace");
+    tx.commit().await.expect("commit workspace creation");
 }

--- a/crates/coral-app/src/test_support.rs
+++ b/crates/coral-app/src/test_support.rs
@@ -116,6 +116,14 @@ pub(crate) async fn seed_principal(
     Principal::parse(&user.user_id, PrincipalKind::User).expect("federated principal")
 }
 
+/// The name of the one ordinary workspace a suite runs in.
+///
+/// The name is ordinary on purpose: a fixture that leaned on a well-known one
+/// would prove the workspace was resolved by name rather than created.
+pub(crate) fn test_workspace() -> WorkspaceName {
+    WorkspaceName::parse("work").expect("workspace name")
+}
+
 /// Creates one ordinary workspace for a suite to run in.
 ///
 /// An install provisions none, so a fixture that needs one creates it the way

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -10,7 +10,7 @@ use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::ConfigStore;
 use crate::state::db::{
     AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbRepos, RemoveMemberOutcome,
-    WorkspaceMemberRecord, now_unix_nanos_i64,
+    WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
 };
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
@@ -147,10 +147,28 @@ impl WorkspaceManager {
             else {
                 return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
             };
-            let deleted = self
+            // Move the directory out of the workspaces root before anything
+            // commits. Nothing on disk records that a workspace was deleted,
+            // so a directory still sitting there afterwards reads as a live
+            // workspace to every later scan — the legacy catalog cutover
+            // included, which would resurrect it. Staging is also the only
+            // step here that is still fully reversible, the config removal
+            // below being durable, so a failure to move aborts the deletion
+            // and the caller retries once whatever held the directory lets go.
+            // That trades an undeletable workspace on a filesystem that
+            // refuses the rename for never reporting a deletion that left the
+            // workspace's contents in place.
+            let workspace_dir_backup = match self.stage_deleted_workspace_dir(workspace_name) {
+                Ok(backup) => backup,
+                Err(error) => {
+                    Self::roll_back_workspace_deletion(workspace_name, deletion).await;
+                    return Err(error);
+                }
+            };
+            let deleted = match self
                 .config_store
-                .remove_workspace_config_entries(workspace_name);
-            let deleted = match deleted {
+                .remove_workspace_config_entries(workspace_name)
+            {
                 Ok(deleted) => deleted.unwrap_or_else(|| DeletedWorkspace {
                     workspace: WorkspaceRecord {
                         name: workspace_name.clone(),
@@ -158,19 +176,17 @@ impl WorkspaceManager {
                     sources: Vec::new(),
                 }),
                 Err(error) => {
-                    if let Err(rollback_error) = deletion.rollback().await {
-                        warn!(
-                            workspace = %workspace_name,
-                            "workspace config cleanup failed, and database rollback also failed: {rollback_error}"
-                        );
-                    }
+                    Self::restore_staged_workspace_dir(workspace_name, &workspace_dir_backup);
+                    Self::roll_back_workspace_deletion(workspace_name, deletion).await;
                     return Err(error);
                 }
             };
-            deletion.commit().await?;
+            if let Err(error) = deletion.commit().await {
+                Self::restore_staged_workspace_dir(workspace_name, &workspace_dir_backup);
+                return Err(error.into());
+            }
             self.pool_registry.remove(workspace_name);
             self.remove_deleted_workspace_credentials(&deleted);
-            let workspace_dir_backup = self.stage_deleted_workspace_dir(&deleted.workspace.name);
             (deleted, workspace_dir_backup)
         };
         drop(deletion_marker);
@@ -178,7 +194,7 @@ impl WorkspaceManager {
         let deleted_workspace_name = deleted.workspace.name.clone();
         self.diagnostic_reporter
             .clear_workspace(&deleted_workspace_name);
-        Self::commit_deleted_workspace_dir(&deleted_workspace_name, workspace_dir_backup);
+        Self::commit_deleted_workspace_dir(&deleted_workspace_name, &workspace_dir_backup);
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
         Ok(deleted.workspace)
@@ -218,31 +234,47 @@ impl WorkspaceManager {
         }
     }
 
-    fn stage_deleted_workspace_dir(
-        &self,
+    async fn roll_back_workspace_deletion(
         workspace_name: &WorkspaceName,
-    ) -> Option<DirectoryBackup> {
-        let workspace_dir = self.workspace_dir(workspace_name);
-        match DirectoryBackup::move_for_delete(&workspace_dir, workspace_name) {
-            Ok(backup) => Some(backup),
-            Err(error) => {
-                warn!(
-                    workspace = %workspace_name,
-                    workspace_dir = %workspace_dir.display(),
-                    "workspace deleted, but failed to stage workspace directory cleanup: {error}"
-                );
-                None
-            }
+        deletion: WorkspaceDeletion<'_>,
+    ) {
+        if let Err(rollback_error) = deletion.rollback().await {
+            warn!(
+                workspace = %workspace_name,
+                "workspace deletion was aborted, and the database rollback also failed: {rollback_error}"
+            );
         }
     }
 
-    fn commit_deleted_workspace_dir(
+    fn restore_staged_workspace_dir(workspace_name: &WorkspaceName, backup: &DirectoryBackup) {
+        if let Err(error) = backup.restore() {
+            warn!(
+                workspace = %workspace_name,
+                backup_path = %backup.backup_path().display(),
+                "workspace deletion was aborted, but the staged workspace directory could not be put back: {error}"
+            );
+        }
+    }
+
+    fn stage_deleted_workspace_dir(
+        &self,
         workspace_name: &WorkspaceName,
-        backup: Option<DirectoryBackup>,
-    ) {
-        let Some(backup) = backup else {
-            return;
-        };
+    ) -> Result<DirectoryBackup, AppError> {
+        let workspace_dir = self.workspace_dir(workspace_name);
+        DirectoryBackup::move_for_delete_into(
+            &workspace_dir,
+            &self.paths.deleted_workspaces_root(),
+            workspace_name,
+        )
+        .map_err(|error| {
+            AppError::Internal(format!(
+                "failed to stage workspace directory '{}' for deletion: {error}",
+                workspace_dir.display()
+            ))
+        })
+    }
+
+    fn commit_deleted_workspace_dir(workspace_name: &WorkspaceName, backup: &DirectoryBackup) {
         if let Err(error) = backup.commit() {
             warn!(
                 workspace = %workspace_name,
@@ -643,6 +675,58 @@ mod tests {
                 .await
                 .unwrap_or_else(|error| panic!("'{name}' should be creatable again: {error}"));
         }
+    }
+
+    /// Nothing on disk records that a workspace was deleted, so a directory
+    /// left in the workspaces root reads as a live workspace to every later
+    /// scan. A deletion that cannot move the directory out therefore aborts
+    /// whole rather than reporting a success that left the contents in place —
+    /// the caller retries once whatever refused the move lets go.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_workspace_whose_directory_cannot_be_staged_is_not_deleted() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (temp, db, manager) = membership_manager().await;
+        let creator = seed_user(&db, "creator").await;
+        let name = workspace("work");
+        manager
+            .create_workspace_for_user(&name, &creator)
+            .await
+            .expect("create workspace");
+        let workspaces_root = temp.path().join("coral-config").join("workspaces");
+        let workspace_dir = workspaces_root.join("work");
+        std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
+        std::fs::set_permissions(&workspaces_root, std::fs::Permissions::from_mode(0o500))
+            .expect("refuse the move out of the workspaces root");
+
+        let error = manager
+            .delete_workspace(&name)
+            .await
+            .expect_err("a directory that cannot be staged must fail the deletion");
+
+        std::fs::set_permissions(&workspaces_root, std::fs::Permissions::from_mode(0o700))
+            .expect("restore the workspaces root");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to stage workspace directory"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            workspace_dir.exists(),
+            "an aborted deletion keeps the workspace's contents"
+        );
+        assert_eq!(
+            manager.list_workspaces().await.expect("list workspaces"),
+            vec![WorkspaceRecord { name: name.clone() }],
+            "an aborted deletion leaves the workspace live"
+        );
+        assert_eq!(
+            role_for(&db, &name, &creator).await,
+            Some(MemberRole::Owner),
+            "an aborted deletion leaves its memberships alone"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -4,14 +4,15 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::bootstrap::AppError;
+use crate::credentials::CredentialStorageKind;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::identity::Principal;
 use crate::sources::materialization::SourceDiagnosticReporter;
-use crate::state::ConfigStore;
 use crate::state::db::{
     AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbRepos, RemoveMemberOutcome,
     WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
 };
+use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
     DeletedWorkspace, MemberRole, WorkspaceLifecycleLock, WorkspaceLifecycleRevision,
@@ -186,7 +187,7 @@ impl WorkspaceManager {
                 return Err(error.into());
             }
             self.pool_registry.remove(workspace_name);
-            self.remove_deleted_workspace_credentials(&deleted);
+            self.remove_deleted_workspace_credentials(&deleted, workspace_dir_backup.backup_path());
             (deleted, workspace_dir_backup)
         };
         drop(deletion_marker);
@@ -200,12 +201,37 @@ impl WorkspaceManager {
         Ok(deleted.workspace)
     }
 
-    fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
+    /// Erases the credential material of a workspace that has just been deleted.
+    ///
+    /// The workspace directory is already staged aside by this point, so
+    /// file-backed material is addressed at its staged path: the live layout
+    /// no longer reaches it, and asking the store to erase it there would find
+    /// nothing and report success while the secret sat in the staged copy.
+    /// Keychain material lives outside the directory and is erased through the
+    /// store as before.
+    fn remove_deleted_workspace_credentials(
+        &self,
+        deleted: &DeletedWorkspace,
+        staged_workspace_dir: &std::path::Path,
+    ) {
         let workspace_name = &deleted.workspace.name;
         for source in &deleted.sources {
             let Some(storage) = source.credential_storage_for_material() else {
                 continue;
             };
+            if storage == CredentialStorageKind::File {
+                let staged_secret =
+                    AppStateLayout::staged_secret_file(staged_workspace_dir, &source.name);
+                if let Err(error) = crate::storage::fs::remove_file_if_exists(&staged_secret) {
+                    warn!(
+                        workspace = %workspace_name,
+                        source = %source.name,
+                        staged_secret = %staged_secret.display(),
+                        "workspace deleted, but failed to remove staged credential material: {error}"
+                    );
+                }
+                continue;
+            }
             let credential_set_id = CredentialSetId::for_source(&source.name);
             let guard = match self
                 .credential_manager

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -314,12 +314,6 @@ impl WorkspaceManager {
         }
     }
 
-    /// Lists the workspaces `user_id` belongs to, with the role they hold.
-    ///
-    /// This is the caller's own view rather than the deployment's: it is what
-    /// one person may reach, while [`Self::list_workspaces`] stays the
-    /// host-wide inventory that only the local principal and host-scoped work
-    /// may read.
     /// Lists what `principal` holds, which is not always what the membership
     /// rows say.
     ///
@@ -348,6 +342,12 @@ impl WorkspaceManager {
             .await
     }
 
+    /// Lists the workspaces `user_id` belongs to, with the role they hold.
+    ///
+    /// This is one user's own view rather than the deployment's: it is what
+    /// that person may reach, while [`Self::list_workspaces`] stays the
+    /// host-wide inventory that only the local principal and host-scoped work
+    /// may read.
     pub(crate) async fn list_memberships_for_user(
         &self,
         user_id: &str,

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -7,11 +7,11 @@ use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::identity::Principal;
 use crate::sources::materialization::SourceDiagnosticReporter;
-use crate::state::ConfigStore;
 use crate::state::db::{
-    AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbRepos, RemoveMemberOutcome,
+    AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbError, DbRepos, RemoveMemberOutcome,
     WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
 };
+use crate::state::{ConfigStore, RemovedWorkspaceConfig};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
     DeletedWorkspace, MemberRole, WorkspaceLifecycleLock, WorkspaceLifecycleRevision,
@@ -30,6 +30,10 @@ pub(crate) struct WorkspaceManager {
     db: Arc<CoralDb>,
     diagnostic_reporter: SourceDiagnosticReporter,
     pool_registry: Arc<WorkspacePoolRegistry>,
+    /// Makes the deletion transaction refuse to commit, so a test can drive
+    /// the recovery that puts the removed config entries back.
+    #[cfg(test)]
+    deletion_commit_fails: bool,
 }
 
 impl WorkspaceManager {
@@ -70,11 +74,19 @@ impl WorkspaceManager {
             db,
             diagnostic_reporter,
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
+            #[cfg(test)]
+            deletion_commit_fails: false,
         }
     }
 
     pub(crate) fn with_pool_registry(mut self, pool_registry: Arc<WorkspacePoolRegistry>) -> Self {
         self.pool_registry = pool_registry;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_failing_deletion_commit(mut self) -> Self {
+        self.deletion_commit_fails = true;
         self
     }
 
@@ -147,22 +159,33 @@ impl WorkspaceManager {
             else {
                 return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
             };
-            let deleted = match self
+            let removed = match self
                 .config_store
                 .remove_workspace_config_entries(workspace_name)
             {
-                Ok(deleted) => deleted.unwrap_or_else(|| DeletedWorkspace {
-                    workspace: WorkspaceRecord {
-                        name: workspace_name.clone(),
-                    },
-                    sources: Vec::new(),
-                }),
+                Ok(removed) => removed,
                 Err(error) => {
                     Self::roll_back_workspace_deletion(workspace_name, deletion).await;
                     return Err(error);
                 }
             };
-            deletion.commit().await?;
+            if let Err(error) = self.commit_workspace_deletion(deletion).await {
+                // The transaction rolled back, so the workspace is still in
+                // the catalog while its config entries are already gone. The
+                // removal is durable and carries everything it took away, so
+                // put it back rather than leave the two disagreeing.
+                self.restore_workspace_config_entries(workspace_name, removed);
+                return Err(error.into());
+            }
+            let deleted = removed.map_or_else(
+                || DeletedWorkspace {
+                    workspace: WorkspaceRecord {
+                        name: workspace_name.clone(),
+                    },
+                    sources: Vec::new(),
+                },
+                RemovedWorkspaceConfig::into_deleted_workspace,
+            );
             self.pool_registry.remove(workspace_name);
             self.remove_deleted_workspace_credentials(&deleted);
             // Staging comes last, and failing to move the directory only
@@ -236,6 +259,47 @@ impl WorkspaceManager {
             warn!(
                 workspace = %workspace_name,
                 "workspace deletion was aborted, and the database rollback also failed: {rollback_error}"
+            );
+        }
+    }
+
+    /// Commits the deletion transaction.
+    ///
+    /// A seam rather than a call at the one site that needs it, because
+    /// nothing a test can do to a real transaction makes its commit fail on
+    /// demand, and the recovery that failure drives — putting the config
+    /// entries back — is the part worth pinning.
+    async fn commit_workspace_deletion(
+        &self,
+        deletion: WorkspaceDeletion<'_>,
+    ) -> Result<(), DbError> {
+        #[cfg(test)]
+        if self.deletion_commit_fails {
+            deletion.rollback().await?;
+            return Err(DbError::Config(
+                "workspace deletion commit failed for tests".to_string(),
+            ));
+        }
+        deletion.commit().await
+    }
+
+    /// Undoes the config removal of a deletion that could not go through.
+    ///
+    /// Best effort, like every other recovery here: a restore that fails
+    /// leaves the divergence it was meant to close, and saying so is all that
+    /// is left to do about it.
+    fn restore_workspace_config_entries(
+        &self,
+        workspace_name: &WorkspaceName,
+        removed: Option<RemovedWorkspaceConfig>,
+    ) {
+        let Some(removed) = removed else {
+            return;
+        };
+        if let Err(error) = self.config_store.restore_workspace_config_entries(removed) {
+            warn!(
+                workspace = %workspace_name,
+                "workspace deletion was aborted, but its config entries could not be put back: {error}"
             );
         }
     }
@@ -669,6 +733,58 @@ mod tests {
                 .await
                 .unwrap_or_else(|error| panic!("'{name}' should be creatable again: {error}"));
         }
+    }
+
+    /// The config removal is durable the moment it returns, while the
+    /// transaction it accompanies is not. A commit that fails after it has to
+    /// put the entries back, or the workspace stays in the catalog with its
+    /// sources missing from `config.toml`.
+    #[tokio::test]
+    async fn a_deletion_whose_commit_fails_leaves_config_and_database_agreeing() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let db = test_db(&layout).await;
+        let manager = WorkspaceManager::new_for_tests(
+            store.clone(),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            None,
+            Arc::clone(&db),
+        )
+        .with_failing_deletion_commit();
+        let workspace_name = workspace("work");
+        let owner = seed_user(&db, "owner").await;
+        manager
+            .create_workspace_for_user(&workspace_name, &owner)
+            .await
+            .expect("create workspace");
+        store
+            .upsert_source(&workspace_name, installed_source("github"))
+            .expect("upsert source");
+
+        manager
+            .delete_workspace(&workspace_name)
+            .await
+            .expect_err("a deletion whose commit fails must report the failure");
+
+        assert_eq!(
+            manager.list_workspaces().await.expect("list workspaces"),
+            vec![WorkspaceRecord {
+                name: workspace_name.clone()
+            }],
+            "a failed commit leaves the workspace in the catalog"
+        );
+        assert_eq!(
+            store
+                .list_workspace_sources(&workspace_name)
+                .expect("list workspace sources")
+                .into_iter()
+                .map(|source| source.name)
+                .collect::<Vec<_>>(),
+            vec![SourceName::parse("github").expect("source")],
+            "a workspace still in the catalog keeps its sources in the config"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -34,6 +34,8 @@ pub(crate) struct WorkspaceManager {
     /// the recovery that puts the removed config entries back.
     #[cfg(test)]
     deletion_commit_fails: bool,
+    #[cfg(test)]
+    config_restore_fails: bool,
 }
 
 impl WorkspaceManager {
@@ -76,6 +78,8 @@ impl WorkspaceManager {
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
             #[cfg(test)]
             deletion_commit_fails: false,
+            #[cfg(test)]
+            config_restore_fails: false,
         }
     }
 
@@ -87,6 +91,12 @@ impl WorkspaceManager {
     #[cfg(test)]
     pub(crate) const fn with_failing_deletion_commit(mut self) -> Self {
         self.deletion_commit_fails = true;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_failing_config_restore(mut self) -> Self {
+        self.config_restore_fails = true;
         self
     }
 
@@ -169,13 +179,24 @@ impl WorkspaceManager {
                     return Err(error);
                 }
             };
-            if let Err(error) = self.commit_workspace_deletion(deletion).await {
+            if let Err(commit_error) = self.commit_workspace_deletion(deletion).await {
                 // The transaction rolled back, so the workspace is still in
                 // the catalog while its config entries are already gone. The
                 // removal is durable and carries everything it took away, so
                 // put it back rather than leave the two disagreeing.
-                self.restore_workspace_config_entries(workspace_name, removed);
-                return Err(error.into());
+                if let Err(restore_error) = self.restore_workspace_config_entries(removed) {
+                    // Both halves failed, which is the split this restore
+                    // exists to prevent. Report it instead of the commit
+                    // failure alone, so the caller knows the deployment needs
+                    // attention rather than a retry.
+                    return Err(AppError::Internal(format!(
+                        "deleting workspace '{workspace_name}' failed to commit ({commit_error}), \
+                         and its config entries could not be put back ({restore_error}); the \
+                         workspace is still in the catalog while its sources and functions are \
+                         missing from config.toml"
+                    )));
+                }
+                return Err(commit_error.into());
             }
             let deleted = removed.map_or_else(
                 || DeletedWorkspace {
@@ -288,20 +309,26 @@ impl WorkspaceManager {
     /// Best effort, like every other recovery here: a restore that fails
     /// leaves the divergence it was meant to close, and saying so is all that
     /// is left to do about it.
+    /// Puts back what the aborted deletion removed from `config.toml`.
+    ///
+    /// The failure is returned rather than logged: it is the one that leaves
+    /// the database holding a workspace whose sources and functions are gone
+    /// from the file, and a caller that only hears about the step which
+    /// triggered the abort would never learn the two now disagree.
     fn restore_workspace_config_entries(
         &self,
-        workspace_name: &WorkspaceName,
         removed: Option<RemovedWorkspaceConfig>,
-    ) {
+    ) -> Result<(), AppError> {
         let Some(removed) = removed else {
-            return;
+            return Ok(());
         };
-        if let Err(error) = self.config_store.restore_workspace_config_entries(removed) {
-            warn!(
-                workspace = %workspace_name,
-                "workspace deletion was aborted, but its config entries could not be put back: {error}"
-            );
+        #[cfg(test)]
+        if self.config_restore_fails {
+            return Err(AppError::Internal(
+                "workspace config restore failed for tests".to_string(),
+            ));
         }
+        self.config_store.restore_workspace_config_entries(removed)
     }
 
     fn stage_deleted_workspace_dir(
@@ -733,6 +760,50 @@ mod tests {
                 .await
                 .unwrap_or_else(|error| panic!("'{name}' should be creatable again: {error}"));
         }
+    }
+
+    /// Both halves of the recovery can fail. When they do, the caller must
+    /// hear that the two disagree rather than only that the commit failed,
+    /// because the deployment needs attention and a retry will not give it.
+    #[tokio::test]
+    async fn a_deletion_that_cannot_put_its_config_back_reports_the_split() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let db = test_db(&layout).await;
+        let manager = WorkspaceManager::new_for_tests(
+            store.clone(),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            None,
+            Arc::clone(&db),
+        )
+        .with_failing_deletion_commit()
+        .with_failing_config_restore();
+        let workspace_name = workspace("work");
+        let owner = seed_user(&db, "owner").await;
+        manager
+            .create_workspace_for_user(&workspace_name, &owner)
+            .await
+            .expect("create workspace");
+        store
+            .upsert_source(&workspace_name, installed_source("github"))
+            .expect("upsert source");
+
+        let error = manager
+            .delete_workspace(&workspace_name)
+            .await
+            .expect_err("a deletion that cannot restore its config must report the failure");
+
+        let reported = error.to_string();
+        assert!(
+            reported.contains("could not be put back"),
+            "the failure must name the unrestored config, not just the commit: {reported}"
+        );
+        assert!(
+            reported.contains("missing from config.toml"),
+            "the failure must say what state the deployment is left in: {reported}"
+        );
     }
 
     /// The config removal is durable the moment it returns, while the

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -4,15 +4,14 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::bootstrap::AppError;
-use crate::credentials::CredentialStorageKind;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::identity::Principal;
 use crate::sources::materialization::SourceDiagnosticReporter;
+use crate::state::ConfigStore;
 use crate::state::db::{
     AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbRepos, RemoveMemberOutcome,
     WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
 };
-use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
     DeletedWorkspace, MemberRole, WorkspaceLifecycleLock, WorkspaceLifecycleRevision,
@@ -148,24 +147,6 @@ impl WorkspaceManager {
             else {
                 return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
             };
-            // Move the directory out of the workspaces root before anything
-            // commits. Nothing on disk records that a workspace was deleted,
-            // so a directory still sitting there afterwards reads as a live
-            // workspace to every later scan — the legacy catalog cutover
-            // included, which would resurrect it. Staging is also the only
-            // step here that is still fully reversible, the config removal
-            // below being durable, so a failure to move aborts the deletion
-            // and the caller retries once whatever held the directory lets go.
-            // That trades an undeletable workspace on a filesystem that
-            // refuses the rename for never reporting a deletion that left the
-            // workspace's contents in place.
-            let workspace_dir_backup = match self.stage_deleted_workspace_dir(workspace_name) {
-                Ok(backup) => backup,
-                Err(error) => {
-                    Self::roll_back_workspace_deletion(workspace_name, deletion).await;
-                    return Err(error);
-                }
-            };
             let deleted = match self
                 .config_store
                 .remove_workspace_config_entries(workspace_name)
@@ -177,17 +158,23 @@ impl WorkspaceManager {
                     sources: Vec::new(),
                 }),
                 Err(error) => {
-                    Self::restore_staged_workspace_dir(workspace_name, &workspace_dir_backup);
                     Self::roll_back_workspace_deletion(workspace_name, deletion).await;
                     return Err(error);
                 }
             };
-            if let Err(error) = deletion.commit().await {
-                Self::restore_staged_workspace_dir(workspace_name, &workspace_dir_backup);
-                return Err(error.into());
-            }
+            deletion.commit().await?;
             self.pool_registry.remove(workspace_name);
-            self.remove_deleted_workspace_credentials(&deleted, workspace_dir_backup.backup_path());
+            self.remove_deleted_workspace_credentials(&deleted);
+            // Staging comes last, and failing to move the directory only
+            // warns. Everything above it is already durable, so an abort here
+            // would report a failure for a deletion that happened. The cost is
+            // an accepted one: a directory left in the workspaces root carries
+            // no evidence that it was deleted, so a later scan — the legacy
+            // catalog cutover — reads it as a live workspace and resurrects it.
+            // Staging before the commit would close that, but a crash between
+            // the rename and the commit would then leave a live workspace with
+            // no directory at all, which is worse.
+            let workspace_dir_backup = self.stage_deleted_workspace_dir(&deleted.workspace.name);
             (deleted, workspace_dir_backup)
         };
         drop(deletion_marker);
@@ -195,7 +182,7 @@ impl WorkspaceManager {
         let deleted_workspace_name = deleted.workspace.name.clone();
         self.diagnostic_reporter
             .clear_workspace(&deleted_workspace_name);
-        Self::commit_deleted_workspace_dir(&deleted_workspace_name, &workspace_dir_backup);
+        Self::commit_deleted_workspace_dir(&deleted_workspace_name, workspace_dir_backup);
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
         Ok(deleted.workspace)
@@ -203,35 +190,16 @@ impl WorkspaceManager {
 
     /// Erases the credential material of a workspace that has just been deleted.
     ///
-    /// The workspace directory is already staged aside by this point, so
-    /// file-backed material is addressed at its staged path: the live layout
-    /// no longer reaches it, and asking the store to erase it there would find
-    /// nothing and report success while the secret sat in the staged copy.
-    /// Keychain material lives outside the directory and is erased through the
-    /// store as before.
-    fn remove_deleted_workspace_credentials(
-        &self,
-        deleted: &DeletedWorkspace,
-        staged_workspace_dir: &std::path::Path,
-    ) {
+    /// Runs while the workspace directory is still in place, because staging
+    /// it aside is the step after this one: file-backed material is where the
+    /// live layout says it is, and keychain material lives outside the
+    /// directory either way.
+    fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
         let workspace_name = &deleted.workspace.name;
         for source in &deleted.sources {
             let Some(storage) = source.credential_storage_for_material() else {
                 continue;
             };
-            if storage == CredentialStorageKind::File {
-                let staged_secret =
-                    AppStateLayout::staged_secret_file(staged_workspace_dir, &source.name);
-                if let Err(error) = crate::storage::fs::remove_file_if_exists(&staged_secret) {
-                    warn!(
-                        workspace = %workspace_name,
-                        source = %source.name,
-                        staged_secret = %staged_secret.display(),
-                        "workspace deleted, but failed to remove staged credential material: {error}"
-                    );
-                }
-                continue;
-            }
             let credential_set_id = CredentialSetId::for_source(&source.name);
             let guard = match self
                 .credential_manager
@@ -272,35 +240,35 @@ impl WorkspaceManager {
         }
     }
 
-    fn restore_staged_workspace_dir(workspace_name: &WorkspaceName, backup: &DirectoryBackup) {
-        if let Err(error) = backup.restore() {
-            warn!(
-                workspace = %workspace_name,
-                backup_path = %backup.backup_path().display(),
-                "workspace deletion was aborted, but the staged workspace directory could not be put back: {error}"
-            );
-        }
-    }
-
     fn stage_deleted_workspace_dir(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<DirectoryBackup, AppError> {
+    ) -> Option<DirectoryBackup> {
         let workspace_dir = self.workspace_dir(workspace_name);
-        DirectoryBackup::move_for_delete_into(
+        match DirectoryBackup::move_for_delete_into(
             &workspace_dir,
             &self.paths.deleted_workspaces_root(),
             workspace_name,
-        )
-        .map_err(|error| {
-            AppError::Internal(format!(
-                "failed to stage workspace directory '{}' for deletion: {error}",
-                workspace_dir.display()
-            ))
-        })
+        ) {
+            Ok(backup) => Some(backup),
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    workspace_dir = %workspace_dir.display(),
+                    "workspace deleted, but failed to stage workspace directory cleanup: {error}"
+                );
+                None
+            }
+        }
     }
 
-    fn commit_deleted_workspace_dir(workspace_name: &WorkspaceName, backup: &DirectoryBackup) {
+    fn commit_deleted_workspace_dir(
+        workspace_name: &WorkspaceName,
+        backup: Option<DirectoryBackup>,
+    ) {
+        let Some(backup) = backup else {
+            return;
+        };
         if let Err(error) = backup.commit() {
             warn!(
                 workspace = %workspace_name,
@@ -701,58 +669,6 @@ mod tests {
                 .await
                 .unwrap_or_else(|error| panic!("'{name}' should be creatable again: {error}"));
         }
-    }
-
-    /// Nothing on disk records that a workspace was deleted, so a directory
-    /// left in the workspaces root reads as a live workspace to every later
-    /// scan. A deletion that cannot move the directory out therefore aborts
-    /// whole rather than reporting a success that left the contents in place —
-    /// the caller retries once whatever refused the move lets go.
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn a_workspace_whose_directory_cannot_be_staged_is_not_deleted() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let (temp, db, manager) = membership_manager().await;
-        let creator = seed_user(&db, "creator").await;
-        let name = workspace("work");
-        manager
-            .create_workspace_for_user(&name, &creator)
-            .await
-            .expect("create workspace");
-        let workspaces_root = temp.path().join("coral-config").join("workspaces");
-        let workspace_dir = workspaces_root.join("work");
-        std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
-        std::fs::set_permissions(&workspaces_root, std::fs::Permissions::from_mode(0o500))
-            .expect("refuse the move out of the workspaces root");
-
-        let error = manager
-            .delete_workspace(&name)
-            .await
-            .expect_err("a directory that cannot be staged must fail the deletion");
-
-        std::fs::set_permissions(&workspaces_root, std::fs::Permissions::from_mode(0o700))
-            .expect("restore the workspaces root");
-        assert!(
-            error
-                .to_string()
-                .contains("failed to stage workspace directory"),
-            "unexpected error: {error}"
-        );
-        assert!(
-            workspace_dir.exists(),
-            "an aborted deletion keeps the workspace's contents"
-        );
-        assert_eq!(
-            manager.list_workspaces().await.expect("list workspaces"),
-            vec![WorkspaceRecord { name: name.clone() }],
-            "an aborted deletion leaves the workspace live"
-        );
-        assert_eq!(
-            role_for(&db, &name, &creator).await,
-            Some(MemberRole::Owner),
-            "an aborted deletion leaves its memberships alone"
-        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -124,36 +124,6 @@ impl WorkspaceManager {
         self.lifecycle_lock.clone()
     }
 
-    pub(crate) async fn create_workspace(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<WorkspaceRecord, AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock_async().await;
-        let mut tx = self.db.begin().await?;
-        if tx
-            .workspaces()
-            .get(workspace_name.as_str())
-            .await?
-            .is_some()
-        {
-            return Err(AppError::WorkspaceAlreadyExists(workspace_name.to_string()));
-        }
-        if let Err(error) = tx
-            .workspaces()
-            .create(workspace_name.as_str(), now_unix_nanos_i64()?)
-            .await
-        {
-            if error.is_unique_violation() {
-                return Err(AppError::WorkspaceAlreadyExists(workspace_name.to_string()));
-            }
-            return Err(error.into());
-        }
-        tx.commit().await?;
-        Ok(WorkspaceRecord {
-            name: workspace_name.clone(),
-        })
-    }
-
     pub(crate) async fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
@@ -942,9 +912,10 @@ mod tests {
         let source = installed_source("github");
         let source_name = source.name.clone();
         let credential_set_id = CredentialSetId::for_source(&source.name);
+        let owner = seed_user(&db, "owner").await;
 
         manager
-            .create_workspace(&workspace_name)
+            .create_workspace_for_user(&workspace_name, &owner)
             .await
             .expect("create workspace");
         store

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -158,12 +158,6 @@ impl WorkspaceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
-        if workspace_name.is_default() {
-            return Err(AppError::FailedPrecondition(
-                "default workspace cannot be removed".to_string(),
-            ));
-        }
-
         let deletion_marker = self
             .lifecycle_lock
             .mark_workspace_deleting(workspace_name)
@@ -614,6 +608,45 @@ mod tests {
     /// are ordinary caller-chosen names, so a caller cannot reach a workspace
     /// they never created by guessing a reserved-looking one.
     #[tokio::test]
+    async fn deleting_a_workspace_owns_every_valid_name_alike() {
+        let (_temp, db, manager) = membership_manager().await;
+        let creator = seed_user(&db, "creator").await;
+
+        for name in [
+            "default".to_string(),
+            format!("default-{}", uuid::Uuid::new_v4()),
+            "default-team".to_string(),
+            "work".to_string(),
+        ] {
+            let workspace = workspace(&name);
+            manager
+                .create_workspace_for_user(&workspace, &creator)
+                .await
+                .expect("create workspace");
+
+            assert_eq!(
+                manager
+                    .delete_workspace(&workspace)
+                    .await
+                    .unwrap_or_else(|error| panic!("'{name}' should be deletable: {error}"))
+                    .name,
+                workspace
+            );
+            assert!(
+                matches!(
+                    manager.delete_workspace(&workspace).await,
+                    Err(AppError::WorkspaceNotFound(_))
+                ),
+                "'{name}' must be gone once deleted"
+            );
+            manager
+                .create_workspace_for_user(&workspace, &creator)
+                .await
+                .unwrap_or_else(|error| panic!("'{name}' should be creatable again: {error}"));
+        }
+    }
+
+    #[tokio::test]
     async fn creating_a_workspace_owns_every_valid_name_alike() {
         let (_temp, db, manager) = membership_manager().await;
         let creator = seed_user(&db, "creator").await;
@@ -997,7 +1030,7 @@ mod tests {
             diagnostic_reporter.clone(),
         )
         .with_pool_registry(Arc::clone(&pool_registry));
-        let workspace_name = WorkspaceName::default();
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
         let pool_registry_before_delete = pool_registry.for_workspace(&workspace_name);
         let source_name = SourceName::parse("github").expect("source name");
         diagnostic_reporter.report_source_load_failure(
@@ -1007,10 +1040,12 @@ mod tests {
             "test failure",
         );
 
+        // The workspace was never created, so deletion fails before it can
+        // touch any of the state a successful deletion sweeps.
         manager
             .delete_workspace(&workspace_name)
             .await
-            .expect_err("default workspace deletion should fail");
+            .expect_err("deleting a workspace that was never created should fail");
 
         assert!(diagnostic_reporter.tracks_diagnostic(
             &workspace_name,

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -5,6 +5,7 @@ use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
+use crate::identity::Principal;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::ConfigStore;
 use crate::state::db::{
@@ -319,6 +320,34 @@ impl WorkspaceManager {
     /// one person may reach, while [`Self::list_workspaces`] stays the
     /// host-wide inventory that only the local principal and host-scoped work
     /// may read.
+    /// Lists what `principal` holds, which is not always what the membership
+    /// rows say.
+    ///
+    /// A deployment that admits the local principal treats it as owner of
+    /// everything, and it holds no membership rows a listing could be read
+    /// from for the workspaces it never created. Which of the two readings
+    /// applies is a property of the principal and the deployment, so it is
+    /// settled here rather than at the transport, where it would be one more
+    /// thing every caller of this had to remember.
+    pub(crate) async fn list_memberships_for_principal(
+        &self,
+        principal: &Principal,
+    ) -> Result<Vec<WorkspaceMembership>, AppError> {
+        if principal.is_local() {
+            return Ok(self
+                .list_workspaces()
+                .await?
+                .into_iter()
+                .map(|workspace| WorkspaceMembership {
+                    workspace,
+                    role: MemberRole::Owner,
+                })
+                .collect());
+        }
+        self.list_memberships_for_user(principal.id().as_str())
+            .await
+    }
+
     pub(crate) async fn list_memberships_for_user(
         &self,
         user_id: &str,

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -26,11 +26,6 @@ impl WorkspaceName {
     pub(crate) fn as_str(&self) -> &str {
         &self.0
     }
-
-    #[must_use]
-    pub(crate) fn is_default(&self) -> bool {
-        self.0 == DEFAULT_WORKSPACE_ID
-    }
 }
 
 impl fmt::Display for WorkspaceName {
@@ -39,6 +34,12 @@ impl fmt::Display for WorkspaceName {
     }
 }
 
+/// Names the legacy `default` workspace, which is now an ordinary name.
+///
+/// Nothing provisions, protects, or resolves this name any more: it exists so
+/// legacy on-disk state and fixtures can still spell the one workspace older
+/// installs were given. Do not reach for it to stand in for "the caller's
+/// workspace" — a caller's workspace comes from their memberships.
 impl Default for WorkspaceName {
     fn default() -> Self {
         Self(DEFAULT_WORKSPACE_ID.to_string())
@@ -52,5 +53,21 @@ mod tests {
     #[test]
     fn parses_default_workspace_name() {
         assert_eq!(WorkspaceName::default().as_str(), DEFAULT_WORKSPACE_ID);
+    }
+
+    /// `default` carries no reserved status, so it round-trips through the same
+    /// parser every other name does and compares equal to nothing else.
+    #[test]
+    fn the_legacy_default_name_is_an_ordinary_parsed_name() {
+        assert_eq!(
+            WorkspaceName::parse(DEFAULT_WORKSPACE_ID).expect("parse legacy default name"),
+            WorkspaceName::default()
+        );
+        for ordinary in ["default-team", "work"] {
+            assert_ne!(
+                WorkspaceName::parse(ordinary).expect("parse ordinary name"),
+                WorkspaceName::default()
+            );
+        }
     }
 }

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -36,10 +36,12 @@ impl fmt::Display for WorkspaceName {
 
 /// Names the legacy `default` workspace, which is now an ordinary name.
 ///
-/// Nothing provisions, protects, or resolves this name any more: it exists so
-/// legacy on-disk state and fixtures can still spell the one workspace older
-/// installs were given. Do not reach for it to stand in for "the caller's
-/// workspace" — a caller's workspace comes from their memberships.
+/// Test-only, and gated so the compiler enforces it: nothing provisions,
+/// protects, or resolves this name any more, so no production path may reach
+/// for it to stand in for "the caller's workspace" — a caller's workspace comes
+/// from their memberships. It exists so fixtures can still spell the one
+/// workspace older installs were given.
+#[cfg(test)]
 impl Default for WorkspaceName {
     fn default() -> Self {
         Self(DEFAULT_WORKSPACE_ID.to_string())

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -36,11 +36,14 @@ impl fmt::Display for WorkspaceName {
 
 /// Names the legacy `default` workspace, which is now an ordinary name.
 ///
-/// Test-only, and gated so the compiler enforces it: nothing provisions,
-/// protects, or resolves this name any more, so no production path may reach
-/// for it to stand in for "the caller's workspace" — a caller's workspace comes
-/// from their memberships. It exists so fixtures can still spell the one
-/// workspace older installs were given.
+/// Test-only, and `#[cfg(test)]` is what keeps it that way: no production path
+/// can reach for this impl to stand in for "the caller's workspace", which
+/// comes from their memberships. Nothing provisions or protects the name any
+/// more either. One production resolver of it survives — the CLI falls back to
+/// `DEFAULT_WORKSPACE_ID` when neither `--workspace` nor `CORAL_WORKSPACE`
+/// names a workspace (`coral-cli/src/lib.rs`) — and the MCP workspace-binding
+/// slice (#2210) closes that one. This impl exists so fixtures can still spell
+/// the one workspace older installs were given.
 #[cfg(test)]
 impl Default for WorkspaceName {
     fn default() -> Self {

--- a/crates/coral-app/src/workspaces/paths.rs
+++ b/crates/coral-app/src/workspaces/paths.rs
@@ -5,4 +5,8 @@ use crate::workspaces::WorkspaceName;
 /// Path capability for workspace-owned filesystem artifacts.
 pub(crate) trait WorkspacePaths: Send + Sync + 'static {
     fn workspace_dir(&self, workspace_name: &WorkspaceName) -> PathBuf;
+
+    /// Where a deletion stages a workspace directory, outside the root the
+    /// live ones live in.
+    fn deleted_workspaces_root(&self) -> PathBuf;
 }

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -83,6 +83,14 @@ impl WorkspaceServiceApi for WorkspaceService {
         .await
     }
 
+    /// Creates one workspace owned by the caller who asked for it.
+    ///
+    /// The local principal is no exception. Its `coral:local` directory row is
+    /// guaranteed by the one-time local-ownership migration the composition
+    /// root runs at startup, so its ownership grant commits in the same
+    /// transaction as the workspace itself. No caller creates a workspace with
+    /// no owner, which a later switch to shared mode would conceal from
+    /// everyone.
     async fn create_workspace(
         &self,
         request: Request<CreateWorkspaceRequest>,
@@ -97,30 +105,10 @@ impl WorkspaceServiceApi for WorkspaceService {
             authorizer
                 .authorize_creation(&principal)
                 .map_err(app_status)?;
-            let creator = principal.id().as_str();
-            let workspace = if principal.is_local() {
-                // Being admitted at all means this deployment treats the local
-                // principal as owner of everything, and it has no directory row
-                // an ownership grant could reference: the `coral:local` user is
-                // written by the one-time local-ownership migration, which does
-                // not exist yet, and the membership foreign key forbids granting
-                // ownership to a subject the directory does not hold.
-                //
-                // This branch is therefore a bridge, not the intended shape. It
-                // persists a workspace with zero owner rows, which a later
-                // switch to shared mode would leave concealed from every
-                // authenticated caller. Once the migration guarantees the
-                // `coral:local` row, local creation routes through
-                // `create_workspace_for_user` like every other creator and this
-                // branch goes away, so that owner insertion stays in the same
-                // transaction as workspace creation for all callers.
-                workspaces.create_workspace(&workspace_name).await
-            } else {
-                workspaces
-                    .create_workspace_for_user(&workspace_name, creator)
-                    .await
-            }
-            .map_err(app_status)?;
+            let workspace = workspaces
+                .create_workspace_for_user(&workspace_name, principal.id().as_str())
+                .await
+                .map_err(app_status)?;
             Ok(Response::new(CreateWorkspaceResponse {
                 workspace: Some(workspace_record_to_proto(&workspace)),
             }))
@@ -306,6 +294,7 @@ mod tests {
     use crate::request_context::RequestContext;
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
+        inaccessible_workspaces, migrate_local_ownership_once,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::transport::workspace_to_proto;
@@ -817,13 +806,24 @@ mod tests {
         local
             .create(&Principal::local(), "team")
             .await
-            .expect("the implicit owner creates without a directory row");
-        // The absent membership pins the bridge, not the destination: no
-        // `coral:local` directory row exists to grant ownership to yet. When
-        // the one-time local-ownership migration guarantees that row, local
-        // creation grants ownership like any other creator and this assertion
-        // flips to `Some(MemberRole::Owner)`.
-        assert_eq!(local.role_of("team", LOCAL_PRINCIPAL_ID).await, None);
+            .expect("the implicit owner creates against its migrated directory row");
+        assert_eq!(
+            local.role_of("team", LOCAL_PRINCIPAL_ID).await,
+            Some(MemberRole::Owner),
+            "the local principal owns what it creates, in the same transaction"
+        );
+        let inaccessible = inaccessible_workspaces(&local.db)
+            .await
+            .expect("report the workspaces nobody can reach");
+        assert!(
+            inaccessible.without_owner.is_empty(),
+            "an ownerless workspace would be concealed from everyone once this deployment became a shared one"
+        );
+        assert_eq!(
+            inaccessible.local_owner_only,
+            vec!["team".to_string()],
+            "it is owned, so a shared deployment reports it as ownership to transfer rather than as lost"
+        );
     }
 
     /// The adapter reads its caller from request context, so a request that
@@ -989,8 +989,15 @@ mod tests {
         deployment(WorkspaceAuthorizer::new).await
     }
 
+    /// Builds a single-user deployment the way the composition root does: the
+    /// one-time local-ownership migration runs at startup, so the `coral:local`
+    /// directory row an ownership grant references is already there.
     async fn local_deployment() -> Deployment {
-        deployment(WorkspaceAuthorizer::trusting_local_principal).await
+        let deployment = deployment(WorkspaceAuthorizer::trusting_local_principal).await;
+        migrate_local_ownership_once(&deployment.db)
+            .await
+            .expect("run the one-time local-ownership migration");
+        deployment
     }
 
     async fn deployment(

--- a/crates/coral-app/src/workspaces/service.rs
+++ b/crates/coral-app/src/workspaces/service.rs
@@ -57,27 +57,13 @@ impl WorkspaceServiceApi for WorkspaceService {
         let principal = request_context(&request)?.principal().clone();
         instrument_grpc(span, async move {
             authorizer.admit(&principal).map_err(app_status)?;
-            let caller = principal.id().as_str();
-            let memberships = if principal.is_local() {
-                // Being admitted at all means this deployment treats the local
-                // principal as owner of everything, and it holds no membership
-                // rows the listing could be read from.
-                workspaces
-                    .list_workspaces()
-                    .await
-                    .map_err(app_status)?
-                    .into_iter()
-                    .map(|workspace| membership_to_proto(&workspace, MemberRole::Owner))
-                    .collect()
-            } else {
-                workspaces
-                    .list_memberships_for_user(caller)
-                    .await
-                    .map_err(app_status)?
-                    .into_iter()
-                    .map(|membership| membership_to_proto(&membership.workspace, membership.role))
-                    .collect()
-            };
+            let memberships = workspaces
+                .list_memberships_for_principal(&principal)
+                .await
+                .map_err(app_status)?
+                .into_iter()
+                .map(|membership| membership_to_proto(&membership.workspace, membership.role))
+                .collect();
             Ok(Response::new(ListWorkspacesResponse { memberships }))
         })
         .await

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -23,6 +23,8 @@ mod harness;
 mod health_service_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
+#[path = "grpc/ownership_migration_tests.rs"]
+mod ownership_migration_tests;
 #[path = "grpc/resilience_tests.rs"]
 mod resilience_tests;
 #[path = "grpc/search_tests.rs"]

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -17,8 +17,7 @@ use super::harness::{
 
 #[tokio::test]
 async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -79,8 +78,7 @@ async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
 
 #[tokio::test]
 async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagination() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -166,8 +164,7 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
 
 #[tokio::test]
 async fn search_catalog_matches_table_function_guide() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -202,8 +199,7 @@ async fn search_catalog_matches_table_function_guide() {
 
 #[tokio::test]
 async fn list_columns_filters_required_columns_and_patterns() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_required_filter_yaml(),
@@ -273,8 +269,7 @@ async fn list_columns_filters_required_columns_and_patterns() {
 
 #[tokio::test]
 async fn describe_missing_surface_returns_missing() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
@@ -302,8 +297,7 @@ async fn describe_missing_surface_returns_missing() {
 
 #[tokio::test]
 async fn describe_catalog_surface_returns_exact_table_function() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -334,8 +328,7 @@ async fn describe_catalog_surface_returns_exact_table_function() {
 
 #[tokio::test]
 async fn describe_catalog_surface_does_not_resolve_partial_function_name() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -363,8 +356,7 @@ async fn describe_catalog_surface_does_not_resolve_partial_function_name() {
 
 #[tokio::test]
 async fn list_columns_missing_table_takes_precedence_over_invalid_pattern() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
@@ -393,8 +385,7 @@ async fn list_columns_missing_table_takes_precedence_over_invalid_pattern() {
 
 #[tokio::test]
 async fn invalid_regex_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .catalog_client()

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -18,6 +18,7 @@ use super::harness::{
 #[tokio::test]
 async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -79,6 +80,7 @@ async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
 #[tokio::test]
 async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagination() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -165,6 +167,7 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
 #[tokio::test]
 async fn search_catalog_matches_table_function_guide() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -200,6 +203,7 @@ async fn search_catalog_matches_table_function_guide() {
 #[tokio::test]
 async fn list_columns_filters_required_columns_and_patterns() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_required_filter_yaml(),
@@ -270,6 +274,7 @@ async fn list_columns_filters_required_columns_and_patterns() {
 #[tokio::test]
 async fn describe_missing_surface_returns_missing() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
@@ -298,6 +303,7 @@ async fn describe_missing_surface_returns_missing() {
 #[tokio::test]
 async fn describe_catalog_surface_returns_exact_table_function() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -329,6 +335,7 @@ async fn describe_catalog_surface_returns_exact_table_function() {
 #[tokio::test]
 async fn describe_catalog_surface_does_not_resolve_partial_function_name() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_functions_yaml(),
@@ -357,6 +364,7 @@ async fn describe_catalog_surface_does_not_resolve_partial_function_name() {
 #[tokio::test]
 async fn list_columns_missing_table_takes_precedence_over_invalid_pattern() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
@@ -386,6 +394,7 @@ async fn list_columns_missing_table_takes_precedence_over_invalid_pattern() {
 #[tokio::test]
 async fn invalid_regex_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .catalog_client()

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -32,6 +32,7 @@ guide: Use this function to echo a typed value.
 #[tokio::test]
 async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let work = workspace("work");
     harness
         .workspace_client()
@@ -125,6 +126,7 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
 #[tokio::test]
 async fn function_sources_are_returned_when_added_and_listed() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_yaml(harness.temp_path()),
@@ -170,6 +172,7 @@ async fn function_sources_are_returned_when_added_and_listed() {
 #[tokio::test]
 async fn untyped_function_is_not_persisted() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .function_client()
@@ -264,6 +267,7 @@ export async function run(owner: string): Promise<string> {
 #[tokio::test]
 async fn create_only_preserves_an_existing_function_and_legacy_add_replaces_it() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let workspace = default_workspace();
     let original = function_sql("select cast($value as VARCHAR) as value");
     let added = harness

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -207,6 +207,7 @@ async fn untyped_function_is_not_persisted() {
 #[tokio::test]
 async fn typescript_function_is_rejected_without_persistence() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let artifact = r"/*
 name: review_summary
 schema: functions

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -31,8 +31,7 @@ guide: Use this function to echo a typed value.
 
 #[tokio::test]
 async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let work = workspace("work");
     harness
         .workspace_client()
@@ -125,8 +124,7 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
 
 #[tokio::test]
 async fn function_sources_are_returned_when_added_and_listed() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_yaml(harness.temp_path()),
@@ -171,8 +169,7 @@ async fn function_sources_are_returned_when_added_and_listed() {
 
 #[tokio::test]
 async fn untyped_function_is_not_persisted() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .function_client()
@@ -206,8 +203,7 @@ async fn untyped_function_is_not_persisted() {
 
 #[tokio::test]
 async fn typescript_function_is_rejected_without_persistence() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let artifact = r"/*
 name: review_summary
 schema: functions
@@ -267,8 +263,7 @@ export async function run(owner: string): Promise<string> {
 
 #[tokio::test]
 async fn create_only_preserves_an_existing_function_and_legacy_add_replaces_it() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let workspace = default_workspace();
     let original = function_sql("select cast($value as VARCHAR) as value");
     let added = harness

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -416,8 +416,15 @@ impl Install {
     }
 }
 
-/// A running server that authenticates its callers, plus the directory rows
-/// login provisioning would have written for them.
+/// One running server over an [`Install`], plus the directory rows login
+/// provisioning would have written for its callers.
+///
+/// It authenticates its callers under [`Admission::Tokens`], which is how
+/// [`SharedDeployment::start`] builds it and what every test predating the
+/// mode-transition work gets. Started under [`Admission::LocalPrincipal`] the
+/// same server admits unauthenticated requests as the built-in local principal
+/// instead — see [`SharedDeployment::as_host`] — because a mode transition has
+/// to bring one install up both ways.
 pub(crate) struct SharedDeployment {
     install: Arc<Install>,
     endpoint_uri: String,

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -20,6 +20,7 @@ use coral_client::{
 use serde_json::{Value, json};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
+use toml_edit::{DocumentMut, Item, Table};
 use tonic::{Code, Request, Response, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
@@ -275,23 +276,150 @@ impl GrpcHarness {
 /// which is what leaves the local principal owning everything.
 const LOCAL_PRINCIPAL_CONFIG: &str = "[credentials]\nstorage = \"file\"\n";
 
-/// Writes `config.toml` as the install's own configuration plus `mode`.
+/// Rewrites `config.toml` so the install runs under `mode`, keeping the rest of
+/// the file.
 ///
-/// Composing from the base each time is what lets one install move between
-/// modes: an `[auth]` section a previous start wrote is gone rather than
-/// lingering to contradict the mode being started now.
-fn write_config(config_dir: &Path, base: &str, mode: &str) {
+/// Only the tables that say how callers are admitted are replaced. Everything
+/// else — the legacy workspace tables a test seeds, the sources a running
+/// server installed — survives, because moving an install between modes is a
+/// change to its auth configuration rather than a new install.
+///
+/// The admission tables a previous mode wrote are removed rather than merged
+/// over, so an `[auth]` section cannot linger and contradict the mode being
+/// started now.
+fn write_config(config_dir: &Path, mode: &str) {
     std::fs::create_dir_all(config_dir).expect("create config dir");
-    let separator = if base.is_empty() || base.ends_with('\n') {
-        ""
-    } else {
-        "\n"
+    let config_file = config_dir.join("config.toml");
+    let mut config: DocumentMut = std::fs::read_to_string(&config_file)
+        .unwrap_or_default()
+        .parse()
+        .expect("the install's config.toml is valid TOML");
+
+    config.remove("auth");
+    if let Some(server) = config.get_mut("server").and_then(Item::as_table_mut) {
+        server.remove("mcp_http");
+        if server.is_empty() {
+            config.remove("server");
+        }
+    }
+
+    let incoming: DocumentMut = mode.parse().expect("the mode's config is valid TOML");
+    for (key, value) in incoming.iter() {
+        merge_config_table(config.as_table_mut(), key, value);
+    }
+
+    std::fs::write(config_file, config.to_string()).expect("write the deployment config");
+}
+
+/// Puts `value` into `table` under `key`, descending one level into a table the
+/// two share.
+///
+/// Descending rather than overwriting is what lets a mode name
+/// `[server.mcp_http]` without taking the rest of `[server]` with it. One level
+/// is all the admission configuration nests, and stopping there keeps what a
+/// deeper merge would have to guess at out of the harness.
+fn merge_config_table(table: &mut Table, key: &str, value: &Item) {
+    let (Some(incoming), Some(existing)) = (value.as_table(), table.get_mut(key)) else {
+        table.insert(key, value.clone());
+        return;
     };
-    std::fs::write(
-        config_dir.join("config.toml"),
-        format!("{base}{separator}\n{mode}"),
-    )
-    .expect("write the deployment config");
+    let Some(existing) = existing.as_table_mut() else {
+        table.insert(key, value.clone());
+        return;
+    };
+    for (nested_key, nested_value) in incoming {
+        existing.insert(nested_key, nested_value.clone());
+    }
+}
+
+#[cfg(test)]
+mod write_config_tests {
+    use super::{LOCAL_PRINCIPAL_CONFIG, write_config};
+    use crate::session_auth::SessionAuthFixture;
+    use tempfile::TempDir;
+
+    fn config_after(seed: &str, modes: &[&str]) -> String {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(config_dir.join("config.toml"), seed).expect("seed config");
+        for mode in modes {
+            write_config(&config_dir, mode);
+        }
+        std::fs::read_to_string(config_dir.join("config.toml")).expect("read config")
+    }
+
+    /// What a running server persisted between two starts has to outlive the
+    /// second one, or a restart silently undoes work the deployment did. This
+    /// is the case a snapshot taken before the first start cannot express.
+    #[test]
+    fn a_restart_keeps_what_the_running_server_persisted() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let config_file = config_dir.join("config.toml");
+        std::fs::write(&config_file, "[workspaces.analytics]\n").expect("seed config");
+
+        write_config(&config_dir, LOCAL_PRINCIPAL_CONFIG);
+
+        // The server comes up and installs a source, which it persists here.
+        let running = std::fs::read_to_string(&config_file).expect("read config");
+        std::fs::write(
+            &config_file,
+            format!("{running}\n[workspaces.analytics.sources.installed]\norigin = \"imported\"\n"),
+        )
+        .expect("persist a source the way a running server would");
+
+        write_config(&config_dir, LOCAL_PRINCIPAL_CONFIG);
+
+        let written = std::fs::read_to_string(&config_file).expect("read config");
+        assert!(
+            written.contains("[workspaces.analytics.sources.installed]"),
+            "a source installed between starts must survive the next one: {written}"
+        );
+        assert!(
+            written.contains("[credentials]"),
+            "the mode's own tables must still be written: {written}"
+        );
+    }
+
+    /// Moving back to single-user has to take the login configuration with it,
+    /// or the next start reads an `[auth]` section the mode does not want.
+    #[test]
+    fn leaving_token_admission_removes_what_it_wrote() {
+        let written = config_after(
+            "[workspaces.analytics]\n",
+            &[&SessionAuthFixture::config_toml(), LOCAL_PRINCIPAL_CONFIG],
+        );
+
+        assert!(
+            !written.contains("[auth"),
+            "an auth section must not linger into single-user mode: {written}"
+        );
+        assert!(
+            !written.contains("mcp_http"),
+            "the shared listener must not linger either: {written}"
+        );
+        assert!(
+            written.contains("[workspaces.analytics]"),
+            "the install's own tables survive the mode change: {written}"
+        );
+    }
+
+    /// The mode names one key inside `[server]`, so the rest of that table is
+    /// not its to take away.
+    #[test]
+    fn swapping_the_listener_leaves_the_rest_of_server_alone() {
+        let written = config_after(
+            "[server]\nbind = '127.0.0.1:7777'\n",
+            &[&SessionAuthFixture::config_toml(), LOCAL_PRINCIPAL_CONFIG],
+        );
+
+        assert!(
+            written.contains("bind = '127.0.0.1:7777'"),
+            "an unrelated server key must survive the listener being removed: {written}"
+        );
+    }
 }
 
 fn ensure_file_credentials_config(config_dir: &Path) {
@@ -332,13 +460,6 @@ pub(crate) enum Admission {
 pub(crate) struct Install {
     temp: Mutex<Option<TempDir>>,
     config_dir: PathBuf,
-    /// The `config.toml` this install started life with, captured before any
-    /// mode wrote its own sections over it.
-    ///
-    /// The legacy tables a test seeds here are the subject of these tests, so
-    /// each start composes its configuration on top of them rather than
-    /// replacing them.
-    base_config: Mutex<Option<String>>,
 }
 
 impl Install {
@@ -348,28 +469,11 @@ impl Install {
         Arc::new(Self {
             temp: Mutex::new(Some(temp)),
             config_dir,
-            base_config: Mutex::new(None),
         })
     }
 
     pub(crate) fn config_dir(&self) -> &Path {
         &self.config_dir
-    }
-
-    /// The configuration this install held before any server started over it.
-    ///
-    /// Read once and remembered, and every start rewrites `config.toml` as this
-    /// snapshot plus the admission section — so whatever a running server
-    /// persisted into that file is discarded by the next restart. A test that
-    /// needs config-backed state across restarts declares it here, in the
-    /// configuration the install starts life with, rather than installing it
-    /// through an RPC and expecting the file to keep it.
-    fn base_config(&self) -> String {
-        let mut base = self.base_config.lock().expect("install base config");
-        base.get_or_insert_with(|| {
-            std::fs::read_to_string(self.config_dir.join("config.toml")).unwrap_or_default()
-        })
-        .clone()
     }
 
     /// Starts a server over whatever this install already holds, so a restart
@@ -386,15 +490,14 @@ impl Install {
         // than varying how the server is built. The `[auth]` section is the
         // whole of the difference: with it the server authenticates session
         // tokens, and without it the local principal owns everything.
-        let base = self.base_config();
         let session_auth = match admission {
             Admission::LocalPrincipal => {
-                write_config(&self.config_dir, &base, LOCAL_PRINCIPAL_CONFIG);
+                write_config(&self.config_dir, LOCAL_PRINCIPAL_CONFIG);
                 None
             }
             Admission::Tokens => {
                 let session_auth = SessionAuthFixture::key_in(&self.config_dir);
-                write_config(&self.config_dir, &base, &SessionAuthFixture::config_toml());
+                write_config(&self.config_dir, &SessionAuthFixture::config_toml());
                 Some(session_auth)
             }
         };

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -39,6 +39,8 @@ pub(crate) struct FailingHttpFixture {
 }
 
 impl GrpcHarness {
+    /// Starts a server on empty state, the way a fresh install comes up: it
+    /// owns no workspace until someone creates one.
     pub(crate) async fn new() -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
         let config_dir = temp_dir.path().join("coral-config");
@@ -110,6 +112,17 @@ impl GrpcHarness {
             app,
             _server: server,
         }
+    }
+
+    /// Creates the one workspace the scoped fixtures work in.
+    ///
+    /// Nothing provisions it: a fixture that needs workspace state asks for it
+    /// here, through the same public RPC any client would use, and
+    /// `default_workspace()` then names it on every request that follows.
+    pub(crate) async fn seed_workspace(&self) {
+        create_workspace(&self.app, &default_workspace().name)
+            .await
+            .expect("seed the workspace this fixture works in");
     }
 
     pub(crate) fn temp_path(&self) -> &Path {
@@ -391,6 +404,20 @@ impl SharedDeployment {
         )
         .await
         .expect("connect a test client")
+    }
+
+    /// Every workspace this deployment holds, read from its own state rather
+    /// than through a listing that answers only for the caller who asked. Each
+    /// deployment keeps its own database, so this counts nothing another test
+    /// owns.
+    pub(crate) async fn workspace_names(&self) -> Vec<String> {
+        let pool = self.app_database().await;
+        let names = sqlx::query_scalar::<_, String>("SELECT id FROM workspaces ORDER BY id")
+            .fetch_all(&pool)
+            .await
+            .expect("read the workspaces this deployment holds");
+        pool.close().await;
+        names
     }
 
     /// Reads what `workspace_name` has on record, straight from the state the

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -47,6 +47,20 @@ impl GrpcHarness {
         Self::start_with_parts(temp_dir, config_dir, FeatureOverrides::default()).await
     }
 
+    /// Starts a server and creates the one workspace the fixture works in.
+    ///
+    /// This is what a suite that is about something else wants: nearly every
+    /// scoped fixture pairs [`Self::new`] with [`Self::seed_workspace`], and a
+    /// test that copies the surrounding style but forgets the second call
+    /// compiles and then fails deep inside an RPC with an unknown-workspace
+    /// error that does not point back at the missing setup. [`Self::new`]
+    /// stays for the suites whose subject is the fresh install itself.
+    pub(crate) async fn with_workspace() -> Self {
+        let harness = Self::new().await;
+        harness.seed_workspace().await;
+        harness
+    }
+
     pub(crate) async fn new_with_observed_values_search() -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
         let config_dir = temp_dir.path().join("coral-config");

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -357,6 +357,13 @@ impl Install {
     }
 
     /// The configuration this install held before any server started over it.
+    ///
+    /// Read once and remembered, and every start rewrites `config.toml` as this
+    /// snapshot plus the admission section — so whatever a running server
+    /// persisted into that file is discarded by the next restart. A test that
+    /// needs config-backed state across restarts declares it here, in the
+    /// configuration the install starts life with, rather than installing it
+    /// through an RPC and expecting the file to keep it.
     fn base_config(&self) -> String {
         let mut base = self.base_config.lock().expect("install base config");
         base.get_or_insert_with(|| {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use coral_api::v1::{
     AddWorkspaceMemberRequest, AddWorkspaceMemberResponse, CreateWorkspaceRequest,
@@ -257,6 +257,29 @@ impl GrpcHarness {
     }
 }
 
+/// The configuration an unauthenticated deployment reads: no `[auth]` at all,
+/// which is what leaves the local principal owning everything.
+const LOCAL_PRINCIPAL_CONFIG: &str = "[credentials]\nstorage = \"file\"\n";
+
+/// Writes `config.toml` as the install's own configuration plus `mode`.
+///
+/// Composing from the base each time is what lets one install move between
+/// modes: an `[auth]` section a previous start wrote is gone rather than
+/// lingering to contradict the mode being started now.
+fn write_config(config_dir: &Path, base: &str, mode: &str) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    let separator = if base.is_empty() || base.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    std::fs::write(
+        config_dir.join("config.toml"),
+        format!("{base}{separator}\n{mode}"),
+    )
+    .expect("write the deployment config");
+}
+
 fn ensure_file_credentials_config(config_dir: &Path) {
     std::fs::create_dir_all(config_dir).expect("create config dir");
     let config_file = config_dir.join("config.toml");
@@ -277,15 +300,132 @@ fn ensure_file_credentials_config(config_dir: &Path) {
 /// leaked one would be recognizable on the wire.
 pub(crate) const TEST_ISSUER: &str = "https://issuer.test/authorization";
 
+/// How a deployment admits its callers, which is also what settles whether it
+/// honors the built-in local principal: installing any provider retires it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Admission {
+    /// Nothing authenticates callers, so every request arrives as the host.
+    LocalPrincipal,
+    /// Bearer tokens name each caller, the way a shared deployment admits them.
+    Tokens,
+}
+
+/// One install's state directory, which outlives the servers started over it.
+///
+/// A deployment's mode is settled when its server starts, so moving an install
+/// between modes means shutting one server down and starting the next over the
+/// same directory.
+pub(crate) struct Install {
+    temp: Mutex<Option<TempDir>>,
+    config_dir: PathBuf,
+    /// The `config.toml` this install started life with, captured before any
+    /// mode wrote its own sections over it.
+    ///
+    /// The legacy tables a test seeds here are the subject of these tests, so
+    /// each start composes its configuration on top of them rather than
+    /// replacing them.
+    base_config: Mutex<Option<String>>,
+}
+
+impl Install {
+    pub(crate) fn new() -> Arc<Self> {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        Arc::new(Self {
+            temp: Mutex::new(Some(temp)),
+            config_dir,
+            base_config: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+
+    /// The configuration this install held before any server started over it.
+    fn base_config(&self) -> String {
+        let mut base = self.base_config.lock().expect("install base config");
+        base.get_or_insert_with(|| {
+            std::fs::read_to_string(self.config_dir.join("config.toml")).unwrap_or_default()
+        })
+        .clone()
+    }
+
+    /// Starts a server over whatever this install already holds, so a restart
+    /// reads the state the previous one left behind.
+    ///
+    /// The error is reported as text rather than swallowed: a startup that
+    /// refuses because of the state on disk is itself part of the contract.
+    pub(crate) async fn start(
+        self: &Arc<Self>,
+        admission: Admission,
+    ) -> Result<SharedDeployment, String> {
+        // What admits a deployment's callers is what its configuration says, so
+        // moving an install between modes rewrites that configuration rather
+        // than varying how the server is built. The `[auth]` section is the
+        // whole of the difference: with it the server authenticates session
+        // tokens, and without it the local principal owns everything.
+        let base = self.base_config();
+        let session_auth = match admission {
+            Admission::LocalPrincipal => {
+                write_config(&self.config_dir, &base, LOCAL_PRINCIPAL_CONFIG);
+                None
+            }
+            Admission::Tokens => {
+                let session_auth = SessionAuthFixture::key_in(&self.config_dir);
+                write_config(&self.config_dir, &base, &SessionAuthFixture::config_toml());
+                Some(session_auth)
+            }
+        };
+        let server = match &session_auth {
+            Some(session_auth) => session_authenticated_server(session_auth)
+                .await
+                .map_err(|error| error.to_string())?,
+            None => ServerBuilder::new()
+                .with_config_dir(&self.config_dir)
+                .start()
+                .await
+                .map_err(|error| error.to_string())?,
+        };
+        let trace_store_dir = server.local_trace_store_dir().map(Path::to_path_buf);
+        self.keep_when_it_holds_the_installed_trace_store(trace_store_dir.as_deref());
+        Ok(SharedDeployment {
+            endpoint_uri: server.endpoint_uri().to_string(),
+            trace_store_dir,
+            install: Arc::clone(self),
+            session_auth,
+            server,
+        })
+    }
+
+    /// The local trace store is installed once per process, by whichever server
+    /// starts first, and the trace-history tests write into whatever directory
+    /// that turned out to be. When it is this install's, the directory must
+    /// outlive every server started over it: removing it would delete the
+    /// installed store out from under a concurrently running test.
+    fn keep_when_it_holds_the_installed_trace_store(&self, trace_store_dir: Option<&Path>) {
+        let mut temp = self.temp.lock().expect("install state directory");
+        let Some(owned) = temp.take() else {
+            return;
+        };
+        if trace_store_dir.is_some_and(|dir| dir.starts_with(owned.path())) {
+            let _installed_store_root: PathBuf = owned.keep();
+        } else {
+            *temp = Some(owned);
+        }
+    }
+}
+
 /// A running server that authenticates its callers, plus the directory rows
 /// login provisioning would have written for them.
 pub(crate) struct SharedDeployment {
-    _temp: Option<TempDir>,
-    config_dir: PathBuf,
+    install: Arc<Install>,
     endpoint_uri: String,
     trace_store_dir: Option<PathBuf>,
-    session_auth: SessionAuthFixture,
-    _server: RunningServer,
+    /// Present only while this deployment authenticates its callers; a
+    /// local-principal deployment has no tokens to mint.
+    session_auth: Option<SessionAuthFixture>,
+    server: RunningServer,
 }
 
 /// What one workspace has on record from work its callers asked for.
@@ -302,40 +442,20 @@ pub(crate) struct WorkspaceWork {
 
 impl SharedDeployment {
     pub(crate) async fn start() -> Self {
-        let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("coral-config");
-        // Configuring session authentication is what makes a deployment a
-        // shared one: it retires the implicit local owner, so each request over
-        // this transport arrives as a distinct person or agent rather than as
-        // the host. The fixture writes the credentials config too.
-        let session_auth = SessionAuthFixture::write(&config_dir);
-        let server = session_authenticated_server(&session_auth)
+        Install::new()
+            .start(Admission::Tokens)
             .await
-            .expect("start an authenticated server");
-        let endpoint_uri = server.endpoint_uri().to_string();
-        let trace_store_dir = server.local_trace_store_dir().map(Path::to_path_buf);
-        // The local trace store is installed once per process, by whichever
-        // server starts first, and the trace-history tests write into whatever
-        // directory that turned out to be. When it is this one's, the temp dir
-        // must outlive the deployment: removing it would delete the installed
-        // store out from under a concurrently running test.
-        let temp = if trace_store_dir
-            .as_ref()
-            .is_some_and(|dir| dir.starts_with(temp.path()))
-        {
-            let _installed_store_root: PathBuf = temp.keep();
-            None
-        } else {
-            Some(temp)
-        };
-        Self {
-            _temp: temp,
-            config_dir,
-            endpoint_uri,
-            trace_store_dir,
-            session_auth,
-            _server: server,
-        }
+            .expect("start an authenticated server")
+    }
+
+    /// Shuts this server down and hands back the install it ran over, so the
+    /// next start can bring the same state up under another admission mode.
+    pub(crate) async fn shutdown(self) -> Arc<Install> {
+        let Self {
+            install, server, ..
+        } = self;
+        server.shutdown().await.expect("shut the server down");
+        install
     }
 
     /// Writes one directory row the way a completed login would, and returns
@@ -345,6 +465,20 @@ impl SharedDeployment {
     /// not the OIDC round trip — that these transport tests need. Authorization
     /// never sees the upstream subject: it is stored here and nowhere else.
     pub(crate) async fn seed_user(&self, handle: &str, display_name: &str) -> String {
+        self.seed_user_with_subject(handle, &format!("upstream-subject-{handle}"), display_name)
+            .await
+    }
+
+    /// Writes a directory row carrying `subject` verbatim.
+    ///
+    /// A verified identity always carries a non-empty `sub`, so this is the
+    /// only way to put on record the corrupted rows a login could not produce.
+    pub(crate) async fn seed_user_with_subject(
+        &self,
+        handle: &str,
+        subject: &str,
+        display_name: &str,
+    ) -> String {
         let user_id = format!("user-{handle}");
         let pool = self.app_database().await;
         sqlx::query(
@@ -352,7 +486,7 @@ impl SharedDeployment {
         )
         .bind(&user_id)
         .bind(TEST_ISSUER)
-        .bind(format!("upstream-subject-{handle}"))
+        .bind(subject)
         .bind(display_name)
         .bind(1_i64)
         .bind(1_i64)
@@ -361,6 +495,62 @@ impl SharedDeployment {
         .expect("seed a provisioned login");
         pool.close().await;
         user_id
+    }
+
+    /// Removes one directory row, for the corrupted state an operator repairs
+    /// between two starts.
+    pub(crate) async fn remove_user(&self, user_id: &str) {
+        let pool = self.app_database().await;
+        sqlx::query("DELETE FROM users WHERE user_id = ?")
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("remove a directory row");
+        pool.close().await;
+    }
+
+    /// Writes the workspace row a pre-membership install left behind: one that
+    /// exists with no memberships at all, which is what the upgrade adopts.
+    pub(crate) async fn seed_ownerless_workspace(&self, name: &str) {
+        let pool = self.app_database().await;
+        sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES (?, ?)")
+            .bind(name)
+            .bind(1_i64)
+            .execute(&pool)
+            .await
+            .expect("seed an ownerless workspace");
+        pool.close().await;
+    }
+
+    /// Every membership on record as `(workspace, user, role)`, read from the
+    /// deployment's own state rather than through a listing that answers only
+    /// for the caller who asked — and which the local principal is answered
+    /// without any membership row existing at all.
+    pub(crate) async fn memberships(&self) -> Vec<(String, String, String)> {
+        let pool = self.app_database().await;
+        let rows = sqlx::query_as::<_, (String, String, String)>(
+            "SELECT workspace_id, user_id, role FROM workspace_members ORDER BY workspace_id, user_id",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("read the memberships this deployment holds");
+        pool.close().await;
+        rows
+    }
+
+    /// Whether the one-time local-ownership upgrade has been claimed against
+    /// this state directory. A claim that a failed upgrade rolled back leaves
+    /// no row, which is what lets a later start retry it.
+    pub(crate) async fn local_ownership_migration_claimed(&self) -> bool {
+        let pool = self.app_database().await;
+        let claims = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM app_state_migrations WHERE id = 'local_workspace_ownership_v1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("read the migration marker");
+        pool.close().await;
+        claims == 1
     }
 
     pub(crate) async fn as_person(&self, user_id: &str) -> AppClient {
@@ -378,6 +568,14 @@ impl SharedDeployment {
         self.connect(agent_id, PrincipalKind::Agent).await
     }
 
+    /// Connects the way a no-login install's only caller does: unauthenticated,
+    /// and therefore admitted as the built-in local principal.
+    pub(crate) async fn as_host(&self) -> AppClient {
+        AppClient::connect(self.endpoint_uri())
+            .await
+            .expect("connect a test client")
+    }
+
     /// The address to dial for a service `AppClient` does not carry, such as
     /// `TraceService` or `FeatureService`.
     pub(crate) fn endpoint_uri(&self) -> &str {
@@ -393,13 +591,20 @@ impl SharedDeployment {
     /// The bearer credential an actor of `principal_kind` presents for
     /// `user_id`, for tests that dial a service `AppClient` does not carry.
     pub(crate) fn credential(&self, user_id: &str, principal_kind: PrincipalKind) -> String {
-        self.session_auth.access_token_for(user_id, principal_kind)
+        self.session_auth
+            .as_ref()
+            .expect("a local-principal deployment admits the host, not a named caller")
+            .access_token_for(user_id, principal_kind)
     }
 
     async fn connect(&self, user_id: &str, principal_kind: PrincipalKind) -> AppClient {
+        let session_auth = self
+            .session_auth
+            .as_ref()
+            .expect("a local-principal deployment admits the host, not a named caller");
         connect_with_loopback_bearer(
             self.endpoint_uri(),
-            BearerToken::new(self.session_auth.access_token_for(user_id, principal_kind))
+            BearerToken::new(session_auth.access_token_for(user_id, principal_kind))
                 .expect("test bearer token"),
         )
         .await
@@ -473,7 +678,9 @@ impl SharedDeployment {
 
     async fn app_database(&self) -> sqlx::SqlitePool {
         SqlitePoolOptions::new()
-            .connect_with(SqliteConnectOptions::new().filename(self.config_dir.join("coral.db")))
+            .connect_with(
+                SqliteConnectOptions::new().filename(self.install.config_dir().join("coral.db")),
+            )
             .await
             .expect("open the app database")
     }

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -27,8 +27,7 @@ use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
 #[tokio::test]
 async fn query_refreshes_expired_oauth_access_token_at_request_time() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -86,8 +85,7 @@ async fn query_refreshes_expired_oauth_access_token_at_request_time() {
 #[tokio::test]
 async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -136,8 +134,7 @@ async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
 #[tokio::test]
 async fn list_catalog_does_not_refresh_expired_oauth_access_token() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -178,8 +175,7 @@ async fn list_catalog_does_not_refresh_expired_oauth_access_token() {
 #[tokio::test]
 async fn search_catalog_does_not_refresh_expired_oauth_access_token() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -229,8 +225,7 @@ async fn search_catalog_does_not_refresh_expired_oauth_access_token() {
 #[tokio::test]
 async fn query_surfaces_oauth_refresh_failure_instead_of_skipping_source() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -275,8 +270,7 @@ async fn query_surfaces_oauth_refresh_failure_instead_of_skipping_source() {
 #[tokio::test]
 async fn expired_oauth_access_token_without_refresh_token_tells_user_to_reconnect() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -319,8 +313,7 @@ async fn expired_oauth_access_token_without_refresh_token_tells_user_to_reconnec
 #[tokio::test]
 async fn concurrent_queries_share_one_expired_oauth_refresh() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -418,8 +411,7 @@ async fn concurrent_servers_share_one_expired_oauth_refresh() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn manual_credential_replacement_waits_for_in_flight_refresh() {
     let fixture = RefreshingHttpFixture::new_blocked_token_response().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -516,8 +508,7 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
 #[tokio::test]
 async fn successful_refresh_is_persisted_before_later_oauth_input_failure() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             two_oauth_inputs_manifest_yaml(&fixture.base_url, &fixture.token_url),

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -28,6 +28,7 @@ use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
 async fn query_refreshes_expired_oauth_access_token_at_request_time() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -86,6 +87,7 @@ async fn query_refreshes_expired_oauth_access_token_at_request_time() {
 async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -135,6 +137,7 @@ async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
 async fn list_catalog_does_not_refresh_expired_oauth_access_token() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -176,6 +179,7 @@ async fn list_catalog_does_not_refresh_expired_oauth_access_token() {
 async fn search_catalog_does_not_refresh_expired_oauth_access_token() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -226,6 +230,7 @@ async fn search_catalog_does_not_refresh_expired_oauth_access_token() {
 async fn query_surfaces_oauth_refresh_failure_instead_of_skipping_source() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -271,6 +276,7 @@ async fn query_surfaces_oauth_refresh_failure_instead_of_skipping_source() {
 async fn expired_oauth_access_token_without_refresh_token_tells_user_to_reconnect() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -314,6 +320,7 @@ async fn expired_oauth_access_token_without_refresh_token_tells_user_to_reconnec
 async fn concurrent_queries_share_one_expired_oauth_refresh() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -363,6 +370,7 @@ async fn concurrent_servers_share_one_expired_oauth_refresh() {
     let config_root = TempDir::new().expect("config root");
     let config_dir = config_root.path().join("coral-config");
     let first_harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    first_harness.seed_workspace().await;
     first_harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -411,6 +419,7 @@ async fn concurrent_servers_share_one_expired_oauth_refresh() {
 async fn manual_credential_replacement_waits_for_in_flight_refresh() {
     let fixture = RefreshingHttpFixture::new_blocked_token_response().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
@@ -508,6 +517,7 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
 async fn successful_refresh_is_persisted_before_later_oauth_input_failure() {
     let fixture = RefreshingHttpFixture::new().await;
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             two_oauth_inputs_manifest_yaml(&fixture.base_url, &fixture.token_url),

--- a/crates/coral-app/tests/grpc/ownership_migration_tests.rs
+++ b/crates/coral-app/tests/grpc/ownership_migration_tests.rs
@@ -1,0 +1,388 @@
+//! What the one-time local-ownership upgrade does to an install, and what it
+//! must not do, across every deployment-mode change the product specifies.
+//!
+//! Every scenario here starts a real server over a state directory and then
+//! starts another one over the same directory, because a deployment's mode is
+//! settled when its server starts. State is read back from the deployment's own
+//! database rather than through a listing: under the single-user policy the
+//! local principal is answered about every workspace whether or not a
+//! membership row exists, so only the rows themselves show what the upgrade
+//! wrote.
+
+use std::path::Path;
+
+use coral_api::v1::{ListSourcesRequest, WorkspaceRole};
+use coral_client::AppClient;
+use tonic::{Code, Request};
+
+use crate::harness::{
+    Admission, Install, concealed_refusal, create_workspace, execute_sql, membership_rows,
+    named_workspace,
+};
+
+/// The user id the upgrade writes its ownership under.
+const LOCAL_OWNER: &str = "coral:local";
+
+/// A valid workspace name no test ever creates, so a refusal naming it can only
+/// come from the workspace rule rather than from a row.
+const MISSING_WORKSPACE: &str = "never_existed";
+
+/// A legacy install whose `analytics` workspace already has a source installed
+/// in it, so an upgrade that dropped a workspace's contents would show up here.
+const LEGACY_CONFIG_WITH_DATA: &str = r#"
+version = 1
+
+[workspaces.analytics]
+
+[workspaces.analytics.sources.legacy_messages]
+origin = "imported"
+version = "0.1.0"
+
+[workspaces.reports]
+"#;
+
+/// Writes the `config.toml` a pre-membership Coral left behind.
+///
+/// Its workspaces exist only as config tables. The legacy cutover is what turns
+/// them into directory rows, and it leaves them with no memberships at all,
+/// which is precisely the state the upgrade exists to repair.
+fn write_legacy_config(config_dir: &Path, config: &str) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("config.toml"), config).expect("write legacy config");
+}
+
+fn legacy_config_naming(workspaces: &[&str]) -> String {
+    let mut config = String::from("version = 1\n");
+    for workspace in workspaces {
+        config.push_str("\n[workspaces.");
+        config.push_str(workspace);
+        config.push_str("]\n");
+    }
+    config
+}
+
+/// The membership rows an upgrade that adopted `workspaces` leaves behind.
+fn adopted_by_local(workspaces: &[&str]) -> Vec<(String, String, String)> {
+    workspaces
+        .iter()
+        .map(|workspace| {
+            (
+                (*workspace).to_string(),
+                LOCAL_OWNER.to_string(),
+                "owner".to_string(),
+            )
+        })
+        .collect()
+}
+
+/// What a caller is told when they name a workspace, with the name they
+/// supplied themselves factored out. Two names that agree here are
+/// indistinguishable to that caller.
+async fn refusal(client: &AppClient, workspace: &str) -> (Code, String, Vec<String>) {
+    let status = execute_sql(client, workspace, "select 1")
+        .await
+        .expect_err("a caller with no membership must be refused");
+    concealed_refusal(&status, workspace)
+}
+
+async fn source_names(client: &AppClient, workspace: &str) -> Vec<String> {
+    client
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(named_workspace(workspace)),
+        }))
+        .await
+        .expect("a workspace's owner may list its sources")
+        .into_inner()
+        .sources
+        .into_iter()
+        .map(|source| source.name)
+        .collect()
+}
+
+/// Reads the caller's own listing in a stable order.
+async fn listed_memberships(client: &AppClient) -> Vec<(String, WorkspaceRole)> {
+    let mut rows = membership_rows(client).await;
+    rows.sort();
+    rows
+}
+
+/// The upgrade an existing single-user install gets on its first start: every
+/// workspace keeps its name and its contents, and each ownerless one gains
+/// exactly one owner.
+#[tokio::test]
+async fn a_single_user_upgrade_adopts_every_legacy_workspace_once_and_keeps_its_name_and_data() {
+    let install = Install::new();
+    write_legacy_config(install.config_dir(), LEGACY_CONFIG_WITH_DATA);
+
+    let deployment = install
+        .start(Admission::LocalPrincipal)
+        .await
+        .expect("a legacy install must come up in single-user mode");
+
+    assert_eq!(
+        deployment.workspace_names().await,
+        vec!["analytics".to_string(), "reports".to_string()],
+        "the upgrade must not rename, drop, or invent a workspace"
+    );
+    assert_eq!(
+        deployment.memberships().await,
+        adopted_by_local(&["analytics", "reports"]),
+        "every ownerless workspace is adopted, and each of them exactly once"
+    );
+    assert!(deployment.local_ownership_migration_claimed().await);
+    assert_eq!(
+        source_names(&deployment.as_host().await, "analytics").await,
+        vec!["legacy_messages".to_string()],
+        "a workspace must come out of the upgrade with the contents it went in with"
+    );
+}
+
+/// An operator who enables login without first starting the new version in
+/// single-user mode gets no upgrade at all: the legacy workspaces stay in
+/// place, unreachable and undisclosed, and the marker stays unclaimed so a
+/// later single-user start can still run it.
+#[tokio::test]
+async fn a_direct_shared_upgrade_conceals_the_legacy_workspaces_and_leaves_the_upgrade_unclaimed() {
+    let install = Install::new();
+    write_legacy_config(install.config_dir(), &legacy_config_naming(&["legacy"]));
+
+    let deployment = install
+        .start(Admission::Tokens)
+        .await
+        .expect("an ownerless workspace must not refuse a shared server its startup");
+    let alice = deployment.seed_user("alice", "Alice").await;
+    let alice_client = deployment.as_person(&alice).await;
+
+    assert_eq!(
+        deployment.workspace_names().await,
+        vec!["legacy".to_string()]
+    );
+    assert!(
+        deployment.memberships().await.is_empty(),
+        "a shared deployment appoints nobody"
+    );
+    assert!(
+        !deployment.local_ownership_migration_claimed().await,
+        "claiming the marker here would retire the upgrade for a later single-user start"
+    );
+    assert_eq!(listed_memberships(&alice_client).await, Vec::new());
+    assert_eq!(
+        refusal(&alice_client, "legacy").await,
+        refusal(&alice_client, MISSING_WORKSPACE).await,
+        "an ownerless workspace must be indistinguishable from one that never existed"
+    );
+}
+
+/// Configuring login over an upgraded install keeps the built-in local user's
+/// ownership on record without handing any of it to an authenticated user. The
+/// workspace the local user created after the upgrade is owned from the moment
+/// it exists, so it survives the switch on the same footing as the adopted one.
+#[tokio::test]
+async fn login_over_an_upgraded_install_keeps_the_local_owner_and_grants_nobody_else() {
+    let install = Install::new();
+    write_legacy_config(install.config_dir(), &legacy_config_naming(&["notebook"]));
+
+    let single_user = install
+        .start(Admission::LocalPrincipal)
+        .await
+        .expect("start the upgraded single-user deployment");
+    create_workspace(&single_user.as_host().await, "journal")
+        .await
+        .expect("the host creates a workspace of its own");
+
+    assert_eq!(
+        single_user.memberships().await,
+        adopted_by_local(&["journal", "notebook"]),
+        "a workspace created after the upgrade is owned at creation rather than ownerless"
+    );
+
+    let install = single_user.shutdown().await;
+    let shared = install
+        .start(Admission::Tokens)
+        .await
+        .expect("configure login over the same state");
+    let bob = shared.seed_user("bob", "Bob").await;
+    let bob_client = shared.as_person(&bob).await;
+
+    assert_eq!(
+        shared.memberships().await,
+        adopted_by_local(&["journal", "notebook"]),
+        "the local user's ownership remains in the database"
+    );
+    assert_eq!(
+        listed_memberships(&bob_client).await,
+        Vec::new(),
+        "an authenticated user inherits none of it"
+    );
+    for workspace in ["journal", "notebook"] {
+        assert_eq!(
+            refusal(&bob_client, workspace).await,
+            refusal(&bob_client, MISSING_WORKSPACE).await,
+            "{workspace} was disclosed to a user who was never given it"
+        );
+    }
+
+    let install = shared.shutdown().await;
+    let single_user = install
+        .start(Admission::LocalPrincipal)
+        .await
+        .expect("disable login again");
+
+    assert_eq!(
+        listed_memberships(&single_user.as_host().await).await,
+        vec![
+            ("journal".to_string(), WorkspaceRole::Owner),
+            ("notebook".to_string(), WorkspaceRole::Owner),
+        ],
+        "both workspaces are still the local user's once it is admitted again"
+    );
+}
+
+/// Disabling login on a shared deployment runs the upgrade on the next start.
+/// It adopts the workspaces that are still ownerless and leaves every workspace
+/// an authenticated user already owns exactly as it was.
+#[tokio::test]
+async fn a_shared_deployment_switched_to_single_user_adopts_only_the_still_ownerless_workspaces() {
+    let install = Install::new();
+    write_legacy_config(install.config_dir(), &legacy_config_naming(&["orphan"]));
+
+    let shared = install
+        .start(Admission::Tokens)
+        .await
+        .expect("start shared over a legacy install");
+    let carol = shared.seed_user("carol", "Carol").await;
+    create_workspace(&shared.as_person(&carol).await, "carol_space")
+        .await
+        .expect("an authenticated user creates their own workspace");
+
+    let install = shared.shutdown().await;
+    let single_user = install
+        .start(Admission::LocalPrincipal)
+        .await
+        .expect("disable login on the next start");
+
+    assert_eq!(
+        single_user.memberships().await,
+        vec![
+            (
+                "carol_space".to_string(),
+                carol.clone(),
+                "owner".to_string()
+            ),
+            (
+                "orphan".to_string(),
+                LOCAL_OWNER.to_string(),
+                "owner".to_string()
+            ),
+        ],
+        "the upgrade takes only what nobody owned"
+    );
+    assert!(single_user.local_ownership_migration_claimed().await);
+}
+
+/// The two situations startup has to tell an operator about stay distinct in
+/// the state it reads them from: `adopted` is owned only by the built-in local
+/// user, `orphan` by nobody at all. They need different repairs — transfer
+/// ownership off the local user versus appoint one — while being equally
+/// unreachable to every authenticated caller.
+#[tokio::test]
+async fn a_shared_start_keeps_the_two_inaccessible_categories_distinct() {
+    let install = Install::new();
+    write_legacy_config(install.config_dir(), &legacy_config_naming(&["adopted"]));
+
+    let single_user = install
+        .start(Admission::LocalPrincipal)
+        .await
+        .expect("start the upgraded single-user deployment");
+    // This one never went through the upgrade, which is the only way a
+    // workspace still has no owner at all once the marker is claimed.
+    single_user.seed_ownerless_workspace("orphan").await;
+
+    let install = single_user.shutdown().await;
+    let shared = install
+        .start(Admission::Tokens)
+        .await
+        .expect("a workspace nobody can reach must not refuse the server its startup");
+    let dana = shared.seed_user("dana", "Dana").await;
+    let dana_client = shared.as_person(&dana).await;
+
+    assert_eq!(
+        shared.workspace_names().await,
+        vec!["adopted".to_string(), "orphan".to_string()],
+        "both categories keep serving nobody rather than being removed"
+    );
+    assert_eq!(
+        shared.memberships().await,
+        adopted_by_local(&["adopted"]),
+        "`adopted` has the local user as its only owner and `orphan` has none"
+    );
+    for workspace in ["adopted", "orphan"] {
+        assert_eq!(
+            refusal(&dana_client, workspace).await,
+            refusal(&dana_client, MISSING_WORKSPACE).await,
+            "{workspace} was disclosed to a user who cannot reach it"
+        );
+    }
+}
+
+/// A row squatting on the local user's unique empty subject makes the upgrade
+/// fail its membership foreign key after it has already claimed its marker.
+/// The claim must not survive: startup fails outright, the state is left
+/// exactly as it was, and the start after an operator repairs the directory
+/// runs the whole upgrade.
+#[tokio::test]
+async fn a_rolled_back_upgrade_leaves_no_claim_and_a_later_start_retries_it() {
+    let install = Install::new();
+    write_legacy_config(
+        install.config_dir(),
+        &legacy_config_naming(&["first", "second"]),
+    );
+
+    let shared = install
+        .start(Admission::Tokens)
+        .await
+        .expect("start shared over a legacy install");
+    // A verified identity always carries a non-empty `sub`, so only a corrupted
+    // directory can hold the local user's empty subject.
+    let squatter = shared
+        .seed_user_with_subject("squatter", "", "Squatter")
+        .await;
+    let install = shared.shutdown().await;
+
+    let Err(error) = install.start(Admission::LocalPrincipal).await else {
+        panic!("the upgrade must fail its membership foreign key")
+    };
+
+    assert!(
+        error.contains("FOREIGN KEY constraint failed"),
+        "unexpected startup failure: {error}"
+    );
+
+    let shared = install
+        .start(Admission::Tokens)
+        .await
+        .expect("a shared start never runs the upgrade");
+
+    assert!(
+        !shared.local_ownership_migration_claimed().await,
+        "a claim that outlived its rolled-back transaction would retire the upgrade forever"
+    );
+    assert!(
+        shared.memberships().await.is_empty(),
+        "a rolled-back upgrade must leave no ownership behind either"
+    );
+
+    shared.remove_user(&squatter).await;
+    let install = shared.shutdown().await;
+    let retried = install
+        .start(Admission::LocalPrincipal)
+        .await
+        .expect("the repaired install upgrades");
+
+    assert_eq!(
+        retried.memberships().await,
+        adopted_by_local(&["first", "second"])
+    );
+    assert!(retried.local_ownership_migration_claimed().await);
+}

--- a/crates/coral-app/tests/grpc/ownership_migration_tests.rs
+++ b/crates/coral-app/tests/grpc/ownership_migration_tests.rs
@@ -326,11 +326,11 @@ async fn a_shared_start_keeps_the_two_inaccessible_categories_distinct() {
     }
 }
 
-/// A row squatting on the local user's unique empty subject makes the upgrade
-/// fail its membership foreign key after it has already claimed its marker.
-/// The claim must not survive: startup fails outright, the state is left
-/// exactly as it was, and the start after an operator repairs the directory
-/// runs the whole upgrade.
+/// A row squatting on the local user's unique empty subject swallows the
+/// upgrade's own insert of the local user, so it fails after it has already
+/// claimed its marker. The claim must not survive: startup fails outright, the
+/// state is left exactly as it was, and the start after an operator repairs the
+/// directory runs the whole upgrade.
 #[tokio::test]
 async fn a_rolled_back_upgrade_leaves_no_claim_and_a_later_start_retries_it() {
     let install = Install::new();
@@ -351,11 +351,11 @@ async fn a_rolled_back_upgrade_leaves_no_claim_and_a_later_start_retries_it() {
     let install = shared.shutdown().await;
 
     let Err(error) = install.start(Admission::LocalPrincipal).await else {
-        panic!("the upgrade must fail its membership foreign key")
+        panic!("the upgrade must fail on the local user row it could not write")
     };
 
     assert!(
-        error.contains("FOREIGN KEY constraint failed"),
+        error.contains("the local user row is absent"),
         "unexpected startup failure: {error}"
     );
 

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -15,6 +15,7 @@ use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_man
 #[tokio::test]
 async fn broken_source_does_not_block_healthy_sources() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     harness
         .import_source(

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -14,8 +14,7 @@ use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_man
 
 #[tokio::test]
 async fn broken_source_does_not_block_healthy_sources() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     harness
         .import_source(

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -234,8 +234,7 @@ fn catalog_item_matches(item: &CatalogItem, schema_name: &str, item_name: &str) 
 
 #[tokio::test]
 async fn search_and_list_catalog_share_runtime_catalog_items() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let workspace = default_workspace();
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
@@ -270,8 +269,7 @@ async fn search_and_list_catalog_share_runtime_catalog_items() {
 
 #[tokio::test]
 async fn search_and_list_catalog_share_installed_udf_metadata() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let workspace = default_workspace();
 
     search_entry(&harness, &workspace, "coral", "tables")
@@ -334,8 +332,7 @@ async fn search_and_list_catalog_share_installed_udf_metadata() {
 
 #[tokio::test]
 async fn natural_language_review_queue_query_ranks_installed_udf_in_top_three() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
@@ -372,8 +369,7 @@ async fn natural_language_review_queue_query_ranks_installed_udf_in_top_three() 
 
 #[tokio::test]
 async fn unified_catalog_keeps_source_metadata_isolated_by_workspace() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let default = default_workspace();
     let work = workspace("work");
     harness
@@ -445,8 +441,7 @@ async fn unified_catalog_keeps_source_metadata_isolated_by_workspace() {
 
 #[tokio::test]
 async fn search_service_returns_structured_shell_response() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let response = harness
         .search_client()
@@ -495,8 +490,7 @@ fn search_completes_with_one_blocking_thread() {
         .build()
         .expect("build constrained Tokio runtime");
     let search = runtime.block_on(async {
-        let harness = GrpcHarness::new().await;
-        harness.seed_workspace().await;
+        let harness = GrpcHarness::with_workspace().await;
         let search = tokio::time::timeout(
             Duration::from_secs(5),
             harness.search_client().search(Request::new(SearchRequest {
@@ -611,8 +605,7 @@ async fn search_paused_in_catalog_resolution_does_not_recreate_deleted_workspace
 
 #[tokio::test]
 async fn search_service_rejects_empty_query() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let status = harness
         .search_client()
@@ -634,8 +627,7 @@ async fn search_service_rejects_empty_query() {
 
 #[tokio::test]
 async fn table_function_proto_exposes_search_metadata() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -668,8 +660,7 @@ async fn table_function_proto_exposes_search_metadata() {
 
 #[tokio::test]
 async fn search_matches_table_function_guide() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -693,8 +684,7 @@ async fn search_matches_table_function_guide() {
 
 #[tokio::test]
 async fn search_returns_catalog_metadata_for_search_functions_and_column_hints() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -762,8 +752,7 @@ async fn search_returns_catalog_metadata_for_search_functions_and_column_hints()
 
 #[tokio::test]
 async fn search_reports_partial_catalog_coverage_and_recovers_after_source_repair() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -831,8 +820,7 @@ async fn search_reports_partial_catalog_coverage_and_recovers_after_source_repai
 
 #[tokio::test]
 async fn search_isolates_identity_gated_source_as_partial_catalog_failure() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -914,8 +902,7 @@ surface:
 
 #[tokio::test]
 async fn rebuild_search_index_forces_catalog_projection_refresh() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1008,8 +995,7 @@ async fn rebuild_search_index_unspecified_rebuilds_catalog_and_observed_values()
 
 #[tokio::test]
 async fn rebuild_search_index_all_rebuilds_catalog_and_skips_disabled_observed_values() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1035,8 +1021,7 @@ async fn rebuild_search_index_all_rebuilds_catalog_and_skips_disabled_observed_v
 
 #[tokio::test]
 async fn rebuild_search_index_observed_values_skips_without_creating_storage_when_disabled() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let sqlite_path = search_sqlite_path(&harness);
     assert!(!sqlite_path.exists());
 
@@ -1095,8 +1080,7 @@ async fn rebuild_search_index_observed_values_rebuilds_projection() {
 
 #[tokio::test]
 async fn drain_search_queue_rejects_invalid_budget_when_disabled() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let sqlite_path = search_sqlite_path(&harness);
     assert!(!sqlite_path.exists());
 
@@ -1118,8 +1102,7 @@ async fn drain_search_queue_rejects_invalid_budget_when_disabled() {
 
 #[tokio::test]
 async fn drain_search_queue_skips_without_creating_storage_when_disabled() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let sqlite_path = search_sqlite_path(&harness);
     assert!(!sqlite_path.exists());
 
@@ -1178,8 +1161,7 @@ async fn drain_search_queue_reports_observed_provider_detail() {
 
 #[tokio::test]
 async fn clear_search_data_remains_available_when_observed_values_search_is_disabled() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let response = harness
         .search_client()
@@ -1208,8 +1190,7 @@ async fn clear_search_data_remains_available_when_observed_values_search_is_disa
 
 #[tokio::test]
 async fn clear_search_data_accepts_source_target_with_internal_whitespace() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let response = harness
         .search_client()
@@ -1231,8 +1212,7 @@ async fn clear_search_data_accepts_source_target_with_internal_whitespace() {
 
 #[tokio::test]
 async fn clear_search_data_rejects_invalid_source_targets_at_transport_edge() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     for source_name in [
         "",
@@ -1268,8 +1248,7 @@ async fn clear_search_data_rejects_invalid_source_targets_at_transport_edge() {
 
 #[tokio::test]
 async fn clear_search_data_removes_catalog_projection_and_next_search_recreates_it() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1470,8 +1449,7 @@ async fn source_scoped_clear_leaves_the_other_installed_source_intact() {
 
 #[tokio::test]
 async fn search_table_preview_columns_do_not_inherit_table_matched_fields() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1588,8 +1566,7 @@ async fn search_groups_observed_values_under_their_table() {
 
 #[tokio::test]
 async fn search_provider_coverage_counts_mapped_candidates() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             many_matching_columns_manifest_yaml(),
@@ -1639,8 +1616,7 @@ async fn search_provider_coverage_counts_mapped_candidates() {
 
 #[tokio::test]
 async fn search_truncation_reflects_provider_retrieval_limit() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             many_retrieved_columns_manifest_yaml(),

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -235,6 +235,7 @@ fn catalog_item_matches(item: &CatalogItem, schema_name: &str, item_name: &str) 
 #[tokio::test]
 async fn search_and_list_catalog_share_runtime_catalog_items() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let workspace = default_workspace();
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
@@ -270,6 +271,7 @@ async fn search_and_list_catalog_share_runtime_catalog_items() {
 #[tokio::test]
 async fn search_and_list_catalog_share_installed_udf_metadata() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let workspace = default_workspace();
 
     search_entry(&harness, &workspace, "coral", "tables")
@@ -333,6 +335,7 @@ async fn search_and_list_catalog_share_installed_udf_metadata() {
 #[tokio::test]
 async fn natural_language_review_queue_query_ranks_installed_udf_in_top_three() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
@@ -370,6 +373,7 @@ async fn natural_language_review_queue_query_ranks_installed_udf_in_top_three() 
 #[tokio::test]
 async fn unified_catalog_keeps_source_metadata_isolated_by_workspace() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let default = default_workspace();
     let work = workspace("work");
     harness
@@ -442,6 +446,7 @@ async fn unified_catalog_keeps_source_metadata_isolated_by_workspace() {
 #[tokio::test]
 async fn search_service_returns_structured_shell_response() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let response = harness
         .search_client()
@@ -491,6 +496,7 @@ fn search_completes_with_one_blocking_thread() {
         .expect("build constrained Tokio runtime");
     let search = runtime.block_on(async {
         let harness = GrpcHarness::new().await;
+        harness.seed_workspace().await;
         let search = tokio::time::timeout(
             Duration::from_secs(5),
             harness.search_client().search(Request::new(SearchRequest {
@@ -606,6 +612,7 @@ async fn search_paused_in_catalog_resolution_does_not_recreate_deleted_workspace
 #[tokio::test]
 async fn search_service_rejects_empty_query() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let status = harness
         .search_client()
@@ -628,6 +635,7 @@ async fn search_service_rejects_empty_query() {
 #[tokio::test]
 async fn table_function_proto_exposes_search_metadata() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -661,6 +669,7 @@ async fn table_function_proto_exposes_search_metadata() {
 #[tokio::test]
 async fn search_matches_table_function_guide() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -685,6 +694,7 @@ async fn search_matches_table_function_guide() {
 #[tokio::test]
 async fn search_returns_catalog_metadata_for_search_functions_and_column_hints() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -753,6 +763,7 @@ async fn search_returns_catalog_metadata_for_search_functions_and_column_hints()
 #[tokio::test]
 async fn search_reports_partial_catalog_coverage_and_recovers_after_source_repair() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -821,6 +832,7 @@ async fn search_reports_partial_catalog_coverage_and_recovers_after_source_repai
 #[tokio::test]
 async fn search_isolates_identity_gated_source_as_partial_catalog_failure() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -903,6 +915,7 @@ surface:
 #[tokio::test]
 async fn rebuild_search_index_forces_catalog_projection_refresh() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -962,6 +975,7 @@ async fn rebuild_search_index_forces_catalog_projection_refresh() {
 #[tokio::test]
 async fn rebuild_search_index_unspecified_rebuilds_catalog_and_observed_values() {
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -995,6 +1009,7 @@ async fn rebuild_search_index_unspecified_rebuilds_catalog_and_observed_values()
 #[tokio::test]
 async fn rebuild_search_index_all_rebuilds_catalog_and_skips_disabled_observed_values() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1021,6 +1036,7 @@ async fn rebuild_search_index_all_rebuilds_catalog_and_skips_disabled_observed_v
 #[tokio::test]
 async fn rebuild_search_index_observed_values_skips_without_creating_storage_when_disabled() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let sqlite_path = search_sqlite_path(&harness);
     assert!(!sqlite_path.exists());
 
@@ -1049,6 +1065,7 @@ async fn rebuild_search_index_observed_values_skips_without_creating_storage_whe
 #[tokio::test]
 async fn rebuild_search_index_observed_values_rebuilds_projection() {
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
 
     let response = harness
         .search_client()
@@ -1079,6 +1096,7 @@ async fn rebuild_search_index_observed_values_rebuilds_projection() {
 #[tokio::test]
 async fn drain_search_queue_rejects_invalid_budget_when_disabled() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let sqlite_path = search_sqlite_path(&harness);
     assert!(!sqlite_path.exists());
 
@@ -1101,6 +1119,7 @@ async fn drain_search_queue_rejects_invalid_budget_when_disabled() {
 #[tokio::test]
 async fn drain_search_queue_skips_without_creating_storage_when_disabled() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let sqlite_path = search_sqlite_path(&harness);
     assert!(!sqlite_path.exists());
 
@@ -1125,6 +1144,7 @@ async fn drain_search_queue_skips_without_creating_storage_when_disabled() {
 #[tokio::test]
 async fn drain_search_queue_reports_observed_provider_detail() {
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
 
     let response = harness
         .search_client()
@@ -1159,6 +1179,7 @@ async fn drain_search_queue_reports_observed_provider_detail() {
 #[tokio::test]
 async fn clear_search_data_remains_available_when_observed_values_search_is_disabled() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let response = harness
         .search_client()
@@ -1188,6 +1209,7 @@ async fn clear_search_data_remains_available_when_observed_values_search_is_disa
 #[tokio::test]
 async fn clear_search_data_accepts_source_target_with_internal_whitespace() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let response = harness
         .search_client()
@@ -1210,6 +1232,7 @@ async fn clear_search_data_accepts_source_target_with_internal_whitespace() {
 #[tokio::test]
 async fn clear_search_data_rejects_invalid_source_targets_at_transport_edge() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     for source_name in [
         "",
@@ -1246,6 +1269,7 @@ async fn clear_search_data_rejects_invalid_source_targets_at_transport_edge() {
 #[tokio::test]
 async fn clear_search_data_removes_catalog_projection_and_next_search_recreates_it() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1314,6 +1338,7 @@ async fn clear_search_data_removes_catalog_projection_and_next_search_recreates_
 #[tokio::test]
 async fn source_scoped_all_clear_does_not_load_manifest_and_bumps_generation() {
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
     harness
         .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1378,6 +1403,7 @@ async fn source_scoped_clear_leaves_the_other_installed_source_intact() {
     // that #1791 made two independent sources. Clearing one must not disturb
     // the other, all the way out through the public RPC.
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
     for source_name in ["github_v4", "github_mcp_v4"] {
         harness
             .import_source(
@@ -1445,6 +1471,7 @@ async fn source_scoped_clear_leaves_the_other_installed_source_intact() {
 #[tokio::test]
 async fn search_table_preview_columns_do_not_inherit_table_matched_fields() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(table_preview_manifest_yaml(), Vec::new(), Vec::new())
         .await;
@@ -1485,6 +1512,7 @@ async fn search_table_preview_columns_do_not_inherit_table_matched_fields() {
 #[tokio::test]
 async fn search_groups_observed_values_under_their_table() {
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
     let source = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/messages"))
@@ -1561,6 +1589,7 @@ async fn search_groups_observed_values_under_their_table() {
 #[tokio::test]
 async fn search_provider_coverage_counts_mapped_candidates() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             many_matching_columns_manifest_yaml(),
@@ -1611,6 +1640,7 @@ async fn search_provider_coverage_counts_mapped_candidates() {
 #[tokio::test]
 async fn search_truncation_reflects_provider_retrieval_limit() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             many_retrieved_columns_manifest_yaml(),
@@ -1650,6 +1680,7 @@ async fn search_truncation_reflects_provider_retrieval_limit() {
 #[tokio::test]
 async fn observed_search_handles_live_scopes_beyond_sqlite_variable_limit() {
     let harness = GrpcHarness::new_with_observed_values_search().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             many_table_surfaces_manifest_yaml(SQLITE_VARIABLE_LIMIT_REGRESSION_SURFACE_COUNT),

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -8,7 +8,7 @@
 
 use std::fs;
 
-use coral_api::v1::ListSourcesRequest;
+use coral_api::v1::{CreateWorkspaceRequest, ListSourcesRequest};
 use coral_client::{
     AppClient, default_workspace,
     local::{LocalServerError, ServerBuilder},
@@ -22,7 +22,7 @@ async fn server_lifecycle_can_repeat_within_process() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
 
-    for _ in 0..2 {
+    for start in 0..2 {
         let server = ServerBuilder::new()
             .with_config_dir(&config_dir)
             .start()
@@ -32,6 +32,18 @@ async fn server_lifecycle_can_repeat_within_process() {
         let app = AppClient::connect(server.endpoint_uri())
             .await
             .expect("connect client");
+
+        // Only the first start has a workspace to create: the second reaches
+        // the one the first left behind, which is what makes the repeat a
+        // lifecycle claim rather than two unrelated starts.
+        if start == 0 {
+            app.workspace_client()
+                .create_workspace(Request::new(CreateWorkspaceRequest {
+                    workspace: Some(default_workspace()),
+                }))
+                .await
+                .expect("create the workspace this fixture lists");
+        }
 
         let sources = app
             .source_client()

--- a/crates/coral-app/tests/grpc/session_auth.rs
+++ b/crates/coral-app/tests/grpc/session_auth.rs
@@ -28,20 +28,51 @@ pub(crate) struct SessionAuthFixture {
 
 impl SessionAuthFixture {
     /// Writes the signing key and the config an authenticated server needs.
+    ///
+    /// A directory that already holds a key keeps it. A deployment restarted
+    /// over its own state is the same deployment, and re-minting its key would
+    /// silently invalidate every token the previous server handed out.
     pub(crate) fn write(config_dir: &Path) -> Self {
+        let fixture = Self::key_in(config_dir);
+        fs::write(config_dir.join("config.toml"), Self::config_toml())
+            .expect("write the session auth config");
+        fixture
+    }
+
+    /// Resolves the signing key in `config_dir` without touching its config.
+    ///
+    /// A caller that owns the rest of `config.toml` — an install whose contents
+    /// are the subject of the test — composes it from [`Self::config_toml`]
+    /// instead, so the configuration it started from survives the write.
+    pub(crate) fn key_in(config_dir: &Path) -> Self {
         fs::create_dir_all(config_dir).expect("create config dir");
-        let signing_key =
-            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+        let key_file = config_dir.join("session.key");
+        let signing_key = match fs::read(&key_file) {
+            Ok(existing) => existing,
+            Err(_absent) => {
+                let generated = EcdsaKeyPair::generate_pkcs8(
+                    &ECDSA_P256_SHA256_FIXED_SIGNING,
+                    &SystemRandom::new(),
+                )
                 .expect("generate a session signing key");
-        fs::write(config_dir.join("session.key"), signing_key.as_ref())
-            .expect("write the session signing key");
-        // The MCP HTTP surface is what gives the deployment a public audience;
-        // the private gRPC API admits every audience that fronts it, so tokens
-        // minted for this one reach the services under test.
-        fs::write(
-            config_dir.join("config.toml"),
-            format!(
-                "[credentials]
+                fs::write(&key_file, generated.as_ref()).expect("write the session signing key");
+                generated.as_ref().to_vec()
+            }
+        };
+        Self {
+            config_dir: config_dir.to_path_buf(),
+            signing_key,
+        }
+    }
+
+    /// The configuration that turns a deployment into an authenticated one.
+    ///
+    /// The MCP HTTP surface is what gives the deployment a public audience; the
+    /// private gRPC API admits every audience that fronts it, so tokens minted
+    /// for this one reach the services under test.
+    pub(crate) fn config_toml() -> String {
+        format!(
+            "[credentials]
 storage = \"file\"
 
 [server.mcp_http]
@@ -61,14 +92,7 @@ client_id = 'upstream-client'
 client_secret = 'test-secret'
 redirect_uri = '{ISSUER}/auth/oidc/callback'
 "
-            ),
         )
-        .expect("write the session auth config");
-
-        Self {
-            config_dir: config_dir.to_path_buf(),
-            signing_key: signing_key.as_ref().to_vec(),
-        }
     }
 
     pub(crate) fn config_dir(&self) -> &Path {

--- a/crates/coral-app/tests/grpc/session_auth.rs
+++ b/crates/coral-app/tests/grpc/session_auth.rs
@@ -6,6 +6,7 @@
 //! stub that agrees with neither.
 
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -49,6 +50,12 @@ impl SessionAuthFixture {
         let key_file = config_dir.join("session.key");
         let signing_key = match fs::read(&key_file) {
             Ok(existing) => existing,
+            // Only an absent key may be minted. Any other fault would replace a
+            // key that is still in use, invalidating the tokens minted from it
+            // and surfacing far away as an authentication failure.
+            Err(fault) if fault.kind() != io::ErrorKind::NotFound => {
+                panic!("read the session signing key: {fault}")
+            }
             Err(_absent) => {
                 let generated = EcdsaKeyPair::generate_pkcs8(
                     &ECDSA_P256_SHA256_FIXED_SIGNING,

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -28,8 +28,7 @@ use crate::harness::{
 
 #[tokio::test]
 async fn import_source_persists_and_lists() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
 
     let added = harness
@@ -74,8 +73,7 @@ async fn import_source_persists_and_lists() {
 
 #[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let imported = harness
         .import_source(
@@ -121,8 +119,7 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
 
 #[tokio::test]
 async fn import_duplicate_source_overwrites_existing_source() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml.clone(), Vec::new(), Vec::new())
@@ -167,8 +164,7 @@ async fn import_duplicate_source_overwrites_existing_source() {
 
 #[tokio::test]
 async fn import_invalid_manifest_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -186,8 +182,7 @@ async fn import_invalid_manifest_returns_invalid_argument() {
 
 #[tokio::test]
 async fn delete_source_removes_from_list_and_disk() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())
@@ -220,8 +215,7 @@ async fn delete_source_removes_from_list_and_disk() {
 
 #[tokio::test]
 async fn delete_nonexistent_source_returns_not_found() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -236,8 +230,7 @@ async fn delete_nonexistent_source_returns_not_found() {
 
 #[tokio::test]
 async fn validate_source_returns_tables() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())
@@ -259,8 +252,7 @@ async fn validate_source_returns_tables() {
 
 #[tokio::test]
 async fn validate_source_returns_table_functions() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_function_only_manifest_yaml(),
@@ -284,8 +276,7 @@ async fn validate_source_returns_table_functions() {
 
 #[tokio::test]
 async fn list_catalog_supports_table_kind_and_pagination() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
@@ -358,8 +349,7 @@ async fn list_catalog_supports_table_kind_and_pagination() {
 
 #[tokio::test]
 async fn explain_sql_returns_logical_and_physical_plans() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     harness
         .import_source(
             fixture_manifest_yaml(harness.temp_path()),
@@ -392,8 +382,7 @@ async fn explain_sql_returns_logical_and_physical_plans() {
 
 #[tokio::test]
 async fn validate_source_returns_query_test_results_without_unary_error() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_with_test_queries_yaml(
         harness.temp_path(),
         &[
@@ -421,8 +410,7 @@ async fn validate_source_returns_query_test_results_without_unary_error() {
 
 #[tokio::test]
 async fn query_execution_rejects_non_read_only_sql() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())
@@ -474,8 +462,7 @@ async fn query_execution_rejects_non_read_only_sql() {
 
 #[tokio::test]
 async fn validate_source_with_unreachable_api_returns_declared_tables() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(failing_http.manifest_yaml(), Vec::new(), Vec::new())
@@ -498,8 +485,7 @@ async fn validate_source_with_unreachable_api_returns_declared_tables() {
 
 #[tokio::test]
 async fn validate_source_with_unreachable_api_and_test_queries_returns_query_failures() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(
@@ -522,8 +508,7 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
 
 #[tokio::test]
 async fn validate_source_with_non_read_only_test_query_returns_stable_query_error() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let manifest_yaml = fixture_manifest_with_test_queries_yaml(
         harness.temp_path(),
         &["SET datafusion.execution.batch_size = 1"],
@@ -543,8 +528,7 @@ async fn validate_source_with_non_read_only_test_query_returns_stable_query_erro
 
 #[tokio::test]
 async fn validate_source_skipped_registration_returns_unary_failed_precondition() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let missing_dir = harness.temp_path().join("missing");
     let manifest_yaml = serde_yaml::to_string(&serde_json::json!({
         "name": "missing_messages",
@@ -583,8 +567,7 @@ async fn validate_source_skipped_registration_returns_unary_failed_precondition(
 
 #[tokio::test]
 async fn execute_sql_with_unreachable_api_returns_unavailable_error() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(failing_http.manifest_yaml(), Vec::new(), Vec::new())
@@ -605,8 +588,7 @@ async fn execute_sql_with_unreachable_api_returns_unavailable_error() {
 
 #[tokio::test]
 async fn import_source_missing_required_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -632,8 +614,7 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
 
 #[tokio::test]
 async fn import_source_missing_required_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -659,8 +640,7 @@ async fn import_source_missing_required_variable_returns_invalid_argument() {
 
 #[tokio::test]
 async fn import_source_unknown_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -685,8 +665,7 @@ async fn import_source_unknown_variable_returns_invalid_argument() {
 
 #[tokio::test]
 async fn import_source_unknown_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -721,8 +700,7 @@ async fn import_source_unknown_secret_returns_invalid_argument() {
 
 #[tokio::test]
 async fn import_source_repeated_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -757,8 +735,7 @@ async fn import_source_repeated_variable_returns_invalid_argument() {
 
 #[tokio::test]
 async fn import_source_repeated_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -793,8 +770,7 @@ async fn import_source_repeated_secret_returns_invalid_argument() {
 
 #[tokio::test]
 async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let discovered = harness
         .source_client()
@@ -847,8 +823,7 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
 
 #[tokio::test]
 async fn get_source_info_returns_available_bundled_metadata() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let info = harness
         .source_client()
@@ -879,8 +854,7 @@ async fn get_source_info_returns_available_bundled_metadata() {
 
 #[tokio::test]
 async fn get_source_info_returns_sentry_oauth_credential_metadata() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let info = harness
         .source_client()
@@ -954,8 +928,7 @@ async fn get_source_info_returns_sentry_oauth_credential_metadata() {
 
 #[tokio::test]
 async fn get_source_info_uses_effective_installed_imported_manifest() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     harness
         .import_source(
@@ -1004,8 +977,7 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
 
 #[tokio::test]
 async fn create_bundled_source_registers_tables() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     harness
         .source_client()
@@ -1033,8 +1005,7 @@ async fn create_bundled_source_registers_tables() {
 
 #[tokio::test]
 async fn create_bundled_source_missing_required_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -1059,8 +1030,7 @@ async fn create_bundled_source_missing_required_secret_returns_invalid_argument(
 
 #[tokio::test]
 async fn create_bundled_source_missing_required_variable_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -1085,8 +1055,7 @@ async fn create_bundled_source_missing_required_variable_returns_invalid_argumen
 
 #[tokio::test]
 async fn create_bundled_source_unknown_input_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -1116,8 +1085,7 @@ async fn create_bundled_source_unknown_input_returns_invalid_argument() {
 
 #[tokio::test]
 async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -1151,8 +1119,7 @@ async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
 
 #[tokio::test]
 async fn create_bundled_source_does_not_persist_manifest_to_config_dir() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let created = harness
         .source_client()
@@ -1291,8 +1258,7 @@ origin = "bundled"
 
 #[tokio::test]
 async fn get_nonexistent_source_returns_not_found() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let error = harness
         .source_client()
@@ -1495,8 +1461,7 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
 
 #[tokio::test]
 async fn rejects_invalid_workspace_and_source_names() {
-    let harness = GrpcHarness::new().await;
-    harness.seed_workspace().await;
+    let harness = GrpcHarness::with_workspace().await;
 
     let invalid_workspace = harness
         .catalog_client()

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -29,6 +29,7 @@ use crate::harness::{
 #[tokio::test]
 async fn import_source_persists_and_lists() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
 
     let added = harness
@@ -74,6 +75,7 @@ async fn import_source_persists_and_lists() {
 #[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let imported = harness
         .import_source(
@@ -120,6 +122,7 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
 #[tokio::test]
 async fn import_duplicate_source_overwrites_existing_source() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml.clone(), Vec::new(), Vec::new())
@@ -165,6 +168,7 @@ async fn import_duplicate_source_overwrites_existing_source() {
 #[tokio::test]
 async fn import_invalid_manifest_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -183,6 +187,7 @@ async fn import_invalid_manifest_returns_invalid_argument() {
 #[tokio::test]
 async fn delete_source_removes_from_list_and_disk() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())
@@ -216,6 +221,7 @@ async fn delete_source_removes_from_list_and_disk() {
 #[tokio::test]
 async fn delete_nonexistent_source_returns_not_found() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -231,6 +237,7 @@ async fn delete_nonexistent_source_returns_not_found() {
 #[tokio::test]
 async fn validate_source_returns_tables() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())
@@ -253,6 +260,7 @@ async fn validate_source_returns_tables() {
 #[tokio::test]
 async fn validate_source_returns_table_functions() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_function_only_manifest_yaml(),
@@ -277,6 +285,7 @@ async fn validate_source_returns_table_functions() {
 #[tokio::test]
 async fn list_catalog_supports_table_kind_and_pagination() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
@@ -350,6 +359,7 @@ async fn list_catalog_supports_table_kind_and_pagination() {
 #[tokio::test]
 async fn explain_sql_returns_logical_and_physical_plans() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_yaml(harness.temp_path()),
@@ -383,6 +393,7 @@ async fn explain_sql_returns_logical_and_physical_plans() {
 #[tokio::test]
 async fn validate_source_returns_query_test_results_without_unary_error() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_with_test_queries_yaml(
         harness.temp_path(),
         &[
@@ -411,6 +422,7 @@ async fn validate_source_returns_query_test_results_without_unary_error() {
 #[tokio::test]
 async fn query_execution_rejects_non_read_only_sql() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
     harness
         .import_source(manifest_yaml, Vec::new(), Vec::new())
@@ -463,6 +475,7 @@ async fn query_execution_rejects_non_read_only_sql() {
 #[tokio::test]
 async fn validate_source_with_unreachable_api_returns_declared_tables() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(failing_http.manifest_yaml(), Vec::new(), Vec::new())
@@ -486,6 +499,7 @@ async fn validate_source_with_unreachable_api_returns_declared_tables() {
 #[tokio::test]
 async fn validate_source_with_unreachable_api_and_test_queries_returns_query_failures() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(
@@ -509,6 +523,7 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
 #[tokio::test]
 async fn validate_source_with_non_read_only_test_query_returns_stable_query_error() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let manifest_yaml = fixture_manifest_with_test_queries_yaml(
         harness.temp_path(),
         &["SET datafusion.execution.batch_size = 1"],
@@ -529,6 +544,7 @@ async fn validate_source_with_non_read_only_test_query_returns_stable_query_erro
 #[tokio::test]
 async fn validate_source_skipped_registration_returns_unary_failed_precondition() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let missing_dir = harness.temp_path().join("missing");
     let manifest_yaml = serde_yaml::to_string(&serde_json::json!({
         "name": "missing_messages",
@@ -568,6 +584,7 @@ async fn validate_source_skipped_registration_returns_unary_failed_precondition(
 #[tokio::test]
 async fn execute_sql_with_unreachable_api_returns_unavailable_error() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(failing_http.manifest_yaml(), Vec::new(), Vec::new())
@@ -589,6 +606,7 @@ async fn execute_sql_with_unreachable_api_returns_unavailable_error() {
 #[tokio::test]
 async fn import_source_missing_required_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -615,6 +633,7 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
 #[tokio::test]
 async fn import_source_missing_required_variable_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -641,6 +660,7 @@ async fn import_source_missing_required_variable_returns_invalid_argument() {
 #[tokio::test]
 async fn import_source_unknown_variable_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -666,6 +686,7 @@ async fn import_source_unknown_variable_returns_invalid_argument() {
 #[tokio::test]
 async fn import_source_unknown_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -701,6 +722,7 @@ async fn import_source_unknown_secret_returns_invalid_argument() {
 #[tokio::test]
 async fn import_source_repeated_variable_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -736,6 +758,7 @@ async fn import_source_repeated_variable_returns_invalid_argument() {
 #[tokio::test]
 async fn import_source_repeated_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -771,6 +794,7 @@ async fn import_source_repeated_secret_returns_invalid_argument() {
 #[tokio::test]
 async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let discovered = harness
         .source_client()
@@ -824,6 +848,7 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
 #[tokio::test]
 async fn get_source_info_returns_available_bundled_metadata() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let info = harness
         .source_client()
@@ -855,6 +880,7 @@ async fn get_source_info_returns_available_bundled_metadata() {
 #[tokio::test]
 async fn get_source_info_returns_sentry_oauth_credential_metadata() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let info = harness
         .source_client()
@@ -929,6 +955,7 @@ async fn get_source_info_returns_sentry_oauth_credential_metadata() {
 #[tokio::test]
 async fn get_source_info_uses_effective_installed_imported_manifest() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     harness
         .import_source(
@@ -978,6 +1005,7 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
 #[tokio::test]
 async fn create_bundled_source_registers_tables() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     harness
         .source_client()
@@ -1006,6 +1034,7 @@ async fn create_bundled_source_registers_tables() {
 #[tokio::test]
 async fn create_bundled_source_missing_required_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -1031,6 +1060,7 @@ async fn create_bundled_source_missing_required_secret_returns_invalid_argument(
 #[tokio::test]
 async fn create_bundled_source_missing_required_variable_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -1056,6 +1086,7 @@ async fn create_bundled_source_missing_required_variable_returns_invalid_argumen
 #[tokio::test]
 async fn create_bundled_source_unknown_input_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -1086,6 +1117,7 @@ async fn create_bundled_source_unknown_input_returns_invalid_argument() {
 #[tokio::test]
 async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -1120,6 +1152,7 @@ async fn create_bundled_source_repeated_secret_returns_invalid_argument() {
 #[tokio::test]
 async fn create_bundled_source_does_not_persist_manifest_to_config_dir() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let created = harness
         .source_client()
@@ -1259,6 +1292,7 @@ origin = "bundled"
 #[tokio::test]
 async fn get_nonexistent_source_returns_not_found() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let error = harness
         .source_client()
@@ -1319,6 +1353,7 @@ enabled = false
 
     {
         let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness.seed_workspace().await;
         harness
             .import_source(manifest_yaml, Vec::new(), Vec::new())
             .await;
@@ -1369,6 +1404,7 @@ async fn import_rolls_back_on_config_write_failure() {
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(&config_dir).expect("create config dir");
     let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    harness.seed_workspace().await;
     let sources_root = harness
         .config_dir()
         .join("workspaces")
@@ -1410,6 +1446,8 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
     use std::os::unix::fs::PermissionsExt;
 
     let harness = GrpcHarness::new().await;
+
+    harness.seed_workspace().await;
     harness
         .import_source(
             fixture_manifest_with_inputs_yaml(),
@@ -1458,6 +1496,7 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
 #[tokio::test]
 async fn rejects_invalid_workspace_and_source_names() {
     let harness = GrpcHarness::new().await;
+    harness.seed_workspace().await;
 
     let invalid_workspace = harness
         .catalog_client()

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -118,10 +118,13 @@ fn local_trace_store_dir(harness: &GrpcHarness) -> std::path::PathBuf {
 }
 
 #[tokio::test]
-async fn lists_default_workspace_when_config_is_missing() {
+async fn lists_no_workspace_when_config_is_missing() {
     let harness = GrpcHarness::new().await;
 
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "a fresh install owns no workspace until someone creates one",
+    );
 }
 
 #[tokio::test]
@@ -132,7 +135,10 @@ async fn startup_cutover_removes_stale_shadow_workspace_rows() {
 
     let harness = GrpcHarness::start_with_config_dir(config_dir).await;
 
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "the cutover keeps what legacy config held and invents nothing",
+    );
 }
 
 #[tokio::test]
@@ -151,7 +157,7 @@ async fn create_workspace_persists_database_row_without_config_scaffolding() {
         .expect("create workspace response");
 
     assert_eq!(created.name, "work");
-    assert_eq!(workspace_names(&harness).await, vec!["default", "work"]);
+    assert_eq!(workspace_names(&harness).await, vec!["work"]);
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
     assert!(
@@ -184,7 +190,7 @@ async fn list_workspaces_reads_database_after_config_becomes_invalid() {
         .expect("create workspace");
     fs::write(harness.config_dir().join("config.toml"), "[[workspaces]\n").expect("corrupt config");
 
-    assert_eq!(workspace_names(&harness).await, vec!["default", "work"]);
+    assert_eq!(workspace_names(&harness).await, vec!["work"]);
 }
 
 #[tokio::test]
@@ -347,7 +353,10 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
         .expect("delete workspace response");
     assert_eq!(deleted.name, "work");
 
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "deleting the only workspace leaves the deployment with none",
+    );
     assert!(
         !source_dir.exists(),
         "delete should remove workspace artifacts"
@@ -484,7 +493,10 @@ async fn delete_workspace_ignores_malformed_trace_history() {
         .workspace
         .expect("delete workspace response");
     assert_eq!(deleted.name, "work");
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "deleting the only workspace leaves the deployment with none",
+    );
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
     assert!(
@@ -574,7 +586,10 @@ async fn delete_workspace_removes_state_when_trace_cleanup_fails() {
         .expect("restore trace file permissions");
 
     assert_eq!(deleted.name, "work");
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "deleting the only workspace leaves the deployment with none",
+    );
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
     assert!(
@@ -634,7 +649,10 @@ async fn delete_workspace_ignores_stale_trace_files_when_trace_history_disabled(
         .expect("delete workspace response");
 
     assert_eq!(deleted.name, "work");
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "deleting the only workspace leaves the deployment with none",
+    );
     assert!(
         stale_trace_file.exists(),
         "disabled trace history should skip trace cleanup"
@@ -701,7 +719,10 @@ async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete
         .expect("restore backup sources permissions");
     fs::remove_dir_all(&backup).expect("remove backup after assertion");
 
-    assert_eq!(workspace_names(&harness).await, vec!["default"]);
+    assert!(
+        workspace_names(&harness).await.is_empty(),
+        "deleting the only workspace leaves the deployment with none",
+    );
     assert!(
         !workspace_dir.exists(),
         "deleted workspace should no longer exist at its normal artifact path"
@@ -714,26 +735,34 @@ async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete
     );
 }
 
+/// `default` is a name like any other now that nothing provisions it. A caller
+/// who wants one creates it, and may delete it again — the reserved-name guard
+/// that used to refuse that is gone, so a deployment left holding an
+/// undeletable workspace nobody asked for would be the regression.
 #[tokio::test]
-async fn delete_default_workspace_returns_failed_precondition() {
+async fn default_like_names_are_created_and_deleted_like_any_other() {
     let harness = GrpcHarness::new().await;
+    let default_name = default_workspace().name;
 
-    let error = harness
-        .workspace_client()
-        .delete_workspace(Request::new(DeleteWorkspaceRequest {
-            workspace: Some(default_workspace()),
-        }))
-        .await
-        .expect_err("default workspace delete should fail");
+    for name in [default_name.as_str(), "default-2", "work"] {
+        harness
+            .workspace_client()
+            .create_workspace(Request::new(CreateWorkspaceRequest {
+                workspace: Some(workspace(name)),
+            }))
+            .await
+            .unwrap_or_else(|error| panic!("create workspace '{name}': {error}"));
+        assert_eq!(workspace_names(&harness).await, vec![name.to_string()]);
 
-    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
-    assert!(
-        error
-            .message()
-            .contains("default workspace cannot be removed"),
-        "expected default workspace guard, got: {}",
-        error.message()
-    );
+        harness
+            .workspace_client()
+            .delete_workspace(Request::new(DeleteWorkspaceRequest {
+                workspace: Some(workspace(name)),
+            }))
+            .await
+            .unwrap_or_else(|error| panic!("delete workspace '{name}': {error}"));
+        assert!(workspace_names(&harness).await.is_empty());
+    }
 }
 
 async fn delete_workspace(
@@ -805,6 +834,11 @@ async fn control_plane_refusals(
 
 /// A caller who belongs to nothing is answered, not refused: the listing is
 /// their own view, and an empty view is a complete answer to it.
+///
+/// Signing in also creates nothing to belong to. The empty listing alone would
+/// not show that — it reads the same whether the deployment holds no workspace
+/// or one this caller cannot reach — so the deployment's own state is checked
+/// beside it.
 #[tokio::test]
 async fn a_caller_with_no_membership_is_listed_nothing_rather_than_denied() {
     let deployment = SharedDeployment::start().await;
@@ -812,6 +846,10 @@ async fn a_caller_with_no_membership_is_listed_nothing_rather_than_denied() {
     let newcomer = deployment.as_person(&ada).await;
 
     assert_eq!(membership_rows(&newcomer).await, Vec::new());
+    assert!(
+        deployment.workspace_names().await.is_empty(),
+        "provisioning a login must not create a workspace",
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -98,8 +98,8 @@ fn find_workspace_delete_backup(
     workspace_name: &str,
 ) -> std::path::PathBuf {
     let prefix = format!("{workspace_name}.delete.rollback.");
-    fs::read_dir(config_dir.join("workspaces"))
-        .expect("read workspaces dir")
+    fs::read_dir(config_dir.join("deleted-workspaces"))
+        .expect("read deleted workspaces dir")
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .find(|path| {
@@ -108,6 +108,20 @@ fn find_workspace_delete_backup(
                 .is_some_and(|name| name.starts_with(&prefix))
         })
         .expect("workspace delete backup dir")
+}
+
+/// Every entry a scan of the workspaces root finds is read as a live
+/// workspace, so a deletion must leave none of its own behind there — the
+/// staged directory included, wherever its removal got to.
+fn workspace_root_entries(config_dir: &std::path::Path) -> Vec<String> {
+    match fs::read_dir(config_dir.join("workspaces")) {
+        Ok(entries) => entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => panic!("read workspaces dir: {error}"),
+    }
 }
 
 fn local_trace_store_dir(harness: &GrpcHarness) -> std::path::PathBuf {
@@ -360,6 +374,11 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
     assert!(
         !source_dir.exists(),
         "delete should remove workspace artifacts"
+    );
+    assert_eq!(
+        workspace_root_entries(harness.config_dir()),
+        Vec::<String>::new(),
+        "delete should leave nothing in the workspaces root for a later scan to read as live"
     );
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
@@ -713,6 +732,15 @@ async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete
         .workspace
         .expect("delete workspace response");
     assert_eq!(deleted.name, "work");
+
+    // The staged directory outlived the deletion, which is the whole point of
+    // this test — but it did so outside the workspaces root, so nothing left
+    // there can be read back as a live workspace.
+    assert_eq!(
+        workspace_root_entries(harness.config_dir()),
+        Vec::<String>::new(),
+        "a deletion whose cleanup failed still leaves the workspaces root empty"
+    );
 
     let backup = find_workspace_delete_backup(harness.config_dir(), "work");
     fs::set_permissions(backup.join("sources"), fs::Permissions::from_mode(0o700))

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -35,12 +35,28 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
     )
     .expect("write config");
 
+    // `make postgres-tests` points every Postgres test at one database, where
+    // the legacy default name is now an ordinary one somebody may legitimately
+    // have created, so what is asserted is what this startup adds rather than
+    // what the database already held.
+    let legacy_default_before = count_legacy_default_workspaces(&database_url)
+        .await
+        .unwrap_or(0);
+
     let server = ServerBuilder::new()
         .with_config_dir(&config_dir)
         .start()
         .await
         .expect("start server with Postgres config");
-    assert_postgres_db_is_migrated_and_unprovisioned(&database_url).await;
+    let legacy_default_after = count_legacy_default_workspaces(&database_url)
+        .await
+        .expect("startup should migrate the workspaces table");
+    assert_eq!(
+        legacy_default_after,
+        legacy_default_before,
+        "startup must not invent a '{}' workspace",
+        default_workspace().name
+    );
 
     server.shutdown().await.expect("shutdown server");
 }
@@ -155,13 +171,14 @@ fn postgres_source(database_url: &str) -> QuerySource {
     .expect("build Postgres inventory source")
 }
 
-/// Checks that startup migrated the schema and provisioned nothing into it.
+/// Counts the workspace rows holding the name a fresh install used to be given.
 ///
-/// The absent name is the one a fresh install used to be given. Asking about
-/// that one name rather than about a total is deliberate: `make postgres-tests`
-/// points every Postgres test at a single database, so the row count belongs to
-/// no test in particular.
-async fn assert_postgres_db_is_migrated_and_unprovisioned(database_url: &str) {
+/// Reports `None` while the schema is unmigrated, which is how a first run
+/// against an empty database tells "no table yet" from "no such row". Asking
+/// about that one name rather than about a total is deliberate: `make
+/// postgres-tests` points every Postgres test at a single database, so the row
+/// count belongs to no test in particular.
+async fn count_legacy_default_workspaces(database_url: &str) -> Option<i64> {
     let pool = PgPoolOptions::new()
         .connect(database_url)
         .await
@@ -171,18 +188,16 @@ async fn assert_postgres_db_is_migrated_and_unprovisioned(database_url: &str) {
             .fetch_one(&pool)
             .await
             .expect("inspect migrated Postgres schema");
-    assert!(table_exists, "workspaces table should be migrated");
+    if !table_exists {
+        return None;
+    }
 
-    let legacy_default = default_workspace().name;
-    let provisioned: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspaces WHERE id = $1")
-        .bind(&legacy_default)
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspaces WHERE id = $1")
+        .bind(default_workspace().name)
         .fetch_one(&pool)
         .await
-        .expect("look for a provisioned workspace row");
-    assert_eq!(
-        provisioned, 0,
-        "startup must not invent a '{legacy_default}' workspace"
-    );
+        .expect("count the workspace rows holding the legacy default name");
+    Some(count)
 }
 
 #[expect(

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 
+use coral_client::default_workspace;
 use coral_client::local::ServerBuilder;
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
@@ -39,7 +40,7 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         .start()
         .await
         .expect("start server with Postgres config");
-    assert_postgres_db_is_migrated(&database_url).await;
+    assert_postgres_db_is_migrated_and_unprovisioned(&database_url).await;
 
     server.shutdown().await.expect("shutdown server");
 }
@@ -154,7 +155,13 @@ fn postgres_source(database_url: &str) -> QuerySource {
     .expect("build Postgres inventory source")
 }
 
-async fn assert_postgres_db_is_migrated(database_url: &str) {
+/// Checks that startup migrated the schema and provisioned nothing into it.
+///
+/// The absent name is the one a fresh install used to be given. Asking about
+/// that one name rather than about a total is deliberate: `make postgres-tests`
+/// points every Postgres test at a single database, so the row count belongs to
+/// no test in particular.
+async fn assert_postgres_db_is_migrated_and_unprovisioned(database_url: &str) {
     let pool = PgPoolOptions::new()
         .connect(database_url)
         .await
@@ -165,6 +172,17 @@ async fn assert_postgres_db_is_migrated(database_url: &str) {
             .await
             .expect("inspect migrated Postgres schema");
     assert!(table_exists, "workspaces table should be migrated");
+
+    let legacy_default = default_workspace().name;
+    let provisioned: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspaces WHERE id = $1")
+        .bind(&legacy_default)
+        .fetch_one(&pool)
+        .await
+        .expect("look for a provisioned workspace row");
+    assert_eq!(
+        provisioned, 0,
+        "startup must not invent a '{legacy_default}' workspace"
+    );
 }
 
 #[expect(

--- a/crates/coral-app/tests/telemetry_host_subscriber.rs
+++ b/crates/coral-app/tests/telemetry_host_subscriber.rs
@@ -22,8 +22,10 @@
 )]
 
 use coral_api::v1::trace_service_client::TraceServiceClient;
-use coral_api::v1::{ListSourcesRequest, ListTracesRequest, SearchRequest, TraceView};
-use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use coral_api::v1::{
+    CreateWorkspaceRequest, ListSourcesRequest, ListTracesRequest, SearchRequest, TraceView,
+};
+use coral_client::{AppClient, local::ServerBuilder, workspace};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
 use tempfile::TempDir;
@@ -33,6 +35,7 @@ use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
 const SEARCH_SENTINEL: &str = "HOST_SUBSCRIBER_LOCAL_SEARCH_SENTINEL";
+const WORKSPACE: &str = "host-subscriber";
 
 #[tokio::test]
 async fn host_subscriber_keeps_server_available_without_local_only_attributes() {
@@ -58,10 +61,20 @@ async fn host_subscriber_keeps_server_available_without_local_only_attributes() 
         .await
         .expect("connect client");
 
+    // A fresh install owns no workspace, so the one this test reads through has
+    // to be created before any workspace-scoped call.
+    let test_workspace = workspace(WORKSPACE);
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(test_workspace.clone()),
+        }))
+        .await
+        .expect("create the workspace this test reads through");
+
     let sources = app
         .source_client()
         .list_sources(Request::new(ListSourcesRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(test_workspace.clone()),
         }))
         .await
         .expect("list sources")
@@ -71,7 +84,7 @@ async fn host_subscriber_keeps_server_available_without_local_only_attributes() 
 
     app.search_client()
         .search(Request::new(SearchRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(test_workspace),
             query: SEARCH_SENTINEL.to_string(),
             limit: 0,
         }))

--- a/crates/coral-app/tests/telemetry_otlp_loopback.rs
+++ b/crates/coral-app/tests/telemetry_otlp_loopback.rs
@@ -20,12 +20,13 @@ use tonic::Request;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request as WiremockRequest, ResponseTemplate};
 
-use coral_api::v1::{ExecuteSqlRequest, SearchRequest};
+use coral_api::v1::{CreateWorkspaceRequest, ExecuteSqlRequest, SearchRequest};
 use coral_app::{ServerBuilder, shutdown_tracing};
-use coral_client::{AppClient, decode_execute_sql_response, default_workspace};
+use coral_client::{AppClient, decode_execute_sql_response, workspace};
 
 const LOCAL_ONLY_SENTINEL: &str = "LOCAL_ONLY_FUTURE_TOOL_SENTINEL";
 const SEARCH_QUERY_SENTINEL: &str = "LOCAL_ONLY_SEARCH_QUERY_SENTINEL";
+const WORKSPACE: &str = "otlp-loopback";
 
 #[tokio::test]
 async fn otlp_export_loopback_covers_traces_logs_and_metrics() {
@@ -104,10 +105,20 @@ async fn emit_test_telemetry(endpoint_uri: &str) {
     let app = AppClient::connect(endpoint_uri)
         .await
         .expect("connect loopback client");
+    // A fresh install owns no workspace, so the one this test queries through
+    // has to be created before any workspace-scoped call.
+    let test_workspace = workspace(WORKSPACE);
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(test_workspace.clone()),
+        }))
+        .await
+        .expect("create the workspace this test queries through");
+
     let response = app
         .query_client()
         .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(test_workspace.clone()),
             sql: "SELECT 1 AS loopback_value".to_string(),
             guide_read_context: None,
             task_attribution: None,
@@ -120,7 +131,7 @@ async fn emit_test_telemetry(endpoint_uri: &str) {
 
     app.search_client()
         .search(Request::new(SearchRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(test_workspace),
             query: SEARCH_QUERY_SENTINEL.to_string(),
             limit: 0,
         }))

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -115,9 +115,10 @@ fn bootstrap_endpoint() -> Option<String> {
 mod tests {
     use std::sync::Mutex;
 
+    use coral_api::v1::CreateWorkspaceRequest;
     use coral_api::v1::ExecuteSqlRequest;
     use coral_app::{EngineExtensions, QuerySource};
-    use coral_client::default_workspace;
+    use coral_client::workspace;
     use tempfile::TempDir;
     use tonic::Request;
 
@@ -159,9 +160,17 @@ mod tests {
             .await
             .expect("connect client");
 
+        // Nothing provisions a workspace any more, so the probe creates the
+        // one it queries.
+        app.workspace_client()
+            .create_workspace(Request::new(CreateWorkspaceRequest {
+                workspace: Some(workspace("engine-probe")),
+            }))
+            .await
+            .expect("create workspace");
         app.query_client()
             .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace("engine-probe")),
                 sql: "SELECT 1".to_string(),
                 guide_read_context: None,
                 task_attribution: None,

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -369,13 +369,14 @@ async fn start_mcp_http(
     Ok(Some(server))
 }
 
-/// Probes engine readiness over the unauthenticated gRPC health service.
+/// Probes server readiness over the unauthenticated gRPC health service.
 ///
 /// A data-plane call cannot serve here: with `[auth]` on it would need a bearer
 /// token the probe does not hold, and its `Unauthenticated` rejection reads as
 /// "reachable" — turning `/readyz` into a port check. The health service reports
-/// catalog reachability server-side instead, under its readiness service name so
-/// the aggregate liveness check stays a constant.
+/// server-side instead whether this instance can reach the database it serves
+/// out of, under its readiness service name so the aggregate liveness check
+/// stays a constant.
 async fn probe_serving_health(client: &AppClient) -> Result<(), Code> {
     match client.check_engine_ready().await {
         Ok(true) => Ok(()),

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -549,7 +549,10 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
-        McpOptions::default(),
+        McpOptions {
+            workspace: Some(test_workspace()),
+            ..McpOptions::default()
+        },
         None,
     )
     .await
@@ -560,6 +563,9 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
     // Dial through loopback: the point here is that the listener started and
     // serves; reachability from other interfaces is the operator's affair.
     let dial = SocketAddr::from((Ipv4Addr::LOCALHOST, mcp_addr.port()));
+    // The tools this asserts are workspace-scoped, and nothing provisions a
+    // workspace any more, so the fixture creates the one it scopes MCP to.
+    create_test_workspace(server.endpoint_uri()).await;
     assert_catalog_tool(format!("http://{dial}/mcp")).await;
     server.shutdown().await.expect("shutdown composite server");
 }

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -2,8 +2,10 @@ use std::net::TcpListener;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
-use coral_client::default_workspace;
+use coral_api::v1::{
+    CatalogItemKind, CreateWorkspaceRequest, ListCatalogRequest, PaginationRequest, Workspace,
+};
+use coral_client::workspace;
 use coral_mcp::{McpSurface, McpSurfaceProvider, McpSurfaceProviderError, McpToolRoute};
 use jsonwebtoken::jwk::{Jwk, ThumbprintHash};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
@@ -195,9 +197,32 @@ async fn assert_grpc_rejects_unauthenticated(endpoint: &str) {
     assert_eq!(denied.code(), Code::Unauthenticated);
 }
 
+/// The ordinary workspace these fixtures name.
+///
+/// Nothing provisions a workspace any more, so naming one keeps these fixtures
+/// off the `DEFAULT_WORKSPACE_ID` fallback. Most call sites never create it: the
+/// probes below assert on authentication, which is decided before the workspace
+/// is ever looked up.
+fn test_workspace() -> Workspace {
+    workspace("analytics")
+}
+
+/// Creates [`test_workspace`] over the unauthenticated loopback gRPC endpoint.
+async fn create_test_workspace(endpoint: &str) {
+    AppClient::connect(endpoint)
+        .await
+        .expect("local gRPC client")
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(test_workspace()),
+        }))
+        .await
+        .expect("create workspace");
+}
+
 fn catalog_request() -> ListCatalogRequest {
     ListCatalogRequest {
-        workspace: Some(default_workspace()),
+        workspace: Some(test_workspace()),
         catalog_name: String::new(),
         schema_name: String::new(),
         kind: CatalogItemKind::Unspecified as i32,
@@ -463,7 +488,10 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
-        McpOptions::default(),
+        McpOptions {
+            workspace: Some(test_workspace()),
+            ..McpOptions::default()
+        },
         Some(Arc::new(TestMcpProvider)),
     )
     .await
@@ -473,6 +501,9 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     assert!(!server.mcp_http_authentication_enabled());
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
     assert!(server.oauth_addr().is_none());
+    // The tools this asserts are workspace-scoped, and nothing provisions a
+    // workspace any more, so the fixture creates the one it scopes MCP to.
+    create_test_workspace(server.endpoint_uri()).await;
     assert_catalog_tool(format!("http://{mcp_addr}/mcp")).await;
     assert_cli_extension_filter(format!("http://{mcp_addr}/mcp")).await;
     server.shutdown().await.expect("shutdown composite server");
@@ -546,6 +577,7 @@ async fn companion_uses_supplied_mcp_options() {
             .with_noop_feedback_uploads(),
         McpOptions {
             feedback_enabled: true,
+            workspace: Some(test_workspace()),
             ..McpOptions::default()
         },
         None,
@@ -553,6 +585,9 @@ async fn companion_uses_supplied_mcp_options() {
     .await
     .expect("start composite server");
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
+    // `tools/list` enumerates the workspace's table functions, so it needs the
+    // workspace MCP is scoped to actually exist.
+    create_test_workspace(server.endpoint_uri()).await;
     assert_feedback_tool(format!("http://{mcp_addr}/mcp")).await;
     server.shutdown().await.expect("shutdown composite server");
 }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -26,7 +26,7 @@ use tempfile::tempdir;
 use tonic::Code;
 
 use harness::{
-    MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name,
+    MockServer, MockServerConfig, TEST_WORKSPACE, assert_test_workspace, assert_workspace_name,
     encode_arrow_ipc_stream, membership,
 };
 
@@ -55,7 +55,7 @@ async fn sql_command_renders_table_output() {
     let requests = server.execute_sql_requests();
     assert_eq!(requests.len(), 1, "expected one execute_sql call");
     assert_eq!(requests[0].sql, "select 1 as value");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -295,7 +295,7 @@ async fn workspace_list_renders_each_membership_with_its_role() {
     let server = MockServer::start_with_config(MockServerConfig::default().with_list_workspaces(
         ListWorkspacesResponse {
             memberships: vec![
-                membership("default", WorkspaceRole::Owner),
+                membership(TEST_WORKSPACE, WorkspaceRole::Owner),
                 membership("work", WorkspaceRole::Member),
             ],
         },
@@ -310,10 +310,34 @@ async fn workspace_list_renders_each_membership_with_its_role() {
         vec![
             "Workspace  Role",
             "---------  ------",
-            "default    owner",
+            "analytics  owner",
             "work       member",
         ],
         "expected workspace list"
+    );
+    assert_eq!(
+        server.list_workspaces_requests().len(),
+        1,
+        "expected one list_workspaces call"
+    );
+
+    server.shutdown().await;
+}
+
+/// Nothing provisions a workspace any more, so a caller who has not been
+/// granted one must be told it holds no membership rather than shown a
+/// `default` row the server never created.
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_list_reports_no_memberships_on_fresh_state() {
+    let server = MockServer::start().await;
+
+    let assert = server.cmd().args(["workspace", "list"]).assert().success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(
+        nonempty_lines(&stdout),
+        vec!["No workspaces available."],
+        "fresh state must list no workspace"
     );
     assert_eq!(
         server.list_workspaces_requests().len(),
@@ -382,7 +406,7 @@ async fn source_list_renders_configured_sources() {
 
     let requests = server.list_sources_requests();
     assert_eq!(requests.len(), 1, "expected one list_sources call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -436,7 +460,7 @@ async fn sql_command_renders_json_output() {
     let requests = server.execute_sql_requests();
     assert_eq!(requests.len(), 1, "expected one execute_sql call");
     assert_eq!(requests[0].sql, "select 1 as value");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -461,7 +485,7 @@ async fn source_discover_renders_available_sources() {
 
     let requests = server.discover_sources_requests();
     assert_eq!(requests.len(), 1, "expected one discover_sources call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -486,7 +510,7 @@ async fn source_discover_renders_empty_state() {
 
     let requests = server.discover_sources_requests();
     assert_eq!(requests.len(), 1, "expected one discover_sources call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -529,7 +553,7 @@ async fn source_info_renders_metadata_for_installed_source() {
     let requests = server.get_source_info_requests();
     assert_eq!(requests.len(), 1, "expected one get_source_info call");
     assert_eq!(requests[0].name, "github");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -602,7 +626,7 @@ async fn source_info_renders_installed_imported_source() {
     let requests = server.get_source_info_requests();
     assert_eq!(requests.len(), 1, "expected one get_source_info call");
     assert_eq!(requests[0].name, "jira");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -669,7 +693,7 @@ async fn source_list_renders_empty_state() {
 
     let requests = server.list_sources_requests();
     assert_eq!(requests.len(), 1, "expected one list_sources call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -714,7 +738,7 @@ async fn source_test_renders_validation_summary() {
     let requests = server.validate_source_requests();
     assert_eq!(requests.len(), 1, "expected one validate_source call");
     assert_eq!(requests[0].name, "github");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -739,7 +763,7 @@ async fn source_remove_reports_removed_source() {
     let requests = server.delete_source_requests();
     assert_eq!(requests.len(), 1, "expected one delete_source call");
     assert_eq!(requests[0].name, "github");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -863,7 +887,7 @@ async fn sql_table_output_renders_multiple_columns_and_rows() {
     let requests = server.execute_sql_requests();
     assert_eq!(requests.len(), 1, "expected one execute_sql call");
     assert_eq!(requests[0].sql, "select id, name from users");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -912,7 +936,7 @@ async fn sql_json_output_renders_multiple_rows() {
     let requests = server.execute_sql_requests();
     assert_eq!(requests.len(), 1, "expected one execute_sql call");
     assert_eq!(requests[0].sql, "select id, name from users");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -957,7 +981,7 @@ async fn search_command_renders_text_output_and_provider_statuses() {
     assert_eq!(requests.len(), 1, "expected one search call");
     assert_eq!(requests[0].query, "messages text");
     assert_eq!(requests[0].limit, 10);
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -1002,7 +1026,7 @@ async fn search_json_output_preserves_typed_payloads_and_statuses() {
     assert_eq!(requests.len(), 1, "expected one search call");
     assert_eq!(requests[0].query, "messages");
     assert_eq!(requests[0].limit, 5);
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -1055,7 +1079,7 @@ async fn search_index_rebuild_calls_app_maintenance_rpc() {
     );
     let requests = server.rebuild_search_index_requests();
     assert_eq!(requests.len(), 1, "expected one rebuild call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
     assert_eq!(requests[0].provider, SearchIndexProvider::All as i32);
     assert!(requests[0].force);
 
@@ -1130,7 +1154,7 @@ async fn search_index_drain_calls_app_maintenance_rpc() {
     );
     let requests = server.drain_search_queue_requests();
     assert_eq!(requests.len(), 1, "expected one drain call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
     assert_eq!(requests[0].budget_ms, 2500);
 
     server
@@ -1157,7 +1181,7 @@ async fn search_index_clear_calls_app_maintenance_rpc() {
             "--scope",
             "all",
             "--workspace",
-            "default",
+            TEST_WORKSPACE,
             "--yes",
         ])
         .assert()
@@ -1179,7 +1203,7 @@ async fn search_index_clear_calls_app_maintenance_rpc() {
     );
     let requests = server.clear_search_data_requests();
     assert_eq!(requests.len(), 1, "expected one clear call");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
     assert_eq!(requests[0].scope, SearchDataScope::All as i32);
     match requests[0]
         .target
@@ -1219,14 +1243,14 @@ async fn search_index_clear_calls_app_maintenance_rpc() {
             "--source",
             "searchable",
             "--workspace",
-            "default",
+            TEST_WORKSPACE,
             "--yes",
         ])
         .assert()
         .success();
     let requests = server.clear_search_data_requests();
     assert_eq!(requests.len(), 3, "expected source clear call");
-    assert_default_workspace(requests[2].workspace.as_ref());
+    assert_test_workspace(requests[2].workspace.as_ref());
     assert_eq!(requests[2].scope, SearchDataScope::All as i32);
     match requests[2]
         .target
@@ -1305,7 +1329,7 @@ async fn sql_table_output_renders_empty_result() {
     let requests = server.execute_sql_requests();
     assert_eq!(requests.len(), 1, "expected one execute_sql call");
     assert_eq!(requests[0].sql, "select id, name from empty_table");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }
@@ -1332,7 +1356,7 @@ async fn sql_json_output_renders_empty_result() {
     let requests = server.execute_sql_requests();
     assert_eq!(requests.len(), 1, "expected one execute_sql call");
     assert_eq!(requests[0].sql, "select id from empty_table");
-    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_test_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -64,9 +64,19 @@ use tonic::transport::Server;
 use tonic::{Code, Request, Response, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
+/// The ordinary workspace every fixture selects explicitly.
+///
+/// Nothing provisions a workspace any more, so a fixture that names no
+/// workspace would fall through to `selected_workspace_name`'s
+/// `DEFAULT_WORKSPACE_ID` fallback — which still exists, is exercised only by
+/// its own resolver unit test, and is itself due for removal. Fixtures
+/// therefore select this name through the ordinary `CORAL_WORKSPACE` selector
+/// (see [`MockServer::cmd`]) rather than leaning on that fallback.
+pub(crate) const TEST_WORKSPACE: &str = "analytics";
+
 fn workspace() -> Workspace {
     Workspace {
-        name: "default".to_string(),
+        name: TEST_WORKSPACE.to_string(),
     }
 }
 
@@ -80,8 +90,8 @@ pub(crate) fn membership(name: &str, role: WorkspaceRole) -> WorkspaceMembership
     }
 }
 
-pub(crate) fn assert_default_workspace(workspace: Option<&Workspace>) {
-    assert_workspace_name(workspace, "default");
+pub(crate) fn assert_test_workspace(workspace: Option<&Workspace>) {
+    assert_workspace_name(workspace, TEST_WORKSPACE);
 }
 
 pub(crate) fn assert_workspace_name(workspace: Option<&Workspace>, expected: &str) {
@@ -731,8 +741,9 @@ impl Default for MockServerConfig {
                     },
                 ],
             }),
+            // Fresh state: the caller holds no membership until a test says so.
             list_workspaces: MockResult::ok(ListWorkspacesResponse {
-                memberships: vec![membership("default", WorkspaceRole::Owner)],
+                memberships: Vec::new(),
             }),
             validate_source: MockResult::ok(mock_validate_response()),
             delete_source: MockResult::ok(()),
@@ -1656,10 +1667,17 @@ impl MockServer {
         .await
     }
 
+    /// Builds a `coral` invocation that explicitly targets [`TEST_WORKSPACE`].
+    ///
+    /// The selection is a plain `CORAL_WORKSPACE` value, so `--workspace` still
+    /// overrides it and the precedence tests keep working. Selecting it here
+    /// keeps every other fixture off the resolver fallback, so removing that
+    /// fallback stays a change to the resolver and its own test.
     pub(crate) fn cmd(&self) -> Command {
         let mut cmd = Command::cargo_bin("coral").expect("cargo bin");
         cmd.env("CORAL_ENDPOINT", &self.endpoint_uri);
         cmd.env("CORAL_CONFIG_DIR", self.config_dir.path());
+        cmd.env("CORAL_WORKSPACE", TEST_WORKSPACE);
         cmd
     }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -16,12 +16,14 @@ use std::time::Duration;
 use std::{fs, io};
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ImportSourceRequest, ListSourcesResponse, Source, SourceCredentialStorage,
-    SourceOrigin, Workspace, import_source_response,
+    CreateWorkspaceRequest, ExecuteSqlRequest, ImportSourceRequest, ListSourcesResponse, Source,
+    SourceCredentialStorage, SourceOrigin, Workspace, import_source_response,
 };
 use coral_app::{ServerBuilder, shutdown_tracing};
-use coral_client::{AppClient, default_workspace};
-use harness::{MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name};
+use coral_client::{AppClient, workspace as workspace_resource};
+use harness::{
+    MockServer, MockServerConfig, TEST_WORKSPACE, assert_test_workspace, assert_workspace_name,
+};
 use rmcp::{
     RoleClient, ServiceExt,
     model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams},
@@ -81,13 +83,15 @@ fn write_config(server: &MockServer, raw: &str) -> Result<(), io::Error> {
 fn write_workspace_scoped_source_config(server: &MockServer) -> Result<(), io::Error> {
     write_config(
         server,
-        r#"
-[workspaces.default.sources.github]
+        &format!(
+            r#"
+[workspaces.{TEST_WORKSPACE}.sources.github]
 origin = "bundled"
 
 [workspaces.work.sources.jira]
 origin = "bundled"
-"#,
+"#
+        ),
     )
 }
 
@@ -184,7 +188,8 @@ async fn start_mcp_client_with_args(
             cmd.arg("mcp-stdio")
                 .args(args)
                 .env("CORAL_ENDPOINT", server.endpoint_uri())
-                .env("CORAL_CONFIG_DIR", server.config_dir());
+                .env("CORAL_CONFIG_DIR", server.config_dir())
+                .env("CORAL_WORKSPACE", TEST_WORKSPACE);
         }),
     )?;
     let client = ().serve(transport).await?;
@@ -202,7 +207,7 @@ async fn coral_client_task_id_metadata_reaches_execute_sql()
     coral_client::with_task_metadata(Some(task_id_metadata), async {
         app.query_client()
             .execute_sql(Request::new(ExecuteSqlRequest {
-                workspace: Some(default_workspace()),
+                workspace: Some(workspace_resource(TEST_WORKSPACE)),
                 sql: "SELECT 1".to_string(),
                 guide_read_context: None,
                 task_attribution: None,
@@ -255,6 +260,16 @@ tables:
     ))
 }
 
+/// Creates [`TEST_WORKSPACE`] on a real server, which now provisions none.
+async fn create_test_workspace(app: &AppClient) -> Result<(), Box<dyn std::error::Error>> {
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace_resource(TEST_WORKSPACE)),
+        }))
+        .await?;
+    Ok(())
+}
+
 async fn import_real_fixture_source(
     app: &AppClient,
     manifest_yaml: String,
@@ -262,7 +277,7 @@ async fn import_real_fixture_source(
     let mut source_client = app.source_client();
     let mut stream = source_client
         .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace_resource(TEST_WORKSPACE)),
             manifest_yaml,
             variables: Vec::new(),
             secrets: Vec::new(),
@@ -436,18 +451,21 @@ async fn mcp_stdio_raw_tools_list_advertises_client_compatible_schemas()
     let server = MockServer::start().await;
     write_config(
         &server,
-        r#"
-[workspaces.default.sources.jira]
+        &format!(
+            r#"
+[workspaces.{TEST_WORKSPACE}.sources.jira]
 origin = "bundled"
 
-[workspaces.default.sources.github]
+[workspaces.{TEST_WORKSPACE}.sources.github]
 origin = "bundled"
-"#,
+"#
+        ),
     )?;
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
         .env("CORAL_ENDPOINT", server.endpoint_uri())
         .env("CORAL_CONFIG_DIR", server.config_dir())
+        .env("CORAL_WORKSPACE", TEST_WORKSPACE)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -538,11 +556,12 @@ storage = "file"
         .start()
         .await?;
     let app = AppClient::connect(server.endpoint_uri()).await?;
+    create_test_workspace(&app).await?;
     import_real_fixture_source(&app, write_real_fixture_manifest(temp.path())?).await?;
     let sql = "SELECT text FROM local_messages.messages ORDER BY text";
     app.query_client()
         .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(workspace_resource(TEST_WORKSPACE)),
             sql: sql.to_string(),
             guide_read_context: None,
             task_attribution: None,
@@ -552,6 +571,7 @@ storage = "file"
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
+        .args(["--workspace", TEST_WORKSPACE])
         .env("CORAL_ENDPOINT", server.endpoint_uri())
         .env("CORAL_CONFIG_DIR", &config_dir)
         .stdin(Stdio::piped())
@@ -623,8 +643,8 @@ async fn mcp_stdio_workspace_flag_scopes_server_instance() -> Result<(), Box<dyn
         server.config_dir(),
         &[
             query_history_trace_record(
-                "default",
-                "default-history",
+                TEST_WORKSPACE,
+                "analytics-history",
                 "SELECT title FROM github.issues",
                 &["github"],
                 7,
@@ -1021,7 +1041,7 @@ async fn mcp_stdio_task_tools_send_lifecycle_requests() -> Result<(), Box<dyn st
     let task_id = start_test_task(&client).await?;
     let start_requests = server.start_task_requests();
     assert_eq!(start_requests.len(), 1);
-    assert_default_workspace(start_requests[0].workspace.as_ref());
+    assert_test_workspace(start_requests[0].workspace.as_ref());
     assert_eq!(
         start_requests[0].intent,
         "Exercise the MCP CLI test contract"
@@ -1040,7 +1060,7 @@ async fn mcp_stdio_task_tools_send_lifecycle_requests() -> Result<(), Box<dyn st
 
     let end_requests = server.end_task_requests();
     assert_eq!(end_requests.len(), 1);
-    assert_default_workspace(end_requests[0].workspace.as_ref());
+    assert_test_workspace(end_requests[0].workspace.as_ref());
     assert_eq!(end_requests[0].task_id, task_id);
     assert_eq!(
         end_requests[0].task_status,
@@ -1229,6 +1249,7 @@ future_flag = true
         .arg("mcp-stdio")
         .env("CORAL_ENDPOINT", server.endpoint_uri())
         .env("CORAL_CONFIG_DIR", server.config_dir())
+        .env("CORAL_WORKSPACE", TEST_WORKSPACE)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -1442,7 +1463,7 @@ async fn assert_search_tool(
     let request = search_requests.last().expect("search request");
     assert_eq!(request.query, "messages");
     assert_eq!(request.limit, 5);
-    assert_default_workspace(request.workspace.as_ref());
+    assert_test_workspace(request.workspace.as_ref());
     Ok(())
 }
 

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -19,6 +19,14 @@ use coral_api::v1::{
 #[cfg(feature = "cli-test-server")]
 use harness::MockServer;
 
+/// The ordinary workspace this suite targets explicitly.
+///
+/// Mirrors `harness::TEST_WORKSPACE`, which the filesystem-only test below
+/// cannot import because the harness is `cli-test-server`-gated. Nothing provisions
+/// a workspace any more, so naming one here keeps these fixtures off the CLI's
+/// `DEFAULT_WORKSPACE_ID` resolver fallback.
+const TEST_WORKSPACE: &str = "analytics";
+
 #[test]
 fn source_test_errors_when_required_secret_is_missing() {
     let config_dir = tempdir().expect("failed to create temp dir");
@@ -52,7 +60,7 @@ fn source_test_errors_when_required_secret_is_missing() {
     let manifest_dir = config_dir
         .path()
         .join("workspaces")
-        .join("default")
+        .join(TEST_WORKSPACE)
         .join("sources")
         .join("fake");
     let manifest_file_path = manifest_dir.join("manifest.yaml");
@@ -62,19 +70,22 @@ fn source_test_errors_when_required_secret_is_missing() {
     std::fs::write(secrets_env_path, "").expect("failed to write secrets.env");
 
     // Write a basic config that references the fake source, but don't set the required secret.
-    let config = r#"
-        [workspaces.default.sources.fake]
+    let config = format!(
+        r#"
+        [workspaces.{TEST_WORKSPACE}.sources.fake]
         version = "1.0.0"
-        variables = {}
+        variables = {{}}
         secrets = []
         origin = "imported"
-    "#;
+    "#
+    );
     std::fs::write(config_dir.path().join("config.toml"), config).expect("failed to write config");
 
     let output = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("source")
         .arg("test")
         .arg("fake")
+        .args(["--workspace", TEST_WORKSPACE])
         .env("CORAL_CONFIG_DIR", config_dir.path())
         .output()
         .expect("failed to run coral source test");
@@ -93,7 +104,7 @@ async fn source_test_exits_non_zero_when_query_tests_fail() {
     let server = MockServer::start_with_validate_source_response(ValidateSourceResponse {
         source: Some(Source {
             workspace: Some(Workspace {
-                name: "default".to_string(),
+                name: TEST_WORKSPACE.to_string(),
             }),
             name: "local_messages".to_string(),
             version: "0.1.0".to_string(),
@@ -144,7 +155,7 @@ async fn source_test_succeeds_when_query_tests_pass() {
     let server = MockServer::start_with_validate_source_response(ValidateSourceResponse {
         source: Some(Source {
             workspace: Some(Workspace {
-                name: "default".to_string(),
+                name: TEST_WORKSPACE.to_string(),
             }),
             name: "local_messages".to_string(),
             version: "0.1.0".to_string(),

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -22,9 +22,8 @@ use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
-use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
 use coral_app::{CanonicalOauthUrl, OauthUrlError};
-use coral_client::{AppClient, default_workspace};
+use coral_client::AppClient;
 use futures::{Stream, StreamExt as _};
 use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ServerJsonRpcMessage};
 use rmcp::transport::{
@@ -50,7 +49,6 @@ use tokio::net::TcpListener;
 use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore, oneshot};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::Request as GrpcRequest;
 use tower::ServiceExt;
 use url::{Position, Url};
 
@@ -715,24 +713,30 @@ fn spawn_http_server(
 struct ReadinessProbe(Arc<dyn Fn() -> ProbeFuture + Send + Sync>);
 
 impl ReadinessProbe {
+    /// Probes the server over the unauthenticated gRPC health service.
+    ///
+    /// A data-plane call cannot serve here. It would have to name a workspace,
+    /// and the only name available without reading state is one nothing
+    /// provisions — whose `NotFound` [`catalog_rejection_is_reachable`] reads as
+    /// reachable, so `/readyz` would answer ready for a server that can reach
+    /// nothing at all. The health service asks about the instance itself,
+    /// server-side, and names no workspace.
+    ///
+    /// Twin of `probe_serving_health` in `coral-cli/src/serve.rs`, which
+    /// supplies this probe for the authenticated surface. The mapping — ready,
+    /// not-ready as `Unavailable`, the status code otherwise — is duplicated on
+    /// purpose: only the surface-specific reasoning around it differs. Change
+    /// one mapping and the other needs the same change, or the two `/readyz`
+    /// surfaces drift apart.
     fn from_app(app: AppClient) -> Self {
         Self(Arc::new(move || {
-            let mut catalog = app.catalog_client();
+            let app = app.clone();
             Box::pin(async move {
-                catalog
-                    .list_catalog(GrpcRequest::new(ListCatalogRequest {
-                        workspace: Some(default_workspace()),
-                        catalog_name: String::new(),
-                        schema_name: String::new(),
-                        kind: CatalogItemKind::Unspecified as i32,
-                        pagination: Some(PaginationRequest {
-                            limit: 1,
-                            offset: 0,
-                        }),
-                    }))
-                    .await
-                    .map(|_response| ())
-                    .map_err(|status| status.code())
+                match app.check_engine_ready().await {
+                    Ok(true) => Ok(()),
+                    Ok(false) => Err(tonic::Code::Unavailable),
+                    Err(status) => Err(status.code()),
+                }
             })
         }))
     }

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -717,7 +717,7 @@ impl ReadinessProbe {
     ///
     /// A data-plane call cannot serve here. It would have to name a workspace,
     /// and the only name available without reading state is one nothing
-    /// provisions — whose `NotFound` [`catalog_rejection_is_reachable`] reads as
+    /// provisions — whose `NotFound` [`rejection_is_reachable`] reads as
     /// reachable, so `/readyz` would answer ready for a server that can reach
     /// nothing at all. The health service asks about the instance itself,
     /// server-side, and names no workspace.
@@ -1126,12 +1126,17 @@ async fn readyz(State(state): State<Arc<HttpState>>) -> StatusCode {
 async fn readiness_status(probe: &ReadinessProbe, timeout: Duration) -> StatusCode {
     match tokio::time::timeout(timeout, (probe.0)()).await {
         Ok(Ok(())) => StatusCode::NO_CONTENT,
-        Ok(Err(code)) if catalog_rejection_is_reachable(code) => StatusCode::NO_CONTENT,
+        Ok(Err(code)) if rejection_is_reachable(code) => StatusCode::NO_CONTENT,
         Ok(Err(_)) | Err(_) => StatusCode::SERVICE_UNAVAILABLE,
     }
 }
 
-fn catalog_rejection_is_reachable(code: tonic::Code) -> bool {
+/// Whether a rejection still proves the server on the other end is reachable.
+///
+/// The probe's own transport failures — and the codes a server emits when it
+/// cannot serve — mean unready. Everything else arrived *from* a server that
+/// answered, so it reports reachability even though the call itself failed.
+fn rejection_is_reachable(code: tonic::Code) -> bool {
     !matches!(
         code,
         tonic::Code::Cancelled

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::{Router, response::Response};
-use coral_client::{AppClient, local::ServerBuilder};
+use coral_api::v1::CreateWorkspaceRequest;
+use coral_client::{AppClient, local::ServerBuilder, workspace};
 use futures::{future::BoxFuture, poll};
 use rmcp::handler::server::router::tool::IntoToolRoute;
 use rmcp::model::{CallToolRequestParams, ClientJsonRpcMessage};
@@ -23,6 +24,7 @@ use rmcp::{ErrorData, Json, ServiceExt as _};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpStream;
+use tonic::Request as GrpcRequest;
 use tower::ServiceExt as _;
 
 use crate::{McpOptions, McpSurface, McpToolContext};
@@ -150,6 +152,26 @@ async fn assert_invalid_initialize_protocols_rejected(router: &Router) {
             send(router, invalid).await.status(),
             StatusCode::BAD_REQUEST
         );
+    }
+}
+
+/// The one ordinary workspace the HTTP fixtures work in. A fresh app owns no
+/// workspace, so only the tests that reach a workspace-scoped tool create it,
+/// and they name it in their [`McpOptions`] rather than leaving the choice to
+/// the server.
+const TEST_WORKSPACE: &str = "analytics";
+
+/// Creates [`TEST_WORKSPACE`] and returns options scoped to it.
+async fn workspace_scoped_options(app: &AppClient) -> McpOptions {
+    app.workspace_client()
+        .create_workspace(GrpcRequest::new(CreateWorkspaceRequest {
+            workspace: Some(workspace(TEST_WORKSPACE)),
+        }))
+        .await
+        .expect("create test workspace");
+    McpOptions {
+        workspace: Some(workspace(TEST_WORKSPACE)),
+        ..McpOptions::default()
     }
 }
 
@@ -503,10 +525,10 @@ async fn streamable_http_executes_tools_and_shutdown_is_bounded() {
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
     let server = start_auth_disabled(
         config,
-        app,
+        app.clone(),
         McpOptions {
             feedback_enabled: true,
-            ..McpOptions::default()
+            ..workspace_scoped_options(&app).await
         },
     )
     .await

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -1134,10 +1134,16 @@ async fn authenticated_discovery_and_challenge_do_not_advertise_scopes() {
 #[tokio::test]
 async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
     let (_temp, app_server, app) = local_app().await;
+    // Nothing provisions a workspace any more, so the fixture creates the one
+    // its session serves and scopes the options to it.
+    let options = workspace_scoped_options(&app).await;
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        extension_options(),
+        McpOptions {
+            surface: extension_options().surface,
+            ..options
+        },
         || async { Ok::<_, tonic::Code>(()) },
     );
     let server = start_authenticated(
@@ -1162,7 +1168,8 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
         .expect("extension structured content");
     assert_eq!(
         extension.get("workspace"),
-        Some(&serde_json::json!("default"))
+        Some(&serde_json::json!(TEST_WORKSPACE)),
+        "the session serves the workspace its options name"
     );
     let sessions = authenticated_sessions(&server);
     let state = Arc::downgrade(&server.state);
@@ -1186,6 +1193,9 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
 async fn authenticated_extension_uses_its_session_app_client() {
     let (_live_temp, live_server, live_app) = local_app().await;
     let (_stopped_temp, stopped_server, stopped_app) = local_app().await;
+    // Nothing provisions a workspace any more, so the fixture creates the one
+    // the sessions serve and scopes the options to it.
+    let options = workspace_scoped_options(&live_app).await;
     stopped_server
         .shutdown()
         .await
@@ -1201,7 +1211,10 @@ async fn authenticated_extension_uses_its_session_app_client() {
             };
             std::future::ready(Ok::<_, ()>(app))
         },
-        extension_options(),
+        McpOptions {
+            surface: extension_options().surface,
+            ..options
+        },
         || async { Ok::<_, tonic::Code>(()) },
     );
     let server = start_authenticated(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -7,10 +7,13 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use coral_api::v1::{ImportSourceRequest, Workspace, import_source_response};
+use coral_api::v1::{
+    CreateWorkspaceRequest, ImportSourceRequest, Workspace, import_source_response,
+};
 use coral_client::{
-    AppClient, SourceClient, default_workspace,
+    AppClient, SourceClient,
     local::{RunningServer, ServerBuilder},
+    workspace,
 };
 use futures::future::BoxFuture;
 use jsonschema::Validator;
@@ -347,10 +350,36 @@ async fn start_test_task(client: &RunningService<RoleClient, ()>) -> String {
     task_id
 }
 
+/// The one ordinary workspace these fixtures work in.
+///
+/// Nothing provisions a workspace any more, so a session that reaches a
+/// workspace-scoped tool has to create this one and name it in [`McpOptions`].
+const TEST_WORKSPACE: &str = "analytics";
+
+fn test_workspace() -> Workspace {
+    workspace(TEST_WORKSPACE)
+}
+
+async fn create_test_workspace(app: &AppClient) {
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(test_workspace()),
+        }))
+        .await
+        .expect("create test workspace");
+}
+
+/// Where the feedback tool records reports for [`TEST_WORKSPACE`].
+fn feedback_reports_path(root: &Path) -> PathBuf {
+    root.join("coral-config/workspaces")
+        .join(TEST_WORKSPACE)
+        .join("feedback/reports.jsonl")
+}
+
 async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String) {
     let mut stream = source_client
         .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(test_workspace()),
             manifest_yaml,
             variables: Vec::new(),
             secrets: Vec::new(),
@@ -404,6 +433,7 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
     let app = AppClient::connect(server.endpoint_uri())
         .await
         .expect("connect client");
+    let options = with_created_workspace(&app, options).await;
     let source_client = app.source_client();
     let factory = CoralMcpServerFactory::new(app, options);
     let (client, mcp_server_task) = start_mcp_session(factory.create()).await;
@@ -413,6 +443,21 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
         client,
         app_server: server,
         mcp_server_task,
+    }
+}
+
+/// Creates [`TEST_WORKSPACE`] and scopes the session to it, unless the caller
+/// already named the workspace it wants to exercise. Leaving `workspace` unset
+/// would fall through to the server's own choice, which is exactly what these
+/// fixtures must not depend on.
+async fn with_created_workspace(app: &AppClient, options: McpOptions) -> McpOptions {
+    if options.workspace.is_some() {
+        return options;
+    }
+    create_test_workspace(app).await;
+    McpOptions {
+        workspace: Some(test_workspace()),
+        ..options
     }
 }
 
@@ -2155,12 +2200,14 @@ async fn factory_shares_configuration_and_task_guide_state_across_sessions() {
     let app = AppClient::connect(app_server.endpoint_uri())
         .await
         .expect("connect client");
+    create_test_workspace(&app).await;
     let mut source_client = app.source_client();
     add_demo_source(&mut source_client, manifest_yaml).await;
     let factory = CoralMcpServerFactory::new(
         app,
         McpOptions {
             feedback_enabled: true,
+            workspace: Some(test_workspace()),
             ..McpOptions::default()
         },
     );
@@ -2438,16 +2485,13 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     assert_eq!(structured["message"], "Feedback report stored.");
     assert!(structured.get("upload").is_none());
 
-    let raw = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
-    )
-    .expect("feedback file should exist");
+    let raw =
+        fs::read_to_string(feedback_reports_path(temp.path())).expect("feedback file should exist");
     let records = raw.lines().collect::<Vec<_>>();
     assert_eq!(records.len(), 1);
     let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
     assert_eq!(record["id"], structured["feedback_id"]);
-    assert_eq!(record["workspace"], "default");
+    assert_eq!(record["workspace"], TEST_WORKSPACE);
     assert_eq!(record["trying_to_do"], "Fix failing tests");
     assert_eq!(
         record["tried"],
@@ -2477,11 +2521,8 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .contains("missing string argument 'tried'")
     );
 
-    let raw_after_error = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
-    )
-    .expect("feedback file should still exist");
+    let raw_after_error = fs::read_to_string(feedback_reports_path(temp.path()))
+        .expect("feedback file should still exist");
     assert_eq!(raw_after_error.lines().count(), 1);
 
     session.shutdown().await;
@@ -2524,11 +2565,8 @@ async fn mcp_feedback_tool_always_accepts_task_context() {
         "Feedback report stored."
     );
 
-    let raw = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
-    )
-    .expect("feedback file should exist");
+    let raw =
+        fs::read_to_string(feedback_reports_path(temp.path())).expect("feedback file should exist");
     let records = raw.lines().collect::<Vec<_>>();
     assert_eq!(records.len(), 1);
     let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
@@ -2572,12 +2610,7 @@ async fn mcp_feedback_tool_is_disabled_by_default() {
         .await
         .expect_err("feedback should not be exposed by default");
     assert!(feedback.to_string().contains("tool 'feedback' not found"));
-    assert!(
-        !temp
-            .path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl")
-            .exists()
-    );
+    assert!(!feedback_reports_path(temp.path()).exists());
 
     session.shutdown().await;
 }

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -11,6 +11,12 @@ use serde_json::Value;
 
 const DEFAULT_SQL: &str = "select * from coral.tables";
 
+/// The workspace this check creates and measures against.
+///
+/// A fresh state directory owns no workspace, so the harness has to create the
+/// one it benchmarks and name it on every command that follows.
+const WORKSPACE: &str = "perf";
+
 #[derive(Debug, clap::Args)]
 pub(crate) struct Args {
     /// Path to the release Coral binary to benchmark.
@@ -51,6 +57,7 @@ pub(crate) fn run(args: &Args) -> Result<bool> {
     )
     .with_context(|| format!("writing {}", config_dir.join("config.toml").display()))?;
 
+    create_workspace(&coral_bin, &config_dir)?;
     install_github_source(&coral_bin, &config_dir, &args.github_token)?;
     run_coral_sql(&coral_bin, &config_dir)?;
 
@@ -113,16 +120,39 @@ fn ensure_executable(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn install_github_source(coral_bin: &Path, config_dir: &Path, github_token: &str) -> Result<()> {
-    let output = Command::new(coral_bin)
-        .args(["source", "add", "github"])
+/// Builds a `coral` invocation pinned to this check's config directory and
+/// workspace, so every command targets the workspace the check provisions.
+fn coral_command(coral_bin: &Path, config_dir: &Path) -> Command {
+    let mut command = Command::new(coral_bin);
+    command
         .env("CORAL_CONFIG_DIR", config_dir)
+        .env("CORAL_WORKSPACE", WORKSPACE);
+    command
+}
+
+fn create_workspace(coral_bin: &Path, config_dir: &Path) -> Result<()> {
+    let output = coral_command(coral_bin, config_dir)
+        .args(["workspace", "create", WORKSPACE])
+        .output()
+        .with_context(|| format!("running {} workspace create", coral_bin.display()))?;
+
+    if !output.status.success() {
+        print!("{}", command_log(&output));
+        bail!("failed to create the {WORKSPACE} workspace");
+    }
+
+    println!("Created the {WORKSPACE} workspace.");
+    Ok(())
+}
+
+fn install_github_source(coral_bin: &Path, config_dir: &Path, github_token: &str) -> Result<()> {
+    let output = coral_command(coral_bin, config_dir)
+        .args(["source", "add", "github"])
         .env("GITHUB_TOKEN", github_token)
         .output()
         .with_context(|| format!("running {} source add github", coral_bin.display()))?;
 
-    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
-    log.push_str(&String::from_utf8_lossy(&output.stderr));
+    let log = command_log(&output);
 
     if !output.status.success() {
         print!("{log}");
@@ -134,10 +164,15 @@ fn install_github_source(coral_bin: &Path, config_dir: &Path, github_token: &str
     Ok(())
 }
 
+fn command_log(output: &std::process::Output) -> String {
+    let mut log = String::from_utf8_lossy(&output.stdout).into_owned();
+    log.push_str(&String::from_utf8_lossy(&output.stderr));
+    log
+}
+
 fn run_coral_sql(coral_bin: &Path, config_dir: &Path) -> Result<()> {
-    let status = Command::new(coral_bin)
+    let status = coral_command(coral_bin, config_dir)
         .args(["sql", DEFAULT_SQL])
-        .env("CORAL_CONFIG_DIR", config_dir)
         .stdout(Stdio::null())
         .status()
         .with_context(|| format!("running {} sql", coral_bin.display()))?;
@@ -175,6 +210,7 @@ fn run_hyperfine(
             &command,
         ])
         .env("CORAL_CONFIG_DIR", config_dir)
+        .env("CORAL_WORKSPACE", WORKSPACE)
         .status()
         .context("running hyperfine")?;
     if !status.success() {

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -163,9 +163,20 @@ fn coral_command(coral_bin: &Path, config_dir: &Path) -> Command {
     command
 }
 
+/// Builds the invocation that provisions the workspace the check measures.
+///
+/// Separate from running it so a test can read back the workspace this check
+/// creates and the environment it carries, which is the pairing a fresh state
+/// directory depends on and the one that broke when provisioning became
+/// explicit.
+fn workspace_create_command(coral_bin: &Path, config_dir: &Path) -> Command {
+    let mut command = coral_command(coral_bin, config_dir);
+    command.args(["workspace", "create", WORKSPACE]);
+    command
+}
+
 fn create_workspace(coral_bin: &Path, config_dir: &Path) -> Result<()> {
-    let output = coral_command(coral_bin, config_dir)
-        .args(["workspace", "create", WORKSPACE])
+    let output = workspace_create_command(coral_bin, config_dir)
         .output()
         .with_context(|| format!("running {} workspace create", coral_bin.display()))?;
 
@@ -344,7 +355,60 @@ impl Drop for TempDir {
 
 #[cfg(test)]
 mod tests {
-    use super::{HyperfineResult, is_regression, report_measurement, shell_quote};
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    use super::{
+        HyperfineResult, WORKSPACE, coral_command, is_regression, report_measurement, shell_quote,
+        workspace_create_command,
+    };
+
+    fn env_of(command: &std::process::Command, key: &str) -> Option<String> {
+        command.get_envs().find_map(|(name, value)| {
+            (name == OsStr::new(key)).then(|| {
+                value
+                    .expect("the check sets this variable rather than clearing it")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+        })
+    }
+
+    /// Every command the check runs has to name the workspace it provisions.
+    /// A fresh state directory has none, so an invocation that carries no
+    /// selection reaches the server as the legacy `default` and is refused.
+    #[test]
+    fn every_invocation_carries_the_provisioned_workspace() {
+        let command = coral_command(Path::new("/tmp/coral"), Path::new("/tmp/coral-config"));
+
+        assert_eq!(
+            env_of(&command, "CORAL_WORKSPACE").as_deref(),
+            Some(WORKSPACE)
+        );
+        assert_eq!(
+            env_of(&command, "CORAL_CONFIG_DIR").as_deref(),
+            Some("/tmp/coral-config")
+        );
+    }
+
+    /// The workspace the check measures is the one it creates, so the create
+    /// argv and the selection every later command carries must name the same
+    /// workspace.
+    #[test]
+    fn the_check_creates_the_workspace_it_selects() {
+        let command = workspace_create_command(Path::new("/tmp/coral"), Path::new("/tmp/cfg"));
+
+        let args: Vec<String> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, vec!["workspace", "create", WORKSPACE]);
+        assert_eq!(
+            env_of(&command, "CORAL_WORKSPACE").as_deref(),
+            Some(WORKSPACE),
+            "the workspace created and the workspace selected must be the same one"
+        );
+    }
 
     #[test]
     fn a_mean_under_the_threshold_is_not_a_regression() {

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -44,40 +44,38 @@ pub(crate) fn run(args: &Args) -> Result<bool> {
     validate_args(args)?;
     require_command("hyperfine")?;
 
-    let coral_bin = absolute_path(&args.coral_bin)?;
-    ensure_executable(&coral_bin)?;
-
+    let coral_bin = resolve_coral_bin(&args.coral_bin)?;
     let temp_dir = TempDir::create("coral-tables-perf")?;
-    let config_dir = temp_dir.path().join("coral-config");
-    fs::create_dir_all(&config_dir)
-        .with_context(|| format!("creating {}", config_dir.display()))?;
-    fs::write(
-        config_dir.join("config.toml"),
-        "[credentials]\nstorage = \"file\"\n",
-    )
-    .with_context(|| format!("writing {}", config_dir.join("config.toml").display()))?;
-
-    create_workspace(&coral_bin, &config_dir)?;
-    install_github_source(&coral_bin, &config_dir, &args.github_token)?;
-    run_coral_sql(&coral_bin, &config_dir)?;
+    let config_dir = prepare_config_dir(temp_dir.path())?;
+    provision_measured_workspace(&coral_bin, &config_dir, &args.github_token)?;
 
     let result_json = temp_dir.path().join("hyperfine.json");
     run_hyperfine(args, &coral_bin, &config_dir, &result_json)?;
-
     let result = load_hyperfine_result(&result_json)?;
+
+    Ok(report_measurement(&result, args.max_mean_seconds))
+}
+
+/// Prints the measurement and answers whether it stayed within the threshold.
+fn report_measurement(result: &HyperfineResult, max_mean_seconds: f64) -> bool {
     println!(
         "coral.tables mean: {:.3}s (stddev {:.3}s, threshold {:.3}s)",
-        result.mean, result.stddev, args.max_mean_seconds
+        result.mean, result.stddev, max_mean_seconds
     );
-    if result.mean > args.max_mean_seconds {
+    if is_regression(result.mean, max_mean_seconds) {
         eprintln!(
             "Performance regression: mean {:.3}s exceeds {:.3}s",
-            result.mean, args.max_mean_seconds
+            result.mean, max_mean_seconds
         );
-        return Ok(false);
+        return false;
     }
+    true
+}
 
-    Ok(true)
+/// The pass/fail rule this check exists to apply: a mean at the threshold still
+/// passes, and only one above it counts as a regression.
+fn is_regression(mean: f64, max_mean_seconds: f64) -> bool {
+    mean > max_mean_seconds
 }
 
 fn validate_args(args: &Args) -> Result<()> {
@@ -103,6 +101,14 @@ fn require_command(command: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolves the binary under test to an absolute path and refuses anything that
+/// is not a file we can hand to hyperfine.
+fn resolve_coral_bin(coral_bin: &Path) -> Result<PathBuf> {
+    let coral_bin = absolute_path(coral_bin)?;
+    ensure_executable(&coral_bin)?;
+    Ok(coral_bin)
+}
+
 fn absolute_path(path: &Path) -> Result<PathBuf> {
     if path.is_absolute() {
         return Ok(path.to_path_buf());
@@ -118,6 +124,33 @@ fn ensure_executable(path: &Path) -> Result<()> {
         bail!("Coral binary is not a file: {}", path.display());
     }
     Ok(())
+}
+
+/// Lays out a throwaway config directory so the check never reads or writes the
+/// developer's own Coral state.
+fn prepare_config_dir(temp_dir: &Path) -> Result<PathBuf> {
+    let config_dir = temp_dir.join("coral-config");
+    fs::create_dir_all(&config_dir)
+        .with_context(|| format!("creating {}", config_dir.display()))?;
+    fs::write(
+        config_dir.join("config.toml"),
+        "[credentials]\nstorage = \"file\"\n",
+    )
+    .with_context(|| format!("writing {}", config_dir.join("config.toml").display()))?;
+    Ok(config_dir)
+}
+
+/// Brings the fresh state directory to the state the benchmark measures: the
+/// workspace exists, carries the github source, and has answered the query once
+/// so the timed runs are not paying for first-run work.
+fn provision_measured_workspace(
+    coral_bin: &Path,
+    config_dir: &Path,
+    github_token: &str,
+) -> Result<()> {
+    create_workspace(coral_bin, config_dir)?;
+    install_github_source(coral_bin, config_dir, github_token)?;
+    run_coral_sql(coral_bin, config_dir)
 }
 
 /// Builds a `coral` invocation pinned to this check's config directory and
@@ -311,7 +344,36 @@ impl Drop for TempDir {
 
 #[cfg(test)]
 mod tests {
-    use super::shell_quote;
+    use super::{HyperfineResult, is_regression, report_measurement, shell_quote};
+
+    #[test]
+    fn a_mean_under_the_threshold_is_not_a_regression() {
+        assert!(!is_regression(0.5, 0.75));
+    }
+
+    #[test]
+    fn a_mean_at_the_threshold_is_not_a_regression() {
+        assert!(!is_regression(0.75, 0.75));
+    }
+
+    #[test]
+    fn a_mean_above_the_threshold_is_a_regression() {
+        assert!(is_regression(0.751, 0.75));
+    }
+
+    #[test]
+    fn the_check_passes_only_while_the_mean_stays_within_the_threshold() {
+        let within = HyperfineResult {
+            mean: 0.5,
+            stddev: 0.01,
+        };
+        let over = HyperfineResult {
+            mean: 1.5,
+            stddev: 0.01,
+        };
+        assert!(report_measurement(&within, 0.75));
+        assert!(!report_measurement(&over, 0.75));
+    }
 
     #[test]
     fn shell_quote_leaves_safe_paths_unquoted() {


### PR DESCRIPTION
## Intent

Coral used to silently create a `default` workspace on first run and fall back to it whenever selection was ambiguous. Under access control that guess is wrong: a workspace must have an owner, and an implicit one has nobody to own it. This slice removes implicit provisioning entirely and, for deployments that already have workspaces, bootstraps ownership onto the rows that exist.

## What it enables

- **Breaking:** a fresh install has no workspaces. `coral workspace create` is the only way one comes into existence, and its creator owns it. `default` and `default-*` become ordinary names — nothing provisions, protects, or resolves them specially.
- Every CLI, test, and benchmark fixture now names its workspace explicitly rather than riding the old fallback. Removing the CLI's own `DEFAULT_WORKSPACE_ID` fallback, and the actionable zero-workspace and multi-workspace errors that replace it, land in slice 4.
- Ownership bootstrap for existing deployments: on upgrade, legacy workspaces gain owners derived from the deployment's records; workspaces whose only candidate is the synthetic local principal are reported at startup as needing an operator-appointed owner (recovery tooling lands in slice 5). The upgrade writes its marker and the local principal's row in one transaction and proves the row landed, so a failed upgrade rolls back whole and a later start retries rather than retiring itself half-done.
- The legacy config-to-database import cuts over deleted workspaces correctly: a leftover on-disk directory does not resurrect a workspace the database records as deleted, even when the directory lacks a deletion marker.
- When the legacy config names no workspaces at all, the cutover reconstructs them by scanning the workspaces directory — the one path where a directory name becomes authoritative for a workspace's identity. Candidates are validated as workspace names, deletion-staging directories are filtered by the full suffix shape a staged deletion actually writes, and a dangling symlink is skipped rather than failing startup.
- Two residuals of that scan, both permanent because the cutover marker never re-runs. A config that names *some* workspaces skips the scan entirely, so an implicit workspace living beside a named one is not recovered. And if a deletion committed its config removal before directory staging failed, the leftover directory beside an emptied config is indistinguishable from a legacy implicit install, so the scan resurrects it. A directory alone carries no evidence that separates these cases; closing them needs deletion evidence persisted before the scan, which is its own change.
- Public docs follow the new contract: the CLI reference, configuration reference, and MCP guide no longer describe `default` as implicit or protected.
- Readiness stops asking about any workspace. Both the gRPC health service and `/readyz` now answer from whether this instance is up and can reach its database — no catalog resolution, no workspace named. A catalog answer would be a stronger signal, but it reports on a workspace and its sources rather than on this replica, and a probe that empties a fleet cannot act on it. The probe is cached, single-flighted, and deadline-bounded so an unauthenticated surface cannot drive a database round trip per request, and a hung database reports unready instead of wedging the answer.

## Usage examples

```bash
# Fresh install: nothing exists until you create it
coral workspace list        # "No workspaces available."
coral workspace create analytics

# Upgrade of an existing deployment: startup logs an ownership report;
# ownerless workspaces are named so an operator can appoint owners.

# Readiness names no workspace and needs no token
curl -sf http://localhost:8080/readyz     # 204 while the database answers
```

---
Slice 3 of 5 (milestones m5–m6; 40 commits). Requires slices 1–2.
