### PR TITLE
feat(mcp)!: serve each workspace at its own MCP URL

### DIFF
--- a/apps/docs/guides/deploy-on-kubernetes.mdx
+++ b/apps/docs/guides/deploy-on-kubernetes.mdx
@@ -351,7 +351,8 @@ kubectl -n coral rollout status deploy/coral-ui
 
 Then verify the public surfaces exactly as in the
 [Compose guide](/guides/self-host-with-docker#start-and-verify):
-`https://coral.example.com/readyz` returns ready, `https://mcp.coral.example.com/mcp`
+`https://coral.example.com/readyz` returns ready, a workspace URL such as
+`https://mcp.coral.example.com/mcp/workspace/analytics`
 returns `401` with a `WWW-Authenticate` challenge, and opening
 `https://coral.example.com` signs you in through your identity provider —
 without Coral's approval page, since Coral UI's client ID is listed in

--- a/apps/docs/guides/self-host-with-docker.mdx
+++ b/apps/docs/guides/self-host-with-docker.mdx
@@ -30,8 +30,9 @@ cleartext, all configured in `config.toml` (see
 
 - **Native gRPC** (`[server].bind_addr`, port `14555` in the image's default
   config) — the data plane Coral UI talks to.
-- **MCP Streamable HTTP** (`[server.mcp_http]`, opt-in) — serves `/mcp` for MCP
-  clients, plus health-check endpoints.
+- **MCP Streamable HTTP** (`[server.mcp_http]`, opt-in) — serves each
+  workspace at `/mcp/workspace/{workspace}` for MCP clients, plus health-check
+  endpoints.
 - **OAuth authorization server** (`[auth].http_bind_addr`, only with `[auth]`)
   — serves login, token, and discovery endpoints.
 
@@ -106,11 +107,12 @@ curl -fsS http://localhost:3000/readyz
 MCP Streamable HTTP is published on loopback too — the seed config opts the
 unauthenticated listener into a non-loopback bind with
 `allow_unauthenticated_non_loopback` (see
-[Configuration](/reference/configuration#server)). Point any MCP client that
-supports the transport at:
+[Configuration](/reference/configuration#server)). Every workspace is served
+at its own URL; point any MCP client that supports the transport at the
+workspace it should work in, for example:
 
 ```text
-http://localhost:14556/mcp
+http://localhost:14556/mcp/workspace/analytics
 ```
 
 The listener performs no authentication — reachability is the entire access
@@ -277,14 +279,16 @@ curl -fsS https://coral.example.com/readyz
 ```
 
 ```shellscript
-curl -i https://mcp.coral.example.com/mcp
+curl -i https://mcp.coral.example.com/mcp/workspace/analytics
 ```
 
 The first returns `{"coral":"reachable","status":"ok"}` once Coral UI can
 reach a ready Coral server. The second returns `401 Unauthorized` with a
-`WWW-Authenticate` header pointing at the OAuth resource metadata — that is an
-MCP client's entry point into the login flow, so a `401` here means MCP is
-wired correctly.
+`WWW-Authenticate` header pointing at that workspace URL's own OAuth resource
+metadata — that is an MCP client's entry point into the login flow, so a `401`
+here means MCP is wired correctly. Every well-formed workspace URL answers the
+same way whether or not the workspace exists; who can actually open a session
+there is decided by workspace membership at the handshake.
 
 Open `https://coral.example.com` in a browser. You are redirected to your
 identity provider's login and land back in Coral UI signed in. The
@@ -295,10 +299,11 @@ pause on the approval page instead (see
 
 ### Connect an MCP client
 
-Point any MCP client that supports Streamable HTTP and OAuth at:
+Point any MCP client that supports Streamable HTTP and OAuth at the URL of a
+workspace the signed-in teammate is a member of:
 
 ```text
-https://mcp.coral.example.com/mcp
+https://mcp.coral.example.com/mcp/workspace/analytics
 ```
 
 The client discovers Coral's authorization server from the protected-resource

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -107,12 +107,16 @@ bind = "127.0.0.1:14556"
 | ------------------------------------ | ---------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
 | `enabled`                            | boolean          | `false`       | Starts the MCP Streamable HTTP listener alongside the gRPC server.                                    |
 | `bind`                               | string           | `127.0.0.1:0` | Listener address as a literal IP and port. Loopback-only without `[auth]` unless opted in below.      |
-| `public_url`                         | string           | unset         | Externally reachable identifier for the MCP endpoint. Required when the listener is enabled with `[auth]`; forbidden without `[auth]`. |
+| `public_url`                         | string           | unset         | Externally reachable base of the per-workspace MCP URLs. Required when the listener is enabled with `[auth]`; forbidden without `[auth]`. |
 | `allow_unauthenticated_non_loopback` | boolean          | `false`       | Opt-in that lets the unauthenticated listener bind non-loopback addresses. Rejected with `[auth]`.    |
 | `allowed_hosts`                      | array of strings | `[]`          | Extra `Host` header names the unauthenticated listener accepts. Rejected with `[auth]`.               |
 
-The MCP endpoint is always served at the `/mcp` path on this listener, next to
-`GET /livez` and `GET /readyz` health routes.
+Every workspace is served at its own MCP URL on this listener,
+`/mcp/workspace/{workspace}` — for example `/mcp/workspace/analytics` — next to
+`GET /livez` and `GET /readyz` health routes. There is no single-workspace
+endpoint and no `workspace` key: the URL a client connects to names the
+workspace its sessions reach, a workspace is reachable as soon as it exists,
+and the retired `/mcp` path answers not-found.
 
 Without `[auth]`, the listener is unauthenticated, `public_url` must stay
 unset, and the listener is restricted to loopback addresses by default. To
@@ -148,12 +152,16 @@ allowed_hosts = ["coral"]
 ```
 
 With `[auth]`, `bind` may be any address and an enabled listener must set
-`public_url`; its value is the OAuth resource identifier and token audience
-for the endpoint, so
-keep its path consistent with the served endpoint, for example
-`https://mcp.example.com/mcp`. Both opt-in keys are rejected when `[auth]` is
-configured: remote binds then need no opt-in, and accepted hosts derive from
-`public_url`, the bind IP, plus the loopback names.
+`public_url`; it is the public base the per-workspace URLs hang under, for
+example `https://mcp.example.com/mcp` serving each workspace at
+`https://mcp.example.com/mcp/workspace/{workspace}`. Each such workspace URL —
+never the base itself — is its own OAuth resource identifier and token
+audience, with its own protected-resource metadata document, so a token minted
+for one workspace's URL is invalid at every other's. The listener mounts the
+family under the base's path, so keep that path consistent with what the
+ingress forwards. Both opt-in keys are rejected when `[auth]` is configured:
+remote binds then need no opt-in, and accepted hosts derive from `public_url`,
+the bind IP, plus the loopback names.
 
 ## Authentication
 

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -14,6 +14,7 @@ use super::session::SessionTokenIssuer;
 use super::state_store::{ApprovalStore, CodeStore, InMemoryStateStore, SessionStore};
 use crate::oauth_resource::{CanonicalOauthUrl, OauthUrlError};
 use crate::state::db::CoralDb;
+use crate::workspace_mcp_urls::WorkspaceMcpUrls;
 use axum::Router;
 use axum::extract::State;
 use axum::http::header;
@@ -40,6 +41,7 @@ pub struct CoralAuthorizationServer {
     session_tokens: SessionTokenIssuer,
     state_store: Arc<InMemoryStateStore>,
     authorization_resources: BTreeSet<String>,
+    workspace_resource_family: Option<WorkspaceMcpUrls>,
     database: Option<Arc<CoralDb>>,
 }
 
@@ -102,6 +104,7 @@ impl CoralAuthorizationServer {
             session_tokens,
             state_store: Arc::new(InMemoryStateStore::new()),
             authorization_resources: BTreeSet::new(),
+            workspace_resource_family: None,
             database: None,
         }
     }
@@ -146,6 +149,21 @@ impl CoralAuthorizationServer {
         Ok(self)
     }
 
+    /// Registers the per-workspace MCP resource family under one base URL.
+    ///
+    /// Authorization requests may then target any canonical per-workspace
+    /// resource — `<base>/workspace/<name>` — in addition to the exact
+    /// resources registered individually. Membership in the family is decided
+    /// by the URL template alone, never by whether a workspace by that name
+    /// exists: existence is concealed from the OAuth flow on purpose, and a
+    /// token minted for a workspace nobody created authorizes nothing because
+    /// MCP admission checks the caller's memberships per session.
+    #[must_use]
+    pub fn with_workspace_resource_family(mut self, family: WorkspaceMcpUrls) -> Self {
+        self.workspace_resource_family = Some(family);
+        self
+    }
+
     /// Returns registered resources for assertions outside this module.
     #[cfg(test)]
     pub(crate) fn authorization_resources(&self) -> &BTreeSet<String> {
@@ -168,6 +186,7 @@ impl CoralAuthorizationServer {
             self.session_tokens,
             self.state_store,
             Arc::new(self.authorization_resources),
+            self.workspace_resource_family,
             self.database,
         )?;
         start_listener(bind_addr, state).await
@@ -286,6 +305,7 @@ struct AuthorizationServerHttpState {
     code_store: Arc<dyn CodeStore>,
     provider_client: OidcProviderClient,
     authorization_resources: Arc<BTreeSet<String>>,
+    workspace_resource_family: Option<Arc<WorkspaceMcpUrls>>,
     client_metadata_resolver: Arc<dyn ClientMetadataResolver>,
     /// Where the OIDC callback provisions a verified login.
     ///
@@ -300,11 +320,21 @@ impl AuthorizationServerHttpState {
         session_tokens: SessionTokenIssuer,
         state_store: Arc<InMemoryStateStore>,
         authorization_resources: Arc<BTreeSet<String>>,
+        workspace_resource_family: Option<WorkspaceMcpUrls>,
         database: Option<Arc<CoralDb>>,
     ) -> Result<Self, AuthServerError> {
+        // The workspace family cannot be enumerated, but loopback client-ID
+        // derivation needs a concrete set of resources to derive from — and the
+        // family's base is exactly the resource that used to be registered
+        // individually, so it joins the derivation set without becoming an
+        // acceptable audience of its own.
+        let mut client_id_derivation_resources = (*authorization_resources).clone();
+        if let Some(family) = &workspace_resource_family {
+            client_id_derivation_resources.insert(family.base().identifier().to_string());
+        }
         let client_metadata_resolver = HttpClientMetadataResolver::new(
             settings.authorization_server().issuer(),
-            &authorization_resources,
+            &client_id_derivation_resources,
         )
         .map_err(|error| AuthServerError::ClientMetadataResolver(error.to_string()))?;
         // Config validation already held these entries to canonical spellings;
@@ -330,9 +360,25 @@ impl AuthorizationServerHttpState {
             provider_client: OidcProviderClient::new()
                 .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
             authorization_resources,
+            workspace_resource_family: workspace_resource_family.map(Arc::new),
             client_metadata_resolver,
             database,
         })
+    }
+
+    /// Whether authorization requests may target `resource`.
+    ///
+    /// A canonical resource is acceptable when it was registered exactly or
+    /// when it is a member of the per-workspace family. Workspace existence is
+    /// deliberately not consulted: the OAuth flow answers identically for
+    /// every well-formed workspace resource, so it discloses nothing about
+    /// which workspaces exist.
+    pub(super) fn accepts_authorization_resource(&self, resource: &str) -> bool {
+        self.authorization_resources.contains(resource)
+            || self
+                .workspace_resource_family
+                .as_ref()
+                .is_some_and(|family| family.parse_resource(resource).is_some())
     }
 
     #[cfg(test)]
@@ -351,6 +397,7 @@ impl AuthorizationServerHttpState {
             code_store: state_store,
             provider_client: OidcProviderClient::new().map_err(|error| error.to_string())?,
             authorization_resources,
+            workspace_resource_family: None,
             client_metadata_resolver,
             database: None,
         })
@@ -585,6 +632,7 @@ mod tests {
             prepared.session_tokens,
             prepared.state_store,
             Arc::new(prepared.authorization_resources),
+            prepared.workspace_resource_family,
             prepared.database,
         )
         .expect("authorization server state");

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -170,6 +170,16 @@ impl CoralAuthorizationServer {
         &self.authorization_resources
     }
 
+    /// Whether the per-workspace MCP family is registered, for assertions
+    /// outside this module. The family is not an enumerable resource, so a
+    /// test that only inspects [`Self::authorization_resources`] cannot catch a
+    /// composition that forgot to register it — and forgetting would refuse
+    /// every real MCP login.
+    #[cfg(test)]
+    pub(crate) fn serves_workspace_resource_family(&self) -> bool {
+        self.workspace_resource_family.is_some()
+    }
+
     /// Starts the HTTP listener.
     ///
     /// The server is intended to run on loopback or behind a TLS-terminating
@@ -560,6 +570,65 @@ mod tests {
             prepared.authorization_resources,
             ["https://coral-ui.example.test".to_string()].into()
         );
+    }
+
+    /// The per-workspace MCP family is an authorization resource an authorize
+    /// request may target, decided by the URL template rather than by any
+    /// registered set: every canonical `<base>/workspace/<name>` is accepted,
+    /// the base itself is not, and no non-canonical spelling sneaks in. Every
+    /// exactly-registered resource still stands beside the family. This is the
+    /// acceptance `authorize` consults, so a regression that dropped the family
+    /// would refuse every real MCP login with `invalid_target`.
+    #[test]
+    fn accepts_the_workspace_family_beside_exact_resources() {
+        use crate::oauth_resource::CanonicalOauthUrl;
+        use crate::workspace_mcp_urls::WorkspaceMcpUrls;
+
+        let dir = authorization_server("");
+        let base = CanonicalOauthUrl::parse("https://mcp.example.test/mcp").expect("base");
+        let prepared = server(&dir)
+            .with_authorization_resource("https://coral-ui.example.test/")
+            .expect("register the exact extra")
+            .with_workspace_resource_family(WorkspaceMcpUrls::new(base));
+
+        let state = super::AuthorizationServerHttpState::new(
+            prepared.settings,
+            prepared.session_tokens,
+            prepared.state_store,
+            Arc::new(prepared.authorization_resources),
+            prepared.workspace_resource_family,
+            prepared.database,
+        )
+        .expect("authorization server state");
+
+        for accepted in [
+            "https://mcp.example.test/mcp/workspace/team",
+            "https://mcp.example.test/mcp/workspace/analytics-staging",
+            "https://coral-ui.example.test",
+        ] {
+            assert!(
+                state.accepts_authorization_resource(accepted),
+                "must accept {accepted}"
+            );
+        }
+
+        for refused in [
+            // The base is the family's root, not a resource of its own.
+            "https://mcp.example.test/mcp",
+            // Non-canonical members never match: no name, trailing slash,
+            // percent-encoding, an extra segment, or the wrong origin.
+            "https://mcp.example.test/mcp/workspace",
+            "https://mcp.example.test/mcp/workspace/",
+            "https://mcp.example.test/mcp/workspace/team/",
+            "https://mcp.example.test/mcp/workspace/te%61m",
+            "https://mcp.example.test/mcp/workspace/team/extra",
+            "https://other.example.test/mcp/workspace/team",
+        ] {
+            assert!(
+                !state.accepts_authorization_resource(refused),
+                "must refuse {refused}"
+            );
+        }
     }
 
     /// `from_toml` holds `trusted_clients` to canonical spellings, but whether

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -68,7 +68,7 @@ pub(super) async fn oauth_authorize_get(
     let Ok(resource) = canonical_authorization_resource(resource) else {
         return trusted.error("invalid_target", "resource is invalid");
     };
-    if !state.authorization_resources.contains(&resource) {
+    if !state.accepts_authorization_resource(&resource) {
         return trusted.error("invalid_target", "resource does not match this server");
     }
     let approval = OAuthAuthorizationApprovalRecord {

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -320,6 +320,7 @@ mod tests {
             code_store: store,
             provider_client: OidcProviderClient::new().expect("client"),
             authorization_resources,
+            workspace_resource_family: None,
             client_metadata_resolver,
             database: None,
         }

--- a/crates/coral-app/src/auth/authorization_server/token.rs
+++ b/crates/coral-app/src/auth/authorization_server/token.rs
@@ -384,6 +384,7 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
             code_store: store.clone(),
             provider_client: OidcProviderClient::new().expect("client"),
             authorization_resources,
+            workspace_resource_family: None,
             client_metadata_resolver,
             database: None,
         };

--- a/crates/coral-app/src/auth/session.rs
+++ b/crates/coral-app/src/auth/session.rs
@@ -257,6 +257,23 @@ impl SessionTokenVerifier {
                 "accepted audiences must be non-empty and have no surrounding whitespace",
             ));
         }
+        self.validate_access_token_where(token, &|audience| {
+            accepted_audiences.contains(&audience)
+        })
+    }
+
+    /// Validates an access token whose audience is judged by `audience_ok`.
+    ///
+    /// This exists for audience families that cannot be enumerated into a
+    /// list — the per-workspace MCP resources. Every other check is identical
+    /// to [`Self::validate_access_token`]: the signature covers the audience
+    /// claim, so judging it after signature validation admits exactly the
+    /// tokens an enumerated allowlist would have.
+    pub(crate) fn validate_access_token_where(
+        &self,
+        token: &str,
+        audience_ok: &dyn Fn(&str) -> bool,
+    ) -> Result<ValidatedSession, SessionTokenError> {
         let header =
             decode_header(token).map_err(|error| format!("invalid Coral access token: {error}"))?;
         if header.alg != SESSION_TOKEN_ALGORITHM {
@@ -276,7 +293,7 @@ impl SessionTokenVerifier {
             .ok_or_else(|| invalid_token("unknown signing key id"))?;
 
         let mut validation = Validation::new(SESSION_TOKEN_ALGORITHM);
-        validation.set_audience(accepted_audiences);
+        validation.validate_aud = false;
         validation.set_issuer(&[self.issuer.as_str()]);
         validation.set_required_spec_claims(&[
             "aud",
@@ -293,6 +310,9 @@ impl SessionTokenVerifier {
         let claims = decode::<SessionTokenClaims>(token, verification_key, &validation)
             .map_err(|error| format!("invalid Coral access token: {error}"))?
             .claims;
+        if !audience_ok(&claims.aud) {
+            return Err(invalid_token("audience is not accepted by this surface"));
+        }
         self.validate_claims(&claims)?;
         Ok(ValidatedSession {
             token_id: claims.jti,

--- a/crates/coral-app/src/auth/session.rs
+++ b/crates/coral-app/src/auth/session.rs
@@ -243,6 +243,13 @@ impl SessionTokenVerifier {
         &self.verification_jwks
     }
 
+    /// Validates an access token against an enumerated audience allowlist.
+    ///
+    /// The request path no longer enumerates allowlists — every provider routes
+    /// through [`Self::validate_access_token_where`] with the allowlist config
+    /// guard lifted to `AudiencePolicy` — so this list-form entry point remains
+    /// only as the direct test of that guard's admission and rejection rules.
+    #[cfg(test)]
     pub(crate) fn validate_access_token(
         &self,
         token: &str,

--- a/crates/coral-app/src/auth/session.rs
+++ b/crates/coral-app/src/auth/session.rs
@@ -257,9 +257,7 @@ impl SessionTokenVerifier {
                 "accepted audiences must be non-empty and have no surrounding whitespace",
             ));
         }
-        self.validate_access_token_where(token, &|audience| {
-            accepted_audiences.contains(&audience)
-        })
+        self.validate_access_token_where(token, &|audience| accepted_audiences.contains(&audience))
     }
 
     /// Validates an access token whose audience is judged by `audience_ok`.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -347,7 +347,7 @@ impl ServerBuilder {
     fn resolve_authentication(&self) -> (Arc<dyn PrincipalProvider>, LocalPrincipalPolicy) {
         match &self.session_auth {
             Some(session_auth) => (
-                session_auth.principal_provider(session_auth.public_audiences().to_vec()),
+                session_auth.private_api_provider(),
                 LocalPrincipalPolicy::NoLocalPrincipal,
             ),
             None => (
@@ -1437,9 +1437,11 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
     }
 
     /// The private API is reached through every public surface in front of it,
-    /// so a token minted for any of them authenticates. Which surface it came
-    /// through says nothing about the caller: the identity in the token is a
-    /// person's, so that is who authenticates.
+    /// so a token minted for any of them authenticates — and the MCP surface's
+    /// audiences are the per-workspace resources under its public base, an
+    /// unenumerable family the base itself is not a member of. Which surface a
+    /// token came through says nothing about the caller: the identity in the
+    /// token is a person's, so that is who authenticates.
     #[tokio::test]
     async fn session_auth_admits_a_token_minted_for_any_fronting_surface() {
         let temp = TempDir::new().expect("temp dir");
@@ -1447,31 +1449,39 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         configure_serve_session_auth(&config_dir);
         let (builder, session_auth) = serve_session_auth(&config_dir);
         let user_id = "1f0d2b8a-6d51-4f6e-9a0d-3c8f21b4e7a5";
-        let token = session_auth
-            .session_tokens
-            .issue_access_token(
-                user_id,
-                "https://client.example/client.json",
-                "https://mcp.example.test",
-            )
-            .expect("session token")
-            .access_token;
+        let mint = |audience: &str| {
+            session_auth
+                .session_tokens
+                .issue_access_token(user_id, "https://client.example/client.json", audience)
+                .expect("session token")
+                .access_token
+        };
+        let workspace_token = mint("https://mcp.example.test/workspace/analytics");
+        let base_token = mint("https://mcp.example.test");
         let (private_api, _) = builder
             .with_session_auth(session_auth)
             .resolve_authentication();
 
-        let mut metadata = tonic::metadata::MetadataMap::new();
-        metadata.insert(
-            "authorization",
-            tonic::metadata::MetadataValue::try_from(format!("Bearer {token}"))
-                .expect("authorization metadata"),
-        );
+        let bearer_metadata = |token: &str| {
+            let mut metadata = tonic::metadata::MetadataMap::new();
+            metadata.insert(
+                "authorization",
+                tonic::metadata::MetadataValue::try_from(format!("Bearer {token}"))
+                    .expect("authorization metadata"),
+            );
+            metadata
+        };
         let principal = private_api
-            .principal_for_metadata(&metadata)
+            .principal_for_metadata(&bearer_metadata(&workspace_token))
             .await
-            .expect("token minted for the MCP surface");
+            .expect("token minted for a workspace's MCP resource");
         assert_eq!(principal.id().as_str(), user_id);
         assert_eq!(principal.kind(), PrincipalKind::User);
+
+        private_api
+            .principal_for_metadata(&bearer_metadata(&base_token))
+            .await
+            .expect_err("the MCP base is the family's root, not an audience of its own");
     }
 
     /// The built-in `coral:local` principal is what the default provider hands

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -15,7 +15,7 @@ use crate::auth::{AuthSettings, CoralAuthorizationServer, ResolvedAuthSettings};
 use crate::oauth_resource::CanonicalOauthUrl;
 use crate::request_auth::SessionPrincipalProvider;
 use crate::state::AppStateLayout;
-use crate::workspaces::WorkspaceName;
+use crate::workspace_mcp_urls::WorkspaceMcpUrls;
 
 #[derive(Debug, Default, Deserialize)]
 struct GrpcConfigFile {
@@ -105,13 +105,28 @@ impl LoadedServerConfig {
             Some(auth_settings.authorization_server().issuer()),
         )?;
         let mcp_http = self.resolve_mcp_http(Some(&authorization_server))?;
-        let public_audiences = public_surface_audiences(mcp_http.as_ref(), &allowed_audiences)?;
+        let mcp_workspace_urls = match &mcp_http {
+            Some(McpHttpServeConfig::Authenticated { public_url, .. }) => {
+                // The variant carries the canonical identifier, and parsing is
+                // idempotent on canonical output, so this cannot fail — but a
+                // panic here would turn a config bug into a crash, so it maps
+                // to the same configuration error every other bad URL gets.
+                let base = CanonicalOauthUrl::parse(public_url).map_err(|error| {
+                    AppError::FailedPrecondition(format!("server.mcp_http.public_url {error}"))
+                })?;
+                Some(WorkspaceMcpUrls::new(base))
+            }
+            _ => None,
+        };
+        let public_audiences =
+            public_surface_audiences(mcp_workspace_urls.as_ref(), &allowed_audiences)?;
         Ok(ServeSettings {
             mcp_http,
             session_auth: Some(SessionAuthSettings {
                 settings: auth_settings,
                 session_tokens: session,
                 public_audiences,
+                mcp_workspace_urls,
             }),
         })
     }
@@ -185,7 +200,6 @@ struct RawMcpHttpSettings {
     public_url: Option<String>,
     allow_unauthenticated_non_loopback: bool,
     allowed_hosts: Vec<String>,
-    workspace: Option<String>,
 }
 
 impl Default for RawMcpHttpSettings {
@@ -196,7 +210,6 @@ impl Default for RawMcpHttpSettings {
             public_url: None,
             allow_unauthenticated_non_loopback: false,
             allowed_hosts: Vec::new(),
-            workspace: None,
         }
     }
 }
@@ -229,7 +242,6 @@ impl RawMcpHttpSettings {
                 bind_addr: self.bind,
                 expose_non_loopback,
                 allowed_hosts: validated_mcp_allowed_hosts(&self.allowed_hosts)?,
-                workspace: self.workspace()?,
             }));
         };
 
@@ -255,27 +267,7 @@ impl RawMcpHttpSettings {
             bind_addr: self.bind,
             public_url,
             authorization_server,
-            workspace: self.workspace()?,
         }))
-    }
-
-    /// Normalizes the configured workspace name without asking whether it
-    /// exists.
-    ///
-    /// Existence is a request-time question answered against the caller's
-    /// memberships, so checking it here would make startup depend on workspace
-    /// state that may legitimately be created later.
-    fn workspace(&self) -> Result<Option<String>, AppError> {
-        self.workspace
-            .as_deref()
-            .map(|name| {
-                WorkspaceName::parse(name)
-                    .map(|name| name.as_str().to_string())
-                    .map_err(|error| {
-                        AppError::FailedPrecondition(format!("server.mcp_http.workspace: {error}"))
-                    })
-            })
-            .transpose()
     }
 }
 
@@ -318,31 +310,20 @@ pub enum McpHttpServeConfig {
         /// Extra Host header values accepted beside the loopback defaults,
         /// e.g. a Docker Compose service name.
         allowed_hosts: Vec<String>,
-        /// Validated name of the workspace this local surface serves.
-        ///
-        /// `None` means the operator named none, which is distinct from any
-        /// name they could have written: no default is substituted here, and
-        /// the adapter resolves the sole local workspace instead. The name is
-        /// only checked for shape — whether a workspace by that name exists is
-        /// answered when a request needs it.
-        workspace: Option<String>,
     },
     /// Session-authenticated MCP HTTP backed by per-session clients.
     Authenticated {
         /// Address for the MCP HTTP listener.
         bind_addr: SocketAddr,
-        /// Canonical public MCP URL advertised to clients and used as JWT audience.
+        /// Canonical public base of the per-workspace MCP URLs.
+        ///
+        /// Each workspace is served at `<public_url>/workspace/<name>`, and
+        /// that full per-workspace URL — never this base — is the OAuth
+        /// resource and JWT audience of the sessions it admits. The URL names
+        /// the workspace, so no workspace is configured here.
         public_url: String,
         /// OAuth authorization server advertised to MCP clients.
         authorization_server: String,
-        /// Validated name of the shared workspace every session is bound to.
-        ///
-        /// `None` means the operator named none, which stays a valid server
-        /// configuration: whether a session may proceed is answered per session
-        /// against the caller's memberships, so refusing to start would deny an
-        /// instance that is otherwise serving its other surfaces. Only the name's
-        /// shape is checked here — existence is a request-time question.
-        workspace: Option<String>,
     },
 }
 
@@ -398,13 +379,24 @@ pub struct SessionAuthSettings {
     pub(super) settings: ResolvedAuthSettings,
     pub(super) session_tokens: SessionTokenIssuer,
     pub(super) public_audiences: Vec<String>,
+    pub(super) mcp_workspace_urls: Option<WorkspaceMcpUrls>,
 }
 
 impl SessionAuthSettings {
-    /// The instance's public surfaces, canonicalized.
+    /// The instance's explicitly registered public audiences, canonicalized.
+    ///
+    /// When MCP HTTP is served, its audiences are the per-workspace resource
+    /// family under [`Self::mcp_workspace_urls`] — a set that cannot be
+    /// enumerated here, so it is deliberately not in this list.
     #[must_use]
     pub fn public_audiences(&self) -> &[String] {
         &self.public_audiences
+    }
+
+    /// The per-workspace MCP resource family, when MCP HTTP is served.
+    #[must_use]
+    pub fn mcp_workspace_urls(&self) -> Option<&WorkspaceMcpUrls> {
+        self.mcp_workspace_urls.as_ref()
     }
 
     /// Builds a provider admitting session tokens for exactly `audiences`.
@@ -423,10 +415,45 @@ impl SessionAuthSettings {
         ))
     }
 
+    /// Builds the private gRPC API's provider.
+    ///
+    /// The private API is reached through the public surfaces that front it,
+    /// so it admits every explicitly registered audience plus, when MCP HTTP
+    /// is served, every per-workspace MCP resource — bearer-forwarded backend
+    /// calls arrive under exactly those audiences.
+    #[must_use]
+    pub fn private_api_provider(&self) -> Arc<SessionPrincipalProvider> {
+        match &self.mcp_workspace_urls {
+            Some(urls) => Arc::new(SessionPrincipalProvider::with_workspace_family(
+                self.session_tokens.verifier(),
+                self.public_audiences.clone(),
+                Arc::new(urls.clone()),
+            )),
+            None => self.principal_provider(self.public_audiences.clone()),
+        }
+    }
+
+    /// Builds the authenticator the MCP HTTP surface checks bearers with.
+    ///
+    /// The MCP surface's audience varies by route — each workspace URL is its
+    /// own resource — so this provider is used exclusively through
+    /// [`SessionPrincipalProvider::principal_for_bearer_with_audience`], with
+    /// the expected audience supplied per request. It carries no standing
+    /// allowlist of its own.
+    #[must_use]
+    pub fn mcp_route_authenticator(&self) -> Arc<SessionPrincipalProvider> {
+        Arc::new(SessionPrincipalProvider::new(
+            self.session_tokens.verifier(),
+            [],
+        ))
+    }
+
     /// Consumes these settings into the authorization server for the instance.
     ///
-    /// Every public surface is registered as an authorization resource clients
-    /// may request a token for.
+    /// Every explicitly registered public audience becomes an authorization
+    /// resource clients may request a token for, and the per-workspace MCP
+    /// family — when MCP HTTP is served — is registered as a template rather
+    /// than an enumeration.
     ///
     /// The server returned here has no database attached and so fails every
     /// login closed. `ServerBuilder::with_session_auth` is the path that
@@ -444,32 +471,35 @@ impl SessionAuthSettings {
                 .with_authorization_resource(audience)
                 .map_err(AppError::FailedPrecondition)?;
         }
+        if let Some(urls) = self.mcp_workspace_urls {
+            server = server.with_workspace_resource_family(urls);
+        }
         Ok(server)
     }
 }
 
-/// Collects the resource identifiers that front the instance's private API.
+/// Collects the explicitly registered resource identifiers that front the
+/// instance's private API, beside the per-workspace MCP family.
 ///
 /// Each identifier is both the audience of tokens minted for a public surface
-/// and the authorization resource clients name when requesting one. Some are
-/// derived from a surface Coral serves, while others are explicitly registered
-/// for external fronting surfaces such as a hosted UI BFF.
+/// and the authorization resource clients name when requesting one. The MCP
+/// surface's audiences are not here: they are the per-workspace resources
+/// under the configured public base, which cannot be enumerated and whose base
+/// is itself not an audience.
 ///
 /// The gRPC API has no resource identity of its own and instead accepts every
-/// identifier returned here. At least one is therefore required: with none, no
-/// token can be minted for anything and every login would fail at authorization.
+/// identifier returned here plus the MCP family. At least one public surface
+/// is therefore required: with none, no token can be minted for anything and
+/// every login would fail at authorization.
 ///
 /// An identifier names a surface, not an actor: either kind of caller can arrive
 /// through any of them, so nothing here says what kind a caller is. Actor kind
 /// comes from the authenticated principal instead.
 fn public_surface_audiences(
-    mcp_http: Option<&McpHttpServeConfig>,
+    mcp_workspace_urls: Option<&WorkspaceMcpUrls>,
     allowed_audiences: &[String],
 ) -> Result<Vec<String>, AppError> {
-    let mut audiences = match mcp_http {
-        Some(McpHttpServeConfig::Authenticated { public_url, .. }) => vec![public_url.clone()],
-        _ => Vec::new(),
-    };
+    let mut audiences = Vec::new();
     for (index, configured) in allowed_audiences.iter().enumerate() {
         let label = format!("auth.allowed_audiences[{index}]");
         let audience = required_oauth_url(&label, Some(configured))?;
@@ -478,9 +508,18 @@ fn public_surface_audiences(
                 "{label} duplicates another configured public surface audience"
             )));
         }
+        // The MCP base is deliberately not an audience of its own — it is not
+        // an MCP endpoint any more — so an explicit entry naming it would
+        // resurrect exactly the audience the per-workspace family replaced.
+        if mcp_workspace_urls.is_some_and(|urls| urls.base().identifier() == audience) {
+            return Err(AppError::FailedPrecondition(format!(
+                "{label} duplicates server.mcp_http.public_url, which is the base of the \
+                 per-workspace MCP resources and not an audience of its own"
+            )));
+        }
         audiences.push(audience);
     }
-    if audiences.is_empty() {
+    if audiences.is_empty() && mcp_workspace_urls.is_none() {
         return Err(AppError::FailedPrecondition(
             "configured [auth] requires at least one public surface: an enabled server.mcp_http with a public_url, or a non-empty auth.allowed_audiences"
                 .to_string(),
@@ -623,7 +662,6 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             bind_addr,
             expose_non_loopback,
             allowed_hosts,
-            workspace,
         }) = McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
         else {
             panic!("loopback MCP must be explicitly auth-disabled");
@@ -631,125 +669,38 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         assert_eq!(bind_addr, SocketAddr::from((Ipv6Addr::LOCALHOST, 14556)));
         assert!(!expose_non_loopback);
         assert!(allowed_hosts.is_empty());
-        assert_eq!(workspace, None);
     }
 
-    /// An explicitly named workspace is normalized and carried through, and an
-    /// absent one stays absent: no name is invented for the operator who wrote
-    /// none, so the adapter can still tell "unnamed" from every real name.
+    /// The workspace is named by each request's URL now, so the retired
+    /// `server.mcp_http.workspace` key fails loudly in both modes rather than
+    /// being read as a binding it no longer is.
     #[test]
-    fn auth_disabled_workspace_carries_an_explicit_name_and_nothing_otherwise() {
-        for (workspace_field, expected) in [
-            ("", None),
-            ("workspace = 'analytics'\n", Some("analytics")),
-            // Whitespace is trimmed by the same parser every other workspace
-            // name goes through, so configuration cannot name a workspace the
-            // rest of the app could never match.
-            ("workspace = '  analytics  '\n", Some("analytics")),
-            // `default` carries no reserved status; it is an ordinary name that
-            // resolves only if such a workspace actually exists.
-            ("workspace = 'default'\n", Some("default")),
-        ] {
+    fn the_retired_workspace_key_is_rejected_not_ignored() {
+        for authenticated in [false, true] {
             let temp = TempDir::new().expect("temp dir");
             let layout =
                 AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-            layout.ensure().expect("config dir");
-            fs::write(
-                layout.config_file(),
-                format!("[server.mcp_http]\nenabled = true\n{workspace_field}"),
-            )
-            .expect("config file");
-
-            let Some(McpHttpServeConfig::AuthDisabled { workspace, .. }) =
-                McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
-            else {
-                panic!("loopback MCP must be explicitly auth-disabled");
+            let mcp_http = if authenticated {
+                "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\nworkspace = 'analytics'\n"
+                    .to_string()
+            } else {
+                "[server.mcp_http]\nenabled = true\nworkspace = 'analytics'\n".to_string()
             };
-            assert_eq!(workspace.as_deref(), expected, "config: {workspace_field}");
-        }
-    }
-
-    #[test]
-    fn auth_disabled_workspace_rejects_an_unusable_name() {
-        for invalid in ["", "   ", "..", "team/analytics"] {
-            let temp = TempDir::new().expect("temp dir");
-            let layout =
-                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-            layout.ensure().expect("config dir");
-            fs::write(
-                layout.config_file(),
-                format!("[server.mcp_http]\nenabled = true\nworkspace = '{invalid}'\n"),
-            )
-            .expect("config file");
-
-            let error = McpHttpServeConfig::load(&layout)
-                .expect_err("an unusable workspace name must fail");
-            assert!(
-                error.to_string().contains("server.mcp_http.workspace"),
-                "error: {error}"
-            );
-        }
-    }
-
-    /// An authenticated surface serves the one workspace its configuration
-    /// names, so the name is carried through both modes by the same parser, and
-    /// naming none stays absent rather than becoming a substituted default.
-    #[test]
-    fn authenticated_workspace_carries_an_explicit_name_and_nothing_otherwise() {
-        for (workspace_field, expected) in [
-            ("", None),
-            ("workspace = 'analytics'\n", Some("analytics")),
-            ("workspace = '  analytics  '\n", Some("analytics")),
-            // `default` carries no reserved status on this surface either.
-            ("workspace = 'default'\n", Some("default")),
-        ] {
-            let temp = TempDir::new().expect("temp dir");
-            let layout =
-                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-            write_authenticated_config(
-                &layout,
-                &format!(
-                    "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\n{workspace_field}"
-                ),
-            );
-
-            let companions = LoadedServerConfig::load(&layout)
-                .expect("load")
-                .companion_settings()
-                .expect("a configured workspace is not a startup precondition");
-            let Some(McpHttpServeConfig::Authenticated { workspace, .. }) =
-                companions.mcp_http.as_ref()
-            else {
-                panic!("configured [auth] must produce an authenticated MCP surface");
-            };
-            assert_eq!(workspace.as_deref(), expected, "config: {workspace_field}");
-        }
-    }
-
-    /// A name nothing could ever match is the operator's mistake, so it fails at
-    /// startup in both modes — unlike a well-formed name for a workspace that
-    /// does not exist yet, which stays a per-session question.
-    #[test]
-    fn authenticated_workspace_rejects_an_unusable_name() {
-        for invalid in ["", "   ", "..", "team/analytics"] {
-            let temp = TempDir::new().expect("temp dir");
-            let layout =
-                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-            write_authenticated_config(
-                &layout,
-                &format!(
-                    "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\nworkspace = '{invalid}'\n"
-                ),
-            );
+            if authenticated {
+                write_authenticated_config(&layout, &mcp_http);
+            } else {
+                layout.ensure().expect("config dir");
+                fs::write(layout.config_file(), &mcp_http).expect("config file");
+            }
 
             let error = LoadedServerConfig::load(&layout)
                 .expect("load")
                 .companion_settings()
                 .err()
-                .expect("an unusable workspace name must fail");
+                .expect("the retired workspace key must fail");
             assert!(
-                error.to_string().contains("server.mcp_http.workspace"),
-                "error: {error}"
+                error.to_string().contains("workspace"),
+                "error must name the rejected key: {error}"
             );
         }
     }
@@ -932,21 +883,57 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
                 bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
                 public_url: "https://mcp.example.test".to_string(),
                 authorization_server: "https://auth.example.test".to_string(),
-                workspace: None,
             })
         );
         // Resolution reports that session auth is configured; constructing the
         // providers and the authorization server from it is the composition
         // root's job, covered in `bootstrap::server`.
         let session_auth = companions.session_auth.expect("session auth");
-        // Both surfaces front the private API, so both audiences are admitted;
-        // neither says anything about what kind of actor arrives through it.
+        // The MCP surface's audiences are the per-workspace family under its
+        // base, not an enumerable entry, so the explicit audience list carries
+        // only the configured extras.
         assert_eq!(
             session_auth.public_audiences,
-            [
-                "https://mcp.example.test".to_string(),
-                "https://coral-ui.example.test".to_string(),
-            ]
+            ["https://coral-ui.example.test".to_string()]
+        );
+        assert_eq!(
+            session_auth
+                .mcp_workspace_urls
+                .as_ref()
+                .expect("MCP workspace family")
+                .base()
+                .identifier(),
+            "https://mcp.example.test"
+        );
+    }
+
+    /// With MCP HTTP as the only public surface, the workspace family alone
+    /// satisfies the at-least-one-surface requirement, and the base URL is not
+    /// registered as an exact audience of its own.
+    #[test]
+    fn authenticated_mcp_only_config_serves_only_the_workspace_family() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        write_authenticated_config(
+            &layout,
+            "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\n",
+        );
+
+        let companions = LoadedServerConfig::load(&layout)
+            .expect("load")
+            .companion_settings()
+            .expect("MCP-only companions");
+        let session_auth = companions.session_auth.expect("session auth");
+        assert!(session_auth.public_audiences.is_empty());
+        assert!(session_auth.mcp_workspace_urls.is_some());
+
+        let authorization_server = session_auth
+            .into_authorization_server()
+            .expect("authorization server");
+        assert!(
+            authorization_server.authorization_resources().is_empty(),
+            "the family is a template, not an enumerated resource — and the \
+             base is not a resource at all"
         );
     }
 
@@ -991,7 +978,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             (
                 "[server.mcp_http]\nenabled = true\npublic_url = 'https://MCP.example.test/'\n",
                 "allowed_audiences = ['https://mcp.example.test']",
-                "auth.allowed_audiences[0] duplicates another configured public surface audience",
+                "auth.allowed_audiences[0] duplicates server.mcp_http.public_url",
             ),
             (
                 "",

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -15,6 +15,7 @@ use crate::auth::{AuthSettings, CoralAuthorizationServer, ResolvedAuthSettings};
 use crate::oauth_resource::CanonicalOauthUrl;
 use crate::request_auth::SessionPrincipalProvider;
 use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, Default, Deserialize)]
 struct GrpcConfigFile {
@@ -184,6 +185,7 @@ struct RawMcpHttpSettings {
     public_url: Option<String>,
     allow_unauthenticated_non_loopback: bool,
     allowed_hosts: Vec<String>,
+    workspace: Option<String>,
 }
 
 impl Default for RawMcpHttpSettings {
@@ -194,6 +196,7 @@ impl Default for RawMcpHttpSettings {
             public_url: None,
             allow_unauthenticated_non_loopback: false,
             allowed_hosts: Vec::new(),
+            workspace: None,
         }
     }
 }
@@ -226,6 +229,7 @@ impl RawMcpHttpSettings {
                 bind_addr: self.bind,
                 expose_non_loopback,
                 allowed_hosts: validated_mcp_allowed_hosts(&self.allowed_hosts)?,
+                workspace: self.workspace()?,
             }));
         };
 
@@ -243,6 +247,12 @@ impl RawMcpHttpSettings {
                     .to_string(),
             ));
         }
+        if self.workspace.is_some() {
+            return Err(AppError::FailedPrecondition(
+                "server.mcp_http.workspace applies only to auth-disabled MCP HTTP; an authenticated session's workspace comes from its memberships"
+                    .to_string(),
+            ));
+        }
         let public_url =
             required_oauth_url("server.mcp_http.public_url", self.public_url.as_deref())?;
         let authorization_server = authorization_server.to_string();
@@ -252,6 +262,25 @@ impl RawMcpHttpSettings {
             public_url,
             authorization_server,
         }))
+    }
+
+    /// Normalizes the configured workspace name without asking whether it
+    /// exists.
+    ///
+    /// Existence is a request-time question answered against the caller's
+    /// memberships, so checking it here would make startup depend on workspace
+    /// state that may legitimately be created later.
+    fn workspace(&self) -> Result<Option<String>, AppError> {
+        self.workspace
+            .as_deref()
+            .map(|name| {
+                WorkspaceName::parse(name)
+                    .map(|name| name.as_str().to_string())
+                    .map_err(|error| {
+                        AppError::FailedPrecondition(format!("server.mcp_http.workspace: {error}"))
+                    })
+            })
+            .transpose()
     }
 }
 
@@ -294,6 +323,14 @@ pub enum McpHttpServeConfig {
         /// Extra Host header values accepted beside the loopback defaults,
         /// e.g. a Docker Compose service name.
         allowed_hosts: Vec<String>,
+        /// Validated name of the workspace this local surface serves.
+        ///
+        /// `None` means the operator named none, which is distinct from any
+        /// name they could have written: no default is substituted here, and
+        /// the adapter resolves the sole local workspace instead. The name is
+        /// only checked for shape — whether a workspace by that name exists is
+        /// answered when a request needs it.
+        workspace: Option<String>,
     },
     /// Session-authenticated MCP HTTP backed by per-session clients.
     Authenticated {
@@ -583,6 +620,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             bind_addr,
             expose_non_loopback,
             allowed_hosts,
+            workspace,
         }) = McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
         else {
             panic!("loopback MCP must be explicitly auth-disabled");
@@ -590,6 +628,89 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         assert_eq!(bind_addr, SocketAddr::from((Ipv6Addr::LOCALHOST, 14556)));
         assert!(!expose_non_loopback);
         assert!(allowed_hosts.is_empty());
+        assert_eq!(workspace, None);
+    }
+
+    /// An explicitly named workspace is normalized and carried through, and an
+    /// absent one stays absent: no name is invented for the operator who wrote
+    /// none, so the adapter can still tell "unnamed" from every real name.
+    #[test]
+    fn auth_disabled_workspace_carries_an_explicit_name_and_nothing_otherwise() {
+        for (workspace_field, expected) in [
+            ("", None),
+            ("workspace = 'analytics'\n", Some("analytics")),
+            // Whitespace is trimmed by the same parser every other workspace
+            // name goes through, so configuration cannot name a workspace the
+            // rest of the app could never match.
+            ("workspace = '  analytics  '\n", Some("analytics")),
+            // `default` carries no reserved status; it is an ordinary name that
+            // resolves only if such a workspace actually exists.
+            ("workspace = 'default'\n", Some("default")),
+        ] {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+            layout.ensure().expect("config dir");
+            fs::write(
+                layout.config_file(),
+                format!("[server.mcp_http]\nenabled = true\n{workspace_field}"),
+            )
+            .expect("config file");
+
+            let Some(McpHttpServeConfig::AuthDisabled { workspace, .. }) =
+                McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
+            else {
+                panic!("loopback MCP must be explicitly auth-disabled");
+            };
+            assert_eq!(workspace.as_deref(), expected, "config: {workspace_field}");
+        }
+    }
+
+    #[test]
+    fn auth_disabled_workspace_rejects_an_unusable_name() {
+        for invalid in ["", "   ", "..", "team/analytics"] {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+            layout.ensure().expect("config dir");
+            fs::write(
+                layout.config_file(),
+                format!("[server.mcp_http]\nenabled = true\nworkspace = '{invalid}'\n"),
+            )
+            .expect("config file");
+
+            let error = McpHttpServeConfig::load(&layout)
+                .expect_err("an unusable workspace name must fail");
+            assert!(
+                error.to_string().contains("server.mcp_http.workspace"),
+                "error: {error}"
+            );
+        }
+    }
+
+    /// An authenticated session's workspace comes from the caller's
+    /// memberships, so a configured name there would be silently ignored.
+    #[test]
+    fn auth_disabled_workspace_is_rejected_when_auth_is_configured() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        write_authenticated_config(
+            &layout,
+            "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\nworkspace = 'analytics'\n",
+        );
+
+        let error = LoadedServerConfig::load(&layout)
+            .expect("load")
+            .companion_settings()
+            .err()
+            .expect("a configured workspace must not be silently ignored");
+
+        assert!(
+            error
+                .to_string()
+                .contains("server.mcp_http.workspace applies only to auth-disabled MCP HTTP"),
+            "error: {error}"
+        );
     }
 
     #[test]
@@ -631,6 +752,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             bind_addr,
             expose_non_loopback,
             allowed_hosts,
+            ..
         }) = McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
         else {
             panic!("opted-in non-loopback MCP must stay auth-disabled");

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -935,6 +935,11 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             "the family is a template, not an enumerated resource — and the \
              base is not a resource at all"
         );
+        assert!(
+            authorization_server.serves_workspace_resource_family(),
+            "the family must be registered even though it enumerates to nothing, \
+             or every real MCP login is refused invalid_target"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -247,12 +247,6 @@ impl RawMcpHttpSettings {
                     .to_string(),
             ));
         }
-        if self.workspace.is_some() {
-            return Err(AppError::FailedPrecondition(
-                "server.mcp_http.workspace applies only to auth-disabled MCP HTTP; an authenticated session's workspace comes from its memberships"
-                    .to_string(),
-            ));
-        }
         let public_url =
             required_oauth_url("server.mcp_http.public_url", self.public_url.as_deref())?;
         let authorization_server = authorization_server.to_string();
@@ -261,6 +255,7 @@ impl RawMcpHttpSettings {
             bind_addr: self.bind,
             public_url,
             authorization_server,
+            workspace: self.workspace()?,
         }))
     }
 
@@ -340,6 +335,14 @@ pub enum McpHttpServeConfig {
         public_url: String,
         /// OAuth authorization server advertised to MCP clients.
         authorization_server: String,
+        /// Validated name of the shared workspace every session is bound to.
+        ///
+        /// `None` means the operator named none, which stays a valid server
+        /// configuration: whether a session may proceed is answered per session
+        /// against the caller's memberships, so refusing to start would deny an
+        /// instance that is otherwise serving its other surfaces. Only the name's
+        /// shape is checked here — existence is a request-time question.
+        workspace: Option<String>,
     },
 }
 
@@ -688,29 +691,67 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         }
     }
 
-    /// An authenticated session's workspace comes from the caller's
-    /// memberships, so a configured name there would be silently ignored.
+    /// An authenticated surface serves the one workspace its configuration
+    /// names, so the name is carried through both modes by the same parser, and
+    /// naming none stays absent rather than becoming a substituted default.
     #[test]
-    fn auth_disabled_workspace_is_rejected_when_auth_is_configured() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-        write_authenticated_config(
-            &layout,
-            "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\nworkspace = 'analytics'\n",
-        );
+    fn authenticated_workspace_carries_an_explicit_name_and_nothing_otherwise() {
+        for (workspace_field, expected) in [
+            ("", None),
+            ("workspace = 'analytics'\n", Some("analytics")),
+            ("workspace = '  analytics  '\n", Some("analytics")),
+            // `default` carries no reserved status on this surface either.
+            ("workspace = 'default'\n", Some("default")),
+        ] {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+            write_authenticated_config(
+                &layout,
+                &format!(
+                    "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\n{workspace_field}"
+                ),
+            );
 
-        let error = LoadedServerConfig::load(&layout)
-            .expect("load")
-            .companion_settings()
-            .err()
-            .expect("a configured workspace must not be silently ignored");
+            let companions = LoadedServerConfig::load(&layout)
+                .expect("load")
+                .companion_settings()
+                .expect("a configured workspace is not a startup precondition");
+            let Some(McpHttpServeConfig::Authenticated { workspace, .. }) =
+                companions.mcp_http.as_ref()
+            else {
+                panic!("configured [auth] must produce an authenticated MCP surface");
+            };
+            assert_eq!(workspace.as_deref(), expected, "config: {workspace_field}");
+        }
+    }
 
-        assert!(
-            error
-                .to_string()
-                .contains("server.mcp_http.workspace applies only to auth-disabled MCP HTTP"),
-            "error: {error}"
-        );
+    /// A name nothing could ever match is the operator's mistake, so it fails at
+    /// startup in both modes — unlike a well-formed name for a workspace that
+    /// does not exist yet, which stays a per-session question.
+    #[test]
+    fn authenticated_workspace_rejects_an_unusable_name() {
+        for invalid in ["", "   ", "..", "team/analytics"] {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+            write_authenticated_config(
+                &layout,
+                &format!(
+                    "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\nworkspace = '{invalid}'\n"
+                ),
+            );
+
+            let error = LoadedServerConfig::load(&layout)
+                .expect("load")
+                .companion_settings()
+                .err()
+                .expect("an unusable workspace name must fail");
+            assert!(
+                error.to_string().contains("server.mcp_http.workspace"),
+                "error: {error}"
+            );
+        }
     }
 
     #[test]
@@ -891,6 +932,7 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
                 bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
                 public_url: "https://mcp.example.test".to_string(),
                 authorization_server: "https://auth.example.test".to_string(),
+                workspace: None,
             })
         );
         // Resolution reports that session auth is configured; constructing the

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -511,7 +511,10 @@ fn public_surface_audiences(
         // The MCP base is deliberately not an audience of its own — it is not
         // an MCP endpoint any more — so an explicit entry naming it would
         // resurrect exactly the audience the per-workspace family replaced.
-        if mcp_workspace_urls.is_some_and(|urls| urls.base().identifier() == audience) {
+        // Both spellings are rejected: a trailing-slash `public_url` leaves the
+        // canonical base and the normalized base identifier differing by one
+        // slash, and either would otherwise slip through as a gRPC audience.
+        if mcp_workspace_urls.is_some_and(|urls| urls.is_base_audience(&audience)) {
             return Err(AppError::FailedPrecondition(format!(
                 "{label} duplicates server.mcp_http.public_url, which is the base of the \
                  per-workspace MCP resources and not an audience of its own"
@@ -983,6 +986,16 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             (
                 "[server.mcp_http]\nenabled = true\npublic_url = 'https://MCP.example.test/'\n",
                 "allowed_audiences = ['https://mcp.example.test']",
+                "auth.allowed_audiences[0] duplicates server.mcp_http.public_url",
+            ),
+            // A non-root base with a trailing slash keeps that slash through
+            // canonicalization, so the normalized base identifier every
+            // per-workspace resource extends differs from the canonical base by
+            // one slash. Naming that normalized form must be rejected too, or it
+            // resurrects the base as a private-gRPC audience.
+            (
+                "[server.mcp_http]\nenabled = true\npublic_url = 'https://coral.example/mcp/'\n",
+                "allowed_audiences = ['https://coral.example/mcp']",
                 "auth.allowed_audiences[0] duplicates server.mcp_http.public_url",
             ),
             (

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -674,40 +674,6 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         assert!(allowed_hosts.is_empty());
     }
 
-    /// The workspace is named by each request's URL now, so the retired
-    /// `server.mcp_http.workspace` key fails loudly in both modes rather than
-    /// being read as a binding it no longer is.
-    #[test]
-    fn the_retired_workspace_key_is_rejected_not_ignored() {
-        for authenticated in [false, true] {
-            let temp = TempDir::new().expect("temp dir");
-            let layout =
-                AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-            let mcp_http = if authenticated {
-                "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\npublic_url = 'https://mcp.example.test/'\nworkspace = 'analytics'\n"
-                    .to_string()
-            } else {
-                "[server.mcp_http]\nenabled = true\nworkspace = 'analytics'\n".to_string()
-            };
-            if authenticated {
-                write_authenticated_config(&layout, &mcp_http);
-            } else {
-                layout.ensure().expect("config dir");
-                fs::write(layout.config_file(), &mcp_http).expect("config file");
-            }
-
-            let error = LoadedServerConfig::load(&layout)
-                .expect("load")
-                .companion_settings()
-                .err()
-                .expect("the retired workspace key must fail");
-            assert!(
-                error.to_string().contains("workspace"),
-                "error must name the rejected key: {error}"
-            );
-        }
-    }
-
     #[test]
     fn auth_disabled_mcp_http_rejects_public_bind() {
         let temp = TempDir::new().expect("temp dir");

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -72,6 +72,7 @@ pub mod test_session_tokens;
 mod test_support;
 mod transport;
 mod users;
+mod workspace_mcp_urls;
 mod workspaces;
 
 pub use auth::{
@@ -92,4 +93,8 @@ pub use query::extensions::{
 };
 pub use request_auth::SessionPrincipalProvider;
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
+pub use workspace_mcp_urls::{
+    McpWorkspaceSegment, PROTECTED_RESOURCE_METADATA_ROOT, WORKSPACE_ROUTE_SEGMENT,
+    WorkspaceMcpUrls,
+};
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/request_auth.rs
+++ b/crates/coral-app/src/request_auth.rs
@@ -7,6 +7,7 @@ use tonic::metadata::MetadataMap;
 
 use crate::auth::session::SessionTokenVerifier;
 use crate::identity::{BearerAuthenticator, Principal, PrincipalProvider, PrincipalProviderError};
+use crate::workspace_mcp_urls::WorkspaceMcpUrls;
 
 const AUTHORIZATION_METADATA: &str = "authorization";
 const UNAUTHENTICATED_MESSAGE: &str = "authentication required";
@@ -29,7 +30,35 @@ const UNAUTHENTICATED_MESSAGE: &str = "authentication required";
 #[derive(Clone)]
 pub struct SessionPrincipalProvider {
     verifier: SessionTokenVerifier,
-    accepted_audiences: Arc<[String]>,
+    audiences: AudiencePolicy,
+}
+
+/// Which minted audiences a surface's provider admits.
+#[derive(Clone)]
+enum AudiencePolicy {
+    /// An enumerated allowlist, the shape every surface had before
+    /// per-workspace MCP resources existed.
+    Exact(Arc<[String]>),
+    /// An enumerated allowlist plus every canonical per-workspace MCP
+    /// resource under one base URL. The family cannot be enumerated — its
+    /// members come and go with workspaces — so membership is decided by
+    /// parsing the audience against the one URL template.
+    ExactPlusWorkspaceFamily {
+        exact: Arc<[String]>,
+        family: Arc<WorkspaceMcpUrls>,
+    },
+}
+
+impl AudiencePolicy {
+    fn accepts(&self, audience: &str) -> bool {
+        match self {
+            Self::Exact(exact) => exact.iter().any(|accepted| accepted == audience),
+            Self::ExactPlusWorkspaceFamily { exact, family } => {
+                exact.iter().any(|accepted| accepted == audience)
+                    || family.parse_resource(audience).is_some()
+            }
+        }
+    }
 }
 
 impl SessionPrincipalProvider {
@@ -39,22 +68,59 @@ impl SessionPrincipalProvider {
     ) -> Self {
         Self {
             verifier,
-            accepted_audiences: accepted_audiences.into_iter().collect(),
+            audiences: AudiencePolicy::Exact(accepted_audiences.into_iter().collect()),
+        }
+    }
+
+    /// Builds a provider admitting `accepted_audiences` plus every
+    /// per-workspace MCP resource in `family`.
+    pub(crate) fn with_workspace_family(
+        verifier: SessionTokenVerifier,
+        accepted_audiences: impl IntoIterator<Item = String>,
+        family: Arc<WorkspaceMcpUrls>,
+    ) -> Self {
+        Self {
+            verifier,
+            audiences: AudiencePolicy::ExactPlusWorkspaceFamily {
+                exact: accepted_audiences.into_iter().collect(),
+                family,
+            },
         }
     }
 
     fn principal_for_token(&self, token: &str) -> Result<Principal, PrincipalProviderError> {
+        self.principal_where(token, &|audience| self.audiences.accepts(audience))
+    }
+
+    /// Authenticates a bearer token minted for exactly `audience`.
+    ///
+    /// This is the per-route check for surfaces whose resource identity varies
+    /// by request — a per-workspace MCP URL admits only tokens minted for that
+    /// exact URL, so the expected audience arrives with the call instead of
+    /// living in the provider's own policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same generic authentication failure as every other path.
+    pub fn principal_for_bearer_with_audience(
+        &self,
+        token: &str,
+        audience: &str,
+    ) -> Result<Principal, PrincipalProviderError> {
+        self.principal_where(token, &|minted| minted == audience)
+    }
+
+    fn principal_where(
+        &self,
+        token: &str,
+        audience_ok: &dyn Fn(&str) -> bool,
+    ) -> Result<Principal, PrincipalProviderError> {
         if token.is_empty() || !token.bytes().all(|byte| byte.is_ascii_graphic()) {
             return Err(unauthenticated());
         }
-        let accepted = self
-            .accepted_audiences
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
         let session = self
             .verifier
-            .validate_access_token(token, &accepted)
+            .validate_access_token_where(token, audience_ok)
             .map_err(|_error| unauthenticated())?;
         // The token's subject is Coral's internal `user_id`, so the request
         // principal is that id verbatim — no upstream issuer, subject, or

--- a/crates/coral-app/src/request_auth.rs
+++ b/crates/coral-app/src/request_auth.rs
@@ -59,6 +59,38 @@ impl AudiencePolicy {
             }
         }
     }
+
+    /// The enumerated allowlist this policy consults, family aside.
+    fn exact(&self) -> &[String] {
+        match self {
+            Self::Exact(exact) | Self::ExactPlusWorkspaceFamily { exact, .. } => exact,
+        }
+    }
+
+    /// Rejects a malformed accepted-audiences allowlist as a misconfiguration.
+    ///
+    /// This is the guard [`SessionTokenVerifier::validate_access_token`] applies
+    /// to an enumerated list, lifted here so both policies route through the
+    /// predicate path yet a whitespace-padded entry still fails loudly rather
+    /// than silently admitting a token minted for that exact padded audience.
+    /// Every enumerated entry must be non-empty and free of surrounding
+    /// whitespace; a pure [`Self::Exact`] policy, which accepts nothing but its
+    /// list, must additionally have at least one entry, while the
+    /// workspace-family policy has no such minimum — the family covers
+    /// acceptance when the exact list is empty.
+    fn ensure_well_formed(&self) -> Result<(), ()> {
+        let exact = self.exact();
+        if matches!(self, Self::Exact(_)) && exact.is_empty() {
+            return Err(());
+        }
+        if exact
+            .iter()
+            .any(|audience| audience.is_empty() || audience.trim() != audience.as_str())
+        {
+            return Err(());
+        }
+        Ok(())
+    }
 }
 
 impl SessionPrincipalProvider {
@@ -89,21 +121,13 @@ impl SessionPrincipalProvider {
     }
 
     fn principal_for_token(&self, token: &str) -> Result<Principal, PrincipalProviderError> {
-        // An enumerated allowlist keeps going through the list-validating
-        // entry point, whose empty-and-whitespace guard has no analogue for a
-        // predicate; only the family policy needs one.
-        if let AudiencePolicy::Exact(exact) = &self.audiences {
-            if token.is_empty() || !token.bytes().all(|byte| byte.is_ascii_graphic()) {
-                return Err(unauthenticated());
-            }
-            let accepted = exact.iter().map(String::as_str).collect::<Vec<_>>();
-            let session = self
-                .verifier
-                .validate_access_token(token, &accepted)
-                .map_err(|_error| unauthenticated())?;
-            return Principal::parse(&session.user_id, session.principal_kind)
-                .map_err(|_error| unauthenticated());
-        }
+        // Both policies route through the predicate path; the allowlist's
+        // empty-and-whitespace config guard, once specific to the enumerated
+        // entry point, now runs here so a misconfigured allowlist fails loudly
+        // under either policy rather than only the enumerated one.
+        self.audiences
+            .ensure_well_formed()
+            .map_err(|()| unauthenticated())?;
         self.principal_where(token, &|audience| self.audiences.accepts(audience))
     }
 
@@ -420,6 +444,54 @@ mod tests {
                 .await
                 .expect_err("any other audience");
         }
+    }
+
+    /// The workspace-family policy admits a token minted for a workspace
+    /// resource even when its enumerated exact list is empty — the family
+    /// covers acceptance. A whitespace-padded exact entry, by contrast, is a
+    /// misconfiguration that fails loudly under this policy just as it does
+    /// under a pure allowlist, rather than being silently consulted through the
+    /// predicate path.
+    #[tokio::test]
+    async fn the_workspace_family_policy_guards_its_exact_list() {
+        use std::sync::Arc;
+
+        use crate::oauth_resource::CanonicalOauthUrl;
+        use crate::workspace_mcp_urls::{McpWorkspaceSegment, WorkspaceMcpUrls};
+
+        let signing_key = test_signing_key();
+        let config = session(&signing_key);
+        let base = CanonicalOauthUrl::parse("https://coral.example/mcp").expect("canonical base");
+        let family = Arc::new(WorkspaceMcpUrls::new(base));
+        let workspace_resource =
+            family.resource(&McpWorkspaceSegment::parse("team").expect("segment"));
+        let token = config
+            .issue_access_token_as(USER_ID, CLIENT_ID, &workspace_resource, PrincipalKind::User)
+            .expect("workspace token")
+            .access_token;
+
+        // Empty exact list, family present: the family admits the workspace token.
+        let family_only = super::SessionPrincipalProvider::with_workspace_family(
+            config.verifier(),
+            Vec::<String>::new(),
+            family.clone(),
+        );
+        family_only
+            .principal_for_bearer(&token)
+            .await
+            .expect("the family admits its own workspace resource");
+
+        // A whitespace-padded exact entry is a misconfiguration: every token is
+        // refused, including the otherwise-valid workspace token.
+        let padded = super::SessionPrincipalProvider::with_workspace_family(
+            config.verifier(),
+            [" https://coral.example/other ".to_string()],
+            family,
+        );
+        padded
+            .principal_for_bearer(&token)
+            .await
+            .expect_err("a whitespace-padded allowlist entry must fail loudly");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/request_auth.rs
+++ b/crates/coral-app/src/request_auth.rs
@@ -89,6 +89,21 @@ impl SessionPrincipalProvider {
     }
 
     fn principal_for_token(&self, token: &str) -> Result<Principal, PrincipalProviderError> {
+        // An enumerated allowlist keeps going through the list-validating
+        // entry point, whose empty-and-whitespace guard has no analogue for a
+        // predicate; only the family policy needs one.
+        if let AudiencePolicy::Exact(exact) = &self.audiences {
+            if token.is_empty() || !token.bytes().all(|byte| byte.is_ascii_graphic()) {
+                return Err(unauthenticated());
+            }
+            let accepted = exact.iter().map(String::as_str).collect::<Vec<_>>();
+            let session = self
+                .verifier
+                .validate_access_token(token, &accepted)
+                .map_err(|_error| unauthenticated())?;
+            return Principal::parse(&session.user_id, session.principal_kind)
+                .map_err(|_error| unauthenticated());
+        }
         self.principal_where(token, &|audience| self.audiences.accepts(audience))
     }
 

--- a/crates/coral-app/src/workspace_mcp_urls.rs
+++ b/crates/coral-app/src/workspace_mcp_urls.rs
@@ -36,9 +36,9 @@ impl McpWorkspaceSegment {
     #[must_use]
     pub fn parse(segment: &str) -> Option<Self> {
         let charset_ok = !segment.is_empty()
-            && segment
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'));
+            && segment.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~')
+            });
         if !charset_ok || segment == "." || segment == ".." {
             return None;
         }
@@ -102,10 +102,7 @@ impl WorkspaceMcpUrls {
     /// The listener-relative MCP route path for a workspace.
     #[must_use]
     pub fn route_path(&self, segment: &McpWorkspaceSegment) -> String {
-        format!(
-            "{}/{WORKSPACE_ROUTE_SEGMENT}/{segment}",
-            self.base_path()
-        )
+        format!("{}/{WORKSPACE_ROUTE_SEGMENT}/{segment}", self.base_path())
     }
 
     /// The RFC 9728 metadata URL for a workspace's resource: the well-known
@@ -181,8 +178,19 @@ mod tests {
             assert!(McpWorkspaceSegment::parse(valid).is_some(), "{valid}");
         }
         for invalid in [
-            "", ".", "..", "team/other", "te am", "te%61m", "tëam", "team?", "team#", "team\\",
-            "team\n", "té", "🪸",
+            "",
+            ".",
+            "..",
+            "team/other",
+            "te am",
+            "te%61m",
+            "tëam",
+            "team?",
+            "team#",
+            "team\\",
+            "team\n",
+            "té",
+            "🪸",
         ] {
             assert!(McpWorkspaceSegment::parse(invalid).is_none(), "{invalid:?}");
         }
@@ -228,7 +236,10 @@ mod tests {
     fn the_documented_template_shapes_hold_exactly() {
         let urls = urls("https://coral.example/mcp");
         let team = segment("team");
-        assert_eq!(urls.resource(&team), "https://coral.example/mcp/workspace/team");
+        assert_eq!(
+            urls.resource(&team),
+            "https://coral.example/mcp/workspace/team"
+        );
         assert_eq!(urls.route_path(&team), "/mcp/workspace/team");
         assert_eq!(
             urls.metadata_url(&team),

--- a/crates/coral-app/src/workspace_mcp_urls.rs
+++ b/crates/coral-app/src/workspace_mcp_urls.rs
@@ -77,16 +77,30 @@ impl WorkspaceMcpUrls {
         &self.base
     }
 
-    /// The listener-relative path of the base, with a root path as `""`.
+    /// `scheme://host[:port]`, with no path — borrowed from the base URL.
+    fn origin(&self) -> &str {
+        &self.base.url()[..Position::BeforePath]
+    }
+
+    /// The listener-relative path of the base, with a root path as `""` and no
+    /// trailing slash.
     ///
-    /// Routes and metadata paths are derived by appending to this, so the
-    /// public URL's path decides where the listener mounts the family.
+    /// Routes and metadata paths are derived by appending to this. Normalizing
+    /// here — `CanonicalOauthUrl` strips only a root path, so a non-root
+    /// trailing slash survives canonicalization — is what keeps a
+    /// trailing-slash `public_url` from producing a `//workspace/...` double
+    /// slash; trimming every trailing slash also folds the root path down to
+    /// the empty string under the same rule. The trimmed slice borrows the
+    /// base, so this costs nothing to compute.
     #[must_use]
     pub fn base_path(&self) -> &str {
-        match self.base.url().path() {
-            "/" => "",
-            path => path,
-        }
+        self.base.url().path().trim_end_matches('/')
+    }
+
+    /// The base as a resource identifier — `origin` plus the normalized base
+    /// path — the string every per-workspace resource extends.
+    fn base_identifier(&self) -> String {
+        format!("{}{}", self.origin(), self.base_path())
     }
 
     /// The one MCP resource URL for a workspace: routing key, OAuth resource,
@@ -95,7 +109,7 @@ impl WorkspaceMcpUrls {
     pub fn resource(&self, segment: &McpWorkspaceSegment) -> String {
         format!(
             "{}/{WORKSPACE_ROUTE_SEGMENT}/{segment}",
-            self.base.identifier()
+            self.base_identifier()
         )
     }
 
@@ -109,11 +123,7 @@ impl WorkspaceMcpUrls {
     /// suffix is inserted between the host and the resource's path.
     #[must_use]
     pub fn metadata_url(&self, segment: &McpWorkspaceSegment) -> String {
-        format!(
-            "{}{}",
-            &self.base.url()[..Position::BeforePath],
-            self.metadata_path(segment)
-        )
+        format!("{}{}", self.origin(), self.metadata_path(segment))
     }
 
     /// The listener-relative path [`Self::metadata_url`] is served at.
@@ -131,7 +141,7 @@ impl WorkspaceMcpUrls {
     /// the literal workspace segment, and one charset-valid name is refused.
     #[must_use]
     pub fn parse_resource(&self, resource: &str) -> Option<McpWorkspaceSegment> {
-        Self::parse_tail(resource.strip_prefix(self.base.identifier())?)
+        Self::parse_tail(resource.strip_prefix(&self.base_identifier())?)
     }
 
     /// Parses a listener-relative MCP route path back to its workspace segment.
@@ -248,6 +258,50 @@ mod tests {
         assert_eq!(
             urls.metadata_path(&team),
             "/.well-known/oauth-protected-resource/mcp/workspace/team"
+        );
+    }
+
+    /// A `public_url` with a non-root trailing slash canonicalizes with the
+    /// slash intact, so the family must normalize it — otherwise every derived
+    /// URL doubles the separator into `//workspace/...`.
+    #[test]
+    fn a_trailing_slash_base_does_not_double_the_separator() {
+        for base in [
+            "https://coral.example/mcp/",
+            "https://coral.example/base/mcp/",
+        ] {
+            let urls = urls(base);
+            let team = segment("team");
+            assert!(
+                !urls.resource(&team).contains("//workspace"),
+                "resource for {base}: {}",
+                urls.resource(&team)
+            );
+            assert!(
+                !urls.route_path(&team).contains("//workspace"),
+                "route for {base}: {}",
+                urls.route_path(&team)
+            );
+            assert!(
+                !urls.metadata_path(&team).contains("//workspace"),
+                "metadata for {base}: {}",
+                urls.metadata_path(&team)
+            );
+            // And the normalized derivations still round-trip.
+            assert_eq!(
+                urls.parse_resource(&urls.resource(&team)).as_ref(),
+                Some(&team)
+            );
+            assert_eq!(
+                urls.parse_route_path(&urls.route_path(&team)).as_ref(),
+                Some(&team)
+            );
+        }
+        let urls = urls("https://coral.example/mcp/");
+        assert_eq!(urls.base_path(), "/mcp");
+        assert_eq!(
+            urls.resource(&segment("team")),
+            "https://coral.example/mcp/workspace/team"
         );
     }
 

--- a/crates/coral-app/src/workspace_mcp_urls.rs
+++ b/crates/coral-app/src/workspace_mcp_urls.rs
@@ -1,0 +1,291 @@
+//! Per-workspace MCP resource URLs: one template, three roles.
+//!
+//! Every served workspace has exactly one MCP URL, derived from the configured
+//! public base URL as `<base>/workspace/<name>`. That one string is the routing
+//! key, the OAuth protected-resource identifier, and the access-token audience,
+//! so derivation and parsing live here — a second derivation anywhere else
+//! could mint an audience that no longer matches the advertised resource.
+//! [`CanonicalOauthUrl`] canonicalizes the base; the workspace segment is held
+//! to a charset strict enough that concatenation is itself canonical.
+
+use url::Position;
+
+use crate::oauth_resource::CanonicalOauthUrl;
+
+/// The well-known prefix protected-resource metadata is served under (RFC 9728).
+pub const PROTECTED_RESOURCE_METADATA_ROOT: &str = "/.well-known/oauth-protected-resource";
+
+/// The path segment between the base URL and the workspace name.
+pub const WORKSPACE_ROUTE_SEGMENT: &str = "workspace";
+
+/// A workspace name in the strict charset per-workspace URLs admit.
+///
+/// The charset is the RFC 3986 unreserved set (ASCII alphanumerics plus
+/// `-`, `.`, `_`, `~`), excluding `.` and `..`. It is deliberately tighter
+/// than the app's workspace-name validation: a name outside it cannot appear
+/// in a URL, a challenge header, or an audience without escaping, and escaping
+/// would create a second spelling of the one canonical string. A workspace
+/// whose name falls outside this set is simply unreachable by URL until it is
+/// renamed. No percent-encoding is admitted: `%` is not in the charset, so an
+/// encoded spelling of a valid name is rejected rather than normalized.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct McpWorkspaceSegment(String);
+
+impl McpWorkspaceSegment {
+    /// Parses one raw path segment, refusing anything outside the charset.
+    #[must_use]
+    pub fn parse(segment: &str) -> Option<Self> {
+        let charset_ok = !segment.is_empty()
+            && segment
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~'));
+        if !charset_ok || segment == "." || segment == ".." {
+            return None;
+        }
+        Some(Self(segment.to_string()))
+    }
+
+    /// Borrows the validated workspace name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for McpWorkspaceSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Derives and parses the per-workspace MCP URL family under one base URL.
+#[derive(Clone, Debug)]
+pub struct WorkspaceMcpUrls {
+    base: CanonicalOauthUrl,
+}
+
+impl WorkspaceMcpUrls {
+    /// Builds the URL family under a canonical base, e.g. `https://host/mcp`.
+    #[must_use]
+    pub fn new(base: CanonicalOauthUrl) -> Self {
+        Self { base }
+    }
+
+    /// Returns the canonical base the family hangs under.
+    #[must_use]
+    pub fn base(&self) -> &CanonicalOauthUrl {
+        &self.base
+    }
+
+    /// The listener-relative path of the base, with a root path as `""`.
+    ///
+    /// Routes and metadata paths are derived by appending to this, so the
+    /// public URL's path decides where the listener mounts the family.
+    #[must_use]
+    pub fn base_path(&self) -> &str {
+        match self.base.url().path() {
+            "/" => "",
+            path => path,
+        }
+    }
+
+    /// The one MCP resource URL for a workspace: routing key, OAuth resource,
+    /// and token audience, byte-identical in all three roles.
+    #[must_use]
+    pub fn resource(&self, segment: &McpWorkspaceSegment) -> String {
+        format!(
+            "{}/{WORKSPACE_ROUTE_SEGMENT}/{segment}",
+            self.base.identifier()
+        )
+    }
+
+    /// The listener-relative MCP route path for a workspace.
+    #[must_use]
+    pub fn route_path(&self, segment: &McpWorkspaceSegment) -> String {
+        format!(
+            "{}/{WORKSPACE_ROUTE_SEGMENT}/{segment}",
+            self.base_path()
+        )
+    }
+
+    /// The RFC 9728 metadata URL for a workspace's resource: the well-known
+    /// suffix is inserted between the host and the resource's path.
+    #[must_use]
+    pub fn metadata_url(&self, segment: &McpWorkspaceSegment) -> String {
+        format!(
+            "{}{}",
+            &self.base.url()[..Position::BeforePath],
+            self.metadata_path(segment)
+        )
+    }
+
+    /// The listener-relative path [`Self::metadata_url`] is served at.
+    #[must_use]
+    pub fn metadata_path(&self, segment: &McpWorkspaceSegment) -> String {
+        format!(
+            "{PROTECTED_RESOURCE_METADATA_ROOT}{}/{WORKSPACE_ROUTE_SEGMENT}/{segment}",
+            self.base_path()
+        )
+    }
+
+    /// Parses a canonical resource identifier back to its workspace segment.
+    ///
+    /// The exact inverse of [`Self::resource`]: anything that is not the base,
+    /// the literal workspace segment, and one charset-valid name is refused.
+    #[must_use]
+    pub fn parse_resource(&self, resource: &str) -> Option<McpWorkspaceSegment> {
+        Self::parse_tail(resource.strip_prefix(self.base.identifier())?)
+    }
+
+    /// Parses a listener-relative MCP route path back to its workspace segment.
+    ///
+    /// The exact inverse of [`Self::route_path`].
+    #[must_use]
+    pub fn parse_route_path(&self, path: &str) -> Option<McpWorkspaceSegment> {
+        Self::parse_tail(path.strip_prefix(self.base_path())?)
+    }
+
+    /// Parses a listener-relative metadata path back to its workspace segment.
+    ///
+    /// The exact inverse of [`Self::metadata_path`].
+    #[must_use]
+    pub fn parse_metadata_path(&self, path: &str) -> Option<McpWorkspaceSegment> {
+        self.parse_route_path(path.strip_prefix(PROTECTED_RESOURCE_METADATA_ROOT)?)
+    }
+
+    fn parse_tail(tail: &str) -> Option<McpWorkspaceSegment> {
+        McpWorkspaceSegment::parse(
+            tail.strip_prefix('/')?
+                .strip_prefix(WORKSPACE_ROUTE_SEGMENT)?
+                .strip_prefix('/')?,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{McpWorkspaceSegment, WorkspaceMcpUrls};
+    use crate::oauth_resource::CanonicalOauthUrl;
+
+    fn urls(base: &str) -> WorkspaceMcpUrls {
+        WorkspaceMcpUrls::new(CanonicalOauthUrl::parse(base).expect("canonical base"))
+    }
+
+    fn segment(name: &str) -> McpWorkspaceSegment {
+        McpWorkspaceSegment::parse(name).expect("valid segment")
+    }
+
+    #[test]
+    fn segments_admit_only_the_unreserved_charset() {
+        for valid in ["team", "analytics-staging", "a", "Team_2", "v1.2~x", "..."] {
+            assert!(McpWorkspaceSegment::parse(valid).is_some(), "{valid}");
+        }
+        for invalid in [
+            "", ".", "..", "team/other", "te am", "te%61m", "tëam", "team?", "team#", "team\\",
+            "team\n", "té", "🪸",
+        ] {
+            assert!(McpWorkspaceSegment::parse(invalid).is_none(), "{invalid:?}");
+        }
+    }
+
+    #[test]
+    fn derivation_and_parsing_are_exact_inverses() {
+        for (base, name) in [
+            ("https://coral.example/mcp", "team"),
+            ("https://coral.example/mcp", "analytics-staging"),
+            ("https://coral.example:8443/mcp", "team"),
+            ("http://127.0.0.1:14556/mcp", "team"),
+            ("https://coral.example", "team"),
+        ] {
+            let urls = urls(base);
+            let segment = segment(name);
+            let resource = urls.resource(&segment);
+            assert_eq!(
+                urls.parse_resource(&resource).as_ref(),
+                Some(&segment),
+                "resource round-trip for {base} / {name}"
+            );
+            let route = urls.route_path(&segment);
+            assert_eq!(
+                urls.parse_route_path(&route).as_ref(),
+                Some(&segment),
+                "route round-trip for {base} / {name}"
+            );
+            let metadata_path = urls.metadata_path(&segment);
+            assert_eq!(
+                urls.parse_metadata_path(&metadata_path).as_ref(),
+                Some(&segment),
+                "metadata round-trip for {base} / {name}"
+            );
+            assert!(
+                urls.metadata_url(&segment).ends_with(&metadata_path),
+                "metadata URL must end with its served path"
+            );
+        }
+    }
+
+    #[test]
+    fn the_documented_template_shapes_hold_exactly() {
+        let urls = urls("https://coral.example/mcp");
+        let team = segment("team");
+        assert_eq!(urls.resource(&team), "https://coral.example/mcp/workspace/team");
+        assert_eq!(urls.route_path(&team), "/mcp/workspace/team");
+        assert_eq!(
+            urls.metadata_url(&team),
+            "https://coral.example/.well-known/oauth-protected-resource/mcp/workspace/team"
+        );
+        assert_eq!(
+            urls.metadata_path(&team),
+            "/.well-known/oauth-protected-resource/mcp/workspace/team"
+        );
+    }
+
+    #[test]
+    fn a_root_base_derives_origin_rooted_workspace_urls() {
+        let urls = urls("https://coral.example/");
+        let team = segment("team");
+        assert_eq!(urls.base_path(), "");
+        assert_eq!(urls.resource(&team), "https://coral.example/workspace/team");
+        assert_eq!(urls.route_path(&team), "/workspace/team");
+        assert_eq!(
+            urls.metadata_path(&team),
+            "/.well-known/oauth-protected-resource/workspace/team"
+        );
+    }
+
+    #[test]
+    fn non_canonical_spellings_parse_to_nothing() {
+        let urls = urls("https://coral.example/mcp");
+        for resource in [
+            "https://coral.example/mcp",
+            "https://coral.example/mcp/workspace",
+            "https://coral.example/mcp/workspace/",
+            "https://coral.example/mcp/workspace/team/",
+            "https://coral.example/mcp/workspace/team/extra",
+            "https://coral.example/mcp/workspace/te%61m",
+            "https://coral.example/mcp/workspace/te am",
+            "https://coral.example/mcp/Workspace/team",
+            "https://other.example/mcp/workspace/team",
+            "https://coral.example/other/workspace/team",
+            "http://coral.example/mcp/workspace/team",
+        ] {
+            assert!(urls.parse_resource(resource).is_none(), "{resource}");
+        }
+        for path in [
+            "/mcp",
+            "/mcp/workspace",
+            "/mcp/workspace/",
+            "/mcp/workspace/team/",
+            "/mcp/workspace/team/extra",
+            "/mcp/workspace/te%61m",
+            "/workspace/team",
+        ] {
+            assert!(urls.parse_route_path(path).is_none(), "{path}");
+        }
+        assert!(
+            urls.parse_metadata_path("/.well-known/oauth-protected-resource/mcp")
+                .is_none(),
+            "the base metadata path names no workspace"
+        );
+    }
+}

--- a/crates/coral-app/src/workspace_mcp_urls.rs
+++ b/crates/coral-app/src/workspace_mcp_urls.rs
@@ -106,8 +106,8 @@ impl WorkspaceMcpUrls {
     /// Whether `candidate` names the family base in either spelling.
     ///
     /// The base has two canonical forms: [`Self::base`]'s identifier keeps a
-    /// non-root trailing slash, while [`Self::base_identifier`] — the prefix
-    /// every per-workspace resource extends — trims it. The base is an audience
+    /// non-root trailing slash, while the prefix every per-workspace resource
+    /// extends — see [`Self::resource`] — trims it. The base is an audience
     /// of no surface, so an `auth.allowed_audiences` entry matching *either*
     /// spelling would resurrect the audience the per-workspace family replaced;
     /// configuration rejects both.

--- a/crates/coral-app/src/workspace_mcp_urls.rs
+++ b/crates/coral-app/src/workspace_mcp_urls.rs
@@ -103,6 +103,19 @@ impl WorkspaceMcpUrls {
         format!("{}{}", self.origin(), self.base_path())
     }
 
+    /// Whether `candidate` names the family base in either spelling.
+    ///
+    /// The base has two canonical forms: [`Self::base`]'s identifier keeps a
+    /// non-root trailing slash, while [`Self::base_identifier`] — the prefix
+    /// every per-workspace resource extends — trims it. The base is an audience
+    /// of no surface, so an `auth.allowed_audiences` entry matching *either*
+    /// spelling would resurrect the audience the per-workspace family replaced;
+    /// configuration rejects both.
+    #[must_use]
+    pub fn is_base_audience(&self, candidate: &str) -> bool {
+        self.base().identifier() == candidate || self.base_identifier() == candidate
+    }
+
     /// The one MCP resource URL for a workspace: routing key, OAuth resource,
     /// and token audience, byte-identical in all three roles.
     #[must_use]

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -7,12 +7,11 @@ use coral_api::v1::{
     DescribeCatalogSurfaceRequest, ListCatalogRequest, ListColumnsRequest, PaginationRequest,
     SearchCatalogRequest, catalog_item, describe_catalog_surface_response,
 };
-use coral_client::default_workspace;
 use tonic::Request;
 
 use super::harness::{
-    GrpcHarness, fixture_manifest_with_functions_yaml, fixture_manifest_with_multiple_tables_yaml,
-    fixture_manifest_with_required_filter_yaml,
+    GrpcHarness, default_workspace, fixture_manifest_with_functions_yaml,
+    fixture_manifest_with_multiple_tables_yaml, fixture_manifest_with_required_filter_yaml,
 };
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -4,10 +4,9 @@ use coral_api::v1::{
     AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, FunctionWriteSurface,
     ListFunctionsRequest, Workspace, function,
 };
-use coral_client::default_workspace;
 use tonic::Request;
 
-use crate::harness::{GrpcHarness, fixture_manifest_yaml};
+use crate::harness::{GrpcHarness, default_workspace, fixture_manifest_yaml};
 
 fn workspace(name: &str) -> Workspace {
     Workspace {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -14,7 +14,7 @@ use coral_app::features::{Feature, FeatureOverrides};
 use coral_app::{EngineExtensionsProvider, PrincipalKind};
 use coral_client::{
     AppClient, BearerToken, CatalogClient, FunctionClient, QueryClient, SearchClient, SourceClient,
-    WorkspaceClient, batches_to_json_rows, decode_execute_sql_response, default_workspace,
+    WorkspaceClient, batches_to_json_rows, decode_execute_sql_response,
     local::{RunningServer, ServerBuilder, connect_with_loopback_bearer},
 };
 use serde_json::{Value, json};
@@ -830,6 +830,16 @@ pub(crate) fn named_workspace(name: &str) -> Workspace {
     Workspace {
         name: name.to_string(),
     }
+}
+
+/// Names the one workspace [`GrpcHarness::seed_workspace`] creates.
+///
+/// It is a fixture's own name for state it created itself, not a name any
+/// client library hands out: nothing reconstructs this workspace on a caller's
+/// behalf, so a request naming it before `seed_workspace` runs is refused like
+/// any other unknown workspace.
+pub(crate) fn default_workspace() -> Workspace {
+    named_workspace("default")
 }
 
 /// The workspace and membership helpers hand back the whole response rather

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -15,14 +15,14 @@ use coral_api::v1::{
     ExecuteSqlRequest, ImportSourceRequest, SearchRequest, SourceSecret, SourceVariable,
     import_source_response,
 };
-use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
+use coral_client::{batches_to_json_rows, decode_execute_sql_response};
 use serde_json::json;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::Notify;
 use tonic::{Code, Request};
 
-use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
+use crate::harness::{GrpcHarness, default_workspace, fixture_manifest_yaml, source_dir};
 
 #[tokio::test]
 async fn query_refreshes_expired_oauth_access_token_at_request_time() {

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -7,10 +7,12 @@
 use std::fs;
 
 use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
-use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
+use coral_client::{batches_to_json_rows, decode_execute_sql_response};
 use tonic::Request;
 
-use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
+use crate::harness::{
+    GrpcHarness, default_workspace, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml,
+};
 
 #[tokio::test]
 async fn broken_source_does_not_block_healthy_sources() {

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -17,7 +17,6 @@ use coral_api::v1::{
     search_result,
 };
 use coral_app::EngineExtensionsProvider;
-use coral_client::default_workspace;
 use coral_engine::{
     EngineExtensions, QuerySource, SourceDecorator, SourceDecoratorError, SourceTables,
 };
@@ -27,7 +26,7 @@ use tonic::{Code, Request};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::harness::{GrpcHarness, manifest_yaml, source_dir};
+use super::harness::{GrpcHarness, default_workspace, manifest_yaml, source_dir};
 
 // The old live-scope VALUES CTE bound five fields per surface. At 6,553 surfaces, the
 // count query's two additional fields exceeded bundled SQLite's 32,766-variable limit.

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -10,12 +10,14 @@ use std::fs;
 
 use coral_api::v1::{CreateWorkspaceRequest, ListSourcesRequest};
 use coral_client::{
-    AppClient, default_workspace,
+    AppClient,
     local::{LocalServerError, ServerBuilder},
 };
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
+
+use crate::harness::default_workspace;
 
 #[tokio::test]
 async fn server_lifecycle_can_repeat_within_process() {

--- a/crates/coral-app/tests/grpc/session_auth.rs
+++ b/crates/coral-app/tests/grpc/session_auth.rs
@@ -16,7 +16,11 @@ use ring::rand::SystemRandom;
 use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
 
 const ISSUER: &str = "https://auth.example.test";
-const AUDIENCE: &str = "https://mcp.example.test";
+/// The public base the per-workspace MCP resources hang under. Not an audience
+/// of its own: tokens are minted for [`MINTED_AUDIENCE`], one member of the
+/// family, which the private gRPC API accepts like every other member.
+const PUBLIC_BASE: &str = "https://mcp.example.test";
+const MINTED_AUDIENCE: &str = "https://mcp.example.test/workspace/transport-tests";
 const CLIENT_ID: &str = "https://client.example/client.json";
 const ACCESS_TOKEN_TTL: Duration = Duration::from_mins(5);
 
@@ -85,7 +89,7 @@ storage = \"file\"
 [server.mcp_http]
 enabled = true
 bind = '127.0.0.1:0'
-public_url = '{AUDIENCE}'
+public_url = '{PUBLIC_BASE}'
 
 [auth.authorization_server]
 issuer = '{ISSUER}'
@@ -127,7 +131,7 @@ redirect_uri = '{ISSUER}/auth/oidc/callback'
             ACCESS_TOKEN_TTL,
             user_id,
             CLIENT_ID,
-            AUDIENCE,
+            MINTED_AUDIENCE,
             principal_kind,
         )
         .expect("issue a session access token")

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -15,12 +15,11 @@ use coral_api::v1::{
     query_test_result, source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
-use coral_client::default_workspace;
 use tempfile::TempDir;
 use tonic::Request;
 
 use crate::harness::{
-    FailingHttpFixture, GrpcHarness, fixture_function_only_manifest_yaml,
+    FailingHttpFixture, GrpcHarness, default_workspace, fixture_function_only_manifest_yaml,
     fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
     fixture_manifest_yaml, invalid_manifest_yaml, source_dir,

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -7,7 +7,7 @@ use coral_api::v1::{
     ListWorkspaceMembersResponse, ListWorkspacesRequest, Source, SourceSecret, SourceVariable,
     WorkspaceRole, import_source_response,
 };
-use coral_client::{AppClient, default_workspace};
+use coral_client::AppClient;
 use prost::Message as _;
 use serde_json::json;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
@@ -770,9 +770,8 @@ async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete
 #[tokio::test]
 async fn default_like_names_are_created_and_deleted_like_any_other() {
     let harness = GrpcHarness::new().await;
-    let default_name = default_workspace().name;
 
-    for name in [default_name.as_str(), "default-2", "work"] {
+    for name in ["default", "default-2", "work"] {
         harness
             .workspace_client()
             .create_workspace(Request::new(CreateWorkspaceRequest {

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeMap;
 use std::fs;
 
-use coral_client::default_workspace;
 use coral_client::local::ServerBuilder;
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
@@ -52,10 +51,8 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         .await
         .expect("startup should migrate the workspaces table");
     assert_eq!(
-        legacy_default_after,
-        legacy_default_before,
-        "startup must not invent a '{}' workspace",
-        default_workspace().name
+        legacy_default_after, legacy_default_before,
+        "startup must not invent a 'default' workspace"
     );
 
     server.shutdown().await.expect("shutdown server");
@@ -193,7 +190,7 @@ async fn count_legacy_default_workspaces(database_url: &str) -> Option<i64> {
     }
 
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM workspaces WHERE id = $1")
-        .bind(default_workspace().name)
+        .bind("default")
         .fetch_one(&pool)
         .await
         .expect("count the workspace rows holding the legacy default name");

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -33,8 +33,8 @@ use coral_api::v1::{
     DeleteWorkspaceRequest, DrainSearchQueueRequest, ExecuteSqlRequest, Function,
     FunctionRuntimeReady, FunctionWriteSurface, ListFunctionsRequest, ListWorkspacesRequest,
     RebuildSearchIndexRequest, SearchClearTarget, SearchDataScope, SearchIndexProvider,
-    SearchProvider, SearchRequest, Workspace, WorkspaceRole, function, search_clear_target,
-    search_maintenance_result,
+    SearchProvider, SearchRequest, Source, SourceInfo, Workspace, WorkspaceRole, function,
+    search_clear_target, search_maintenance_result,
 };
 use coral_app::{EngineExtensionsProvider, bootstrap::is_loopback_ip};
 use coral_client::{
@@ -1025,92 +1025,14 @@ async fn run_app_command(
     mcp_surface_provider: Option<&dyn McpSurfaceProvider>,
 ) -> Result<(), CliError> {
     match command {
-        Command::Sql(args) => {
-            let response = match app
-                .query_client()
-                .execute_sql(Request::new(ExecuteSqlRequest {
-                    workspace: Some(workspace.clone()),
-                    sql: args.sql,
-                    guide_read_context: None,
-                    task_attribution: None,
-                }))
-                .await
-            {
-                Ok(response) => response.into_inner(),
-                Err(status) => {
-                    return Err(CliError::Query {
-                        error_message: query_error::telemetry_error_message(&status),
-                        error_type: query_error::telemetry_error_type(&status),
-                        rendered_stderr: query_error::render_query_error(&status),
-                    });
-                }
-            };
-            let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
-            print_batches(result.batches(), args.format)?;
-        }
-        Command::Search(args) => run_search(&app, workspace, args).await?,
-        Command::SearchIndex(args) => run_search_index(&app, workspace, args).await?,
-        Command::Source(args) => run_source(&app, workspace, args).await?,
-        Command::Function(args) => run_function(&app, workspace, args).await?,
-        Command::Onboard => {
-            onboard::run(&app, workspace).await?;
-        }
+        Command::Sql(args) => run_sql(&app, workspace, args).await,
+        Command::Search(args) => run_search(&app, workspace, args).await,
+        Command::SearchIndex(args) => run_search_index(&app, workspace, args).await,
+        Command::Source(args) => run_source(&app, workspace, args).await,
+        Command::Function(args) => run_function(&app, workspace, args).await,
+        Command::Onboard => onboard::run(&app, workspace).await.map_err(CliError::from),
         Command::McpStdio(_) => {
-            let features = coral_app::features::FeatureStore::discover(None)
-                .and_then(|store| store.load_with_overrides(feature_overrides))
-                .map_err(anyhow::Error::from)?;
-            let source_names = match source_ops::list_sources(&app, workspace).await {
-                Ok(sources) => sources.into_iter().map(|source| source.name).collect(),
-                Err(error) => {
-                    eprintln!(
-                        "warning: failed to load source names for MCP initialize instructions: {error}"
-                    );
-                    Vec::new()
-                }
-            };
-            let (source_names, query_examples) =
-                match coral_app::bootstrap::workspace_mcp_startup_context(
-                    &workspace.name,
-                    source_names.clone(),
-                    MCP_INITIAL_QUERY_EXAMPLE_LIMIT,
-                ) {
-                    Ok(context) => (
-                        context.source_names().to_vec(),
-                        context
-                            .query_history()
-                            .iter()
-                            .map(|entry| {
-                                coral_mcp::McpQueryExample::new(entry.sql())
-                                    .with_sources(entry.sources().iter().cloned())
-                                    .with_row_count(entry.row_count())
-                            })
-                            .collect(),
-                    ),
-                    Err(error) => {
-                        eprintln!(
-                            "warning: failed to load MCP startup context for initialize instructions: {error}"
-                        );
-                        (source_names, Vec::new())
-                    }
-                };
-            Box::pin(coral_mcp::run_stdio_with_client(
-                app,
-                coral_mcp::McpOptions {
-                    feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
-                    observed_values_search_enabled: features
-                        .enabled(coral_app::features::Feature::ObservedValuesSearch),
-                    trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
-                    source_names,
-                    query_examples,
-                    workspace: Some(workspace.clone()),
-                    surface: match mcp_surface_provider {
-                        Some(provider) => provider.surface().map_err(anyhow::Error::from_boxed)?,
-                        None => McpSurface::default(),
-                    },
-                },
-            ))
-            .await
-            .map_err(anyhow::Error::from)?;
+            run_mcp_stdio(app, workspace, ctx, feature_overrides, mcp_surface_provider).await
         }
         Command::Workspace(_) => {
             unreachable!("workspace management is routed without a selected workspace")
@@ -1119,8 +1041,122 @@ async fn run_app_command(
             unreachable!("no-runtime commands are routed without an app client")
         }
     }
+}
 
+/// Executes one SQL statement and renders the decoded batches.
+async fn run_sql(app: &AppClient, workspace: &Workspace, args: SqlArgs) -> Result<(), CliError> {
+    let response = app
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(workspace.clone()),
+            sql: args.sql,
+            guide_read_context: None,
+            task_attribution: None,
+        }))
+        .await
+        .map_err(|status| query_failure(&status))?
+        .into_inner();
+    let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
+    print_batches(result.batches(), args.format)?;
     Ok(())
+}
+
+/// Reports a failed query the way the user and telemetry each need it: the
+/// rendered guidance goes to stderr while the classification travels with the
+/// run, both derived from the one status the server returned.
+fn query_failure(status: &tonic::Status) -> CliError {
+    CliError::Query {
+        error_message: query_error::telemetry_error_message(status),
+        error_type: query_error::telemetry_error_type(status),
+        rendered_stderr: query_error::render_query_error(status),
+    }
+}
+
+/// Serves MCP over stdio for the selected workspace.
+async fn run_mcp_stdio(
+    app: AppClient,
+    workspace: &Workspace,
+    ctx: Option<&coral_app::RunContext>,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+    mcp_surface_provider: Option<&dyn McpSurfaceProvider>,
+) -> Result<(), CliError> {
+    let features = coral_app::features::FeatureStore::discover(None)
+        .and_then(|store| store.load_with_overrides(feature_overrides))
+        .map_err(anyhow::Error::from)?;
+    let source_names = mcp_source_names(&app, workspace).await;
+    let (source_names, query_examples) = mcp_startup_context(&workspace.name, source_names);
+    Box::pin(coral_mcp::run_stdio_with_client(
+        app,
+        coral_mcp::McpOptions {
+            feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
+            observed_values_search_enabled: features
+                .enabled(coral_app::features::Feature::ObservedValuesSearch),
+            trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
+            source_names,
+            query_examples,
+            workspace: Some(workspace.clone()),
+            surface: match mcp_surface_provider {
+                Some(provider) => provider.surface().map_err(anyhow::Error::from_boxed)?,
+                None => McpSurface::default(),
+            },
+        },
+    ))
+    .await
+    .map_err(anyhow::Error::from)?;
+    Ok(())
+}
+
+/// Names the installed sources for the MCP initialize instructions.
+///
+/// The instructions are advisory, so a listing failure costs them their source
+/// list rather than the whole MCP session.
+async fn mcp_source_names(app: &AppClient, workspace: &Workspace) -> Vec<String> {
+    match source_ops::list_sources(app, workspace).await {
+        Ok(sources) => sources.into_iter().map(|source| source.name).collect(),
+        Err(error) => {
+            eprintln!(
+                "warning: failed to load source names for MCP initialize instructions: {error}"
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Loads the source names and query examples the MCP initialize instructions
+/// open with, falling back to the names alone when local history is unreadable.
+fn mcp_startup_context(
+    workspace_name: &str,
+    source_names: Vec<String>,
+) -> (Vec<String>, Vec<coral_mcp::McpQueryExample>) {
+    match coral_app::bootstrap::workspace_mcp_startup_context(
+        workspace_name,
+        source_names.clone(),
+        MCP_INITIAL_QUERY_EXAMPLE_LIMIT,
+    ) {
+        Ok(context) => (
+            context.source_names().to_vec(),
+            context
+                .query_history()
+                .iter()
+                .map(mcp_query_example)
+                .collect(),
+        ),
+        Err(error) => {
+            eprintln!(
+                "warning: failed to load MCP startup context for initialize instructions: {error}"
+            );
+            (source_names, Vec::new())
+        }
+    }
+}
+
+/// Presents one recorded query as an MCP startup example.
+fn mcp_query_example(
+    entry: &coral_app::bootstrap::McpQueryHistoryEntry,
+) -> coral_mcp::McpQueryExample {
+    coral_mcp::McpQueryExample::new(entry.sql())
+        .with_sources(entry.sources().iter().cloned())
+        .with_row_count(entry.row_count())
 }
 
 fn run_features(
@@ -1230,41 +1266,10 @@ async fn run_source(
 ) -> Result<(), CliError> {
     match args.command {
         SourceCommand::Discover => {
-            let sources = source_ops::discover_sources(app, workspace).await?;
-            if sources.is_empty() {
-                println!("No bundled sources available.");
-            } else {
-                let rows = sources.into_iter().map(|source| {
-                    let status = if source.installed {
-                        "installed".to_string()
-                    } else {
-                        "available".to_string()
-                    };
-                    [
-                        source.name,
-                        source_ops::display_version(&source.version),
-                        status,
-                    ]
-                });
-                print_text_table(["Source", "Version", "Status"], rows);
-            }
+            print_bundled_sources(source_ops::discover_sources(app, workspace).await?);
         }
         SourceCommand::List => {
-            let sources = source_ops::list_sources(app, workspace).await?;
-            if sources.is_empty() {
-                println!("No sources configured.");
-            } else {
-                let rows = sources.into_iter().map(|source| {
-                    [
-                        source.name,
-                        source_ops::display_version(&source.version),
-                        source_ops::source_origin_label(source.origin).to_string(),
-                        source_ops::source_credential_storage_label(source.credential_storage)
-                            .to_string(),
-                    ]
-                });
-                print_text_table(["Source", "Version", "Origin", "Secrets"], rows);
-            }
+            print_configured_sources(source_ops::list_sources(app, workspace).await?);
         }
         SourceCommand::Info { name, verbose } => {
             source_ops::print_source_info(app, workspace, &name, verbose).await?;
@@ -1288,6 +1293,54 @@ async fn run_source(
         }
     }
     Ok(())
+}
+
+/// Renders the sources Coral bundles, with the install state that says whether
+/// `coral source add` still has work to do for each one.
+fn print_bundled_sources(sources: Vec<SourceInfo>) {
+    if sources.is_empty() {
+        println!("No bundled sources available.");
+        return;
+    }
+    print_text_table(
+        ["Source", "Version", "Status"],
+        sources.into_iter().map(bundled_source_row),
+    );
+}
+
+/// Renders the sources installed in the selected workspace, naming where each
+/// one came from and where its secrets live.
+fn print_configured_sources(sources: Vec<Source>) {
+    if sources.is_empty() {
+        println!("No sources configured.");
+        return;
+    }
+    print_text_table(
+        ["Source", "Version", "Origin", "Secrets"],
+        sources.into_iter().map(configured_source_row),
+    );
+}
+
+fn bundled_source_row(source: SourceInfo) -> [String; 3] {
+    let status = if source.installed {
+        "installed"
+    } else {
+        "available"
+    };
+    [
+        source.name,
+        source_ops::display_version(&source.version),
+        status.to_string(),
+    ]
+}
+
+fn configured_source_row(source: Source) -> [String; 4] {
+    [
+        source.name,
+        source_ops::display_version(&source.version),
+        source_ops::source_origin_label(source.origin).to_string(),
+        source_ops::source_credential_storage_label(source.credential_storage).to_string(),
+    ]
 }
 
 async fn run_search(
@@ -1901,7 +1954,8 @@ mod tests {
 
     use clap::{CommandFactory, Parser};
     use coral_api::v1::{
-        Function, FunctionRuntimeInvalid, FunctionRuntimeReady, TableFunctionResultColumn, function,
+        Function, FunctionRuntimeInvalid, FunctionRuntimeReady, Source, SourceCredentialStorage,
+        SourceInfo, SourceOrigin, TableFunctionResultColumn, function,
     };
 
     use super::{
@@ -2321,6 +2375,98 @@ mod tests {
 
         assert!(!manifest_lint.command.uses_selected_workspace());
         assert!(installed_sources.command.uses_selected_workspace());
+    }
+
+    #[test]
+    fn query_failure_renders_guidance_and_classifies_the_status() {
+        let error = super::query_failure(&tonic::Status::unavailable("connection refused"));
+
+        let super::CliError::Query {
+            rendered_stderr,
+            error_type,
+            error_message,
+        } = &error
+        else {
+            panic!("a query status must stay a renderable query failure: {error:?}");
+        };
+        assert_eq!(rendered_stderr, "Error (unavailable): connection refused\n");
+        assert_eq!(error_message, "connection refused");
+        assert!(
+            !error_type.is_empty(),
+            "telemetry needs a failure class for an undecodable status"
+        );
+    }
+
+    #[test]
+    fn bundled_source_rows_separate_installed_from_available() {
+        let installed = super::bundled_source_row(SourceInfo {
+            name: "github".to_string(),
+            version: "1.2.0".to_string(),
+            installed: true,
+            ..SourceInfo::default()
+        });
+        let available = super::bundled_source_row(SourceInfo {
+            name: "slack".to_string(),
+            version: String::new(),
+            installed: false,
+            ..SourceInfo::default()
+        });
+
+        assert_eq!(
+            installed,
+            [
+                "github".to_string(),
+                "1.2.0".to_string(),
+                "installed".to_string()
+            ]
+        );
+        assert_eq!(
+            available,
+            [
+                "slack".to_string(),
+                "-".to_string(),
+                "available".to_string()
+            ],
+            "an unversioned bundled source still reports as available"
+        );
+    }
+
+    #[test]
+    fn configured_source_rows_label_origin_and_secret_storage() {
+        let row = super::configured_source_row(Source {
+            name: "github".to_string(),
+            version: "1.2.0".to_string(),
+            origin: SourceOrigin::Bundled as i32,
+            credential_storage: SourceCredentialStorage::Keychain as i32,
+            ..Source::default()
+        });
+        let unknown = super::configured_source_row(Source {
+            name: "custom".to_string(),
+            version: String::new(),
+            origin: SourceOrigin::Unspecified as i32,
+            credential_storage: SourceCredentialStorage::Unspecified as i32,
+            ..Source::default()
+        });
+
+        assert_eq!(
+            row,
+            [
+                "github".to_string(),
+                "1.2.0".to_string(),
+                "bundled".to_string(),
+                "keychain".to_string(),
+            ]
+        );
+        assert_eq!(
+            unknown,
+            [
+                "custom".to_string(),
+                "-".to_string(),
+                "unknown".to_string(),
+                "none".to_string(),
+            ],
+            "unset enum values must render as words, not numbers"
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -856,14 +856,16 @@ async fn run_server(
     }
     println!("Coral gRPC server listening on {endpoint}");
     if let Some(address) = server.mcp_http_addr() {
-        let mcp_endpoint = format!("http://{address}/mcp");
+        // Each workspace is served at its own URL under this listener; the
+        // template is the endpoint story, since no single URL is one.
+        let mcp_endpoint = format!("http://{address}/mcp/workspace/{{workspace}}");
         if server_requires_security_warning(address) {
             eprintln!(
                 "{}",
                 mcp_http_exposure_warning(&mcp_endpoint, server.mcp_http_authentication_enabled())
             );
         }
-        println!("Coral MCP HTTP server listening on {mcp_endpoint}");
+        println!("Coral MCP HTTP server serving each workspace at {mcp_endpoint}");
     }
     println!("Connect clients with CORAL_ENDPOINT={endpoint}");
     println!("Press Ctrl-C to stop the server.");

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -804,8 +804,13 @@ async fn resolve_workspace(
     sole_membership_workspace(
         memberships
             .into_iter()
-            .map(|membership| membership.workspace.unwrap_or_default().name)
-            .collect(),
+            .map(|membership| {
+                membership
+                    .workspace
+                    .ok_or_else(|| anyhow::anyhow!("list workspaces response missing workspace"))
+                    .map(|workspace| workspace.name)
+            })
+            .collect::<Result<Vec<_>, _>>()?,
     )
 }
 
@@ -828,7 +833,11 @@ fn sole_membership_workspace(mut names: Vec<String>) -> Result<Workspace, CliErr
     } else {
         format!(
             "multiple workspaces are available ({}). Select one with `--workspace NAME` or `CORAL_WORKSPACE`.",
-            names.join(", ")
+            names
+                .iter()
+                .map(|name| name.escape_default().collect::<String>())
+                .collect::<Vec<_>>()
+                .join(", ")
         )
     };
     Err(CliError::WorkspaceSelection { message })

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -38,9 +38,9 @@ use coral_api::v1::{
 };
 use coral_app::{EngineExtensionsProvider, bootstrap::is_loopback_ip};
 use coral_client::{
-    AppClient, DEFAULT_WORKSPACE_ID, decode_execute_sql_response, format_batches_json,
-    format_batches_table, format_search_response_json, format_search_response_text,
-    manifest_input_from_proto, workspace as workspace_resource,
+    AppClient, decode_execute_sql_response, format_batches_json, format_batches_table,
+    format_search_response_json, format_search_response_text, manifest_input_from_proto,
+    workspace as workspace_resource,
 };
 use coral_mcp::{McpSurface, McpSurfaceProvider};
 use dialoguer::console::measure_text_width;
@@ -481,6 +481,12 @@ pub enum CliError {
         /// Normalized source name requested by the user.
         source_name: String,
     },
+    /// A workspace-scoped command ran without a workspace it could target.
+    #[error("{message}")]
+    WorkspaceSelection {
+        /// Guidance naming the action that makes the command runnable.
+        message: String,
+    },
     /// Any non-renderable internal command failure.
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
@@ -503,6 +509,7 @@ impl CliError {
             Self::SourceRemoveNotFound { source_name } => Some(format!(
                 "source '{source_name}' was not found. Run `coral source list` to see installed sources.\n"
             )),
+            Self::WorkspaceSelection { message } => Some(format!("{message}\n")),
             Self::Internal(_) => None,
         }
     }
@@ -530,16 +537,22 @@ impl Command {
     }
 
     fn uses_selected_workspace(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Command::Sql(_)
-                | Command::Search(_)
-                | Command::SearchIndex(_)
-                | Command::Source(_)
-                | Command::Function(_)
-                | Command::Onboard
-                | Command::McpStdio(_)
-        )
+            | Command::Search(_)
+            | Command::SearchIndex(_)
+            | Command::Function(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => true,
+            // Manifest lint validates a file on disk and never reaches a workspace.
+            Command::Source(args) => !matches!(args.command, SourceCommand::Lint { .. }),
+            Command::Workspace(_)
+            | Command::Features(_)
+            | Command::Completion(_)
+            | Command::Server => false,
+            #[cfg(feature = "embedded-ui")]
+            Command::Ui(_) => false,
+        }
     }
 
     fn apply_workspace_flag_presence(&mut self, present: bool) {
@@ -565,6 +578,7 @@ impl coral_app::RunErrorTelemetry for CliError {
             Self::SourceNotFound { .. } | Self::SourceRemoveNotFound { .. } => {
                 Cow::Borrowed("SOURCE_NOT_FOUND")
             }
+            Self::WorkspaceSelection { .. } => Cow::Borrowed("WORKSPACE_SELECTION"),
             Self::Internal(_) => Cow::Borrowed("INTERNAL"),
         }
     }
@@ -578,6 +592,7 @@ impl coral_app::RunErrorTelemetry for CliError {
             Self::SourceNotFound { source_name } | Self::SourceRemoveNotFound { source_name } => {
                 Cow::Owned(format!("source '{source_name}' was not found"))
             }
+            Self::WorkspaceSelection { message } => Cow::Borrowed(message.as_str()),
             Self::Internal(error) => Cow::Owned(error.to_string()),
         }
     }
@@ -663,11 +678,6 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
 
     match command.required_runtime() {
         RequiredRuntime::AppClient => {
-            let workspace = if command.uses_selected_workspace() {
-                selected_workspace(workspace_selection.workspace)
-            } else {
-                workspace_resource(DEFAULT_WORKSPACE_ID)
-            };
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
             let bootstrap = bootstrap::bootstrap(
                 bootstrap::BootstrapOptions {
@@ -679,25 +689,26 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
             .await
             .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
+            let cli_workspace = workspace_selection.workspace;
             let result = if is_mcp_stdio {
-                run_app_command(
+                run_selected_command(
                     app,
                     command,
                     Some(&ctx),
                     &feature_overrides,
-                    &workspace,
+                    cli_workspace,
                     mcp_surface_provider.as_deref(),
                 )
                 .await
             } else {
                 coral_app::run_with_context(
                     &ctx,
-                    Box::pin(run_app_command(
+                    Box::pin(run_selected_command(
                         app,
                         command,
                         None,
                         &feature_overrides,
-                        &workspace,
+                        cli_workspace,
                         mcp_surface_provider.as_deref(),
                     )),
                 )
@@ -723,14 +734,106 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
     }
 }
 
-fn selected_workspace(cli_workspace: Option<String>) -> Workspace {
-    workspace_resource(selected_workspace_name(cli_workspace, env::workspace()))
+/// Resolves the workspace a command targets, then runs it against the app.
+///
+/// Workspace management runs before any workspace exists, so it is dispatched
+/// without resolution; every other app-client command is workspace-scoped and
+/// fails here rather than reaching the server with a guessed name.
+async fn run_selected_command(
+    app: AppClient,
+    command: Command,
+    ctx: Option<&coral_app::RunContext>,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+    cli_workspace: Option<String>,
+    mcp_surface_provider: Option<&dyn McpSurfaceProvider>,
+) -> Result<(), CliError> {
+    if !command.uses_selected_workspace() {
+        return run_unscoped_app_command(&app, command).await;
+    }
+    if matches!(command, Command::Onboard) {
+        // A wizard without a terminal is unrunnable whatever workspace it would
+        // target, so report that before asking which workspace to resolve.
+        source_ops::require_interactive()?;
+    }
+    let workspace = resolve_workspace(&app, cli_workspace).await?;
+    run_app_command(
+        app,
+        command,
+        ctx,
+        feature_overrides,
+        &workspace,
+        mcp_surface_provider,
+    )
+    .await
 }
 
-fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<String>) -> String {
-    cli_workspace
-        .or_else(|| env_workspace.filter(|value| !value.is_empty()))
-        .unwrap_or_else(|| DEFAULT_WORKSPACE_ID.to_string())
+/// Runs the app-client commands that operate outside any workspace: workspace
+/// management, which has to work before one exists, and manifest lint, which
+/// only validates a file on disk.
+async fn run_unscoped_app_command(app: &AppClient, command: Command) -> Result<(), CliError> {
+    match command {
+        Command::Workspace(args) => run_workspace(app, args).await,
+        Command::Source(SourceArgs {
+            command: SourceCommand::Lint { file },
+        }) => {
+            source_ops::load_validated_manifest_file(&file)?;
+            println!("Manifest is valid");
+            Ok(())
+        }
+        _ => unreachable!("workspace-scoped commands resolve a workspace before dispatch"),
+    }
+}
+
+/// Resolves the workspace a scoped command runs against.
+///
+/// The CLI never invents workspace access: without an explicit selector the
+/// caller must hold exactly one membership, and every other outcome is reported
+/// with the action that resolves it instead of substituting a name.
+async fn resolve_workspace(
+    app: &AppClient,
+    cli_workspace: Option<String>,
+) -> Result<Workspace, CliError> {
+    if let Some(name) = explicit_workspace_name(cli_workspace, env::workspace()) {
+        return Ok(workspace_resource(name));
+    }
+    let memberships = app
+        .workspace_client()
+        .list_workspaces(Request::new(ListWorkspacesRequest {}))
+        .await
+        .map_err(anyhow::Error::from)?
+        .into_inner()
+        .memberships;
+    sole_membership_workspace(
+        memberships
+            .into_iter()
+            .map(|membership| membership.workspace.unwrap_or_default().name)
+            .collect(),
+    )
+}
+
+/// Returns the workspace name the caller selected explicitly, if any.
+fn explicit_workspace_name(
+    cli_workspace: Option<String>,
+    env_workspace: Option<String>,
+) -> Option<String> {
+    cli_workspace.or_else(|| env_workspace.filter(|value| !value.is_empty()))
+}
+
+/// Selects the caller's only workspace, or explains how to make the choice
+/// unambiguous.
+fn sole_membership_workspace(mut names: Vec<String>) -> Result<Workspace, CliError> {
+    if names.len() == 1 {
+        return Ok(workspace_resource(names.remove(0)));
+    }
+    let message = if names.is_empty() {
+        "no workspace is available. Run `coral workspace create NAME` to create one, or select an existing workspace with `--workspace NAME` or `CORAL_WORKSPACE`.".to_string()
+    } else {
+        format!(
+            "multiple workspaces are available ({}). Select one with `--workspace NAME` or `CORAL_WORKSPACE`.",
+            names.join(", ")
+        )
+    };
+    Err(CliError::WorkspaceSelection { message })
 }
 
 async fn run_server(
@@ -948,7 +1051,6 @@ async fn run_app_command(
         Command::Search(args) => run_search(&app, workspace, args).await?,
         Command::SearchIndex(args) => run_search_index(&app, workspace, args).await?,
         Command::Source(args) => run_source(&app, workspace, args).await?,
-        Command::Workspace(args) => run_workspace(&app, args).await?,
         Command::Function(args) => run_function(&app, workspace, args).await?,
         Command::Onboard => {
             onboard::run(&app, workspace).await?;
@@ -1009,6 +1111,9 @@ async fn run_app_command(
             ))
             .await
             .map_err(anyhow::Error::from)?;
+        }
+        Command::Workspace(_) => {
+            unreachable!("workspace management is routed without a selected workspace")
         }
         Command::Completion(_) | Command::Features(_) | Command::Server => {
             unreachable!("no-runtime commands are routed without an app client")
@@ -1165,9 +1270,8 @@ async fn run_source(
             source_ops::print_source_info(app, workspace, &name, verbose).await?;
         }
         SourceCommand::Add(args) => run_source_add(app, workspace, args).await?,
-        SourceCommand::Lint { file } => {
-            source_ops::load_validated_manifest_file(&file)?;
-            println!("Manifest is valid");
+        SourceCommand::Lint { .. } => {
+            unreachable!("manifest lint is routed without a selected workspace")
         }
         SourceCommand::Test { name } => {
             source_ops::test_and_print(
@@ -2099,31 +2203,91 @@ mod tests {
     }
 
     #[test]
-    fn selected_workspace_preserves_raw_name_for_app_validation() {
-        let workspace = super::selected_workspace(Some(" ../bad ".to_string()));
+    fn workspace_resolution_preserves_raw_explicit_name_for_app_validation() {
+        let name = super::explicit_workspace_name(Some(" ../bad ".to_string()), None);
 
-        assert_eq!(workspace.name, " ../bad ");
+        assert_eq!(name.as_deref(), Some(" ../bad "));
     }
 
     #[test]
-    fn selected_workspace_preserves_former_confirmation_marker() {
-        let workspace = super::selected_workspace_name(
+    fn workspace_resolution_preserves_former_confirmation_marker() {
+        let name = super::explicit_workspace_name(
             Some("__coral_current_workspace_confirmation__".to_string()),
             None,
         );
 
-        assert_eq!(workspace, "__coral_current_workspace_confirmation__");
+        assert_eq!(
+            name.as_deref(),
+            Some("__coral_current_workspace_confirmation__")
+        );
     }
 
     #[test]
-    fn selected_workspace_treats_empty_env_value_as_unset() {
-        let workspace = super::selected_workspace_name(None, Some(String::new()));
+    fn workspace_resolution_prefers_the_flag_over_the_environment() {
+        let name = super::explicit_workspace_name(
+            Some("flag".to_string()),
+            Some("environment".to_string()),
+        );
 
-        assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
+        assert_eq!(name.as_deref(), Some("flag"));
     }
 
     #[test]
-    fn only_workspace_scoped_commands_use_selected_workspace() {
+    fn workspace_resolution_uses_a_non_empty_environment_value() {
+        let name = super::explicit_workspace_name(None, Some("environment".to_string()));
+
+        assert_eq!(name.as_deref(), Some("environment"));
+    }
+
+    #[test]
+    fn workspace_resolution_treats_empty_env_value_as_unset() {
+        let name = super::explicit_workspace_name(None, Some(String::new()));
+
+        assert_eq!(
+            name, None,
+            "an empty selector must fall through to memberships"
+        );
+    }
+
+    #[test]
+    fn workspace_resolution_selects_a_sole_membership() {
+        let workspace = super::sole_membership_workspace(vec!["analytics".to_string()])
+            .expect("a single membership resolves without a selector");
+
+        assert_eq!(workspace.name, "analytics");
+    }
+
+    #[test]
+    fn workspace_resolution_without_memberships_explains_how_to_get_one() {
+        let error = super::sole_membership_workspace(Vec::new())
+            .expect_err("no membership must not resolve to a substituted name");
+
+        let rendered = error
+            .rendered_stderr()
+            .expect("workspace guidance is user-facing");
+        assert!(
+            rendered.contains("coral workspace create NAME") && rendered.contains("--workspace"),
+            "unexpected guidance: {rendered}"
+        );
+    }
+
+    #[test]
+    fn workspace_resolution_with_several_memberships_asks_for_an_explicit_name() {
+        let error =
+            super::sole_membership_workspace(vec!["analytics".to_string(), "sales".to_string()])
+                .expect_err("an ambiguous membership set must not be guessed");
+
+        let rendered = error
+            .rendered_stderr()
+            .expect("workspace guidance is user-facing");
+        assert!(
+            rendered.contains("analytics, sales") && rendered.contains("--workspace NAME"),
+            "unexpected guidance: {rendered}"
+        );
+    }
+
+    #[test]
+    fn workspace_resolution_skips_workspace_management_commands() {
         let sql = Cli::try_parse_from(["coral", "sql", "SELECT 1"]).expect("sql parses");
         let search =
             Cli::try_parse_from(["coral", "search", "github", "issues"]).expect("search parses");
@@ -2131,8 +2295,10 @@ mod tests {
         let functions =
             Cli::try_parse_from(["coral", "functions", "list"]).expect("functions parses");
         let onboard = Cli::try_parse_from(["coral", "onboard"]).expect("onboard parses");
-        let workspace =
-            Cli::try_parse_from(["coral", "workspace", "list"]).expect("workspace parses");
+        let list = Cli::try_parse_from(["coral", "workspace", "list"]).expect("workspace parses");
+        let create = Cli::try_parse_from(["coral", "workspace", "create", "analytics"])
+            .expect("workspace create parses");
+        let setup = Cli::try_parse_from(["coral", "features", "list"]).expect("features parses");
         let mcp = Cli::try_parse_from(["coral", "mcp-stdio"]).expect("mcp parses");
 
         assert!(sql.command.uses_selected_workspace());
@@ -2141,7 +2307,20 @@ mod tests {
         assert!(functions.command.uses_selected_workspace());
         assert!(onboard.command.uses_selected_workspace());
         assert!(mcp.command.uses_selected_workspace());
-        assert!(!workspace.command.uses_selected_workspace());
+        assert!(!list.command.uses_selected_workspace());
+        assert!(!create.command.uses_selected_workspace());
+        assert!(!setup.command.uses_selected_workspace());
+    }
+
+    #[test]
+    fn workspace_resolution_skips_manifest_lint_but_not_other_source_commands() {
+        let manifest_lint = Cli::try_parse_from(["coral", "source", "lint", "manifest.yaml"])
+            .expect("source lint parses");
+        let installed_sources =
+            Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
+
+        assert!(!manifest_lint.command.uses_selected_workspace());
+        assert!(installed_sources.command.uses_selected_workspace());
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -861,11 +861,13 @@ async fn run_server(
     if let Some(address) = server.mcp_http_addr() {
         // Each workspace is served at its own URL under this listener, mounted
         // under the configured base path — so the template comes from the
-        // running config rather than a hardcoded `/mcp`, which would name a
-        // path that 404s for any other base.
+        // running server rather than a hardcoded `/mcp`, which would name a
+        // path that 404s for any other base. A bound MCP HTTP listener always
+        // reports its template, so its absence is a wiring bug rather than a
+        // case to paper over with a fallback literal that could silently drift.
         let url_path = server
             .mcp_http_workspace_url_path()
-            .unwrap_or("/mcp/workspace/{workspace}");
+            .expect("a bound MCP HTTP listener reports its per-workspace URL template");
         let mcp_endpoint = format!("http://{address}{url_path}");
         if server_requires_security_warning(address) {
             eprintln!(

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -856,9 +856,14 @@ async fn run_server(
     }
     println!("Coral gRPC server listening on {endpoint}");
     if let Some(address) = server.mcp_http_addr() {
-        // Each workspace is served at its own URL under this listener; the
-        // template is the endpoint story, since no single URL is one.
-        let mcp_endpoint = format!("http://{address}/mcp/workspace/{{workspace}}");
+        // Each workspace is served at its own URL under this listener, mounted
+        // under the configured base path — so the template comes from the
+        // running config rather than a hardcoded `/mcp`, which would name a
+        // path that 404s for any other base.
+        let url_path = server
+            .mcp_http_workspace_url_path()
+            .unwrap_or("/mcp/workspace/{workspace}");
+        let mcp_endpoint = format!("http://{address}{url_path}");
         if server_requires_security_warning(address) {
             eprintln!(
                 "{}",

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -550,8 +550,6 @@ impl Command {
             | Command::Features(_)
             | Command::Completion(_)
             | Command::Server => false,
-            #[cfg(feature = "embedded-ui")]
-            Command::Ui(_) => false,
         }
     }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -838,11 +838,14 @@ async fn run_server(
     feature_overrides: coral_app::features::FeatureOverrides,
     extensions: CoralExtensions,
 ) -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_standalone_server(
+    // Boxed to keep this function's own future under clippy's large-future
+    // threshold: the composed server startup is by far the largest state it
+    // holds, so moving it to the heap keeps `run_server` small.
+    let server = Box::pin(bootstrap::start_standalone_server(
         feature_overrides,
         extensions.engine_providers,
         extensions.mcp_surface_provider,
-    )
+    ))
     .await?;
     let endpoint = server.endpoint_uri().to_string();
 

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -329,9 +329,7 @@ async fn start_mcp_http(
             bind_addr,
             public_url,
             authorization_server,
-            // The authenticated runtime does not carry the configured workspace
-            // yet; forwarding it into per-session admission is the next change.
-            workspace: _configured_workspace,
+            workspace,
         } => {
             let authenticator =
                 mcp_principal_provider.ok_or(McpStartError::MissingSessionProvider)?;
@@ -339,8 +337,23 @@ async fn start_mcp_http(
                 AuthenticatedMcpHttpConfig::new(bind_addr, public_url, authorization_server)?;
             let session_endpoint = grpc_endpoint_uri.clone();
             // One unauthenticated client, connected once and reused, drives every
-            // readiness probe; the gRPC health service answers without a bearer.
+            // readiness probe and nothing else. Deciding admission with it would
+            // list one deployment-wide set of workspaces for every caller, so the
+            // per-caller concealment admission exists to provide would be gone;
+            // the runtime's per-token client below is what admission reads.
             let readiness_client = AppClient::connect(&grpc_endpoint_uri).await?;
+            // The operator's selection scopes this surface the same way
+            // `auth_disabled_options` scopes the loopback one: it replaces
+            // whatever the caller carried, a written name is forwarded byte for
+            // byte, and naming none stays `None`. What the surfaces do with it
+            // differs downstream — here the MCP adapter admits a session only
+            // when the name is one of that caller's own memberships, so an
+            // unnamed surface refuses every session rather than resolving a
+            // workspace on somebody's behalf.
+            let options = McpOptions {
+                workspace: workspace.map(coral_client::workspace),
+                ..mcp_options
+            };
             let runtime = AuthenticatedMcpHttpRuntime::new(
                 move |token| {
                     let authenticator = Arc::clone(&authenticator);
@@ -361,7 +374,7 @@ async fn start_mcp_http(
                             .map_err(|_error| ())
                     }
                 },
-                mcp_options,
+                options,
                 move || {
                     let client = readiness_client.clone();
                     async move { probe_serving_health(&client).await }
@@ -396,6 +409,13 @@ fn auth_disabled_options(options: McpOptions, workspace: Option<String>) -> McpO
 /// server-side instead whether this instance can reach the database it serves
 /// out of, under its readiness service name so the aggregate liveness check
 /// stays a constant.
+///
+/// Twin of `ReadinessProbe::from_app` in `coral-mcp/src/http.rs`, which maps
+/// server readiness onto `/readyz` for the loopback surface. The mapping — ready,
+/// not-ready as `Unavailable`, the status code otherwise — is duplicated on
+/// purpose: only the surface-specific reasoning around it differs, and no shared
+/// helper reconstructs workspace access for a caller. Change one mapping and the
+/// other needs the same change, or the two `/readyz` surfaces drift apart.
 async fn probe_serving_health(client: &AppClient) -> Result<(), Code> {
     match client.check_engine_ready().await {
         Ok(true) => Ok(()),

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -307,14 +307,11 @@ async fn start_mcp_http(
     };
     let grpc_endpoint_uri = loopback_grpc_endpoint_uri(grpc_addr)?;
     let server = match settings {
-        // The configured workspace is not forwarded yet: the auth-disabled MCP
-        // adapter still resolves its own, so naming one here would have no
-        // effect until it accepts the selection.
         McpHttpServeConfig::AuthDisabled {
             bind_addr,
             expose_non_loopback,
             allowed_hosts,
-            workspace: _,
+            workspace,
         } => {
             // Configuration resolution only sets `expose_non_loopback` for a
             // non-loopback bind the operator opted into, so a loopback bind
@@ -326,7 +323,7 @@ async fn start_mcp_http(
             };
             let config = config.with_allowed_hosts(allowed_hosts)?;
             let app = AppClient::connect(&grpc_endpoint_uri).await?;
-            start_auth_disabled(config, app, mcp_options).await?
+            start_auth_disabled(config, app, auth_disabled_options(mcp_options, workspace)).await?
         }
         McpHttpServeConfig::Authenticated {
             bind_addr,
@@ -371,6 +368,21 @@ async fn start_mcp_http(
         }
     };
     Ok(Some(server))
+}
+
+/// Scopes the auth-disabled MCP surface to the workspace its configuration names.
+///
+/// The configuration is the operator's selection for this surface, so it
+/// replaces whatever the caller carried rather than merging with it: a name they
+/// wrote is forwarded byte for byte, and naming none stays `None`. Substituting
+/// a name for the absent case would be this adapter guessing at local
+/// membership state it does not read; the MCP adapter resolves it against the
+/// memberships behind the loopback connection instead.
+fn auth_disabled_options(options: McpOptions, workspace: Option<String>) -> McpOptions {
+    McpOptions {
+        workspace: workspace.map(coral_client::workspace),
+        ..options
+    }
 }
 
 /// Probes server readiness over the unauthenticated gRPC health service.

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -307,10 +307,14 @@ async fn start_mcp_http(
     };
     let grpc_endpoint_uri = loopback_grpc_endpoint_uri(grpc_addr)?;
     let server = match settings {
+        // The configured workspace is not forwarded yet: the auth-disabled MCP
+        // adapter still resolves its own, so naming one here would have no
+        // effect until it accepts the selection.
         McpHttpServeConfig::AuthDisabled {
             bind_addr,
             expose_non_loopback,
             allowed_hosts,
+            workspace: _,
         } => {
             // Configuration resolution only sets `expose_non_loopback` for a
             // non-loopback bind the operator opted into, so a loopback bind

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -3,8 +3,9 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 use coral_app::{
-    AuthServerError, CoralAuthorizationServer, McpHttpServeConfig, RunningCoralAuthorizationServer,
-    SessionAuthSettings, SessionPrincipalProvider,
+    AuthServerError, CanonicalOauthUrl, CoralAuthorizationServer, McpHttpServeConfig,
+    RunningCoralAuthorizationServer, SessionAuthSettings, SessionPrincipalProvider,
+    WorkspaceMcpUrls,
 };
 use coral_client::{
     AppClient, BearerToken, ClientError,
@@ -126,6 +127,7 @@ pub(crate) struct RunningServer {
     mcp_http: Option<RunningMcpHttpServer>,
     grpc_authentication_enabled: bool,
     mcp_http_authentication_enabled: bool,
+    mcp_http_workspace_url_path: Option<String>,
 }
 
 impl RunningServer {
@@ -135,6 +137,17 @@ impl RunningServer {
 
     pub(crate) fn mcp_http_addr(&self) -> Option<SocketAddr> {
         self.mcp_http.as_ref().map(RunningMcpHttpServer::local_addr)
+    }
+
+    /// The listener-relative per-workspace URL template, when MCP HTTP serves.
+    ///
+    /// The authenticated surface mounts the workspace family under the path of
+    /// its `public_url`, so a root public URL serves `/workspace/{workspace}`
+    /// and the usual `/mcp` base serves `/mcp/workspace/{workspace}`. The
+    /// auth-disabled surface has no public URL and always uses `/mcp`. Printing
+    /// a hardcoded path would name one that 404s for any other base.
+    pub(crate) fn mcp_http_workspace_url_path(&self) -> Option<&str> {
+        self.mcp_http_workspace_url_path.as_deref()
     }
 
     pub(crate) fn grpc_authentication_enabled(&self) -> bool {
@@ -163,6 +176,7 @@ impl RunningServer {
             mcp_http,
             grpc_authentication_enabled: _,
             mcp_http_authentication_enabled: _,
+            mcp_http_workspace_url_path: _,
         } = self;
         shutdown_components(grpc, oauth, mcp_http)
             .await
@@ -197,6 +211,7 @@ pub(crate) async fn start(
             )))
         })?;
     }
+    let mcp_http_workspace_url_path = mcp_config.as_ref().map(mcp_http_workspace_url_path);
     let (builder, mcp_principal_provider) =
         compose_session_policies(builder, session_auth, mcp_config.as_ref());
     // App startup owns the state database, so it also builds the authorization
@@ -241,7 +256,29 @@ pub(crate) async fn start(
         mcp_http,
         grpc_authentication_enabled,
         mcp_http_authentication_enabled,
+        mcp_http_workspace_url_path,
     })
+}
+
+/// The listener-relative per-workspace URL template a resolved MCP config serves.
+///
+/// The authenticated surface mounts the workspace family under its
+/// `public_url`'s path (a root URL → `/workspace/{workspace}`, `…/mcp` →
+/// `/mcp/workspace/{workspace}`); the auth-disabled surface has no public URL
+/// and always mounts under `/mcp`. The `public_url` was canonicalized during
+/// resolution, so parsing it here is idempotent — a failure would only mean the
+/// resolver changed, and the loopback template is a safe fallback for a print.
+fn mcp_http_workspace_url_path(config: &McpHttpServeConfig) -> String {
+    let base_path = match config {
+        McpHttpServeConfig::AuthDisabled { .. } => "/mcp".to_string(),
+        McpHttpServeConfig::Authenticated { public_url, .. } => {
+            CanonicalOauthUrl::parse(public_url).map_or_else(
+                |_| "/mcp".to_string(),
+                |base| WorkspaceMcpUrls::new(base).base_path().to_string(),
+            )
+        }
+    };
+    format!("{base_path}/workspace/{{workspace}}")
 }
 
 /// Installs the session policy each served surface enforces.

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -3,8 +3,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 use coral_app::{
-    AuthServerError, BearerAuthenticator, CoralAuthorizationServer, McpHttpServeConfig,
-    RunningCoralAuthorizationServer, SessionAuthSettings,
+    AuthServerError, CoralAuthorizationServer, McpHttpServeConfig, RunningCoralAuthorizationServer,
+    SessionAuthSettings, SessionPrincipalProvider,
 };
 use coral_client::{
     AppClient, BearerToken, ClientError,
@@ -248,22 +248,23 @@ pub(crate) async fn start(
 ///
 /// The two policies differ by design. The gRPC API is private — reached through
 /// the public surfaces in front of it — so it admits a token minted for any of
-/// them; handing the settings back to the builder is what installs that policy,
-/// alongside the authorization server app startup builds from them. MCP HTTP is
-/// a public surface and admits only its own audience, which is what stops a
-/// token minted for a sibling surface being replayed at it.
+/// them (including every per-workspace MCP resource); handing the settings back
+/// to the builder is what installs that policy, alongside the authorization
+/// server app startup builds from them. MCP HTTP admits only the exact audience
+/// of the workspace URL a request arrives at, so its authenticator takes the
+/// expected audience per call — which is what stops a bearer minted for one
+/// workspace being replayed at another's URL.
 fn compose_session_policies(
     builder: ServerBuilder,
     session_auth: Option<SessionAuthSettings>,
     mcp_config: Option<&McpHttpServeConfig>,
-) -> (ServerBuilder, Option<Arc<dyn BearerAuthenticator>>) {
+) -> (ServerBuilder, Option<Arc<SessionPrincipalProvider>>) {
     let Some(session_auth) = session_auth else {
         return (builder, None);
     };
     let mcp_authenticator = match mcp_config {
-        Some(McpHttpServeConfig::Authenticated { public_url, .. }) => {
-            Some(session_auth.principal_provider([public_url.clone()])
-                as Arc<dyn BearerAuthenticator>)
+        Some(McpHttpServeConfig::Authenticated { .. }) => {
+            Some(session_auth.mcp_route_authenticator())
         }
         _ => None,
     };
@@ -298,7 +299,7 @@ async fn shutdown_components(
 
 async fn start_mcp_http(
     settings: Option<McpHttpServeConfig>,
-    mcp_principal_provider: Option<Arc<dyn BearerAuthenticator>>,
+    mcp_principal_provider: Option<Arc<SessionPrincipalProvider>>,
     grpc_addr: SocketAddr,
     mcp_options: McpOptions,
 ) -> Result<Option<RunningMcpHttpServer>, McpStartError> {
@@ -311,7 +312,6 @@ async fn start_mcp_http(
             bind_addr,
             expose_non_loopback,
             allowed_hosts,
-            workspace,
         } => {
             // Configuration resolution only sets `expose_non_loopback` for a
             // non-loopback bind the operator opted into, so a loopback bind
@@ -323,13 +323,12 @@ async fn start_mcp_http(
             };
             let config = config.with_allowed_hosts(allowed_hosts)?;
             let app = AppClient::connect(&grpc_endpoint_uri).await?;
-            start_auth_disabled(config, app, auth_disabled_options(mcp_options, workspace)).await?
+            start_auth_disabled(config, app, mcp_options).await?
         }
         McpHttpServeConfig::Authenticated {
             bind_addr,
             public_url,
             authorization_server,
-            workspace,
         } => {
             let authenticator =
                 mcp_principal_provider.ok_or(McpStartError::MissingSessionProvider)?;
@@ -342,25 +341,15 @@ async fn start_mcp_http(
             // per-caller concealment admission exists to provide would be gone;
             // the runtime's per-token client below is what admission reads.
             let readiness_client = AppClient::connect(&grpc_endpoint_uri).await?;
-            // The operator's selection scopes this surface the same way
-            // `auth_disabled_options` scopes the loopback one: it replaces
-            // whatever the caller carried, a written name is forwarded byte for
-            // byte, and naming none stays `None`. What the surfaces do with it
-            // differs downstream — here the MCP adapter admits a session only
-            // when the name is one of that caller's own memberships, so an
-            // unnamed surface refuses every session rather than resolving a
-            // workspace on somebody's behalf.
-            let options = McpOptions {
-                workspace: workspace.map(coral_client::workspace),
-                ..mcp_options
-            };
+            // The workspace comes from each request's URL, so no workspace is
+            // composed into the surface's options — and the bearer check takes
+            // the route's exact resource as the expected audience per call.
             let runtime = AuthenticatedMcpHttpRuntime::new(
-                move |token| {
+                move |token, audience| {
                     let authenticator = Arc::clone(&authenticator);
                     async move {
                         authenticator
-                            .principal_for_bearer(&token)
-                            .await
+                            .principal_for_bearer_with_audience(&token, &audience)
                             .map(|_principal| ())
                             .map_err(|_error| ())
                     }
@@ -374,7 +363,7 @@ async fn start_mcp_http(
                             .map_err(|_error| ())
                     }
                 },
-                options,
+                mcp_options,
                 move || {
                     let client = readiness_client.clone();
                     async move { probe_serving_health(&client).await }
@@ -384,21 +373,6 @@ async fn start_mcp_http(
         }
     };
     Ok(Some(server))
-}
-
-/// Scopes the auth-disabled MCP surface to the workspace its configuration names.
-///
-/// The configuration is the operator's selection for this surface, so it
-/// replaces whatever the caller carried rather than merging with it: a name they
-/// wrote is forwarded byte for byte, and naming none stays `None`. Substituting
-/// a name for the absent case would be this adapter guessing at local
-/// membership state it does not read; the MCP adapter resolves it against the
-/// memberships behind the loopback connection instead.
-fn auth_disabled_options(options: McpOptions, workspace: Option<String>) -> McpOptions {
-    McpOptions {
-        workspace: workspace.map(coral_client::workspace),
-        ..options
-    }
 }
 
 /// Probes server readiness over the unauthenticated gRPC health service.

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -329,6 +329,9 @@ async fn start_mcp_http(
             bind_addr,
             public_url,
             authorization_server,
+            // The authenticated runtime does not carry the configured workspace
+            // yet; forwarding it into per-session admission is the next change.
+            workspace: _configured_workspace,
         } => {
             let authenticator =
                 mcp_principal_provider.ok_or(McpStartError::MissingSessionProvider)?;

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -191,6 +191,17 @@ impl RunningServer {
 /// enforces, happens here — where the transports' lifecycles are already owned.
 pub(crate) async fn start(
     builder: ServerBuilder,
+    mcp_options: McpOptions,
+    mcp_surface_provider: Option<Arc<dyn McpSurfaceProvider>>,
+) -> Result<RunningServer, ServeError> {
+    // Boxed so every caller stays under clippy's large-future threshold: the
+    // composed startup is by far the largest state this future would hold, so
+    // one box here spares a Box::pin at every call site.
+    Box::pin(start_inner(builder, mcp_options, mcp_surface_provider)).await
+}
+
+async fn start_inner(
+    builder: ServerBuilder,
     mut mcp_options: McpOptions,
     mcp_surface_provider: Option<Arc<dyn McpSurfaceProvider>>,
 ) -> Result<RunningServer, ServeError> {

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -27,6 +27,7 @@ const OAUTH_RESOURCE: &str = "http://localhost:1457";
 const SESSION_ISSUER: &str = "https://auth.example";
 const SESSION_RESOURCE: &str = "https://coral.example/mcp";
 const CORAL_UI_RESOURCE: &str = "https://coral-ui.example";
+const TEST_WORKSPACE_NAME: &str = "analytics";
 
 struct TestMcpProvider;
 
@@ -50,6 +51,20 @@ impl McpSurfaceProvider for UnexpectedMcpProvider {
 
 fn write_config(temp: &TempDir, config: &str) {
     std::fs::write(temp.path().join("config.toml"), config).expect("write config");
+}
+
+/// Writes an auth-disabled companion config naming the workspace MCP serves.
+///
+/// Naming it here rather than in the passed [`McpOptions`] is what makes the
+/// fixtures below exercise the composition: an operator's only way to scope this
+/// surface is `config.toml`.
+fn write_auth_disabled_config(temp: &TempDir, workspace: &str) {
+    write_config(
+        temp,
+        &format!(
+            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\nworkspace = '{workspace}'\n"
+        ),
+    );
 }
 
 fn write_oauth_config(temp: &TempDir, oauth_bind: SocketAddr, mcp_bind: Option<SocketAddr>) {
@@ -204,7 +219,7 @@ async fn assert_grpc_rejects_unauthenticated(endpoint: &str) {
 /// probes below assert on authentication, which is decided before the workspace
 /// is ever looked up.
 fn test_workspace() -> Workspace {
-    workspace("analytics")
+    workspace(TEST_WORKSPACE_NAME)
 }
 
 /// Creates [`test_workspace`] over the unauthenticated loopback gRPC endpoint.
@@ -477,21 +492,45 @@ fn shutdown_failures_retain_every_component_in_order() {
     );
 }
 
+/// The configured selection reaches the adapter unchanged, in both directions.
+///
+/// A name is forwarded byte for byte, and naming none stays none: substituting
+/// one for the absent case is the failure this guards, because the adapter can
+/// only resolve the sole local workspace while it can still tell that nobody
+/// chose. The remaining options are carried through untouched, so scoping the
+/// surface does not quietly reset the feature flags composed alongside it.
+#[test]
+fn auth_disabled_workspace_selection_is_forwarded_without_substitution() {
+    let composed = McpOptions {
+        feedback_enabled: true,
+        workspace: Some(workspace("carried-by-the-caller")),
+        ..McpOptions::default()
+    };
+
+    let named = auth_disabled_options(composed.clone(), Some(TEST_WORKSPACE_NAME.to_string()));
+    assert_eq!(named.workspace, Some(test_workspace()));
+    assert!(named.feedback_enabled);
+
+    let unnamed = auth_disabled_options(composed, None);
+    assert_eq!(
+        unnamed.workspace, None,
+        "an unnamed workspace must reach the adapter unresolved"
+    );
+    assert!(unnamed.feedback_enabled);
+}
+
+/// Also proves the configured workspace reaches the running MCP surface: the
+/// tools asserted here are workspace-scoped, and nothing but `config.toml` names
+/// the workspace they resolve against.
 #[tokio::test]
 async fn auth_disabled_companion_serves_and_shuts_down() {
     let temp = TempDir::new().expect("temp dir");
-    write_config(
-        &temp,
-        "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\n",
-    );
+    write_auth_disabled_config(&temp, TEST_WORKSPACE_NAME);
     let server = start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
-        McpOptions {
-            workspace: Some(test_workspace()),
-            ..McpOptions::default()
-        },
+        McpOptions::default(),
         Some(Arc::new(TestMcpProvider)),
     )
     .await
@@ -502,7 +541,8 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
     assert!(server.oauth_addr().is_none());
     // The tools this asserts are workspace-scoped, and nothing provisions a
-    // workspace any more, so the fixture creates the one it scopes MCP to.
+    // workspace any more, so the fixture creates the one the config scopes MCP
+    // to. Nothing else names it: composition carries it from `config.toml`.
     create_test_workspace(server.endpoint_uri()).await;
     assert_catalog_tool(format!("http://{mcp_addr}/mcp")).await;
     assert_cli_extension_filter(format!("http://{mcp_addr}/mcp")).await;
@@ -574,17 +614,13 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
 #[tokio::test]
 async fn companion_uses_supplied_mcp_options() {
     let temp = TempDir::new().expect("temp dir");
-    write_config(
-        &temp,
-        "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\n",
-    );
+    write_auth_disabled_config(&temp, TEST_WORKSPACE_NAME);
     let server = start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions {
             feedback_enabled: true,
-            workspace: Some(test_workspace()),
             ..McpOptions::default()
         },
         None,

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -164,15 +164,21 @@ async fn initialize_mcp(endpoint: &str, authorization: &str) -> reqwest::Respons
 /// The mirror of [`assert_unauthorized`], and it stops at the handshake because
 /// that is where authentication is decided: everything after it is
 /// workspace-scoped — even `tools/list`, which enumerates a workspace's table
-/// functions — so a caller holding no membership is legitimately refused there
-/// while its audience was accepted here. `coral-app`'s workspace authorization
-/// tests own the boundary behind it.
+/// functions — so `coral-app`'s workspace authorization tests own the boundary
+/// behind it.
+///
+/// An accepted audience is then refused a *session*: nothing names the
+/// workspace an authenticated surface serves, and binding one anyway would
+/// either hand back a session inert at the protocol layer or substitute a
+/// workspace the caller never asked for. The absent challenge is what tells
+/// that refusal apart from a refused audience, which is answered `401` and
+/// carries one.
 async fn assert_mcp_authenticated(endpoint: &str, token: &str) {
     let accepted = initialize_mcp(endpoint, &format!("Bearer {token}")).await;
-    assert!(
-        accepted.status().is_success(),
-        "an accepted audience must initialize an MCP session: {}",
-        accepted.status()
+    assert_eq!(
+        accepted.status(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "an accepted audience must pass authentication and be refused only its workspaceless session"
     );
     assert!(accepted.headers().get(WWW_AUTHENTICATE).is_none());
 }
@@ -214,10 +220,10 @@ async fn assert_grpc_rejects_unauthenticated(endpoint: &str) {
 
 /// The ordinary workspace these fixtures name.
 ///
-/// Nothing provisions a workspace any more, so naming one keeps these fixtures
-/// off the `DEFAULT_WORKSPACE_ID` fallback. Most call sites never create it: the
-/// probes below assert on authentication, which is decided before the workspace
-/// is ever looked up.
+/// Nothing provisions a workspace any more, and no helper reconstructs one, so
+/// these fixtures name the workspace they mean. Most call sites never create it:
+/// the probes below assert on authentication, which is decided before the
+/// workspace is ever looked up.
 fn test_workspace() -> Workspace {
     workspace(TEST_WORKSPACE_NAME)
 }

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -522,6 +522,7 @@ async fn unconsented_non_loopback_settings_fail_closed_in_serve() {
         bind_addr: SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 0)),
         expose_non_loopback: false,
         allowed_hosts: Vec::new(),
+        workspace: None,
     };
     let result = start_mcp_http(
         Some(settings),

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -28,6 +28,19 @@ const SESSION_ISSUER: &str = "https://auth.example";
 const SESSION_RESOURCE: &str = "https://coral.example/mcp";
 const CORAL_UI_RESOURCE: &str = "https://coral-ui.example";
 const TEST_WORKSPACE_NAME: &str = "analytics";
+const MCP_SESSION_ID: &str = "mcp-session-id";
+
+/// The authenticated MCP surface every session fixture below serves.
+///
+/// The fixtures differ from one another by the `workspace` key alone — the bind
+/// and the `public_url` that decides the accepted audience are this constant, so
+/// nothing but the operator's selection can move between them.
+const AUTHENTICATED_MCP_HTTP: &str = r"
+[server.mcp_http]
+enabled = true
+bind = '127.0.0.1:0'
+public_url = 'https://CORAL.example/mcp'
+";
 
 struct TestMcpProvider;
 
@@ -176,6 +189,21 @@ async fn initialize_mcp(endpoint: &str, authorization: &str) -> reqwest::Respons
 /// challenge is what tells that refusal apart from a refused audience, which is
 /// answered `401` and carries one.
 async fn assert_mcp_authenticated(endpoint: &str, token: &str) {
+    let guidance = mcp_refusal_guidance(endpoint, token).await;
+    assert!(
+        guidance.contains("no workspace configured"),
+        "an accepted audience must be refused only its workspaceless session: {guidance}"
+    );
+}
+
+/// Reads the guidance an accepted audience's refused handshake carries.
+///
+/// Every property that separates this refusal from an authentication one is
+/// asserted here rather than at the call sites, which then differ only in the
+/// guidance they expect: the audience passed authentication, so the answer is
+/// `200` with no challenge, and no session was opened for a caller who was not
+/// admitted to one.
+async fn mcp_refusal_guidance(endpoint: &str, token: &str) -> String {
     let accepted = initialize_mcp(endpoint, &format!("Bearer {token}")).await;
     assert_eq!(
         accepted.status(),
@@ -183,18 +211,19 @@ async fn assert_mcp_authenticated(endpoint: &str, token: &str) {
         "an accepted audience must pass authentication and be answered its handshake"
     );
     assert!(accepted.headers().get(WWW_AUTHENTICATE).is_none());
+    assert!(
+        accepted.headers().get(MCP_SESSION_ID).is_none(),
+        "a refused handshake must leave no session behind"
+    );
     let refusal = accepted
         .json::<serde_json::Value>()
         .await
         .expect("JSON-RPC handshake answer");
-    let guidance = refusal
+    refusal
         .pointer("/error/message")
         .and_then(serde_json::Value::as_str)
-        .unwrap_or_else(|| panic!("a refused handshake carries guidance: {refusal}"));
-    assert!(
-        guidance.contains("no workspace configured"),
-        "an accepted audience must be refused only its workspaceless session: {guidance}"
-    );
+        .unwrap_or_else(|| panic!("a refused handshake carries guidance: {refusal}"))
+        .to_string()
 }
 
 async fn assert_unauthorized(base: &str, authorization: &str) {
@@ -325,15 +354,19 @@ fn signed_session_token(
 }
 
 fn write_session_config(temp: &TempDir, signing_key: &[u8]) {
+    write_session_config_with_mcp(temp, signing_key, AUTHENTICATED_MCP_HTTP);
+}
+
+/// Writes the same authenticated companion, scoped to one named workspace.
+///
+/// The written config differs from [`write_session_config`]'s by exactly the
+/// `workspace` key, so a difference in how the surface answers a handshake can
+/// only come from that name having reached it.
+fn write_session_config_with_workspace(temp: &TempDir, signing_key: &[u8], workspace: &str) {
     write_session_config_with_mcp(
         temp,
         signing_key,
-        r"
-[server.mcp_http]
-enabled = true
-bind = '127.0.0.1:0'
-public_url = 'https://CORAL.example/mcp'
-",
+        &format!("{AUTHENTICATED_MCP_HTTP}workspace = '{workspace}'\n"),
     );
 }
 
@@ -809,6 +842,75 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         .shutdown()
         .await
         .expect("shutdown OAuth server");
+}
+
+/// The operator's workspace selection reaches the authenticated MCP surface.
+///
+/// Composition is the only thing under test: this fixture's config differs from
+/// the workspaceless one above by the `workspace` key alone, so the refusal is
+/// the one place a difference can show — and it does. Naming none is answered
+/// "no workspace configured"; naming `analytics` is answered the not-found
+/// guidance *for that name*. A composition that dropped the selection on its way
+/// from `config.toml` to the running surface would answer both handshakes with
+/// the first sentence, which is why the assertion is on which sentence comes
+/// back rather than on there being one.
+///
+/// The refusal also says which client decided it. Admission lists memberships on
+/// the caller's own bearer-bound connection; the unauthenticated loopback client
+/// this surface also holds authenticates as the local principal, which an
+/// authenticated deployment does not admit, so a listing made with it could only
+/// come back as `503`. `/readyz` is answered over that same unauthenticated
+/// client here, so it is present and working — it just decided nothing about a
+/// workspace.
+///
+/// A caller who *does* hold the configured membership needs a provisioned
+/// directory row, which only a completed login writes, so `coral-mcp`'s
+/// admission tests own the admitted case against a directory they can populate.
+#[tokio::test]
+async fn session_authenticated_companion_scopes_mcp_to_the_configured_workspace() {
+    let temp = TempDir::new().expect("temp dir");
+    let signing_key =
+        EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+            .expect("P-256 signing key");
+    write_session_config_with_workspace(&temp, signing_key.as_ref(), TEST_WORKSPACE_NAME);
+    let server = start(
+        ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(temp.path())
+            .with_noop_feedback_uploads(),
+        McpOptions::default(),
+    )
+    .await
+    .expect("start authenticated composite server");
+    let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
+    let base = format!("http://{mcp_addr}");
+
+    let ready = reqwest::get(format!("{base}/readyz"))
+        .await
+        .expect("readiness response");
+    assert_eq!(
+        ready.status(),
+        reqwest::StatusCode::NO_CONTENT,
+        "the unauthenticated client this surface holds serves readiness"
+    );
+
+    let token = session_token(signing_key.as_ref(), SESSION_RESOURCE);
+    // The same token is accepted on both surfaces, so what MCP answers below is
+    // an admission answer about a workspace rather than one about the token.
+    assert_grpc_authenticated(&server, &token).await;
+
+    let guidance = mcp_refusal_guidance(&format!("{base}/mcp"), &token).await;
+    assert!(
+        guidance.contains(&format!("Workspace `{TEST_WORKSPACE_NAME}` was not found")),
+        "the configured name must reach the surface and be the one it answers about: {guidance}"
+    );
+    assert!(
+        !guidance.contains("no workspace configured"),
+        "a surface an operator named a workspace must not report having none: {guidance}"
+    );
+
+    server.shutdown().await.expect("shutdown composite server");
+    let mcp_rebound = TcpListener::bind(mcp_addr).expect("MCP port must be released");
+    drop(mcp_rebound);
 }
 
 /// MCP HTTP is a public surface, so it admits only its own audience: a token

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -520,6 +520,45 @@ fn loopback_grpc_endpoint_maps_wildcards_and_rejects_public_addresses() {
     .expect_err("IPv4-mapped IPv6 address must be rejected");
 }
 
+/// The printed per-workspace URL template follows the served base path, so it
+/// never names a route that would 404 on the listener.
+///
+/// The auth-disabled surface has no public URL and always mounts under `/mcp`;
+/// the authenticated surface mounts under its `public_url`'s path, so a base
+/// with a non-`/mcp` path — the shape older docs recommended — must print that
+/// path rather than a hardcoded one.
+#[test]
+fn mcp_workspace_url_path_follows_the_served_base_path() {
+    let auth_disabled = McpHttpServeConfig::AuthDisabled {
+        bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        expose_non_loopback: false,
+        allowed_hosts: Vec::new(),
+    };
+    assert_eq!(
+        mcp_http_workspace_url_path(&auth_disabled),
+        "/mcp/workspace/{workspace}"
+    );
+
+    let authenticated = |public_url: &str| McpHttpServeConfig::Authenticated {
+        bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        public_url: public_url.to_string(),
+        authorization_server: "https://auth.example".to_string(),
+    };
+    assert_eq!(
+        mcp_http_workspace_url_path(&authenticated("https://mcp.example.com/mcp")),
+        "/mcp/workspace/{workspace}"
+    );
+    assert_eq!(
+        mcp_http_workspace_url_path(&authenticated("https://mcp.example.com")),
+        "/workspace/{workspace}",
+        "a root public_url mounts the family at the origin root"
+    );
+    assert_eq!(
+        mcp_http_workspace_url_path(&authenticated("https://mcp.example.com/base/mcp")),
+        "/base/mcp/workspace/{workspace}"
+    );
+}
+
 #[test]
 fn shutdown_failures_retain_every_component_in_order() {
     let failures = ShutdownFailures::from_results(
@@ -805,6 +844,7 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         mcp_http,
         grpc_authentication_enabled: _,
         mcp_http_authentication_enabled: _,
+        mcp_http_workspace_url_path: _,
     } = server;
     grpc.shutdown().await.expect("shutdown gRPC server");
     let unready = reqwest::get(format!("{base}/readyz"))

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -636,17 +636,17 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
     let temp = TempDir::new().expect("temp dir");
     write_config(
         &temp,
-        "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\n\
-         bind = '0.0.0.0:0'\nallow_unauthenticated_non_loopback = true\n",
+        &format!(
+            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\n\
+             bind = '0.0.0.0:0'\nallow_unauthenticated_non_loopback = true\n\
+             workspace = '{TEST_WORKSPACE_NAME}'\n"
+        ),
     );
     let server = start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
-        McpOptions {
-            workspace: Some(test_workspace()),
-            ..McpOptions::default()
-        },
+        McpOptions::default(),
         None,
     )
     .await

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -167,20 +167,34 @@ async fn initialize_mcp(endpoint: &str, authorization: &str) -> reqwest::Respons
 /// functions — so `coral-app`'s workspace authorization tests own the boundary
 /// behind it.
 ///
-/// An accepted audience is then refused a *session*: nothing names the
-/// workspace an authenticated surface serves, and binding one anyway would
-/// either hand back a session inert at the protocol layer or substitute a
-/// workspace the caller never asked for. The absent challenge is what tells
-/// that refusal apart from a refused audience, which is answered `401` and
-/// carries one.
+/// An accepted audience is then refused a *session*: this composition still
+/// names no workspace for the authenticated surface to serve, and binding one
+/// anyway would either hand back a session inert at the protocol layer or
+/// substitute a workspace the caller never asked for. The refusal answers the
+/// handshake itself, because the handshake is the only exchange here that is
+/// not workspace-scoped and so the only one that can carry guidance. The absent
+/// challenge is what tells that refusal apart from a refused audience, which is
+/// answered `401` and carries one.
 async fn assert_mcp_authenticated(endpoint: &str, token: &str) {
     let accepted = initialize_mcp(endpoint, &format!("Bearer {token}")).await;
     assert_eq!(
         accepted.status(),
-        reqwest::StatusCode::SERVICE_UNAVAILABLE,
-        "an accepted audience must pass authentication and be refused only its workspaceless session"
+        reqwest::StatusCode::OK,
+        "an accepted audience must pass authentication and be answered its handshake"
     );
     assert!(accepted.headers().get(WWW_AUTHENTICATE).is_none());
+    let refusal = accepted
+        .json::<serde_json::Value>()
+        .await
+        .expect("JSON-RPC handshake answer");
+    let guidance = refusal
+        .pointer("/error/message")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("a refused handshake carries guidance: {refusal}"));
+    assert!(
+        guidance.contains("no workspace configured"),
+        "an accepted audience must be refused only its workspaceless session: {guidance}"
+    );
 }
 
 async fn assert_unauthorized(base: &str, authorization: &str) {

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -601,8 +601,8 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
     assert!(server.oauth_addr().is_none());
     // The tools this asserts are workspace-scoped, and nothing provisions a
-    // workspace any more, so the fixture creates the one the config scopes MCP
-    // to. Nothing else names it: composition carries it from `config.toml`.
+    // workspace any more, so the fixture creates the one the dialed URL names.
+    // Nothing in config selects it: the workspace is named only by the URL path.
     create_test_workspace(server.endpoint_uri()).await;
     assert_catalog_tool(format!("http://{mcp_addr}{}", ws_path(TEST_WORKSPACE_NAME))).await;
     assert_cli_extension_filter(format!("http://{mcp_addr}{}", ws_path(TEST_WORKSPACE_NAME))).await;

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -25,16 +25,25 @@ const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","param
 const OAUTH_ISSUER: &str = "http://localhost:9080";
 const OAUTH_RESOURCE: &str = "http://localhost:1457";
 const SESSION_ISSUER: &str = "https://auth.example";
-const SESSION_RESOURCE: &str = "https://coral.example/mcp";
+/// The canonical base of the per-workspace MCP resources the session fixtures
+/// serve; [`SESSION_RESOURCE`] is [`TEST_WORKSPACE_NAME`]'s member of that
+/// family — the audience a token must carry to be valid at its URL.
+const SESSION_BASE: &str = "https://coral.example/mcp";
+const SESSION_RESOURCE: &str = "https://coral.example/mcp/workspace/analytics";
 const CORAL_UI_RESOURCE: &str = "https://coral-ui.example";
 const TEST_WORKSPACE_NAME: &str = "analytics";
 const MCP_SESSION_ID: &str = "mcp-session-id";
 
+/// The listener-relative MCP URL of one workspace.
+fn ws_path(name: &str) -> String {
+    format!("/mcp/workspace/{name}")
+}
+
 /// The authenticated MCP surface every session fixture below serves.
 ///
-/// The fixtures differ from one another by the `workspace` key alone — the bind
-/// and the `public_url` that decides the accepted audience are this constant, so
-/// nothing but the operator's selection can move between them.
+/// The bind and the `public_url` whose per-workspace family decides the
+/// accepted audiences are this constant; which workspace a request is about is
+/// its URL's to say.
 const AUTHENTICATED_MCP_HTTP: &str = r"
 [server.mcp_http]
 enabled = true
@@ -66,17 +75,14 @@ fn write_config(temp: &TempDir, config: &str) {
     std::fs::write(temp.path().join("config.toml"), config).expect("write config");
 }
 
-/// Writes an auth-disabled companion config naming the workspace MCP serves.
+/// Writes an auth-disabled companion config.
 ///
-/// Naming it here rather than in the passed [`McpOptions`] is what makes the
-/// fixtures below exercise the composition: an operator's only way to scope this
-/// surface is `config.toml`.
-fn write_auth_disabled_config(temp: &TempDir, workspace: &str) {
+/// No workspace is named anywhere: the surface serves every existing workspace
+/// at its own URL, so the fixtures scope a session by the URL they dial.
+fn write_auth_disabled_config(temp: &TempDir) {
     write_config(
         temp,
-        &format!(
-            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\nworkspace = '{workspace}'\n"
-        ),
+        "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\n",
     );
 }
 
@@ -180,19 +186,17 @@ async fn initialize_mcp(endpoint: &str, authorization: &str) -> reqwest::Respons
 /// functions — so `coral-app`'s workspace authorization tests own the boundary
 /// behind it.
 ///
-/// An accepted audience is then refused a *session*: this composition still
-/// names no workspace for the authenticated surface to serve, and binding one
-/// anyway would either hand back a session inert at the protocol layer or
-/// substitute a workspace the caller never asked for. The refusal answers the
-/// handshake itself, because the handshake is the only exchange here that is
-/// not workspace-scoped and so the only one that can carry guidance. The absent
-/// challenge is what tells that refusal apart from a refused audience, which is
-/// answered `401` and carries one.
-async fn assert_mcp_authenticated(endpoint: &str, token: &str) {
+/// An accepted audience is then refused *membership*: nothing in these
+/// fixtures provisions a directory row for the caller (only a completed login
+/// writes one), so admission's concealed not-found for the URL's workspace is
+/// exactly what proves the token passed authentication and the URL's name
+/// reached admission. The absent challenge is what tells that refusal apart
+/// from a refused audience, which is answered `401` and carries one.
+async fn assert_mcp_authenticated(endpoint: &str, token: &str, workspace: &str) {
     let guidance = mcp_refusal_guidance(endpoint, token).await;
     assert!(
-        guidance.contains("no workspace configured"),
-        "an accepted audience must be refused only its workspaceless session: {guidance}"
+        guidance.contains(&format!("Workspace `{workspace}` was not found")),
+        "an accepted audience must be refused only its membership: {guidance}"
     );
 }
 
@@ -227,7 +231,11 @@ async fn mcp_refusal_guidance(endpoint: &str, token: &str) -> String {
 }
 
 async fn assert_unauthorized(base: &str, authorization: &str) {
-    let rejected = initialize_mcp(&format!("{base}/mcp"), authorization).await;
+    let rejected = initialize_mcp(
+        &format!("{base}{}", ws_path(TEST_WORKSPACE_NAME)),
+        authorization,
+    )
+    .await;
     assert_eq!(rejected.status(), reqwest::StatusCode::UNAUTHORIZED);
     assert_eq!(
         rejected.headers().get_all(WWW_AUTHENTICATE).iter().count(),
@@ -357,19 +365,6 @@ fn write_session_config(temp: &TempDir, signing_key: &[u8]) {
     write_session_config_with_mcp(temp, signing_key, AUTHENTICATED_MCP_HTTP);
 }
 
-/// Writes the same authenticated companion, scoped to one named workspace.
-///
-/// The written config differs from [`write_session_config`]'s by exactly the
-/// `workspace` key, so a difference in how the surface answers a handshake can
-/// only come from that name having reached it.
-fn write_session_config_with_workspace(temp: &TempDir, signing_key: &[u8], workspace: &str) {
-    write_session_config_with_mcp(
-        temp,
-        signing_key,
-        &format!("{AUTHENTICATED_MCP_HTTP}workspace = '{workspace}'\n"),
-    );
-}
-
 fn write_coral_ui_only_session_config(temp: &TempDir, signing_key: &[u8]) {
     write_session_config_with_mcp(temp, signing_key, "");
 }
@@ -437,7 +432,7 @@ async fn assert_grpc_authenticated(server: &RunningServer, token: &str) {
 
 async fn assert_authenticated_surfaces(server: &RunningServer, mcp_endpoint: &str, token: &str) {
     assert_grpc_authenticated(server, token).await;
-    assert_mcp_authenticated(mcp_endpoint, token).await;
+    assert_mcp_authenticated(mcp_endpoint, token, TEST_WORKSPACE_NAME).await;
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -545,40 +540,13 @@ fn shutdown_failures_retain_every_component_in_order() {
     );
 }
 
-/// The configured selection reaches the adapter unchanged, in both directions.
-///
-/// A name is forwarded byte for byte, and naming none stays none: substituting
-/// one for the absent case is the failure this guards, because the adapter can
-/// only resolve the sole local workspace while it can still tell that nobody
-/// chose. The remaining options are carried through untouched, so scoping the
-/// surface does not quietly reset the feature flags composed alongside it.
-#[test]
-fn auth_disabled_workspace_selection_is_forwarded_without_substitution() {
-    let composed = McpOptions {
-        feedback_enabled: true,
-        workspace: Some(workspace("carried-by-the-caller")),
-        ..McpOptions::default()
-    };
-
-    let named = auth_disabled_options(composed.clone(), Some(TEST_WORKSPACE_NAME.to_string()));
-    assert_eq!(named.workspace, Some(test_workspace()));
-    assert!(named.feedback_enabled);
-
-    let unnamed = auth_disabled_options(composed, None);
-    assert_eq!(
-        unnamed.workspace, None,
-        "an unnamed workspace must reach the adapter unresolved"
-    );
-    assert!(unnamed.feedback_enabled);
-}
-
-/// Also proves the configured workspace reaches the running MCP surface: the
-/// tools asserted here are workspace-scoped, and nothing but `config.toml` names
+/// Also proves the URL's workspace reaches the running MCP surface: the tools
+/// asserted here are workspace-scoped, and nothing but the dialed URL names
 /// the workspace they resolve against.
 #[tokio::test]
 async fn auth_disabled_companion_serves_and_shuts_down() {
     let temp = TempDir::new().expect("temp dir");
-    write_auth_disabled_config(&temp, TEST_WORKSPACE_NAME);
+    write_auth_disabled_config(&temp);
     let server = start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
@@ -597,8 +565,8 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     // workspace any more, so the fixture creates the one the config scopes MCP
     // to. Nothing else names it: composition carries it from `config.toml`.
     create_test_workspace(server.endpoint_uri()).await;
-    assert_catalog_tool(format!("http://{mcp_addr}/mcp")).await;
-    assert_cli_extension_filter(format!("http://{mcp_addr}/mcp")).await;
+    assert_catalog_tool(format!("http://{mcp_addr}{}", ws_path(TEST_WORKSPACE_NAME))).await;
+    assert_cli_extension_filter(format!("http://{mcp_addr}{}", ws_path(TEST_WORKSPACE_NAME))).await;
     server.shutdown().await.expect("shutdown composite server");
     let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC port must be released");
     let mcp_rebound = TcpListener::bind(mcp_addr).expect("MCP port must be released");
@@ -615,7 +583,6 @@ async fn unconsented_non_loopback_settings_fail_closed_in_serve() {
         bind_addr: SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 0)),
         expose_non_loopback: false,
         allowed_hosts: Vec::new(),
-        workspace: None,
     };
     let result = start_mcp_http(
         Some(settings),
@@ -636,11 +603,8 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
     let temp = TempDir::new().expect("temp dir");
     write_config(
         &temp,
-        &format!(
-            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\n\
-             bind = '0.0.0.0:0'\nallow_unauthenticated_non_loopback = true\n\
-             workspace = '{TEST_WORKSPACE_NAME}'\n"
-        ),
+        "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\n\
+         bind = '0.0.0.0:0'\nallow_unauthenticated_non_loopback = true\n",
     );
     let server = start(
         ServerBuilder::configured_standalone_grpc()
@@ -660,14 +624,14 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
     // The tools this asserts are workspace-scoped, and nothing provisions a
     // workspace any more, so the fixture creates the one it scopes MCP to.
     create_test_workspace(server.endpoint_uri()).await;
-    assert_catalog_tool(format!("http://{dial}/mcp")).await;
+    assert_catalog_tool(format!("http://{dial}{}", ws_path(TEST_WORKSPACE_NAME))).await;
     server.shutdown().await.expect("shutdown composite server");
 }
 
 #[tokio::test]
 async fn companion_uses_supplied_mcp_options() {
     let temp = TempDir::new().expect("temp dir");
-    write_auth_disabled_config(&temp, TEST_WORKSPACE_NAME);
+    write_auth_disabled_config(&temp);
     let server = start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
@@ -684,7 +648,7 @@ async fn companion_uses_supplied_mcp_options() {
     // `tools/list` enumerates the workspace's table functions, so it needs the
     // workspace MCP is scoped to actually exist.
     create_test_workspace(server.endpoint_uri()).await;
-    assert_feedback_tool(format!("http://{mcp_addr}/mcp")).await;
+    assert_feedback_tool(format!("http://{mcp_addr}{}", ws_path(TEST_WORKSPACE_NAME))).await;
     server.shutdown().await.expect("shutdown composite server");
 }
 
@@ -787,28 +751,47 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         .await
         .expect("readiness response");
     assert_eq!(ready.status(), reqwest::StatusCode::NO_CONTENT);
-    let advertised = reqwest::get(format!("{base}/.well-known/oauth-protected-resource/mcp"))
-        .await
-        .expect("metadata response")
-        .json::<serde_json::Value>()
-        .await
-        .expect("metadata document");
+    // Metadata is served per workspace, at the path-inserted well-known URL of
+    // the workspace's own resource; the base's metadata path names no
+    // workspace and is gone.
+    let advertised = reqwest::get(format!(
+        "{base}/.well-known/oauth-protected-resource/mcp/workspace/{TEST_WORKSPACE_NAME}"
+    ))
+    .await
+    .expect("metadata response")
+    .json::<serde_json::Value>()
+    .await
+    .expect("metadata document");
     let resource = advertised
         .get("resource")
         .and_then(serde_json::Value::as_str)
         .expect("advertised resource")
         .to_string();
-    assert_eq!(resource, "https://coral.example/mcp");
+    assert_eq!(resource, SESSION_RESOURCE);
+    let retired_base = reqwest::get(format!("{base}/.well-known/oauth-protected-resource/mcp"))
+        .await
+        .expect("base metadata response");
+    assert_eq!(retired_base.status(), reqwest::StatusCode::NOT_FOUND);
 
     assert_unauthorized(&base, "Bearer wrong-token").await;
 
     let wrong_audience = session_token(signing_key.as_ref(), "https://other.example/mcp");
     assert_unauthorized(&base, &format!("Bearer {wrong_audience}")).await;
 
+    // The base itself is no longer an audience: a token minted for it dies at
+    // every workspace URL, exactly like any other wrong audience.
+    let base_audience = session_token(signing_key.as_ref(), SESSION_BASE);
+    assert_unauthorized(&base, &format!("Bearer {base_audience}")).await;
+
     assert_grpc_rejects_unauthenticated(server.endpoint_uri()).await;
 
     let token = session_token(signing_key.as_ref(), &resource);
-    assert_authenticated_surfaces(&server, &format!("{base}/mcp"), &token).await;
+    assert_authenticated_surfaces(
+        &server,
+        &format!("{base}{}", ws_path(TEST_WORKSPACE_NAME)),
+        &token,
+    )
+    .await;
 
     let coral_ui_token = session_token(signing_key.as_ref(), CORAL_UI_RESOURCE);
     assert_grpc_authenticated(&server, &coral_ui_token).await;
@@ -844,40 +827,33 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         .expect("shutdown OAuth server");
 }
 
-/// The operator's workspace selection reaches the authenticated MCP surface.
+/// The URL's workspace reaches the authenticated MCP surface, and the refusal
+/// is the concealed not-found *for that URL's own name*.
 ///
-/// Composition is the only thing under test: this fixture's config differs from
-/// the workspaceless one above by the `workspace` key alone, so the refusal is
-/// the one place a difference can show — and it does. Naming none is answered
-/// "no workspace configured"; naming `analytics` is answered the not-found
-/// guidance *for that name*. A composition that dropped the selection on its way
-/// from `config.toml` to the running surface would answer both handshakes with
-/// the first sentence, which is why the assertion is on which sentence comes
-/// back rather than on there being one.
+/// Two handshakes with valid per-workspace tokens differ only in the workspace
+/// their URL (and audience) names; neither is among the caller's memberships
+/// (only a completed login writes a membership row), and the two answers are
+/// identical once the names are substituted — through the running server, not
+/// a mocked directory. Admission never asks whether a name exists globally, so
+/// nothing else about the names could change the answer.
 ///
-/// The refusal also says which client decided it. Admission lists memberships on
-/// the caller's own bearer-bound connection; the unauthenticated loopback client
-/// this surface also holds authenticates as the local principal, which an
-/// authenticated deployment does not admit, so a listing made with it could only
-/// come back as `503`. `/readyz` is answered over that same unauthenticated
-/// client here, so it is present and working — it just decided nothing about a
-/// workspace.
-///
-/// A caller who *does* hold the configured membership needs a provisioned
-/// directory row, which only a completed login writes, so `coral-mcp`'s
-/// admission tests own the admitted case against a directory they can populate.
+/// The refusal also says which client decided it. Admission lists memberships
+/// on the caller's own bearer-bound connection; the unauthenticated loopback
+/// client this surface also holds serves `/readyz` only, which is asserted
+/// working right beside the refusals it must have played no part in.
 #[tokio::test]
-async fn session_authenticated_companion_scopes_mcp_to_the_configured_workspace() {
+async fn session_authenticated_companion_scopes_mcp_to_the_urls_workspace() {
     let temp = TempDir::new().expect("temp dir");
     let signing_key =
         EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
             .expect("P-256 signing key");
-    write_session_config_with_workspace(&temp, signing_key.as_ref(), TEST_WORKSPACE_NAME);
+    write_session_config(&temp, signing_key.as_ref());
     let server = start(
         ServerBuilder::configured_standalone_grpc()
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        None,
     )
     .await
     .expect("start authenticated composite server");
@@ -898,14 +874,27 @@ async fn session_authenticated_companion_scopes_mcp_to_the_configured_workspace(
     // an admission answer about a workspace rather than one about the token.
     assert_grpc_authenticated(&server, &token).await;
 
-    let guidance = mcp_refusal_guidance(&format!("{base}/mcp"), &token).await;
+    let existing =
+        mcp_refusal_guidance(&format!("{base}{}", ws_path(TEST_WORKSPACE_NAME)), &token).await;
     assert!(
-        guidance.contains(&format!("Workspace `{TEST_WORKSPACE_NAME}` was not found")),
-        "the configured name must reach the surface and be the one it answers about: {guidance}"
+        existing.contains(&format!("Workspace `{TEST_WORKSPACE_NAME}` was not found")),
+        "the URL's name must reach admission and be the one it answers about: {existing}"
     );
+
+    let ghost_token = session_token(
+        signing_key.as_ref(),
+        "https://coral.example/mcp/workspace/ghost",
+    );
+    let ghost = mcp_refusal_guidance(&format!("{base}{}", ws_path("ghost")), &ghost_token).await;
     assert!(
-        !guidance.contains("no workspace configured"),
-        "a surface an operator named a workspace must not report having none: {guidance}"
+        ghost.contains("Workspace `ghost` was not found"),
+        "guidance: {ghost}"
+    );
+    assert_eq!(
+        existing.replace(TEST_WORKSPACE_NAME, "{ws}"),
+        ghost.replace("ghost", "{ws}"),
+        "an existing workspace the caller does not hold and one never created \
+         must be refused with the same sentence"
     );
 
     server.shutdown().await.expect("shutdown composite server");
@@ -913,16 +902,17 @@ async fn session_authenticated_companion_scopes_mcp_to_the_configured_workspace(
     drop(mcp_rebound);
 }
 
-/// MCP HTTP is a public surface, so it admits only its own audience: a token
-/// minted for a sibling surface must not be replayable at it.
+/// MCP HTTP admits only the exact audience of the workspace URL a request
+/// arrives at: a token minted for a sibling surface, or for a *different
+/// workspace's* URL, must not be replayable there.
 ///
 /// This asserts on the authenticator the running MCP surface is handed, composed
 /// from an on-disk config by the same function `start` calls, and starts the
 /// server that composition configured. The regression it guards is `coral serve`
 /// handing MCP the private API's full audience allowlist, which would let a
-/// token minted for the BFF be presented here.
+/// token minted for the BFF — or any workspace — be presented anywhere.
 #[tokio::test]
-async fn session_auth_composes_an_mcp_only_audience_for_mcp() {
+async fn session_auth_composes_a_route_exact_audience_for_mcp() {
     let temp = TempDir::new().expect("temp dir");
     let signing_key =
         EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
@@ -944,13 +934,26 @@ async fn session_auth_composes_an_mcp_only_audience_for_mcp() {
     );
 
     mcp_authenticator
-        .principal_for_bearer(&session_token(signing_key.as_ref(), SESSION_RESOURCE))
-        .await
-        .expect("token minted for the MCP surface");
+        .principal_for_bearer_with_audience(
+            &session_token(signing_key.as_ref(), SESSION_RESOURCE),
+            SESSION_RESOURCE,
+        )
+        .expect("token minted for exactly this workspace's URL");
     mcp_authenticator
-        .principal_for_bearer(&session_token(signing_key.as_ref(), CORAL_UI_RESOURCE))
-        .await
+        .principal_for_bearer_with_audience(
+            &session_token(signing_key.as_ref(), CORAL_UI_RESOURCE),
+            SESSION_RESOURCE,
+        )
         .expect_err("MCP must refuse a token minted for a sibling surface");
+    mcp_authenticator
+        .principal_for_bearer_with_audience(
+            &session_token(
+                signing_key.as_ref(),
+                "https://coral.example/mcp/workspace/other",
+            ),
+            SESSION_RESOURCE,
+        )
+        .expect_err("a bearer for one workspace must die at another's URL");
 
     grpc.shutdown()
         .await
@@ -1037,8 +1040,9 @@ async fn session_failures_and_restart_are_fail_closed() {
     .await
     .expect("start authenticated composite server");
     let mcp_endpoint = format!(
-        "http://{}/mcp",
-        server.mcp_http_addr().expect("MCP HTTP endpoint")
+        "http://{}{}",
+        server.mcp_http_addr().expect("MCP HTTP endpoint"),
+        ws_path(TEST_WORKSPACE_NAME)
     );
 
     let expired_rejection = assert_bearer_rejected(&server, &mcp_endpoint, &expired).await;
@@ -1063,8 +1067,9 @@ async fn session_failures_and_restart_are_fail_closed() {
     .await
     .expect("restart authenticated composite server");
     let restarted_mcp = format!(
-        "http://{}/mcp",
-        restarted.mcp_http_addr().expect("restarted MCP endpoint")
+        "http://{}{}",
+        restarted.mcp_http_addr().expect("restarted MCP endpoint"),
+        ws_path(TEST_WORKSPACE_NAME)
     );
     assert_authenticated_surfaces(&restarted, &restarted_mcp, &valid).await;
     restarted.shutdown().await.expect("restarted shutdown");

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -386,6 +386,189 @@ async fn workspace_remove_sends_request() {
     server.shutdown().await;
 }
 
+// ---------------------------------------------------------------------------
+// Workspace resolution
+//
+// The resolver's own unit tests can only see the values handed to it. These
+// spawn the real binary, so the flag, the environment variable, the process
+// exit status, and the request that does or does not reach the server are all
+// part of what is asserted.
+// ---------------------------------------------------------------------------
+
+fn workspaces(names: &[&str]) -> MockServerConfig {
+    MockServerConfig::default().with_list_workspaces(ListWorkspacesResponse {
+        memberships: names
+            .iter()
+            .map(|name| membership(name, WorkspaceRole::Owner))
+            .collect(),
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_without_memberships_names_the_actions_that_fix_it() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .args(["sql", "select 1 as value"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("coral workspace create NAME")
+            && stderr.contains("--workspace NAME")
+            && stderr.contains("CORAL_WORKSPACE"),
+        "expected guidance naming every way to obtain a workspace: {stderr}"
+    );
+    assert!(
+        server.execute_sql_requests().is_empty(),
+        "a command with no workspace must not reach the server with a guessed name"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_selects_the_sole_membership() {
+    let server = MockServer::start_with_config(workspaces(&["only-work"])).await;
+
+    server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .args(["sql", "select 1 as value"])
+        .assert()
+        .success();
+
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 1, "expected one execute_sql call");
+    assert_workspace_name(requests[0].workspace.as_ref(), "only-work");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_refuses_to_choose_between_memberships() {
+    let server = MockServer::start_with_config(workspaces(&[TEST_WORKSPACE, "work"])).await;
+
+    let assert = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .args(["sql", "select 1 as value"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("analytics, work") && stderr.contains("--workspace NAME"),
+        "expected the candidates and how to pick one: {stderr}"
+    );
+    assert!(
+        server.execute_sql_requests().is_empty(),
+        "an ambiguous membership set must not be resolved by picking one"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_prefers_the_flag_over_every_other_source() {
+    let server = MockServer::start_with_config(workspaces(&["only-work"])).await;
+
+    server
+        .cmd()
+        .env("CORAL_WORKSPACE", "env-work")
+        .args(["--workspace", "flag-work", "sql", "select 1 as value"])
+        .assert()
+        .success();
+
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 1, "expected one execute_sql call");
+    assert_workspace_name(requests[0].workspace.as_ref(), "flag-work");
+    assert!(
+        server.list_workspaces_requests().is_empty(),
+        "an explicit selection must not consult memberships"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_honors_a_non_empty_environment_value() {
+    let server = MockServer::start_with_config(workspaces(&["only-work"])).await;
+
+    server
+        .cmd()
+        .env("CORAL_WORKSPACE", "env-work")
+        .args(["sql", "select 1 as value"])
+        .assert()
+        .success();
+
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 1, "expected one execute_sql call");
+    assert_workspace_name(requests[0].workspace.as_ref(), "env-work");
+    assert!(
+        server.list_workspaces_requests().is_empty(),
+        "an explicit selection must not consult memberships"
+    );
+
+    server.shutdown().await;
+}
+
+/// An empty variable is how a shell reports one that was never set, so it has
+/// to fall through to the membership rather than travel to the server as a
+/// workspace named "".
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_treats_an_empty_environment_value_as_unset() {
+    let server = MockServer::start_with_config(workspaces(&["only-work"])).await;
+
+    server
+        .cmd()
+        .env("CORAL_WORKSPACE", "")
+        .args(["sql", "select 1 as value"])
+        .assert()
+        .success();
+
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 1, "expected one execute_sql call");
+    assert_workspace_name(requests[0].workspace.as_ref(), "only-work");
+
+    server.shutdown().await;
+}
+
+/// A name the caller typed is sent as typed: the command has to fail on the
+/// server's own not-found answer, never on a workspace the CLI substituted.
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_sends_an_explicit_missing_name_unchanged() {
+    let server = MockServer::start_with_config(
+        workspaces(&[TEST_WORKSPACE])
+            .with_execute_sql_error(Code::NotFound, "workspace 'ghost' was not found"),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["--workspace", "ghost", "sql", "select 1 as value"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("workspace 'ghost' was not found"),
+        "expected the server's not-found error: {stderr}"
+    );
+    let requests = server.execute_sql_requests();
+    assert_eq!(requests.len(), 1, "expected one execute_sql call");
+    assert_workspace_name(requests[0].workspace.as_ref(), "ghost");
+    assert!(
+        server.list_workspaces_requests().is_empty(),
+        "a missing explicit name must not fall back to the caller's memberships"
+    );
+
+    server.shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn source_list_renders_configured_sources() {
     let server = MockServer::start().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -66,12 +66,12 @@ use tonic_types::{ErrorDetail, StatusExt as _};
 
 /// The ordinary workspace every fixture selects explicitly.
 ///
-/// Nothing provisions a workspace any more, so a fixture that names no
-/// workspace would fall through to `selected_workspace_name`'s
-/// `DEFAULT_WORKSPACE_ID` fallback — which still exists, is exercised only by
-/// its own resolver unit test, and is itself due for removal. Fixtures
-/// therefore select this name through the ordinary `CORAL_WORKSPACE` selector
-/// (see [`MockServer::cmd`]) rather than leaning on that fallback.
+/// The CLI no longer substitutes a name for the caller who gives none: without
+/// a selector it resolves the caller's sole membership, and this mock lists
+/// none by default, so an unselected fixture would fail workspace selection
+/// before reaching the RPC it means to exercise. Fixtures therefore select this
+/// name through the ordinary `CORAL_WORKSPACE` selector (see
+/// [`MockServer::cmd`]), which is also the path a real user takes.
 pub(crate) const TEST_WORKSPACE: &str = "analytics";
 
 fn workspace() -> Workspace {

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -776,6 +776,81 @@ async fn assert_workspace_initialize_instructions(
     Ok(())
 }
 
+/// `--workspace` is covered above; `CORAL_WORKSPACE` reaches the MCP session
+/// only through the environment of the spawned process, so nothing short of
+/// spawning it can show that the selection survives the handoff.
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_resolution_env_scopes_the_spawned_mcp_stdio_process()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
+        ListSourcesResponse {
+            sources: vec![source_fixture("work", "linear")],
+        },
+    ))
+    .await;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("mcp-stdio")
+        .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env("CORAL_CONFIG_DIR", server.config_dir())
+        .env("CORAL_WORKSPACE", "work")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("mcp stdio stdin");
+    let stdout = child.stdout.take().expect("mcp stdio stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    write_jsonrpc_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "coral-cli-workspace-env-stdio-test",
+                    "version": "0.0.0"
+                }
+            }
+        }),
+    )
+    .await?;
+    let initialize = read_jsonrpc_response(&mut stdout, 1).await?;
+    let instructions = initialize
+        .pointer("/result/instructions")
+        .and_then(Value::as_str)
+        .expect("initialize response should include instructions");
+    assert!(
+        instructions.contains("Current Coral workspace: work."),
+        "the environment selection should scope the MCP session: {instructions}"
+    );
+
+    let list_sources_requests = server.list_sources_requests();
+    assert!(
+        !list_sources_requests.is_empty(),
+        "expected at least one list_sources call"
+    );
+    for request in &list_sources_requests {
+        assert_workspace_name(request.workspace.as_ref(), "work");
+    }
+    assert!(
+        server.list_workspaces_requests().is_empty(),
+        "an explicit selection must not consult memberships"
+    );
+
+    drop(stdin);
+    if timeout(Duration::from_secs(5), child.wait()).await.is_err() {
+        child.start_kill()?;
+        child.wait().await?;
+    }
+    server.shutdown().await;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -22,9 +22,10 @@ use harness::MockServer;
 /// The ordinary workspace this suite targets explicitly.
 ///
 /// Mirrors `harness::TEST_WORKSPACE`, which the filesystem-only test below
-/// cannot import because the harness is `cli-test-server`-gated. Nothing provisions
-/// a workspace any more, so naming one here keeps these fixtures off the CLI's
-/// `DEFAULT_WORKSPACE_ID` resolver fallback.
+/// cannot import because the harness is `cli-test-server`-gated. The CLI
+/// resolves an unselected workspace from the caller's memberships rather than
+/// substituting a name, so these fixtures name one instead of leaving the
+/// command to resolve against a membership set they do not control.
 const TEST_WORKSPACE: &str = "analytics";
 
 #[test]

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -30,17 +30,6 @@ use crate::propagation::{
     AUTHORIZATION_METADATA_KEY, BearerToken, ClientMetadataInterceptor, StaticClientMetadata,
 };
 
-/// Default workspace used by local Coral clients.
-pub use coral_api::DEFAULT_WORKSPACE_ID;
-
-#[must_use]
-/// Returns the default workspace used by local Coral clients.
-pub fn default_workspace() -> Workspace {
-    Workspace {
-        name: DEFAULT_WORKSPACE_ID.to_string(),
-    }
-}
-
 #[must_use]
 /// Returns a workspace resource with the provided name.
 pub fn workspace(name: impl Into<String>) -> Workspace {

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -41,9 +41,8 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, FunctionClient,
-    HealthCheckClient, QueryClient, SearchClient, SourceClient, TaskClient, UserClient,
-    WorkspaceClient, default_workspace, workspace,
+    AppClient, CatalogClient, FeedbackClient, FunctionClient, HealthCheckClient, QueryClient,
+    SearchClient, SourceClient, TaskClient, UserClient, WorkspaceClient, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::{BearerToken, with_task_metadata};

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -24,7 +24,8 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
 use coral_api::v1::ListWorkspacesRequest;
 use coral_app::{
-    CanonicalOauthUrl, McpWorkspaceSegment, OauthUrlError, WORKSPACE_ROUTE_SEGMENT, WorkspaceMcpUrls,
+    CanonicalOauthUrl, McpWorkspaceSegment, OauthUrlError, WORKSPACE_ROUTE_SEGMENT,
+    WorkspaceMcpUrls,
 };
 use coral_client::{AppClient, workspace as workspace_proto};
 use futures::{Stream, StreamExt as _};

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -104,6 +104,15 @@ enum SessionAuthorization {
 struct AuthenticatedSessions {
     records: RwLock<HashMap<SessionId, AuthenticatedSession>>,
     config: SessionConfig,
+    /// The session-admission budget, deliberately **server-global** rather than
+    /// per workspace: adding workspace URLs must not multiply the listener's
+    /// effective session-capacity limit, so every workspace on this listener
+    /// draws from the one pool. A single member can therefore hold the whole
+    /// budget — that is the intended cap, not an isolation gap, and partitioning
+    /// it per workspace would let N workspaces multiply capacity N-fold. The
+    /// permit is reserved before the bearer-bound membership listing so the same
+    /// budget also bounds concurrent admission work, and a refused handshake
+    /// releases it immediately.
     admission: Arc<Semaphore>,
 }
 

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -22,8 +22,9 @@ use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
+use coral_api::v1::ListWorkspacesRequest;
 use coral_app::{CanonicalOauthUrl, OauthUrlError};
-use coral_client::AppClient;
+use coral_client::{AppClient, workspace as workspace_resource};
 use futures::{Stream, StreamExt as _};
 use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ServerJsonRpcMessage};
 use rmcp::transport::{
@@ -49,6 +50,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore, oneshot};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
+use tonic::Request as GrpcRequest;
 use tower::ServiceExt;
 use url::{Position, Url};
 
@@ -532,6 +534,14 @@ pub enum McpHttpError {
         "no workspace is available for the local MCP server. Create one with `coral workspace create NAME`, then name it in `server.mcp_http.workspace`."
     )]
     NoLocalWorkspace,
+    /// Nothing names a workspace and the local user belongs to several.
+    #[error(
+        "several workspaces are available ({0}). Name the one the local MCP server serves in `server.mcp_http.workspace`."
+    )]
+    AmbiguousLocalWorkspace(String),
+    /// The membership listing that resolves the local workspace failed.
+    #[error("failed to list the local workspaces the MCP server could serve")]
+    LocalWorkspaceLookup(#[source] tonic::Status),
     /// The TCP listener could not bind.
     #[error("failed to bind MCP HTTP server to {address}")]
     Bind {
@@ -632,14 +642,16 @@ fn join_server(
 ///
 /// # Errors
 ///
-/// Returns [`McpHttpError`] if the surface has no resolved workspace to serve
-/// or the listener cannot bind.
+/// Returns [`McpHttpError`] if no workspace can be resolved for the surface or
+/// if the listener cannot bind. Resolution runs first so an unservable
+/// configuration is reported without ever holding the port.
 pub async fn start_auth_disabled(
     config: McpHttpConfig,
     app: AppClient,
     options: McpOptions,
 ) -> Result<RunningMcpHttpServer, McpHttpError> {
     options.surface.validate(options.feedback_enabled)?;
+    let options = resolve_local_workspace(&app, options).await?;
     let listener = TcpListener::bind(config.bind_addr())
         .await
         .map_err(|source| McpHttpError::Bind {
@@ -661,6 +673,53 @@ pub async fn start_auth_disabled(
         router,
         state.server.clone(),
     ))
+}
+
+/// Scopes the loopback surface to a workspace the local user actually holds.
+///
+/// A configured name is authoritative and is used byte for byte: composition
+/// already validated its shape, and whether a workspace by that name exists is
+/// answered by the request that needs it, under the ordinary not-found
+/// contract. That keeps a surface configured today servable for a workspace
+/// created tomorrow.
+///
+/// With nothing configured the local user must hold exactly one workspace.
+/// Zero and several are different problems — one person has nothing to serve,
+/// the other has not said which — so they are reported as different errors
+/// naming the action that resolves each, rather than settled by picking one.
+async fn resolve_local_workspace(
+    app: &AppClient,
+    options: McpOptions,
+) -> Result<McpOptions, McpHttpError> {
+    if options.workspace.is_some() {
+        return Ok(options);
+    }
+    let mut names = local_workspace_names(app).await?;
+    if names.len() != 1 {
+        return Err(if names.is_empty() {
+            McpHttpError::NoLocalWorkspace
+        } else {
+            McpHttpError::AmbiguousLocalWorkspace(names.join(", "))
+        });
+    }
+    Ok(McpOptions {
+        workspace: Some(workspace_resource(names.remove(0))),
+        ..options
+    })
+}
+
+/// Names the workspaces the local user belongs to, in listing order.
+async fn local_workspace_names(app: &AppClient) -> Result<Vec<String>, McpHttpError> {
+    Ok(app
+        .workspace_client()
+        .list_workspaces(GrpcRequest::new(ListWorkspacesRequest {}))
+        .await
+        .map_err(McpHttpError::LocalWorkspaceLookup)?
+        .into_inner()
+        .memberships
+        .into_iter()
+        .map(|membership| membership.workspace.unwrap_or_default().name)
+        .collect())
 }
 
 /// Starts authenticated serving; fails when the listener cannot bind.

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -52,7 +52,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tower::ServiceExt;
 use url::{Position, Url};
 
-use crate::{CoralMcpServerFactory, McpOptions};
+use crate::{CoralMcpServerFactory, McpOptions, server::WorkspaceRequired};
 
 /// How long `/readyz` waits on the gRPC readiness probe before answering itself.
 ///
@@ -527,6 +527,11 @@ pub enum McpHttpError {
     /// MCP HTTP serving configuration is invalid.
     #[error("invalid MCP HTTP configuration: {0}")]
     InvalidAuthConfig(&'static str),
+    /// Nothing names a workspace and the local user belongs to none.
+    #[error(
+        "no workspace is available for the local MCP server. Create one with `coral workspace create NAME`, then name it in `server.mcp_http.workspace`."
+    )]
+    NoLocalWorkspace,
     /// The TCP listener could not bind.
     #[error("failed to bind MCP HTTP server to {address}")]
     Bind {
@@ -627,7 +632,8 @@ fn join_server(
 ///
 /// # Errors
 ///
-/// Returns [`McpHttpError`] if the listener cannot bind.
+/// Returns [`McpHttpError`] if the surface has no resolved workspace to serve
+/// or the listener cannot bind.
 pub async fn start_auth_disabled(
     config: McpHttpConfig,
     app: AppClient,
@@ -648,7 +654,7 @@ pub async fn start_auth_disabled(
         readiness,
         local_addr.ip(),
         &config.extra_allowed_hosts,
-    );
+    )?;
     Ok(spawn_http_server(
         listener,
         local_addr,
@@ -742,14 +748,20 @@ impl ReadinessProbe {
     }
 }
 
+/// Builds the loopback router around one workspace-scoped session factory.
+///
+/// The workspace must already be resolved: `HttpState` holds the factory
+/// outright, so a router that could be built without one would serve sessions
+/// with no workspace to reach.
 fn auth_disabled_router(
     app: AppClient,
     options: McpOptions,
     readiness: ReadinessProbe,
     advertised_ip: IpAddr,
     extra_allowed_hosts: &[String],
-) -> (Router, Arc<HttpState>) {
-    let factory = CoralMcpServerFactory::new(app, options);
+) -> Result<(Router, Arc<HttpState>), McpHttpError> {
+    let factory = CoralMcpServerFactory::new(app, options)
+        .map_err(|WorkspaceRequired| McpHttpError::NoLocalWorkspace)?;
     // These are the same loopback names the authenticated listener accepts, so
     // a client dialing `localhost` is not rejected for the bind being
     // `127.0.0.1`. The allowlist stays exact beyond that baseline: it is the
@@ -780,7 +792,7 @@ fn auth_disabled_router(
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
         .with_state(state.clone());
-    (router, state)
+    Ok((router, state))
 }
 
 struct HttpState {
@@ -984,6 +996,13 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
     serve_mcp_request(request, factory, sessions, state.server.config.clone()).await
 }
 
+/// Builds the bearer-bound session factory admitted for one initialize request.
+///
+/// A session is refused when the runtime names no workspace. Admitting one
+/// anyway would hand back a session that is inert at the protocol layer —
+/// `tools/list` enumerates the workspace's table functions, so it is itself
+/// workspace-scoped — and the only way to make it answer would be to substitute
+/// a workspace the caller never asked for.
 async fn create_session_factory(
     state: &AuthenticatedHttpState,
     token: String,
@@ -993,10 +1012,8 @@ async fn create_session_factory(
         () = state.server.config.cancellation_token.cancelled() => Err(StatusCode::SERVICE_UNAVAILABLE),
         client = (state.runtime.session_client_factory)(token) => client.map_err(|()| StatusCode::SERVICE_UNAVAILABLE),
     }?;
-    Ok(CoralMcpServerFactory::new(
-        client,
-        state.runtime.options.clone(),
-    ))
+    CoralMcpServerFactory::new(client, state.runtime.options.clone())
+        .map_err(|WorkspaceRequired| StatusCode::SERVICE_UNAVAILABLE)
 }
 
 async fn authorize_bound_session(

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -23,7 +23,9 @@ use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, heade
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
 use coral_api::v1::ListWorkspacesRequest;
-use coral_app::{CanonicalOauthUrl, McpWorkspaceSegment, OauthUrlError, WorkspaceMcpUrls};
+use coral_app::{
+    CanonicalOauthUrl, McpWorkspaceSegment, OauthUrlError, WORKSPACE_ROUTE_SEGMENT, WorkspaceMcpUrls,
+};
 use coral_client::{AppClient, workspace as workspace_proto};
 use futures::{Stream, StreamExt as _};
 use rmcp::model::{
@@ -72,7 +74,13 @@ const METADATA_ROUTE: &str = "/.well-known/oauth-protected-resource/{*resource_p
 /// The auth-disabled listener has no public URL to derive a mount from, so its
 /// workspace routes live under the fixed `/mcp` prefix.
 const AUTH_DISABLED_MCP_PREFIX: &str = "/mcp";
-const AUTH_DISABLED_MCP_WORKSPACE_ROUTE: &str = "/mcp/workspace/{workspace}";
+
+/// The axum route template the auth-disabled listener mounts its workspaces at,
+/// `/mcp/workspace/{workspace}`, with the segment derived from
+/// [`WORKSPACE_ROUTE_SEGMENT`] so it cannot drift from the authenticated surface.
+fn auth_disabled_mcp_workspace_route() -> String {
+    format!("{AUTH_DISABLED_MCP_PREFIX}/{WORKSPACE_ROUTE_SEGMENT}/{{workspace}}")
+}
 /// What an unmatched path is told, in place of a bare not-found.
 ///
 /// The sentence is static on purpose: it names the URL shape — public
@@ -493,7 +501,10 @@ impl AuthenticatedMcpHttpConfig {
     /// the public URL's path so the served paths match the advertised URLs
     /// without any ingress rewriting.
     fn mcp_route(&self) -> String {
-        format!("{}/workspace/{{workspace}}", self.urls.base_path())
+        format!(
+            "{}/{WORKSPACE_ROUTE_SEGMENT}/{{workspace}}",
+            self.urls.base_path()
+        )
     }
 }
 
@@ -847,7 +858,7 @@ fn auth_disabled_router(
         server: server.clone(),
     });
     let router = Router::new()
-        .route(AUTH_DISABLED_MCP_WORKSPACE_ROUTE, any(mcp))
+        .route(&auth_disabled_mcp_workspace_route(), any(mcp))
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
         .fallback(not_an_mcp_endpoint)
@@ -1028,7 +1039,12 @@ async fn evict_deleted_workspaces(
 
 /// Parses `<prefix>/workspace/<segment>` from a raw request path.
 fn parse_workspace_route(path: &str, prefix: &str) -> Option<McpWorkspaceSegment> {
-    McpWorkspaceSegment::parse(path.strip_prefix(prefix)?.strip_prefix("/workspace/")?)
+    McpWorkspaceSegment::parse(
+        path.strip_prefix(prefix)?
+            .strip_prefix('/')?
+            .strip_prefix(WORKSPACE_ROUTE_SEGMENT)?
+            .strip_prefix('/')?,
+    )
 }
 
 /// Answers every path that is not an MCP endpoint on this listener.

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -721,15 +721,21 @@ pub async fn start_auth_disabled(
 /// The listing is scoped to whoever the client authenticates as, so which
 /// client this is asked with is the whole of the answer's meaning.
 async fn membership_workspace_names(app: &AppClient) -> Result<Vec<String>, tonic::Status> {
-    Ok(app
-        .workspace_client()
+    app.workspace_client()
         .list_workspaces(GrpcRequest::new(ListWorkspacesRequest {}))
         .await?
         .into_inner()
         .memberships
         .into_iter()
-        .map(|membership| membership.workspace.unwrap_or_default().name)
-        .collect())
+        .map(|membership| {
+            membership
+                .workspace
+                .ok_or_else(|| {
+                    tonic::Status::internal("list workspaces response missing workspace")
+                })
+                .map(|workspace| workspace.name)
+        })
+        .collect()
 }
 
 /// Starts authenticated serving; fails when the listener cannot bind.

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -977,6 +977,12 @@ async fn admit_local_workspace(
         return Err(StatusCode::NOT_FOUND.into_response());
     }
     let mut workspaces = state.workspaces.write().await;
+    // The listing above is the whole local inventory, so any cached entry whose
+    // workspace is gone from it and holds no live sessions is dead weight. Drop
+    // it here so repeated create/delete cycles cannot grow this map for the
+    // process's lifetime; a deleted workspace whose sessions are still draining
+    // keeps its entry until they close.
+    evict_deleted_workspaces(&mut workspaces, &names).await;
     if let Some(entry) = workspaces.get(workspace) {
         return Ok((entry.factory.clone(), entry.sessions.clone()));
     }
@@ -995,6 +1001,29 @@ async fn admit_local_workspace(
         },
     );
     Ok((factory, sessions))
+}
+
+/// Drops cached workspace entries that no longer exist and hold no sessions.
+///
+/// `existing` is the caller's full local workspace inventory. An entry whose
+/// name is absent from it names a deleted workspace; if that entry also has no
+/// live session it is safe to remove, since a later handshake for the same
+/// name rebuilds the factory from scratch. An entry with live sessions is kept
+/// so those sessions keep draining against the workspace they opened on.
+async fn evict_deleted_workspaces(
+    workspaces: &mut HashMap<McpWorkspaceSegment, WorkspaceSessions>,
+    existing: &[String],
+) {
+    let mut stale = Vec::new();
+    for (name, entry) in workspaces.iter() {
+        let still_exists = existing.iter().any(|existing| existing == name.as_str());
+        if !still_exists && entry.sessions.sessions.read().await.is_empty() {
+            stale.push(name.clone());
+        }
+    }
+    for name in stale {
+        workspaces.remove(&name);
+    }
 }
 
 /// Parses `<prefix>/workspace/<segment>` from a raw request path.

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -23,8 +23,8 @@ use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, heade
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
 use coral_api::v1::ListWorkspacesRequest;
-use coral_app::{CanonicalOauthUrl, OauthUrlError};
-use coral_client::{AppClient, workspace as workspace_resource};
+use coral_app::{CanonicalOauthUrl, McpWorkspaceSegment, OauthUrlError, WorkspaceMcpUrls};
+use coral_client::{AppClient, workspace as workspace_proto};
 use futures::{Stream, StreamExt as _};
 use rmcp::model::{
     ClientJsonRpcMessage, ClientRequest, ErrorData, RequestId, ServerJsonRpcMessage,
@@ -54,7 +54,6 @@ use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request as GrpcRequest;
 use tower::ServiceExt;
-use url::{Position, Url};
 
 use crate::{CoralMcpServerFactory, McpOptions, server::WorkspaceRequired};
 
@@ -70,13 +69,25 @@ const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(1);
 const SESSION_ID_HEADER: &str = "mcp-session-id";
 const METADATA_ROOT: &str = "/.well-known/oauth-protected-resource";
 const METADATA_ROUTE: &str = "/.well-known/oauth-protected-resource/{*resource_path}";
+/// The auth-disabled listener has no public URL to derive a mount from, so its
+/// workspace routes live under the fixed `/mcp` prefix.
+const AUTH_DISABLED_MCP_PREFIX: &str = "/mcp";
+const AUTH_DISABLED_MCP_WORKSPACE_ROUTE: &str = "/mcp/workspace/{workspace}";
+/// What an unmatched path is told, in place of a bare not-found.
+///
+/// The sentence is static on purpose: it names the URL shape — public
+/// information every startup summary and document states — and never a
+/// workspace, so it discloses nothing a concealed refusal hides. The legacy
+/// `/mcp` endpoint lands here too; this is its entire deprecation notice.
+const WORKSPACE_URL_HINT: &str = "Each workspace is served at its own MCP URL ending in /workspace/{workspace}. Check the URL with your workspace owner.";
 const MAX_MCP_REQUEST_BODY_SIZE: usize = 1_048_576;
 const MAX_AUTHENTICATED_SESSIONS: usize = 4096;
 const AUTHENTICATED_SESSION_IDLE_TIMEOUT: Duration = Duration::from_hours(1);
 
 type ProbeFuture = Pin<Box<dyn Future<Output = Result<(), tonic::Code>> + Send>>;
 type Fut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-type TokenValidator = Arc<dyn Fn(String) -> Fut<Result<(), ()>> + Send + Sync>;
+/// Validates one bearer token for one exact audience — the route's resource.
+type TokenValidator = Arc<dyn Fn(String, String) -> Fut<Result<(), ()>> + Send + Sync>;
 type SessionClientFactory = Arc<dyn Fn(String) -> Fut<Result<AppClient, ()>> + Send + Sync>;
 type AuthState = Arc<AuthenticatedHttpState>;
 
@@ -97,6 +108,12 @@ struct AuthenticatedSessions {
 }
 
 struct AuthenticatedSession {
+    /// The workspace whose URL opened this session.
+    ///
+    /// Checked before the bearer binding: a session presented at another
+    /// workspace's URL does not exist there, whatever credential arrives with
+    /// it, so the answer is the same not-found an unknown session gets.
+    workspace: McpWorkspaceSegment,
     fingerprint: BearerFingerprint,
     handle: LocalSessionHandle,
     _admission_permit: OwnedSemaphorePermit,
@@ -104,6 +121,7 @@ struct AuthenticatedSession {
 
 struct AuthenticatedSessionManager {
     sessions: Arc<AuthenticatedSessions>,
+    workspace: McpWorkspaceSegment,
     fingerprint: BearerFingerprint,
     admission_permit: Mutex<Option<OwnedSemaphorePermit>>,
 }
@@ -138,12 +156,19 @@ impl AuthenticatedSessions {
     async fn authorize(
         &self,
         session_id: &SessionId,
+        workspace: &McpWorkspaceSegment,
         fingerprint: &BearerFingerprint,
     ) -> SessionAuthorization {
         let records = self.records.read().await;
         let Some(session) = records.get(session_id) else {
             return SessionAuthorization::Missing;
         };
+        // Workspace first, deliberately: at the wrong workspace's URL the
+        // session does not exist, even for a bearer that is valid there, so a
+        // cross-workspace replay is indistinguishable from an unknown session.
+        if session.workspace != *workspace {
+            return SessionAuthorization::Missing;
+        }
         if session.fingerprint == *fingerprint {
             SessionAuthorization::Authorized
         } else {
@@ -194,6 +219,10 @@ async fn close_session_handle(handle: LocalSessionHandle) -> Result<(), LocalSes
 }
 
 impl AuthenticatedSessionManager {
+    fn owns(&self, session: &AuthenticatedSession) -> bool {
+        session.workspace == self.workspace && session.fingerprint == self.fingerprint
+    }
+
     async fn session_handle(
         &self,
         session_id: &SessionId,
@@ -203,7 +232,7 @@ impl AuthenticatedSessionManager {
             .read()
             .await
             .get(session_id)
-            .filter(|session| session.fingerprint == self.fingerprint)
+            .filter(|session| self.owns(session))
             .map(|session| session.handle.clone())
             .ok_or_else(|| LocalSessionManagerError::SessionNotFound(session_id.clone()).into())
     }
@@ -227,6 +256,7 @@ impl SessionManager for AuthenticatedSessionManager {
         records.insert(
             session_id.clone(),
             AuthenticatedSession {
+                workspace: self.workspace.clone(),
                 fingerprint: self.fingerprint,
                 handle,
                 _admission_permit: admission_permit,
@@ -252,7 +282,7 @@ impl SessionManager for AuthenticatedSessionManager {
             .read()
             .await
             .get(session_id)
-            .is_some_and(|session| session.fingerprint == self.fingerprint))
+            .is_some_and(|session| self.owns(session)))
     }
 
     async fn close_session(&self, session_id: &SessionId) -> Result<(), Self::Error> {
@@ -260,7 +290,7 @@ impl SessionManager for AuthenticatedSessionManager {
             let mut records = self.sessions.records.write().await;
             match records.get(session_id) {
                 None => None,
-                Some(session) if session.fingerprint != self.fingerprint => {
+                Some(session) if !self.owns(session) => {
                     return Err(
                         LocalSessionManagerError::SessionNotFound(session_id.clone()).into(),
                     );
@@ -404,13 +434,16 @@ impl McpHttpConfig {
 }
 
 /// Validated OAuth protected-resource configuration.
+///
+/// The public URL is the base of the per-workspace resource family: every
+/// workspace is served at `<public_url>/workspace/<name>`, each such URL its
+/// own protected resource with its own metadata document and token audience.
+/// The base itself is not an MCP endpoint.
 #[derive(Clone, Debug)]
 pub struct AuthenticatedMcpHttpConfig {
     bind_addr: SocketAddr,
-    public_url: String,
+    urls: WorkspaceMcpUrls,
     authorization_server: String,
-    metadata_path: String,
-    challenge: HeaderValue,
     allowed_hosts: Vec<String>,
 }
 
@@ -424,10 +457,6 @@ impl AuthenticatedMcpHttpConfig {
     ) -> Result<Self, McpHttpError> {
         let resource = validated_oauth_url(&public_url.into())?;
         let authorization_server = validated_oauth_url(&authorization_server.into())?;
-        let (metadata_url, metadata_path) = protected_resource_metadata_url(resource.url());
-        let challenge = format!("Bearer resource_metadata=\"{metadata_url}\"");
-        let challenge = HeaderValue::from_str(&challenge)
-            .map_err(|_error| McpHttpError::InvalidAuthConfig("invalid challenge header"))?;
         let mut allowed_hosts = vec![
             "localhost".to_string(),
             "127.0.0.1".to_string(),
@@ -445,12 +474,17 @@ impl AuthenticatedMcpHttpConfig {
         }
         Ok(Self {
             bind_addr,
-            public_url: resource.into_identifier(),
+            urls: WorkspaceMcpUrls::new(resource),
             authorization_server: authorization_server.into_identifier(),
-            metadata_path,
-            challenge,
             allowed_hosts,
         })
+    }
+
+    /// The axum route template the workspace family mounts at, derived from
+    /// the public URL's path so the served paths match the advertised URLs
+    /// without any ingress rewriting.
+    fn mcp_route(&self) -> String {
+        format!("{}/workspace/{{workspace}}", self.urls.base_path())
     }
 }
 
@@ -473,7 +507,7 @@ impl AuthenticatedMcpHttpRuntime {
         readiness: R,
     ) -> Self
     where
-        V: Fn(String) -> VF + Send + Sync + 'static,
+        V: Fn(String, String) -> VF + Send + Sync + 'static,
         VF: Future<Output = Result<(), ()>> + Send + 'static,
         F: Fn(String) -> FF + Send + Sync + 'static,
         FF: Future<Output = Result<AppClient, ()>> + Send + 'static,
@@ -481,7 +515,7 @@ impl AuthenticatedMcpHttpRuntime {
         RF: Future<Output = Result<(), tonic::Code>> + Send + 'static,
     {
         Self {
-            validator: Arc::new(move |token| Box::pin(validator(token))),
+            validator: Arc::new(move |token, audience| Box::pin(validator(token, audience))),
             session_client_factory: Arc::new(move |token| Box::pin(session_client_factory(token))),
             options,
             readiness: ReadinessProbe(Arc::new(move || Box::pin(readiness()))),
@@ -504,15 +538,6 @@ fn validated_oauth_url(value: &str) -> Result<CanonicalOauthUrl, McpHttpError> {
     })
 }
 
-fn protected_resource_metadata_url(resource: &Url) -> (String, String) {
-    let resource_path = match resource.path() {
-        "/" => "",
-        path => path,
-    };
-    let path = format!("{METADATA_ROOT}{resource_path}");
-    (format!("{}{path}", &resource[..Position::BeforePath]), path)
-}
-
 fn is_loopback(ip: IpAddr) -> bool {
     ip.is_loopback()
         || matches!(ip, IpAddr::V6(ip) if ip.to_ipv4_mapped().is_some_and(|ip| ip.is_loopback()))
@@ -531,19 +556,6 @@ pub enum McpHttpError {
     /// MCP HTTP serving configuration is invalid.
     #[error("invalid MCP HTTP configuration: {0}")]
     InvalidAuthConfig(&'static str),
-    /// Nothing names a workspace and the local user belongs to none.
-    #[error(
-        "no workspace is available for the local MCP server. Create one with `coral workspace create NAME`, then name it in `server.mcp_http.workspace`."
-    )]
-    NoLocalWorkspace,
-    /// Nothing names a workspace and the local user belongs to several.
-    #[error(
-        "several workspaces are available ({0}). Name the one the local MCP server serves in `server.mcp_http.workspace`."
-    )]
-    AmbiguousLocalWorkspace(String),
-    /// The membership listing that resolves the local workspace failed.
-    #[error("failed to list the local workspaces the MCP server could serve")]
-    LocalWorkspaceLookup(#[source] tonic::Status),
     /// The TCP listener could not bind.
     #[error("failed to bind MCP HTTP server to {address}")]
     Bind {
@@ -642,18 +654,22 @@ fn join_server(
 /// serving must use a distinct construction path that creates a bearer-bound
 /// client after validating each incoming session.
 ///
+/// Every existing workspace is served at `/mcp/workspace/<name>` — the URL
+/// names the workspace, so no workspace is resolved at startup and any value
+/// in `options.workspace` (stdio's carrier for its own resolved selection) is
+/// ignored here. Existence is checked per handshake against the local
+/// client's own workspace listing, so a workspace created after startup is
+/// reachable and a deleted one refuses new sessions immediately.
+///
 /// # Errors
 ///
-/// Returns [`McpHttpError`] if no workspace can be resolved for the surface or
-/// if the listener cannot bind. Resolution runs first so an unservable
-/// configuration is reported without ever holding the port.
+/// Returns [`McpHttpError`] if the listener cannot bind.
 pub async fn start_auth_disabled(
     config: McpHttpConfig,
     app: AppClient,
     options: McpOptions,
 ) -> Result<RunningMcpHttpServer, McpHttpError> {
     options.surface.validate(options.feedback_enabled)?;
-    let options = resolve_local_workspace(&app, options).await?;
     let listener = TcpListener::bind(config.bind_addr())
         .await
         .map_err(|source| McpHttpError::Bind {
@@ -664,52 +680,20 @@ pub async fn start_auth_disabled(
     let readiness = ReadinessProbe::from_app(app.clone());
     let (router, state) = auth_disabled_router(
         app,
-        options,
+        McpOptions {
+            workspace: None,
+            ..options
+        },
         readiness,
         local_addr.ip(),
         &config.extra_allowed_hosts,
-    )?;
+    );
     Ok(spawn_http_server(
         listener,
         local_addr,
         router,
         state.server.clone(),
     ))
-}
-
-/// Scopes the loopback surface to a workspace the local user actually holds.
-///
-/// A configured name is authoritative and is used byte for byte: composition
-/// already validated its shape, and whether a workspace by that name exists is
-/// answered by the request that needs it, under the ordinary not-found
-/// contract. That keeps a surface configured today servable for a workspace
-/// created tomorrow.
-///
-/// With nothing configured the local user must hold exactly one workspace.
-/// Zero and several are different problems — one person has nothing to serve,
-/// the other has not said which — so they are reported as different errors
-/// naming the action that resolves each, rather than settled by picking one.
-async fn resolve_local_workspace(
-    app: &AppClient,
-    options: McpOptions,
-) -> Result<McpOptions, McpHttpError> {
-    if options.workspace.is_some() {
-        return Ok(options);
-    }
-    let mut names = membership_workspace_names(app)
-        .await
-        .map_err(McpHttpError::LocalWorkspaceLookup)?;
-    if names.len() != 1 {
-        return Err(if names.is_empty() {
-            McpHttpError::NoLocalWorkspace
-        } else {
-            McpHttpError::AmbiguousLocalWorkspace(names.join(", "))
-        });
-    }
-    Ok(McpOptions {
-        workspace: Some(workspace_resource(names.remove(0))),
-        ..options
-    })
 }
 
 /// Names the workspaces the client's own caller belongs to, in listing order.
@@ -813,20 +797,20 @@ impl ReadinessProbe {
     }
 }
 
-/// Builds the loopback router around one workspace-scoped session factory.
+/// Builds the loopback router serving every workspace at its own URL.
 ///
-/// The workspace must already be resolved: `HttpState` holds the factory
-/// outright, so a router that could be built without one would serve sessions
-/// with no workspace to reach.
+/// Session factories are created per workspace, on first admitted handshake,
+/// and cached: sessions within one workspace share guide-block state while
+/// sessions in different workspaces share nothing, and each workspace's
+/// sessions live in their own manager so a session id minted at one
+/// workspace's URL structurally does not exist at another's.
 fn auth_disabled_router(
     app: AppClient,
     options: McpOptions,
     readiness: ReadinessProbe,
     advertised_ip: IpAddr,
     extra_allowed_hosts: &[String],
-) -> Result<(Router, Arc<HttpState>), McpHttpError> {
-    let factory = CoralMcpServerFactory::new(app, options)
-        .map_err(|WorkspaceRequired| McpHttpError::NoLocalWorkspace)?;
+) -> (Router, Arc<HttpState>) {
     // These are the same loopback names the authenticated listener accepts, so
     // a client dialing `localhost` is not rejected for the bind being
     // `127.0.0.1`. The allowlist stays exact beyond that baseline: it is the
@@ -840,45 +824,65 @@ fn auth_disabled_router(
     ];
     allowed_hosts.extend(extra_allowed_hosts.iter().cloned());
     let config = StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts);
-    let sessions = Arc::new(LocalSessionManager::default());
+    let workspaces = Arc::new(RwLock::new(HashMap::new()));
     let server = Arc::new(ServerState {
-        sessions: SessionOwner::Local(sessions.clone()),
+        sessions: SessionOwner::Local(workspaces.clone()),
         config,
         requests: RwLock::new(()),
     });
     let state = Arc::new(HttpState {
-        factory,
+        app,
+        options,
+        workspaces,
         readiness,
-        sessions,
         server: server.clone(),
     });
     let router = Router::new()
-        .route("/mcp", any(mcp))
+        .route(AUTH_DISABLED_MCP_WORKSPACE_ROUTE, any(mcp))
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
+        .fallback(not_an_mcp_endpoint)
         .with_state(state.clone());
-    Ok((router, state))
+    (router, state)
 }
 
-struct HttpState {
+/// One served workspace on the auth-disabled surface.
+struct WorkspaceSessions {
     factory: CoralMcpServerFactory,
-    readiness: ReadinessProbe,
     sessions: Arc<LocalSessionManager>,
+}
+
+type LocalWorkspaces = Arc<RwLock<HashMap<McpWorkspaceSegment, WorkspaceSessions>>>;
+
+struct HttpState {
+    app: AppClient,
+    options: McpOptions,
+    workspaces: LocalWorkspaces,
+    readiness: ReadinessProbe,
     server: Arc<ServerState>,
 }
 
 enum SessionOwner {
-    Local(Arc<LocalSessionManager>),
+    Local(LocalWorkspaces),
     Authenticated(Arc<AuthenticatedSessions>),
 }
 
 impl SessionOwner {
     async fn close_all(&self) {
         match self {
-            Self::Local(sessions) => {
-                let session_ids: Vec<_> = sessions.sessions.read().await.keys().cloned().collect();
-                for session_id in session_ids {
-                    let _close_result = sessions.close_session(&session_id).await;
+            Self::Local(workspaces) => {
+                let managers: Vec<_> = workspaces
+                    .read()
+                    .await
+                    .values()
+                    .map(|workspace| workspace.sessions.clone())
+                    .collect();
+                for sessions in managers {
+                    let session_ids: Vec<_> =
+                        sessions.sessions.read().await.keys().cloned().collect();
+                    for session_id in session_ids {
+                        let _close_result = sessions.close_session(&session_id).await;
+                    }
                 }
             }
             Self::Authenticated(sessions) => sessions.close_all().await,
@@ -897,7 +901,14 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
     if request.headers().contains_key(header::ORIGIN) {
         return StatusCode::FORBIDDEN.into_response();
     }
-    let (request, _initialize_id) = tokio::select! {
+    // The raw request path is parsed rather than the router's decoded capture:
+    // the charset admits no percent-encoding, so an encoded spelling of a
+    // valid name is refused instead of normalized into it.
+    let Some(workspace) = parse_workspace_route(request.uri().path(), AUTH_DISABLED_MCP_PREFIX)
+    else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let (request, initialize_id) = tokio::select! {
         biased;
         () = state.server.config.cancellation_token.cancelled() => {
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
@@ -907,13 +918,92 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
             Err(response) => return response,
         },
     };
+    let entry = if initialize_id.is_some() {
+        // Existence is answered per handshake, and absence is never cached:
+        // the local caller's own listing is the whole inventory here, so a
+        // workspace created a moment ago is admitted and a deleted one is the
+        // same plain not-found a name that never existed gets.
+        match admit_local_workspace(&state, &workspace).await {
+            Ok(entry) => entry,
+            Err(response) => return response,
+        }
+    } else {
+        let workspaces = state.workspaces.read().await;
+        let Some(entry) = workspaces.get(&workspace) else {
+            return StatusCode::NOT_FOUND.into_response();
+        };
+        (entry.factory.clone(), entry.sessions.clone())
+    };
+    let (factory, sessions) = entry;
     serve_mcp_request(
         request,
-        Some(state.factory.clone()),
-        state.sessions.clone(),
+        Some(factory),
+        sessions,
         state.server.config.clone(),
     )
     .await
+}
+
+/// Admits one auth-disabled handshake for the workspace its URL names.
+///
+/// Lists the local caller's workspaces to answer existence, then returns the
+/// workspace's cached factory and session manager, creating them on first
+/// admission. The listing failing is a server problem, not an answer about
+/// any workspace, so it maps to service-unavailable rather than not-found.
+async fn admit_local_workspace(
+    state: &HttpState,
+    workspace: &McpWorkspaceSegment,
+) -> Result<(CoralMcpServerFactory, Arc<LocalSessionManager>), Response> {
+    let names = tokio::select! {
+        biased;
+        () = state.server.config.cancellation_token.cancelled() => {
+            return Err(StatusCode::SERVICE_UNAVAILABLE.into_response());
+        }
+        names = membership_workspace_names(&state.app) => names.map_err(|status| {
+            tracing::warn!(%status, "listing local workspaces for MCP admission failed");
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        })?,
+    };
+    if !names.iter().any(|name| name == workspace.as_str()) {
+        return Err(StatusCode::NOT_FOUND.into_response());
+    }
+    let mut workspaces = state.workspaces.write().await;
+    if let Some(entry) = workspaces.get(workspace) {
+        return Ok((entry.factory.clone(), entry.sessions.clone()));
+    }
+    let options = McpOptions {
+        workspace: Some(workspace_proto(workspace.as_str().to_string())),
+        ..state.options.clone()
+    };
+    let factory = CoralMcpServerFactory::new(state.app.clone(), options)
+        .map_err(|WorkspaceRequired| StatusCode::INTERNAL_SERVER_ERROR.into_response())?;
+    let sessions = Arc::new(LocalSessionManager::default());
+    workspaces.insert(
+        workspace.clone(),
+        WorkspaceSessions {
+            factory: factory.clone(),
+            sessions: sessions.clone(),
+        },
+    );
+    Ok((factory, sessions))
+}
+
+/// Parses `<prefix>/workspace/<segment>` from a raw request path.
+fn parse_workspace_route(path: &str, prefix: &str) -> Option<McpWorkspaceSegment> {
+    McpWorkspaceSegment::parse(path.strip_prefix(prefix)?.strip_prefix("/workspace/")?)
+}
+
+/// Answers every path that is not an MCP endpoint on this listener.
+///
+/// The body is one static sentence naming the URL shape; see
+/// [`WORKSPACE_URL_HINT`] for why that discloses nothing.
+async fn not_an_mcp_endpoint() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        [(header::CONTENT_TYPE, "application/json")],
+        json!({ "error": "not_found", "hint": WORKSPACE_URL_HINT }).to_string(),
+    )
+        .into_response()
 }
 
 /// Validates one MCP request, reporting the id of the `initialize` it carries.
@@ -996,11 +1086,12 @@ fn authenticated_router_with_sessions(
         server: server.clone(),
     });
     let router = Router::new()
-        .route("/mcp", any(authenticated_mcp))
+        .route(&state.config.mcp_route(), any(authenticated_mcp))
         .route("/livez", get(livez))
         .route("/readyz", get(authenticated_readyz))
         .route(METADATA_ROOT, get(metadata))
         .route(METADATA_ROUTE, get(metadata))
+        .fallback(not_an_mcp_endpoint)
         .with_state(state.clone());
     (router, state)
 }
@@ -1017,19 +1108,32 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
     if request.headers().contains_key(header::ORIGIN) {
         return StatusCode::FORBIDDEN.into_response();
     }
+    // The raw request path is parsed rather than the router's decoded capture:
+    // the charset admits no percent-encoding, so an encoded spelling of a
+    // valid name is refused instead of normalized into it. A malformed segment
+    // is a plain not-found with no challenge and no metadata; every
+    // well-formed one gets the identical challenge whether or not a workspace
+    // by that name exists, so an anonymous probe learns nothing.
+    let Some(workspace) = state.config.urls.parse_route_path(request.uri().path()) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
     if request.method() == Method::OPTIONS {
         return StatusCode::NO_CONTENT.into_response();
     }
     let Some(token) = bearer_token(request.headers()) else {
-        return unauthorized_response(&state.config);
+        return unauthorized_response(&state.config, &workspace);
     };
+    // The route's resource is the exact audience this request must have been
+    // minted for: a bearer for one workspace is invalid at another's URL, with
+    // that URL's own challenge.
+    let resource = state.config.urls.resource(&workspace);
     let validation = tokio::select! {
         biased;
         () = state.server.config.cancellation_token.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
-        validation = (state.runtime.validator)(token.clone()) => validation,
+        validation = (state.runtime.validator)(token.clone(), resource) => validation,
     };
     if validation.is_err() {
-        return unauthorized_response(&state.config);
+        return unauthorized_response(&state.config, &workspace);
     }
     let (request, initialize_id) = tokio::select! {
         biased;
@@ -1047,7 +1151,8 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
         Err(()) => return StatusCode::BAD_REQUEST.into_response(),
     };
     let (factory, admission_permit) = if let Some(session_id) = request_session.as_deref() {
-        if let Err(status) = authorize_bound_session(&state, session_id, &binding_fingerprint).await
+        if let Err(status) =
+            authorize_bound_session(&state, session_id, &workspace, &binding_fingerprint).await
         {
             return status.into_response();
         }
@@ -1056,7 +1161,7 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
         let Some(admission_permit) = state.sessions.try_admit() else {
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
         };
-        match create_session_factory(&state, token).await {
+        match create_session_factory(&state, token, &workspace).await {
             Ok(factory) => (Some(factory), Some(admission_permit)),
             Err(refusal) => return refusal.into_response(initialize_id),
         }
@@ -1065,6 +1170,7 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
     };
     let sessions = Arc::new(AuthenticatedSessionManager {
         sessions: state.sessions.clone(),
+        workspace,
         fingerprint: binding_fingerprint,
         admission_permit: Mutex::new(admission_permit),
     });
@@ -1079,61 +1185,53 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
 /// caller one deployment-wide answer and collapse the per-caller concealment
 /// this admission exists to provide.
 ///
-/// A session is refused rather than admitted unbound, because every later
-/// exchange is workspace-scoped — `tools/list` enumerates the workspace's table
-/// functions — so an unbound session could only fail opaquely, and the only way
-/// to make it answer would be to substitute a workspace nobody asked for.
+/// The workspace is the one the request's URL names — nothing else selects
+/// it, and no other workspace is ever substituted.
 async fn create_session_factory(
     state: &AuthenticatedHttpState,
     token: String,
+    workspace: &McpWorkspaceSegment,
 ) -> Result<CoralMcpServerFactory, SessionRefusal> {
-    let configured = state
-        .runtime
-        .options
-        .workspace
-        .as_ref()
-        .ok_or(SessionRefusal::NoWorkspaceConfigured)?;
     let client = tokio::select! {
         biased;
         () = state.server.config.cancellation_token.cancelled() => Err(SessionRefusal::Unavailable),
         client = (state.runtime.session_client_factory)(token) => client.map_err(|()| SessionRefusal::Unavailable),
     }?;
-    require_configured_membership(&client, &configured.name).await?;
-    CoralMcpServerFactory::new(client, state.runtime.options.clone())
+    require_membership(&client, workspace.as_str()).await?;
+    let options = McpOptions {
+        workspace: Some(workspace_proto(workspace.as_str().to_string())),
+        ..state.runtime.options.clone()
+    };
+    CoralMcpServerFactory::new(client, options)
         .map_err(|WorkspaceRequired| SessionRefusal::Unavailable)
 }
 
-/// Admits the session only when the caller already holds the configured name.
+/// Admits the session only when the caller already holds the named workspace.
 ///
 /// The single listing this makes is the entire authorization decision: an exact
 /// name match admits, and every other outcome is the one concealed refusal. No
 /// membership is picked on the caller's behalf and no other workspace is
 /// substituted, so nothing here needs to know who the caller is — a listing
 /// scoped to the caller answers the only question admission has.
-async fn require_configured_membership(
-    client: &AppClient,
-    configured: &str,
-) -> Result<(), SessionRefusal> {
+async fn require_membership(client: &AppClient, workspace: &str) -> Result<(), SessionRefusal> {
     let memberships = membership_workspace_names(client).await.map_err(|status| {
         tracing::warn!(%status, "listing memberships for MCP session admission failed");
         SessionRefusal::Unavailable
     })?;
-    if memberships.iter().any(|name| name == configured) {
+    if memberships.iter().any(|name| name == workspace) {
         return Ok(());
     }
-    Err(SessionRefusal::WorkspaceNotFound(configured.to_string()))
+    Err(SessionRefusal::WorkspaceNotFound(workspace.to_string()))
 }
 
 /// Why an authenticated MCP session was not admitted.
 ///
 /// [`Self::WorkspaceNotFound`] is deliberately the only membership answer.
 /// Admission reads the caller's own memberships and never asks whether the
-/// configured name exists, so a workspace the caller may not reach and one that
+/// URL's name exists, so a workspace the caller may not reach and one that
 /// was never created are indistinguishable from here — and from the caller.
 enum SessionRefusal {
-    /// Nothing names a workspace for this surface to serve.
-    NoWorkspaceConfigured,
-    /// The configured workspace is not one of the caller's memberships.
+    /// The URL's workspace is not one of the caller's memberships.
     WorkspaceNotFound(String),
     /// Admission could not be decided; not an answer about any workspace.
     Unavailable,
@@ -1149,7 +1247,6 @@ impl SessionRefusal {
     fn into_response(self, initialize_id: Option<RequestId>) -> Response {
         let guidance = match self {
             Self::Unavailable => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
-            Self::NoWorkspaceConfigured => NO_WORKSPACE_CONFIGURED.to_string(),
             Self::WorkspaceNotFound(name) => workspace_not_found(&name),
         };
         let refusal =
@@ -1161,26 +1258,27 @@ impl SessionRefusal {
     }
 }
 
-/// Guidance for a surface that names no workspace at all.
-const NO_WORKSPACE_CONFIGURED: &str = "This MCP server has no workspace configured. Create a workspace in Reef, then name one you can access in `server.mcp_http.workspace`.";
-
-/// The one answer for a configured workspace the caller does not hold.
+/// The one answer for a workspace URL the caller does not hold.
 ///
 /// It must stay identical for a name that does not exist and a name the caller
 /// may not reach; the two are the same sentence on purpose.
 fn workspace_not_found(name: &str) -> String {
     format!(
-        "Workspace `{name}` was not found. Name a workspace you can access in `server.mcp_http.workspace`, or create one in Reef."
+        "Workspace `{name}` was not found. Check the workspace URL, or ask a workspace owner to add you."
     )
 }
 
 async fn authorize_bound_session(
     state: &AuthenticatedHttpState,
     session_id: &str,
+    workspace: &McpWorkspaceSegment,
     fingerprint: &BearerFingerprint,
 ) -> Result<(), StatusCode> {
     let session_id = Arc::from(session_id);
-    let status = state.sessions.authorize(&session_id, fingerprint).await;
+    let status = state
+        .sessions
+        .authorize(&session_id, workspace, fingerprint)
+        .await;
     match status {
         SessionAuthorization::Authorized => Ok(()),
         SessionAuthorization::Missing => Err(StatusCode::NOT_FOUND),
@@ -1196,14 +1294,22 @@ async fn authenticated_readyz(State(state): State<Arc<AuthenticatedHttpState>>) 
     }
 }
 
+/// Serves one workspace resource's RFC 9728 metadata document.
+///
+/// The document is a pure derivation of the URL — its `resource` value is
+/// exactly the identifier whose path-inserted well-known URL was fetched —
+/// and it is served for every well-formed workspace name, existent or not.
+/// Uniformity is the concealment: gating it on existence would let an
+/// anonymous probe enumerate workspaces. The base URL's own metadata path
+/// names no workspace and is a plain not-found, like every other path.
 async fn metadata(State(state): State<AuthState>, uri: Uri) -> Response {
-    if uri.path() != state.config.metadata_path {
+    let Some(workspace) = state.config.urls.parse_metadata_path(uri.path()) else {
         return StatusCode::NOT_FOUND.into_response();
-    }
+    };
     (
         [(header::CONTENT_TYPE, "application/json")],
         json!({
-            "resource": state.config.public_url,
+            "resource": state.config.urls.resource(&workspace),
             "authorization_servers": [state.config.authorization_server],
             "bearer_methods_supported": ["header"],
         })
@@ -1212,12 +1318,28 @@ async fn metadata(State(state): State<AuthState>, uri: Uri) -> Response {
         .into_response()
 }
 
-fn unauthorized_response(config: &AuthenticatedMcpHttpConfig) -> Response {
-    (
-        StatusCode::UNAUTHORIZED,
-        [(header::WWW_AUTHENTICATE, config.challenge.clone())],
-    )
-        .into_response()
+/// Challenges with the route's own metadata URL.
+///
+/// Clients follow the challenged URL exclusively, so it must agree byte for
+/// byte with the path [`metadata`] serves. Built per request: the workspace
+/// segment's charset guarantees a valid header value, and the fallback arm
+/// exists only because `HeaderValue::from_str` returns a `Result`.
+fn unauthorized_response(
+    config: &AuthenticatedMcpHttpConfig,
+    workspace: &McpWorkspaceSegment,
+) -> Response {
+    let challenge = format!(
+        "Bearer resource_metadata=\"{}\"",
+        config.urls.metadata_url(workspace)
+    );
+    match HeaderValue::from_str(&challenge) {
+        Ok(challenge) => (
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, challenge)],
+        )
+            .into_response(),
+        Err(_error) => StatusCode::UNAUTHORIZED.into_response(),
+    }
 }
 
 fn bearer_token(headers: &HeaderMap) -> Option<String> {

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -26,7 +26,9 @@ use coral_api::v1::ListWorkspacesRequest;
 use coral_app::{CanonicalOauthUrl, OauthUrlError};
 use coral_client::{AppClient, workspace as workspace_resource};
 use futures::{Stream, StreamExt as _};
-use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ServerJsonRpcMessage};
+use rmcp::model::{
+    ClientJsonRpcMessage, ClientRequest, ErrorData, RequestId, ServerJsonRpcMessage,
+};
 use rmcp::transport::{
     WorkerTransport,
     common::{
@@ -694,7 +696,9 @@ async fn resolve_local_workspace(
     if options.workspace.is_some() {
         return Ok(options);
     }
-    let mut names = local_workspace_names(app).await?;
+    let mut names = membership_workspace_names(app)
+        .await
+        .map_err(McpHttpError::LocalWorkspaceLookup)?;
     if names.len() != 1 {
         return Err(if names.is_empty() {
             McpHttpError::NoLocalWorkspace
@@ -708,13 +712,15 @@ async fn resolve_local_workspace(
     })
 }
 
-/// Names the workspaces the local user belongs to, in listing order.
-async fn local_workspace_names(app: &AppClient) -> Result<Vec<String>, McpHttpError> {
+/// Names the workspaces the client's own caller belongs to, in listing order.
+///
+/// The listing is scoped to whoever the client authenticates as, so which
+/// client this is asked with is the whole of the answer's meaning.
+async fn membership_workspace_names(app: &AppClient) -> Result<Vec<String>, tonic::Status> {
     Ok(app
         .workspace_client()
         .list_workspaces(GrpcRequest::new(ListWorkspacesRequest {}))
-        .await
-        .map_err(McpHttpError::LocalWorkspaceLookup)?
+        .await?
         .into_inner()
         .memberships
         .into_iter()
@@ -891,13 +897,13 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
     if request.headers().contains_key(header::ORIGIN) {
         return StatusCode::FORBIDDEN.into_response();
     }
-    let request = tokio::select! {
+    let (request, _initialize_id) = tokio::select! {
         biased;
         () = state.server.config.cancellation_token.cancelled() => {
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
         }
         request = validate_mcp_request(request) => match request {
-            Ok(request) => request,
+            Ok(validated) => validated,
             Err(response) => return response,
         },
     };
@@ -910,9 +916,16 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
     .await
 }
 
-async fn validate_mcp_request(request: Request<Body>) -> Result<Request<Body>, Response> {
+/// Validates one MCP request, reporting the id of the `initialize` it carries.
+///
+/// The id is `Some` exactly for the sessionless POST that opens a session, so a
+/// caller that refuses admission can answer that request in its own terms
+/// instead of re-parsing the body it just handed on.
+async fn validate_mcp_request(
+    request: Request<Body>,
+) -> Result<(Request<Body>, Option<RequestId>), Response> {
     if request.method() != Method::POST {
-        return Ok(request);
+        return Ok((request, None));
     }
 
     let has_session = request
@@ -924,12 +937,14 @@ async fn validate_mcp_request(request: Request<Body>) -> Result<Request<Body>, R
     let bytes = axum::body::to_bytes(body, MAX_MCP_REQUEST_BODY_SIZE)
         .await
         .map_err(|_error| StatusCode::PAYLOAD_TOO_LARGE.into_response())?;
+    let mut initialize_id = None;
     if !has_session {
         let message = serde_json::from_slice::<ClientJsonRpcMessage>(&bytes)
             .map_err(|_error| StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response())?;
         let ClientJsonRpcMessage::Request(request) = message else {
             return Err(StatusCode::BAD_REQUEST.into_response());
         };
+        let request_id = request.id;
         let ClientRequest::InitializeRequest(initialize) = request.request else {
             return Err(StatusCode::BAD_REQUEST.into_response());
         };
@@ -939,8 +954,9 @@ async fn validate_mcp_request(request: Request<Body>) -> Result<Request<Body>, R
         ) {
             return Err(StatusCode::BAD_REQUEST.into_response());
         }
+        initialize_id = Some(request_id);
     }
-    Ok(Request::from_parts(parts, Body::from(bytes)))
+    Ok((Request::from_parts(parts, Body::from(bytes)), initialize_id))
 }
 
 fn initialize_protocol_header_matches(headers: &HeaderMap, body_protocol: &str) -> bool {
@@ -1015,13 +1031,13 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
     if validation.is_err() {
         return unauthorized_response(&state.config);
     }
-    let request = tokio::select! {
+    let (request, initialize_id) = tokio::select! {
         biased;
         () = state.server.config.cancellation_token.cancelled() => {
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
         }
         request = validate_mcp_request(request) => match request {
-            Ok(request) => request,
+            Ok(validated) => validated,
             Err(response) => return response,
         },
     };
@@ -1042,7 +1058,7 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
         };
         match create_session_factory(&state, token).await {
             Ok(factory) => (Some(factory), Some(admission_permit)),
-            Err(status) => return status.into_response(),
+            Err(refusal) => return refusal.into_response(initialize_id),
         }
     } else {
         (None, None)
@@ -1057,22 +1073,105 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
 
 /// Builds the bearer-bound session factory admitted for one initialize request.
 ///
-/// A session is refused when the runtime names no workspace. Admitting one
-/// anyway would hand back a session that is inert at the protocol layer —
-/// `tools/list` enumerates the workspace's table functions, so it is itself
-/// workspace-scoped — and the only way to make it answer would be to substitute
-/// a workspace the caller never asked for.
+/// The membership listing that decides admission runs on the caller's own
+/// bearer-bound client and on nothing else. The unauthenticated client this
+/// surface holds serves health readiness only: listing with it would hand every
+/// caller one deployment-wide answer and collapse the per-caller concealment
+/// this admission exists to provide.
+///
+/// A session is refused rather than admitted unbound, because every later
+/// exchange is workspace-scoped — `tools/list` enumerates the workspace's table
+/// functions — so an unbound session could only fail opaquely, and the only way
+/// to make it answer would be to substitute a workspace nobody asked for.
 async fn create_session_factory(
     state: &AuthenticatedHttpState,
     token: String,
-) -> Result<CoralMcpServerFactory, StatusCode> {
+) -> Result<CoralMcpServerFactory, SessionRefusal> {
+    let configured = state
+        .runtime
+        .options
+        .workspace
+        .as_ref()
+        .ok_or(SessionRefusal::NoWorkspaceConfigured)?;
     let client = tokio::select! {
         biased;
-        () = state.server.config.cancellation_token.cancelled() => Err(StatusCode::SERVICE_UNAVAILABLE),
-        client = (state.runtime.session_client_factory)(token) => client.map_err(|()| StatusCode::SERVICE_UNAVAILABLE),
+        () = state.server.config.cancellation_token.cancelled() => Err(SessionRefusal::Unavailable),
+        client = (state.runtime.session_client_factory)(token) => client.map_err(|()| SessionRefusal::Unavailable),
     }?;
+    require_configured_membership(&client, &configured.name).await?;
     CoralMcpServerFactory::new(client, state.runtime.options.clone())
-        .map_err(|WorkspaceRequired| StatusCode::SERVICE_UNAVAILABLE)
+        .map_err(|WorkspaceRequired| SessionRefusal::Unavailable)
+}
+
+/// Admits the session only when the caller already holds the configured name.
+///
+/// The single listing this makes is the entire authorization decision: an exact
+/// name match admits, and every other outcome is the one concealed refusal. No
+/// membership is picked on the caller's behalf and no other workspace is
+/// substituted, so nothing here needs to know who the caller is — a listing
+/// scoped to the caller answers the only question admission has.
+async fn require_configured_membership(
+    client: &AppClient,
+    configured: &str,
+) -> Result<(), SessionRefusal> {
+    let memberships = membership_workspace_names(client).await.map_err(|status| {
+        tracing::warn!(%status, "listing memberships for MCP session admission failed");
+        SessionRefusal::Unavailable
+    })?;
+    if memberships.iter().any(|name| name == configured) {
+        return Ok(());
+    }
+    Err(SessionRefusal::WorkspaceNotFound(configured.to_string()))
+}
+
+/// Why an authenticated MCP session was not admitted.
+///
+/// [`Self::WorkspaceNotFound`] is deliberately the only membership answer.
+/// Admission reads the caller's own memberships and never asks whether the
+/// configured name exists, so a workspace the caller may not reach and one that
+/// was never created are indistinguishable from here — and from the caller.
+enum SessionRefusal {
+    /// Nothing names a workspace for this surface to serve.
+    NoWorkspaceConfigured,
+    /// The configured workspace is not one of the caller's memberships.
+    WorkspaceNotFound(String),
+    /// Admission could not be decided; not an answer about any workspace.
+    Unavailable,
+}
+
+impl SessionRefusal {
+    /// Answers the `initialize` request that asked to be admitted.
+    ///
+    /// The handshake is the only exchange on this surface that is not
+    /// workspace-scoped, so it is the one place guidance can reach a caller who
+    /// has no workspace to reach. A transport-level status would surface as a
+    /// bare connection failure instead.
+    fn into_response(self, initialize_id: Option<RequestId>) -> Response {
+        let guidance = match self {
+            Self::Unavailable => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+            Self::NoWorkspaceConfigured => NO_WORKSPACE_CONFIGURED.to_string(),
+            Self::WorkspaceNotFound(name) => workspace_not_found(&name),
+        };
+        let refusal =
+            ServerJsonRpcMessage::error(ErrorData::invalid_request(guidance, None), initialize_id);
+        match serde_json::to_string(&refusal) {
+            Ok(body) => ([(header::CONTENT_TYPE, "application/json")], body).into_response(),
+            Err(_error) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        }
+    }
+}
+
+/// Guidance for a surface that names no workspace at all.
+const NO_WORKSPACE_CONFIGURED: &str = "This MCP server has no workspace configured. Create a workspace in Reef, then name one you can access in `server.mcp_http.workspace`.";
+
+/// The one answer for a configured workspace the caller does not hold.
+///
+/// It must stay identical for a name that does not exist and a name the caller
+/// may not reach; the two are the same sentence on purpose.
+fn workspace_not_found(name: &str) -> String {
+    format!(
+        "Workspace `{name}` was not found. Name a workspace you can access in `server.mcp_http.workspace`, or create one in Reef."
+    )
 }
 
 async fn authorize_bound_session(

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -47,9 +47,10 @@ use super::{
     AUTHENTICATED_SESSION_IDLE_TIMEOUT, AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime,
     AuthenticatedSession, AuthenticatedSessionManager, AuthenticatedSessions,
     MAX_AUTHENTICATED_SESSIONS, MAX_MCP_REQUEST_BODY_SIZE, McpHttpConfig, McpHttpError,
-    ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER, SHUTDOWN_GRACE_PERIOD, SessionOwner,
-    auth_disabled_router, authenticated_router, authenticated_router_with_sessions,
-    binding_fingerprint, readiness_status, start_auth_disabled, start_authenticated,
+    McpWorkspaceSegment, ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER,
+    SHUTDOWN_GRACE_PERIOD, SessionOwner, WORKSPACE_URL_HINT, auth_disabled_router,
+    authenticated_router, authenticated_router_with_sessions, binding_fingerprint,
+    readiness_status, start_auth_disabled, start_authenticated,
 };
 
 const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
@@ -80,15 +81,37 @@ fn extension_options() -> McpOptions {
     }
 }
 
+/// The listener-relative MCP URL of one workspace, on either surface.
+fn ws_path(name: &str) -> String {
+    format!("/mcp/workspace/{name}")
+}
+
+fn segment(name: &str) -> McpWorkspaceSegment {
+    McpWorkspaceSegment::parse(name).expect("valid workspace segment")
+}
+
 fn raw_mcp_request(body: impl Into<Body>) -> Request<Body> {
+    raw_mcp_request_at(&ws_path(TEST_WORKSPACE), body)
+}
+
+fn raw_mcp_request_at(path: &str, body: impl Into<Body>) -> Request<Body> {
     Request::builder()
         .method(Method::POST)
-        .uri("/mcp")
+        .uri(path)
         .header(header::HOST, "127.0.0.1")
         .header(header::ACCEPT, "application/json, text/event-stream")
         .header(header::CONTENT_TYPE, "application/json")
         .body(body.into())
         .expect("request")
+}
+
+/// Counts live auth-disabled sessions across every served workspace.
+async fn local_session_count(state: &Arc<super::HttpState>) -> usize {
+    let mut count = 0;
+    for entry in state.workspaces.read().await.values() {
+        count += entry.sessions.sessions.read().await.len();
+    }
+    count
 }
 
 async fn assert_bad_request_without_session(
@@ -98,7 +121,7 @@ async fn assert_bad_request_without_session(
 ) {
     let response = send(router, request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert!(state.sessions.sessions.read().await.is_empty());
+    assert_eq!(local_session_count(state).await, 0);
 }
 
 fn authenticated_config() -> AuthenticatedMcpHttpConfig {
@@ -108,16 +131,26 @@ fn authenticated_config() -> AuthenticatedMcpHttpConfig {
 fn authenticated_config_at(bind_addr: SocketAddr) -> AuthenticatedMcpHttpConfig {
     AuthenticatedMcpHttpConfig::new(
         bind_addr,
-        "https://mcp.example.com/custom%20mcp",
+        "https://mcp.example.com/mcp",
         "https://login.example.com/",
     )
     .unwrap()
 }
 
 fn auth_request(authorization: &str, session: Option<&str>, body: &str) -> Request<Body> {
+    auth_request_at(TEST_WORKSPACE, authorization, session, body)
+}
+
+/// One authenticated request at the named workspace's URL.
+fn auth_request_at(
+    workspace: &str,
+    authorization: &str,
+    session: Option<&str>,
+    body: &str,
+) -> Request<Body> {
     let mut request = Request::builder()
         .method(Method::POST)
-        .uri("/mcp")
+        .uri(ws_path(workspace))
         .header(header::HOST, "mcp.example.com")
         .header(header::ACCEPT, "application/json, text/event-stream")
         .header(header::CONTENT_TYPE, "application/json")
@@ -173,15 +206,18 @@ async fn assert_invalid_initialize_protocols_rejected(router: &Router) {
 }
 
 /// The one ordinary workspace the HTTP fixtures work in. A fresh app owns no
-/// workspace, so only the tests that reach a workspace-scoped tool create it,
-/// and they name it in their [`McpOptions`] rather than leaving the choice to
-/// the server.
+/// workspace, so a fixture whose handshake must be admitted creates it first —
+/// the URL names it, and admission answers existence from a live listing.
 const TEST_WORKSPACE: &str = "analytics";
 
-/// Creates [`TEST_WORKSPACE`] and returns options scoped to it.
+/// Creates [`TEST_WORKSPACE`] and returns the surface's template options.
+///
+/// The options name no workspace: each request's URL does, so the only thing a
+/// fixture must do for a handshake at [`TEST_WORKSPACE`]'s URL to be admitted
+/// is make the workspace exist.
 async fn workspace_scoped_options(app: &AppClient) -> McpOptions {
     create_workspace(app, TEST_WORKSPACE).await;
-    workspace_named_options()
+    McpOptions::default()
 }
 
 /// Creates one workspace through the same public RPC any client would use.
@@ -192,27 +228,6 @@ async fn create_workspace(app: &AppClient, name: &str) {
         }))
         .await
         .expect("create test workspace");
-}
-
-/// Names [`TEST_WORKSPACE`] without creating it.
-///
-/// The auth-disabled session factory demands a *resolved* workspace, not an
-/// existing one: whether the name resolves is answered by the request that
-/// needs it. Loopback fixtures that never reach a workspace-scoped tool
-/// therefore only have to name one, and naming it is what keeps them from
-/// exercising a fallback. Authenticated fixtures need
-/// [`workspace_scoped_options`] instead, because admission there checks the
-/// name against the caller's memberships before opening a session.
-fn workspace_named_options() -> McpOptions {
-    options_naming(TEST_WORKSPACE)
-}
-
-/// Names one workspace for a surface, without creating it.
-fn options_naming(name: &str) -> McpOptions {
-    McpOptions {
-        workspace: Some(workspace(name)),
-        ..McpOptions::default()
-    }
 }
 
 async fn local_app() -> (TempDir, coral_client::local::RunningServer, AppClient) {
@@ -236,7 +251,8 @@ async fn open_stalled_request(server: &RunningMcpHttpServer) -> TcpStream {
     stalled
         .write_all(
             format!(
-                "POST /mcp HTTP/1.1\r\nHost: {}\r\nAccept: application/json, text/event-stream\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n{{\r\n",
+                "POST {} HTTP/1.1\r\nHost: {}\r\nAccept: application/json, text/event-stream\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n{{\r\n",
+                ws_path(TEST_WORKSPACE),
                 server.local_addr()
             )
             .as_bytes(),
@@ -254,13 +270,25 @@ async fn open_stalled_request(server: &RunningMcpHttpServer) -> TcpStream {
     stalled
 }
 
-fn local_sessions(
-    server: &RunningMcpHttpServer,
-) -> std::sync::Weak<rmcp::transport::streamable_http_server::session::local::LocalSessionManager> {
+type WeakLocalWorkspaces = std::sync::Weak<
+    tokio::sync::RwLock<std::collections::HashMap<McpWorkspaceSegment, super::WorkspaceSessions>>,
+>;
+
+fn local_workspaces(server: &RunningMcpHttpServer) -> WeakLocalWorkspaces {
     match &server.state.sessions {
-        SessionOwner::Local(sessions) => Arc::downgrade(sessions),
+        SessionOwner::Local(workspaces) => Arc::downgrade(workspaces),
         SessionOwner::Authenticated(_) => panic!("expected local sessions"),
     }
+}
+
+/// Counts live sessions across the map a running auth-disabled server owns.
+async fn running_local_session_count(workspaces: &WeakLocalWorkspaces) -> usize {
+    let workspaces = workspaces.upgrade().expect("workspaces");
+    let mut count = 0;
+    for entry in workspaces.read().await.values() {
+        count += entry.sessions.sessions.read().await.len();
+    }
+    count
 }
 
 fn authenticated_sessions(
@@ -309,8 +337,8 @@ fn allowed_hosts_must_be_valid_header_values() {
 #[tokio::test]
 async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
     let (_temp, app_server, app) = local_app().await;
-    // Host acceptance is what this asserts, but the router now resolves a
-    // workspace before it exists, so the fixture gives it one to resolve.
+    // Host acceptance is what this asserts, but a handshake is only admitted
+    // for a workspace that exists, so the fixture creates the one its URL names.
     let options = workspace_scoped_options(&app).await;
     let (router, state) = auth_disabled_router(
         app.clone(),
@@ -318,8 +346,7 @@ async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         &["coral".to_string()],
-    )
-    .expect("router scoped to a workspace");
+    );
 
     // The baseline loopback names and the operator-listed host all initialize;
     // anything else keeps hitting the DNS-rebinding 403.
@@ -334,7 +361,7 @@ async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
-                    .uri("/mcp")
+                    .uri(ws_path(TEST_WORKSPACE))
                     .header(header::HOST, host)
                     .header(header::ACCEPT, "application/json, text/event-stream")
                     .header(header::CONTENT_TYPE, "application/json")
@@ -350,7 +377,7 @@ async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/mcp")
+                .uri(ws_path(TEST_WORKSPACE))
                 .header(header::HOST, "coral.example")
                 .header(header::ACCEPT, "application/json, text/event-stream")
                 .header(header::CONTENT_TYPE, "application/json")
@@ -370,14 +397,14 @@ async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
 async fn raw_routes_enforce_health_and_host_contracts() {
     let (_temp, app_server, app) = local_app().await;
     let advertised_ip = IpAddr::V4(Ipv4Addr::new(127, 42, 3, 9));
+    let options = workspace_scoped_options(&app).await;
     let (router, state) = auth_disabled_router(
         app.clone(),
-        workspace_named_options(),
+        options,
         ReadinessProbe::from_app(app),
         advertised_ip,
         &[],
-    )
-    .expect("router scoped to a workspace");
+    );
 
     for path in ["/livez", "/readyz"] {
         let response = router
@@ -398,7 +425,7 @@ async fn raw_routes_enforce_health_and_host_contracts() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/mcp")
+                .uri(ws_path(TEST_WORKSPACE))
                 .header(header::HOST, "attacker.example")
                 .header(header::ACCEPT, "application/json, text/event-stream")
                 .header(header::CONTENT_TYPE, "application/json")
@@ -414,7 +441,7 @@ async fn raw_routes_enforce_health_and_host_contracts() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/mcp")
+                .uri(ws_path(TEST_WORKSPACE))
                 .header(header::HOST, "127.42.3.9:8080")
                 .header(header::ORIGIN, "https://attacker.example")
                 .header(header::ACCEPT, "application/json, text/event-stream")
@@ -425,13 +452,13 @@ async fn raw_routes_enforce_health_and_host_contracts() {
         .await
         .expect("response");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert!(state.sessions.sessions.read().await.is_empty());
+    assert_eq!(local_session_count(&state).await, 0);
 
     let response = router
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/mcp")
+                .uri(ws_path(TEST_WORKSPACE))
                 .header(header::HOST, "127.42.3.9:8080")
                 .header(header::ACCEPT, "application/json, text/event-stream")
                 .header(header::CONTENT_TYPE, "application/json")
@@ -450,14 +477,14 @@ async fn raw_routes_enforce_health_and_host_contracts() {
 #[tokio::test]
 async fn mcp_rejects_uninitialized_and_oversized_requests_without_leaking_sessions() {
     let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
     let (router, state) = auth_disabled_router(
         app.clone(),
-        workspace_named_options(),
+        options,
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         &[],
-    )
-    .expect("router scoped to a workspace");
+    );
 
     for body in [
         PING,
@@ -525,7 +552,7 @@ async fn mcp_rejects_uninitialized_and_oversized_requests_without_leaking_sessio
         .await
         .expect("response");
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
-    assert_eq!(state.sessions.sessions.read().await.len(), 1);
+    assert_eq!(local_session_count(&state).await, 1);
 
     let mut ping = raw_mcp_request(PING);
     ping.headers_mut().insert(SESSION_ID_HEADER, session_id);
@@ -564,10 +591,13 @@ async fn readyz_classifies_auth_transport_and_timeout_results() {
     );
 }
 
-/// Reads the workspace an initialized session was scoped to.
-async fn session_workspace_line(server: &RunningMcpHttpServer) -> String {
-    let transport =
-        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
+/// Reads the workspace the session at one workspace URL was scoped to.
+async fn session_workspace_line(server: &RunningMcpHttpServer, workspace: &str) -> String {
+    let transport = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}{}",
+        server.local_addr(),
+        ws_path(workspace)
+    ));
     let client = ().serve(transport).await.expect("initialize MCP client");
     let line = client
         .peer_info()
@@ -583,15 +613,11 @@ async fn session_workspace_line(server: &RunningMcpHttpServer) -> String {
     line
 }
 
-/// A configured name is used exactly, including one no workspace answers to.
-///
-/// Composition validated the name's shape already, so the adapter wraps it
-/// rather than re-deriving it, and it never consults memberships: a surface
-/// configured today has to start for a workspace created tomorrow. The unnamed
-/// second workspace here would make any membership-based choice ambiguous, so
-/// starting at all proves the configured name was taken as authoritative.
+/// Every existing workspace is served at its own URL, each session scoped to
+/// exactly the workspace its URL names — with several workspaces existing, so
+/// any single-workspace selection rule would have to pick wrong somewhere.
 #[tokio::test]
-async fn auth_disabled_workspace_selection_uses_the_configured_name() {
+async fn auth_disabled_routes_each_workspace_at_its_own_url() {
     let (_temp, app_server, app) = local_app().await;
     let options = workspace_scoped_options(&app).await;
     create_workspace(&app, "reporting").await;
@@ -602,27 +628,11 @@ async fn auth_disabled_workspace_selection_uses_the_configured_name() {
         .expect("start MCP HTTP server");
 
     assert_eq!(
-        session_workspace_line(&server).await,
+        session_workspace_line(&server, TEST_WORKSPACE).await,
         format!("Current Coral workspace: {TEST_WORKSPACE}.")
     );
-
-    server.shutdown().await.expect("shutdown MCP HTTP server");
-    app_server.shutdown().await.expect("shutdown app server");
-}
-
-/// Naming none is answered by the local user's one membership.
-#[tokio::test]
-async fn auth_disabled_workspace_selection_uses_the_sole_membership() {
-    let (_temp, app_server, app) = local_app().await;
-    create_workspace(&app, "reporting").await;
-    let config =
-        McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
-    let server = start_auth_disabled(config, app, McpOptions::default())
-        .await
-        .expect("start MCP HTTP server");
-
     assert_eq!(
-        session_workspace_line(&server).await,
+        session_workspace_line(&server, "reporting").await,
         "Current Coral workspace: reporting."
     );
 
@@ -630,84 +640,134 @@ async fn auth_disabled_workspace_selection_uses_the_sole_membership() {
     app_server.shutdown().await.expect("shutdown app server");
 }
 
-/// Owning nothing and owning several are different problems for the operator,
-/// so they get different guidance instead of one workspace picked for them.
+/// The server starts with no workspaces at all, and existence is answered per
+/// handshake with negatives never cached: a URL that is not-found now becomes
+/// servable the moment its workspace is created, with nothing restarted.
 #[tokio::test]
-async fn auth_disabled_workspace_selection_reports_zero_and_several_distinctly() {
+async fn auth_disabled_serves_with_no_workspaces_and_admits_one_created_later() {
     let (_temp, app_server, app) = local_app().await;
     let config =
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
+    let server = start_auth_disabled(config, app.clone(), McpOptions::default())
+        .await
+        .expect("a server with nothing to serve still starts");
 
-    let Err(McpHttpError::NoLocalWorkspace) =
-        start_auth_disabled(config.clone(), app.clone(), McpOptions::default()).await
-    else {
-        panic!("a local user with no workspace must be told to create one");
-    };
+    let response = initialize_raw(&server, TEST_WORKSPACE).await;
+    assert_eq!(
+        response.0,
+        StatusCode::NOT_FOUND,
+        "before the workspace exists its URL is a plain not-found"
+    );
+    assert!(
+        response.1.is_empty(),
+        "an unknown workspace says nothing at all: {:?}",
+        response.1
+    );
 
     create_workspace(&app, TEST_WORKSPACE).await;
-    create_workspace(&app, "reporting").await;
-    let Err(McpHttpError::AmbiguousLocalWorkspace(available)) =
-        start_auth_disabled(config, app, McpOptions::default()).await
-    else {
-        panic!("a local user with several workspaces must be told to name one");
-    };
-    for name in [TEST_WORKSPACE, "reporting"] {
-        assert!(
-            available.contains(name),
-            "the guidance must name the workspaces to choose between, got {available}"
-        );
-    }
+    assert_eq!(
+        session_workspace_line(&server, TEST_WORKSPACE).await,
+        format!("Current Coral workspace: {TEST_WORKSPACE}."),
+        "the probe that found nothing must not have been cached"
+    );
 
+    server.shutdown().await.expect("shutdown MCP HTTP server");
     app_server.shutdown().await.expect("shutdown app server");
 }
 
-/// A configured name nothing answers to is a request-time not-found, not a
-/// startup failure: the surface serves, and the tool that needs the workspace
-/// reports the ordinary contract rather than reaching another workspace.
+/// Deleting a workspace makes its URL refuse new handshakes immediately.
+///
+/// The already-open session is the stated boundary: admission is decided per
+/// handshake, so the session keeps answering transport-level exchanges while
+/// every workspace-scoped call fails against the backend that no longer has
+/// the workspace.
 #[tokio::test]
-async fn auth_disabled_workspace_selection_defers_a_missing_name_to_the_request() {
+async fn auth_disabled_delete_makes_the_url_not_found_for_new_handshakes() {
     let (_temp, app_server, app) = local_app().await;
-    create_workspace(&app, "reporting").await;
+    let options = workspace_scoped_options(&app).await;
     let config =
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
-    let server = start_auth_disabled(
-        config,
-        app,
-        McpOptions {
-            workspace: Some(workspace("never-created")),
-            ..McpOptions::default()
-        },
-    )
-    .await
-    .expect("a configured name is not checked for existence at startup");
+    let server = start_auth_disabled(config, app.clone(), options)
+        .await
+        .expect("start MCP HTTP server");
 
-    let transport =
-        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
+    let transport = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}{}",
+        server.local_addr(),
+        ws_path(TEST_WORKSPACE)
+    ));
     let client = ().serve(transport).await.expect("initialize MCP client");
+
+    app.workspace_client()
+        .delete_workspace(GrpcRequest::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace(TEST_WORKSPACE)),
+        }))
+        .await
+        .expect("delete the workspace");
+
+    let (status, body) = initialize_raw(&server, TEST_WORKSPACE).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a deleted workspace's URL refuses the next handshake like one that never existed"
+    );
+    assert!(body.is_empty(), "and says nothing at all: {body:?}");
+
     let refused = client
         .call_tool(CallToolRequestParams::new("start_task").with_arguments(
             serde_json::Map::from_iter([(
                 "intent".to_string(),
-                serde_json::json!("Reach the workspace that was configured"),
+                serde_json::json!("Reach the deleted workspace"),
             )]),
         ))
         .await
         .expect("a workspace rejection is an in-band tool result");
-
     assert_eq!(
         refused.is_error,
         Some(true),
-        "a configured workspace that does not exist must be reported, not replaced"
-    );
-    let reported = format!("{:?}", refused.content);
-    assert!(
-        reported.contains("never-created"),
-        "the refusal must name the workspace that was asked for, got {reported}"
+        "the surviving session's workspace-scoped calls fail against the backend"
     );
 
     let _cancel_result = client.cancel().await;
     server.shutdown().await.expect("shutdown MCP HTTP server");
     app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// One raw initialize at a workspace URL, as (status, body bytes).
+async fn initialize_raw(server: &RunningMcpHttpServer, name: &str) -> (StatusCode, Vec<u8>) {
+    let mut stream = TcpStream::connect(server.local_addr())
+        .await
+        .expect("connect");
+    stream
+        .write_all(
+            format!(
+                "POST {} HTTP/1.1\r\nHost: {}\r\nAccept: application/json, text/event-stream\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{INITIALIZE}",
+                ws_path(name),
+                server.local_addr(),
+                INITIALIZE.len(),
+            )
+            .as_bytes(),
+        )
+        .await
+        .expect("write initialize");
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
+        .await
+        .expect("response ends")
+        .expect("read response");
+    let text = String::from_utf8_lossy(&response);
+    let status_line = text.lines().next().expect("status line");
+    let code = status_line
+        .split_whitespace()
+        .nth(1)
+        .expect("status code")
+        .parse::<u16>()
+        .expect("numeric status");
+    let body = text
+        .split_once("\r\n\r\n")
+        .map(|(_headers, body)| body.as_bytes().to_vec())
+        .unwrap_or_default();
+    (StatusCode::from_u16(code).expect("status"), body)
 }
 
 #[tokio::test]
@@ -725,8 +785,11 @@ async fn streamable_http_executes_tools_and_shutdown_is_bounded() {
     )
     .await
     .expect("start MCP HTTP server");
-    let transport =
-        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
+    let transport = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}{}",
+        server.local_addr(),
+        ws_path(TEST_WORKSPACE)
+    ));
     let client = ().serve(transport).await.expect("initialize MCP client");
     let task = client
         .call_tool(CallToolRequestParams::new("start_task").with_arguments(
@@ -766,18 +829,9 @@ async fn streamable_http_executes_tools_and_shutdown_is_bounded() {
         .expect("gRPC rejection is an in-band tool result");
     assert_eq!(rejected.is_error, Some(true));
 
-    let sessions = local_sessions(&server);
+    let sessions = local_workspaces(&server);
     let state = Arc::downgrade(&server.state);
-    assert_eq!(
-        sessions
-            .upgrade()
-            .expect("sessions")
-            .sessions
-            .read()
-            .await
-            .len(),
-        1
-    );
+    assert_eq!(running_local_session_count(&sessions).await, 1);
     drop(
         server
             .state
@@ -816,7 +870,7 @@ async fn shutdown_timeout_matches_one_second_contract() {
     let (_temp, app_server, app) = local_app().await;
     let config =
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
-    let server = start_auth_disabled(config, app, workspace_named_options())
+    let server = start_auth_disabled(config, app, McpOptions::default())
         .await
         .expect("start MCP HTTP server");
     let state = server.state.clone();
@@ -838,27 +892,22 @@ async fn shutdown_timeout_matches_one_second_contract() {
 #[tokio::test]
 async fn dropping_server_cancels_requests_and_releases_state() {
     let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
     let config =
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
-    let server = start_auth_disabled(config, app, workspace_named_options())
+    let server = start_auth_disabled(config, app, options)
         .await
         .expect("start MCP HTTP server");
-    let transport =
-        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
+    let transport = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}{}",
+        server.local_addr(),
+        ws_path(TEST_WORKSPACE)
+    ));
     let client = ().serve(transport).await.expect("initialize MCP client");
 
-    let sessions = local_sessions(&server);
+    let sessions = local_workspaces(&server);
     let state = Arc::downgrade(&server.state);
-    assert_eq!(
-        sessions
-            .upgrade()
-            .expect("sessions")
-            .sessions
-            .read()
-            .await
-            .len(),
-        1
-    );
+    assert_eq!(running_local_session_count(&sessions).await, 1);
     let mut stalled = open_stalled_request(&server).await;
 
     drop(server);
@@ -891,7 +940,7 @@ async fn authenticated_session_lifecycle_is_coherent() {
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |_| {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
@@ -978,7 +1027,7 @@ async fn authenticated_requests_are_bounded_before_and_after_initialization() {
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |_| {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
@@ -1037,7 +1086,7 @@ async fn authenticated_sessions_remain_isolated() {
     let (_temp, app_server, app) = local_app().await;
     let options = workspace_scoped_options(&app).await;
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
         options,
         || async { Ok::<_, tonic::Code>(()) },
@@ -1087,7 +1136,7 @@ async fn authenticated_session_admission_rejects_before_client_creation() {
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |_| {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
@@ -1527,13 +1576,9 @@ fn control_plane_by(token: &str) -> DirectoryCall {
 /// vouch for. Keeping it in the same runtime as the admitted ones is what lets
 /// a test compare an authentication answer against an admission answer without
 /// changing anything else about the surface.
-fn admission_runtime(
-    endpoint: String,
-    options: McpOptions,
-    disowned: &'static str,
-) -> AuthenticatedMcpHttpRuntime {
+fn admission_runtime(endpoint: String, disowned: &'static str) -> AuthenticatedMcpHttpRuntime {
     AuthenticatedMcpHttpRuntime::new(
-        move |token: String| {
+        move |token: String, _audience: String| {
             let vouched = token != disowned;
             async move { if vouched { Ok(()) } else { Err(()) } }
         },
@@ -1541,7 +1586,7 @@ fn admission_runtime(
             let endpoint = endpoint.clone();
             async move { bearer_client(&endpoint, &token).await }
         },
-        options,
+        McpOptions::default(),
         || async { Ok::<_, tonic::Code>(()) },
     )
 }
@@ -1554,44 +1599,31 @@ async fn bearer_client(endpoint: &str, token: &str) -> Result<AppClient, ()> {
         .map_err(|_error| ())
 }
 
-/// One authenticated surface, configured for one workspace of one directory.
+/// One authenticated surface over one directory of workspaces.
 ///
-/// Two of these over the same directory is what a deployment looks like from
-/// two people's desks: one world of workspaces, and a surface each, naming the
-/// workspace its own operator meant to serve.
-fn surface_naming(directory: &RunningDirectory, configured: &str) -> (Router, super::AuthState) {
+/// The surface serves every workspace at its own URL; which workspace a
+/// request is about is the URL's to say, so the fixture configures none.
+fn surface(directory: &RunningDirectory) -> (Router, super::AuthState) {
     authenticated_router(
         authenticated_config(),
-        admission_runtime(
-            directory.endpoint.clone(),
-            options_naming(configured),
-            "impostor",
-        ),
+        admission_runtime(directory.endpoint.clone(), "impostor"),
     )
 }
 
-/// A surface that names no workspace admits nobody, and says what to do.
+/// A surface that cannot build the caller's client answers 503, not not-found.
 ///
-/// The caller holds a workspace here, and it is still not substituted for the
-/// one nothing named: an unnamed workspace is a configuration answer, so no
-/// bearer-bound client is built and the directory is asked nothing at all —
-/// admission cannot pick what it never read. The unauthenticated readiness
-/// probe stays untouched too; it is not a way to find a workspace.
+/// Unavailability is a statement about the server, not about any workspace, so
+/// it must not wear the concealed refusal's shape — and it must not challenge,
+/// because the caller's credential was fine. The directory is asked nothing:
+/// admission never got far enough to have a question.
 #[tokio::test]
-async fn authenticated_admission_requires_a_configured_workspace() {
+async fn authenticated_admission_unavailability_is_not_an_answer_about_a_workspace() {
     let directory = serve_directory(vec![("member", vec![TEST_WORKSPACE.to_string()])]).await;
-    let endpoint = directory.endpoint.clone();
-    let client_calls = Arc::new(AtomicUsize::new(0));
-    let counted_client_calls = Arc::clone(&client_calls);
     let readiness_calls = Arc::new(AtomicUsize::new(0));
     let counted_readiness_calls = Arc::clone(&readiness_calls);
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
-        move |token: String| {
-            counted_client_calls.fetch_add(1, Ordering::Relaxed);
-            let endpoint = endpoint.clone();
-            async move { bearer_client(&endpoint, &token).await }
-        },
+        |_, _| async { Ok::<_, ()>(()) },
+        move |_token: String| std::future::ready(Err::<AppClient, ()>(())),
         McpOptions::default(),
         move || {
             counted_readiness_calls.fetch_add(1, Ordering::Relaxed);
@@ -1600,24 +1632,21 @@ async fn authenticated_admission_requires_a_configured_workspace() {
     );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
 
-    let refused = send(&router, auth_request("Bearer member", None, INITIALIZE)).await;
-    let error = refusal_error(refused).await;
-
-    let guidance = refusal_guidance(&error);
+    let unavailable = send(&router, auth_request("Bearer member", None, INITIALIZE)).await;
+    assert_eq!(unavailable.status(), StatusCode::SERVICE_UNAVAILABLE);
     assert!(
-        guidance.contains("no workspace configured"),
-        "guidance: {guidance}"
+        !unavailable.headers().contains_key(header::WWW_AUTHENTICATE),
+        "an availability answer is not an authentication answer"
     );
     assert!(
-        guidance.contains("Reef") && guidance.contains("server.mcp_http.workspace"),
-        "guidance must name both ways out: {guidance}"
+        unavailable.headers().get(SESSION_ID_HEADER).is_none(),
+        "no session opens on an undecided admission"
     );
-    assert_eq!(client_calls.load(Ordering::Relaxed), 0);
     assert_eq!(readiness_calls.load(Ordering::Relaxed), 0);
     assert_eq!(
         directory.calls(),
         Vec::new(),
-        "with nothing configured there is no membership question to ask"
+        "admission that could not build a client had no question to ask"
     );
     assert_eq!(state.sessions.len().await, 0);
     assert_eq!(
@@ -1654,7 +1683,7 @@ async fn authenticated_admission_binds_only_an_exact_membership() {
     let readiness_calls = Arc::new(AtomicUsize::new(0));
     let counted_readiness_calls = Arc::clone(&readiness_calls);
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |token: String| {
             let endpoint = if token == "stranger" {
                 elsewhere_endpoint.clone()
@@ -1663,7 +1692,7 @@ async fn authenticated_admission_binds_only_an_exact_membership() {
             };
             async move { bearer_client(&endpoint, &token).await }
         },
-        workspace_named_options(),
+        McpOptions::default(),
         move || {
             counted_readiness_calls.fetch_add(1, Ordering::Relaxed);
             async { Ok::<_, tonic::Code>(()) }
@@ -1735,29 +1764,22 @@ async fn authenticated_admission_binds_only_an_exact_membership() {
 
 /// Three ways to be turned away stay three answers for whoever runs the server.
 ///
-/// A caller the authorization server will not vouch for, a surface that names
-/// no workspace, and a configured name the caller does not hold are three
-/// different things to fix — a token, a config file, a membership — and an
-/// operator reading one response has to know which. Concealment is owed to the
-/// *caller* about which workspaces exist, and this is the boundary of that
-/// debt: it never obliged the surface to answer "no" the same way to questions
-/// that are not about a workspace at all.
+/// A caller the authorization server will not vouch for, a workspace the
+/// caller does not hold, and a server that cannot decide are three different
+/// things to fix — a token, a membership, an outage — and an operator reading
+/// one response has to know which. Concealment is owed to the *caller* about
+/// which workspaces exist, and this is the boundary of that debt: it never
+/// obliged the surface to answer "no" the same way to questions that are not
+/// about a workspace at all.
 ///
-/// The rejected bearer never reaches the directory, and the unconfigured
-/// surface never asks it anything even though the caller holds a workspace
-/// there — the configuration answer is settled before the membership question
-/// is worth asking, so neither refusal can be the other in disguise.
+/// The rejected bearer never reaches the directory — authentication is settled
+/// before the membership question is worth asking — and the unavailable
+/// surface asks nothing either, so neither refusal can be the membership
+/// refusal in disguise.
 #[tokio::test]
 async fn authenticated_admission_keeps_its_three_refusals_apart() {
     let directory = serve_directory(vec![("member", vec![TEST_WORKSPACE.to_string()])]).await;
-    let (router, state) = authenticated_router(
-        authenticated_config(),
-        admission_runtime(
-            directory.endpoint.clone(),
-            workspace_named_options(),
-            "impostor",
-        ),
-    );
+    let (router, state) = surface(&directory);
 
     let unvouched = send(&router, auth_request("Bearer impostor", None, INITIALIZE)).await;
     assert_eq!(unvouched.status(), StatusCode::UNAUTHORIZED);
@@ -1777,58 +1799,50 @@ async fn authenticated_admission_keeps_its_three_refusals_apart() {
         "an admission answer must not read as an authentication failure"
     );
     let unreachable = refusal_error(unreachable).await;
-
-    let (bare_router, bare_state) = authenticated_router(
-        authenticated_config(),
-        admission_runtime(
-            directory.endpoint.clone(),
-            McpOptions::default(),
-            "impostor",
-        ),
-    );
-    let unconfigured = send(
-        &bare_router,
-        auth_request("Bearer member", None, INITIALIZE),
-    )
-    .await;
-    assert!(
-        !unconfigured
-            .headers()
-            .contains_key(header::WWW_AUTHENTICATE),
-        "an admission answer must not read as an authentication failure"
-    );
-    let unconfigured = refusal_error(unconfigured).await;
-
     assert!(
         refusal_guidance(&unreachable)
             .contains(&format!("Workspace `{TEST_WORKSPACE}` was not found")),
         "guidance: {}",
         refusal_guidance(&unreachable)
     );
-    assert!(
-        refusal_guidance(&unconfigured).contains("no workspace configured"),
-        "guidance: {}",
-        refusal_guidance(&unconfigured)
+
+    let (broken_router, broken_state) = authenticated_router(
+        authenticated_config(),
+        AuthenticatedMcpHttpRuntime::new(
+            |_, _| async { Ok::<_, ()>(()) },
+            |_token: String| std::future::ready(Err::<AppClient, ()>(())),
+            McpOptions::default(),
+            || async { Ok::<_, tonic::Code>(()) },
+        ),
     );
-    assert_ne!(
-        refusal_guidance(&unreachable),
-        refusal_guidance(&unconfigured),
-        "an unnamed workspace and an unheld one are different things to fix"
+    let unavailable = send(
+        &broken_router,
+        auth_request("Bearer member", None, INITIALIZE),
+    )
+    .await;
+    assert_eq!(
+        unavailable.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a server that cannot decide says so, in nobody's refusal shape"
+    );
+    assert!(
+        !unavailable.headers().contains_key(header::WWW_AUTHENTICATE),
+        "an availability answer must not read as an authentication failure"
     );
 
     assert_eq!(
         directory.calls(),
         vec![listing_by("stranger")],
-        "only the configured surface had a membership question to ask"
+        "only the membership refusal had a question to ask"
     );
     assert_eq!(state.sessions.len().await, 0);
     assert_eq!(
         state.sessions.available_permits(),
         MAX_AUTHENTICATED_SESSIONS
     );
-    assert_eq!(bare_state.sessions.len().await, 0);
+    assert_eq!(broken_state.sessions.len().await, 0);
     assert_eq!(
-        bare_state.sessions.available_permits(),
+        broken_state.sessions.available_permits(),
         MAX_AUTHENTICATED_SESSIONS
     );
 }
@@ -1853,14 +1867,7 @@ async fn authenticated_admission_asks_memberships_once_and_identity_never() {
         ("neighbor", vec!["reporting".to_string()]),
     ])
     .await;
-    let (router, state) = authenticated_router(
-        authenticated_config(),
-        admission_runtime(
-            directory.endpoint.clone(),
-            workspace_named_options(),
-            "impostor",
-        ),
-    );
+    let (router, state) = surface(&directory);
 
     let admitted = send(&router, auth_request("Bearer member", None, INITIALIZE)).await;
     assert_eq!(admitted.status(), StatusCode::OK);
@@ -1943,14 +1950,7 @@ async fn authenticated_admission_asks_memberships_once_and_identity_never() {
 #[tokio::test]
 async fn authenticated_admission_refuses_the_handshake_not_the_first_tool_call() {
     let directory = serve_directory(vec![("orphan", Vec::new())]).await;
-    let (router, state) = authenticated_router(
-        authenticated_config(),
-        admission_runtime(
-            directory.endpoint.clone(),
-            workspace_named_options(),
-            "impostor",
-        ),
-    );
+    let (router, state) = surface(&directory);
 
     let refusal =
         refusal_error(send(&router, auth_request("Bearer orphan", None, INITIALIZE)).await).await;
@@ -1960,7 +1960,7 @@ async fn authenticated_admission_refuses_the_handshake_not_the_first_tool_call()
         "guidance: {guidance}"
     );
     assert!(
-        guidance.contains("server.mcp_http.workspace"),
+        guidance.contains("Check the workspace URL"),
         "the handshake is where a way out still fits: {guidance}"
     );
     assert_eq!(state.sessions.len().await, 0);
@@ -2006,39 +2006,44 @@ async fn authenticated_admission_refuses_the_handshake_not_the_first_tool_call()
 const ALPHA_WORKSPACE: &str = "alpha-ledger";
 const BETA_WORKSPACE: &str = "beta-ledger";
 
-/// Two callers, two surfaces, and neither is ever served the other's workspace.
+/// Two callers, two workspace URLs on one surface, and neither is ever served
+/// the other's workspace.
 ///
-/// A configured workspace belongs to the surface, not to the caller, so two
-/// people sharing one deployment reach it through two surfaces — each naming the
-/// workspace that person holds. What has to hold is that the pairing is the only
-/// one that works: each caller is admitted on their own surface, scoped to the
-/// name that surface configured, and turned away on the other's.
+/// The URL names the workspace, so two people sharing one deployment reach
+/// their workspaces through one surface — each at the URL naming the workspace
+/// that person holds. What has to hold is that the pairing is the only one
+/// that works: each caller is admitted at their own workspace's URL, scoped to
+/// exactly that workspace, and turned away at the other's.
 ///
 /// The refusals are where a fallback would surface. Both of these callers hold a
 /// workspace, and it is an accessible one — exactly the material a "serve
 /// whatever they can reach" rule needs — so being refused the name they do not
-/// hold, and never being offered the name they do, is the claim. A rule that
-/// substituted an accessible workspace would pass every test that only checks a
-/// caller can reach their own.
+/// hold, and never being offered the name they do, is the claim.
+///
+/// The cross-workspace session replay is the sharp edge: beta's session id is
+/// presented at alpha's URL *by beta, whose bearer is valid where the session
+/// really lives* — and it is still a plain not-found, because at that URL the
+/// session does not exist. Only a wrong bearer for a session that does exist
+/// at the URL earns the 403.
 ///
 /// Nothing here asks the directory anything but a membership listing, and the
 /// log proves the absence rather than assuming it: one control-plane attempt at
 /// the end lands in the same log, so the RPCs an MCP credential must never
 /// reach are ones this fixture demonstrably notices.
 #[tokio::test]
-async fn authenticated_admission_binds_two_callers_to_their_own_surfaces() {
+#[expect(clippy::too_many_lines, reason = "one scenario walks both workspaces end to end")]
+async fn authenticated_admission_binds_each_caller_to_the_urls_workspace() {
     let directory = serve_directory(vec![
         ("alpha", vec![ALPHA_WORKSPACE.to_string()]),
         ("beta", vec![BETA_WORKSPACE.to_string()]),
     ])
     .await;
-    let (alpha_router, alpha_state) = surface_naming(&directory, ALPHA_WORKSPACE);
-    let (beta_router, beta_state) = surface_naming(&directory, BETA_WORKSPACE);
+    let (router, state) = surface(&directory);
 
     let alpha_session = admitted_session_scoped_to(
         send(
-            &alpha_router,
-            auth_request("Bearer alpha", None, INITIALIZE),
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
         )
         .await,
         ALPHA_WORKSPACE,
@@ -2046,20 +2051,24 @@ async fn authenticated_admission_binds_two_callers_to_their_own_surfaces() {
     )
     .await;
     let beta_session = admitted_session_scoped_to(
-        send(&beta_router, auth_request("Bearer beta", None, INITIALIZE)).await,
+        send(
+            &router,
+            auth_request_at(BETA_WORKSPACE, "Bearer beta", None, INITIALIZE),
+        )
+        .await,
         BETA_WORKSPACE,
         ALPHA_WORKSPACE,
     )
     .await;
 
-    let mut ping = auth_request("Bearer alpha", Some(&alpha_session), PING);
+    let mut ping = auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", Some(&alpha_session), PING);
     ping.headers_mut()
         .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
-    assert!(send(&alpha_router, ping).await.status().is_success());
+    assert!(send(&router, ping).await.status().is_success());
     assert_eq!(
         send(
-            &alpha_router,
-            auth_request("Bearer beta", Some(&alpha_session), PING)
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer beta", Some(&alpha_session), PING)
         )
         .await
         .status(),
@@ -2068,36 +2077,41 @@ async fn authenticated_admission_binds_two_callers_to_their_own_surfaces() {
     );
     assert_eq!(
         send(
-            &alpha_router,
-            auth_request("Bearer beta", Some(&beta_session), PING)
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer beta", Some(&beta_session), PING)
         )
         .await
         .status(),
         StatusCode::NOT_FOUND,
-        "a session opened on one surface does not exist on the other"
+        "a session opened at one workspace's URL does not exist at another's, \
+         even for the bearer that owns it where it lives"
     );
 
-    let beta_on_alpha =
-        refusal_error(send(&alpha_router, auth_request("Bearer beta", None, INITIALIZE)).await)
-            .await;
+    let beta_on_alpha = refusal_error(
+        send(
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer beta", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     assert_refused_without_a_substitute(&beta_on_alpha, ALPHA_WORKSPACE, BETA_WORKSPACE);
 
-    let alpha_on_beta =
-        refusal_error(send(&beta_router, auth_request("Bearer alpha", None, INITIALIZE)).await)
-            .await;
+    let alpha_on_beta = refusal_error(
+        send(
+            &router,
+            auth_request_at(BETA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     assert_refused_without_a_substitute(&alpha_on_beta, BETA_WORKSPACE, ALPHA_WORKSPACE);
 
-    assert_eq!(alpha_state.sessions.len().await, 1);
-    assert_eq!(beta_state.sessions.len().await, 1);
+    assert_eq!(state.sessions.len().await, 2);
     assert_eq!(
-        alpha_state.sessions.available_permits(),
-        MAX_AUTHENTICATED_SESSIONS - 1,
-        "the refused caller left no admission reserved behind"
-    );
-    assert_eq!(
-        beta_state.sessions.available_permits(),
-        MAX_AUTHENTICATED_SESSIONS - 1,
-        "the refused caller left no admission reserved behind"
+        state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS - 2,
+        "the refused callers left no admission reserved behind"
     );
 
     assert_eq!(
@@ -2130,8 +2144,7 @@ async fn authenticated_admission_binds_two_callers_to_their_own_surfaces() {
         "a control-plane RPC is one this log records, so its absence above was observed"
     );
 
-    alpha_state.sessions.close_all().await;
-    beta_state.sessions.close_all().await;
+    state.sessions.close_all().await;
 }
 
 /// One sentence covers every reason the configured workspace is out of reach.
@@ -2164,7 +2177,7 @@ async fn authenticated_admission_conceals_why_a_workspace_is_out_of_reach() {
     let deployment_endpoint = deployment.endpoint.clone();
     let elsewhere_endpoint = elsewhere.endpoint.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |token: String| {
             let endpoint = if token == "alpha" || token == "beta" {
                 deployment_endpoint.clone()
@@ -2173,17 +2186,35 @@ async fn authenticated_admission_conceals_why_a_workspace_is_out_of_reach() {
             };
             async move { bearer_client(&endpoint, &token).await }
         },
-        options_naming(BETA_WORKSPACE),
+        McpOptions::default(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
 
-    let held_by_another =
-        refusal_error(send(&router, auth_request("Bearer alpha", None, INITIALIZE)).await).await;
-    let never_created =
-        refusal_error(send(&router, auth_request("Bearer nomad", None, INITIALIZE)).await).await;
-    let holds_nothing =
-        refusal_error(send(&router, auth_request("Bearer hermit", None, INITIALIZE)).await).await;
+    let held_by_another = refusal_error(
+        send(
+            &router,
+            auth_request_at(BETA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
+    let never_created = refusal_error(
+        send(
+            &router,
+            auth_request_at(BETA_WORKSPACE, "Bearer nomad", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
+    let holds_nothing = refusal_error(
+        send(
+            &router,
+            auth_request_at(BETA_WORKSPACE, "Bearer hermit", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
 
     assert_eq!(
         held_by_another, never_created,
@@ -2204,8 +2235,14 @@ async fn authenticated_admission_conceals_why_a_workspace_is_out_of_reach() {
         "the shared answer names only the workspace that was asked for: {guidance}"
     );
 
-    let (_session, admitted) =
-        admitted_result(send(&router, auth_request("Bearer beta", None, INITIALIZE)).await).await;
+    let (_session, admitted) = admitted_result(
+        send(
+            &router,
+            auth_request_at(BETA_WORKSPACE, "Bearer beta", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     let instructions = admitted_instructions(&admitted);
     assert!(
         instructions.contains(&format!("Current Coral workspace: {BETA_WORKSPACE}.")),
@@ -2255,10 +2292,16 @@ async fn authenticated_admission_follows_a_revocation_without_a_restart() {
         ("beta", vec![BETA_WORKSPACE.to_string()]),
     ])
     .await;
-    let (router, state) = surface_naming(&directory, ALPHA_WORKSPACE);
+    let (router, state) = surface(&directory);
 
-    let (session, admitted) =
-        admitted_result(send(&router, auth_request("Bearer alpha", None, INITIALIZE)).await).await;
+    let (session, admitted) = admitted_result(
+        send(
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     let instructions = admitted_instructions(&admitted);
     assert!(
         instructions.contains(&format!("Current Coral workspace: {ALPHA_WORKSPACE}.")),
@@ -2267,7 +2310,7 @@ async fn authenticated_admission_follows_a_revocation_without_a_restart() {
 
     directory.revoke("alpha", ALPHA_WORKSPACE);
 
-    let mut ping = auth_request("Bearer alpha", Some(&session), PING);
+    let mut ping = auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", Some(&session), PING);
     ping.headers_mut()
         .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
     assert!(
@@ -2275,24 +2318,41 @@ async fn authenticated_admission_follows_a_revocation_without_a_restart() {
         "the session already admitted is not re-decided per request"
     );
 
-    let after_revocation =
-        refusal_error(send(&router, auth_request("Bearer alpha", None, INITIALIZE)).await).await;
+    let after_revocation = refusal_error(
+        send(
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     let guidance = refusal_guidance(&after_revocation);
     assert!(
         guidance.contains(&format!("Workspace `{ALPHA_WORKSPACE}` was not found")),
         "the same server that admitted this caller a moment ago now refuses them: {guidance}"
     );
 
-    let never_held =
-        refusal_error(send(&router, auth_request("Bearer beta", None, INITIALIZE)).await).await;
+    let never_held = refusal_error(
+        send(
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer beta", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     assert_eq!(
         after_revocation, never_held,
         "a membership taken away reads exactly like one never held"
     );
 
-    let (_colleague_session, colleague) =
-        admitted_result(send(&router, auth_request("Bearer colleague", None, INITIALIZE)).await)
-            .await;
+    let (_colleague_session, colleague) = admitted_result(
+        send(
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer colleague", None, INITIALIZE),
+        )
+        .await,
+    )
+    .await;
     let instructions = admitted_instructions(&colleague);
     assert!(
         instructions.contains(&format!("Current Coral workspace: {ALPHA_WORKSPACE}.")),
@@ -2323,7 +2383,7 @@ async fn authenticated_session_honors_the_declared_idle_timeout() {
     let (_temp, app_server, app) = local_app().await;
     let options = workspace_scoped_options(&app).await;
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
         options,
         || async { Ok::<_, tonic::Code>(()) },
@@ -2380,6 +2440,7 @@ async fn authenticated_session_creation_is_cancellation_atomic() {
     let admission_permit = sessions.try_admit().expect("reserve session");
     let manager = AuthenticatedSessionManager {
         sessions: sessions.clone(),
+        workspace: segment(TEST_WORKSPACE),
         fingerprint: binding_fingerprint("token-a"),
         admission_permit: tokio::sync::Mutex::new(Some(admission_permit)),
     };
@@ -2414,6 +2475,7 @@ async fn cancelled_authenticated_session_close_removes_the_record() {
     sessions.records.write().await.insert(
         session_id.clone(),
         AuthenticatedSession {
+            workspace: segment(TEST_WORKSPACE),
             fingerprint,
             handle,
             _admission_permit: admission_permit,
@@ -2421,6 +2483,7 @@ async fn cancelled_authenticated_session_close_removes_the_record() {
     );
     let manager = AuthenticatedSessionManager {
         sessions: sessions.clone(),
+        workspace: segment(TEST_WORKSPACE),
         fingerprint,
         admission_permit: tokio::sync::Mutex::new(None),
     };
@@ -2456,73 +2519,235 @@ fn authenticated_config_accepts_only_https_or_loopback_http_public_urls() {
 }
 
 #[test]
-fn authenticated_config_omits_scope_and_canonicalizes_root_oauth_identifiers() {
+fn authenticated_config_canonicalizes_oauth_identifiers_and_derives_the_route() {
     let config = AuthenticatedMcpHttpConfig::new(
         "127.0.0.1:0".parse().unwrap(),
         "https://mcp.example.com/",
         "https://login.example.com/",
     )
     .unwrap();
-
-    assert_eq!(config.public_url, "https://mcp.example.com");
+    assert_eq!(config.urls.base().identifier(), "https://mcp.example.com");
     assert_eq!(config.authorization_server, "https://login.example.com");
+    // A root public URL mounts the workspace family at the origin root; the
+    // usual `/mcp` base mounts it under `/mcp`.
+    assert_eq!(config.mcp_route(), "/workspace/{workspace}");
     assert_eq!(
-        config.challenge,
-        HeaderValue::from_static(
-            "Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource\""
-        )
+        authenticated_config().mcp_route(),
+        "/mcp/workspace/{workspace}"
     );
 }
 
+/// Discovery is per workspace, uniform across existence, and scope-free.
+///
+/// The challenge names exactly the metadata URL the wildcard route serves for
+/// that workspace, the document's `resource` is exactly that workspace's URL,
+/// and none of it depends on whether the workspace exists — challenge and
+/// document for a name nobody created are byte-identical to a real one's after
+/// substituting the name, so an anonymous probe learns nothing. The base URL's
+/// own metadata path names no workspace and is a plain not-found.
 #[tokio::test]
-async fn authenticated_discovery_and_challenge_do_not_advertise_scopes() {
-    let config = authenticated_config();
-    let metadata_path = config.metadata_path.clone();
+async fn authenticated_discovery_is_per_workspace_and_existence_blind() {
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         |_| std::future::ready(Err::<AppClient, ()>(())),
-        workspace_named_options(),
+        McpOptions::default(),
         || async { Ok::<_, tonic::Code>(()) },
     );
-    let (router, _state) = authenticated_router(config, runtime);
+    let (router, _state) = authenticated_router(authenticated_config(), runtime);
 
-    let unauthorized = send(&router, raw_mcp_request(INITIALIZE)).await;
-    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
-    let challenge = unauthorized
-        .headers()
-        .get(header::WWW_AUTHENTICATE)
-        .unwrap()
-        .to_str()
-        .unwrap();
-    assert!(challenge.contains("resource_metadata="));
-    assert!(!challenge.contains("scope="));
+    let mut challenges = Vec::new();
+    let mut documents = Vec::new();
+    for name in [TEST_WORKSPACE, "never-created"] {
+        let unauthorized = send(&router, raw_mcp_request_at(&ws_path(name), INITIALIZE)).await;
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED, "{name}");
+        let challenge = unauthorized
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            challenge,
+            format!(
+                "Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource/mcp/workspace/{name}\""
+            ),
+            "the challenge names the route's own metadata URL"
+        );
+        assert!(!challenge.contains("scope="));
 
-    let metadata = send(
+        let metadata = send(
+            &router,
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!(
+                    "/.well-known/oauth-protected-resource/mcp/workspace/{name}"
+                ))
+                .header(header::HOST, "mcp.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(metadata.status(), StatusCode::OK, "{name}");
+        let body = to_bytes(metadata.into_body(), usize::MAX).await.unwrap();
+        let document: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            document.get("resource").expect("resource"),
+            &serde_json::json!(format!("https://mcp.example.com/mcp/workspace/{name}"))
+        );
+        assert_eq!(
+            document.get("authorization_servers").expect("servers"),
+            &serde_json::json!(["https://login.example.com"])
+        );
+        assert!(document.get("scopes_supported").is_none());
+
+        challenges.push(challenge.replace(name, "{ws}"));
+        documents.push(
+            String::from_utf8(body.to_vec())
+                .expect("metadata is text")
+                .replace(name, "{ws}"),
+        );
+    }
+    assert_eq!(
+        challenges.first(),
+        challenges.last(),
+        "existence must not shape the challenge"
+    );
+    assert_eq!(
+        documents.first(),
+        documents.last(),
+        "existence must not shape the metadata document"
+    );
+
+    // The base metadata path names no workspace: not-found, no document.
+    let base = send(
         &router,
         Request::builder()
             .method(Method::GET)
-            .uri(metadata_path)
+            .uri("/.well-known/oauth-protected-resource/mcp")
             .header(header::HOST, "mcp.example.com")
             .body(Body::empty())
             .unwrap(),
     )
     .await;
-    assert_eq!(metadata.status(), StatusCode::OK);
-    let body = to_bytes(metadata.into_body(), usize::MAX).await.unwrap();
-    let document: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(base.status(), StatusCode::NOT_FOUND);
+}
+
+/// Malformed segments and retired paths are plain not-founds with no challenge
+/// and no metadata; the fallback's static hint names only the URL shape.
+#[tokio::test]
+async fn authenticated_routes_refuse_malformed_and_legacy_paths_plainly() {
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_, _| async { Ok::<_, ()>(()) },
+        |_| std::future::ready(Err::<AppClient, ()>(())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let (router, _state) = authenticated_router(authenticated_config(), runtime);
+
+    // A well-formed route with a malformed segment: matched, then refused with
+    // nothing at all — no challenge that would make it look protected.
+    for path in ["/mcp/workspace/te%61m", "/mcp/workspace/te%2Fam"] {
+        let response = send(&router, raw_mcp_request_at(path, INITIALIZE)).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+        assert!(
+            !response.headers().contains_key(header::WWW_AUTHENTICATE),
+            "a non-canonical spelling earns no challenge: {path}"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(body.is_empty(), "{path}: {body:?}");
+    }
+
+    // The retired base endpoint and other unmatched paths fall back to the
+    // static hint, which names the URL shape and never a workspace.
+    for path in ["/mcp", "/mcp/workspace", &format!("{}/", ws_path("team"))] {
+        let response = send(&router, raw_mcp_request_at(path, INITIALIZE)).await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+        assert!(
+            !response.headers().contains_key(header::WWW_AUTHENTICATE),
+            "{path}"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).expect("hint is text");
+        assert!(
+            text.contains(WORKSPACE_URL_HINT),
+            "the fallback carries the shape hint: {path} -> {text}"
+        );
+    }
+}
+
+/// A bearer minted for one workspace's resource dies at another's URL.
+///
+/// The runtime's validator here admits a token only for the exact audience it
+/// was minted for, the way the real composition does — so what this pins is
+/// that the surface hands the validator the route's own resource, making the
+/// route the audience boundary. The refusal is an authentication answer with
+/// the refusing route's own challenge, never a workspace answer.
+#[tokio::test]
+async fn a_bearer_for_one_workspace_is_rejected_at_anothers_url() {
+    let directory = serve_directory(vec![
+        ("alpha", vec![ALPHA_WORKSPACE.to_string()]),
+        ("beta", vec![BETA_WORKSPACE.to_string()]),
+    ])
+    .await;
+    let endpoint = directory.endpoint.clone();
+    let minted_for = |token: &str| match token {
+        "alpha" => format!("https://mcp.example.com/mcp/workspace/{ALPHA_WORKSPACE}"),
+        "beta" => format!("https://mcp.example.com/mcp/workspace/{BETA_WORKSPACE}"),
+        _ => String::new(),
+    };
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        move |token: String, audience: String| {
+            let matches = minted_for(&token) == audience;
+            async move { if matches { Ok(()) } else { Err(()) } }
+        },
+        move |token: String| {
+            let endpoint = endpoint.clone();
+            async move { bearer_client(&endpoint, &token).await }
+        },
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+
+    let admitted = send(
+        &router,
+        auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
+    )
+    .await;
     assert_eq!(
-        document
-            .get("resource")
-            .expect("protected-resource metadata must contain resource"),
-        &serde_json::json!("https://mcp.example.com/custom%20mcp")
+        admitted.status(),
+        StatusCode::OK,
+        "the bearer works at exactly the URL it was minted for"
+    );
+
+    let rejected = send(
+        &router,
+        auth_request_at(BETA_WORKSPACE, "Bearer alpha", None, INITIALIZE),
+    )
+    .await;
+    assert_eq!(
+        rejected.status(),
+        StatusCode::UNAUTHORIZED,
+        "at any other workspace's URL the same bearer is an invalid token"
+    );
+    let challenge = rejected
+        .headers()
+        .get(header::WWW_AUTHENTICATE)
+        .expect("an authentication refusal challenges")
+        .to_str()
+        .unwrap();
+    assert!(
+        challenge.contains(&format!("/mcp/workspace/{BETA_WORKSPACE}")),
+        "the challenge belongs to the refusing route: {challenge}"
     );
     assert_eq!(
-        document
-            .get("authorization_servers")
-            .expect("protected-resource metadata must contain authorization_servers"),
-        &serde_json::json!(["https://login.example.com"])
+        directory.calls(),
+        vec![listing_by("alpha")],
+        "a wrong-audience bearer never reaches the membership question"
     );
-    assert!(document.get("scopes_supported").is_none());
+
+    state.sessions.close_all().await;
 }
 
 #[tokio::test]
@@ -2532,7 +2757,7 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
     // its session serves and scopes the options to it.
     let options = workspace_scoped_options(&app).await;
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
         McpOptions {
             surface: extension_options().surface,
@@ -2548,8 +2773,9 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
     let server = server.expect("start authenticated MCP HTTP server");
     let transport = StreamableHttpClientTransport::from_config(
         StreamableHttpClientTransportConfig::with_uri(format!(
-            "http://{}/mcp",
-            server.local_addr()
+            "http://{}{}",
+            server.local_addr(),
+            ws_path(TEST_WORKSPACE)
         ))
         .auth_header("token-a"),
     );
@@ -2596,7 +2822,7 @@ async fn authenticated_extension_uses_its_session_app_client() {
         .expect("stop second app server");
 
     let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
+        |_, _| async { Ok::<_, ()>(()) },
         move |token| {
             let app = if token == "token-a" {
                 live_app.clone()

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -7,8 +8,16 @@ use std::time::Duration;
 use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::{Router, response::Response};
-use coral_api::v1::CreateWorkspaceRequest;
-use coral_client::{AppClient, local::ServerBuilder, workspace};
+use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
+use coral_api::v1::{
+    AddWorkspaceMemberRequest, AddWorkspaceMemberResponse, CreateWorkspaceRequest,
+    CreateWorkspaceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
+    ListWorkspaceMembersRequest, ListWorkspaceMembersResponse, ListWorkspacesRequest,
+    ListWorkspacesResponse, RemoveWorkspaceMemberRequest, RemoveWorkspaceMemberResponse,
+    WorkspaceMembership, WorkspaceRole,
+};
+use coral_client::local::{ServerBuilder, connect_with_loopback_bearer};
+use coral_client::{AppClient, BearerToken, workspace};
 use futures::{future::BoxFuture, poll};
 use rmcp::handler::server::router::tool::IntoToolRoute;
 use rmcp::model::{CallToolRequestParams, ClientJsonRpcMessage};
@@ -23,8 +32,11 @@ use rmcp::transport::{
 use rmcp::{ErrorData, Json, ServiceExt as _};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-use tokio::net::TcpStream;
-use tonic::Request as GrpcRequest;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::metadata::MetadataMap;
+use tonic::transport::Server;
+use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use tower::ServiceExt as _;
 
 use crate::{McpOptions, McpSurface, McpToolContext};
@@ -179,10 +191,13 @@ async fn create_workspace(app: &AppClient, name: &str) {
 
 /// Names [`TEST_WORKSPACE`] without creating it.
 ///
-/// A session factory demands a *resolved* workspace, not an existing one:
-/// whether the name resolves is answered by the request that needs it. Fixtures
-/// below that never reach a workspace-scoped tool therefore only have to name
-/// one, and naming it is what keeps them from exercising a fallback.
+/// The auth-disabled session factory demands a *resolved* workspace, not an
+/// existing one: whether the name resolves is answered by the request that
+/// needs it. Loopback fixtures that never reach a workspace-scoped tool
+/// therefore only have to name one, and naming it is what keeps them from
+/// exercising a fallback. Authenticated fixtures need
+/// [`workspace_scoped_options`] instead, because admission there checks the
+/// name against the caller's memberships before opening a session.
 fn workspace_named_options() -> McpOptions {
     McpOptions {
         workspace: Some(workspace(TEST_WORKSPACE)),
@@ -908,6 +923,7 @@ async fn dropping_server_cancels_requests_and_releases_state() {
 async fn authenticated_session_lifecycle_is_coherent() {
     let config = authenticated_config();
     let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
@@ -916,7 +932,7 @@ async fn authenticated_session_lifecycle_is_coherent() {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
         },
-        workspace_named_options(),
+        options,
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(config, runtime);
@@ -994,6 +1010,7 @@ async fn authenticated_session_lifecycle_is_coherent() {
 #[tokio::test]
 async fn authenticated_requests_are_bounded_before_and_after_initialization() {
     let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
@@ -1002,7 +1019,7 @@ async fn authenticated_requests_are_bounded_before_and_after_initialization() {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
         },
-        workspace_named_options(),
+        options,
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
@@ -1054,10 +1071,11 @@ async fn authenticated_requests_are_bounded_before_and_after_initialization() {
 #[tokio::test]
 async fn authenticated_sessions_remain_isolated() {
     let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        workspace_named_options(),
+        options,
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
@@ -1101,6 +1119,7 @@ async fn authenticated_sessions_remain_isolated() {
 #[tokio::test]
 async fn authenticated_session_admission_rejects_before_client_creation() {
     let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
     let factory_calls = Arc::new(AtomicUsize::new(0));
     let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
@@ -1109,7 +1128,7 @@ async fn authenticated_session_admission_rejects_before_client_creation() {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
         },
-        workspace_named_options(),
+        options,
         || async { Ok::<_, tonic::Code>(()) },
     );
     let sessions = Arc::new(AuthenticatedSessions::new(1));
@@ -1141,14 +1160,387 @@ async fn authenticated_session_admission_rejects_before_client_creation() {
     app_server.shutdown().await.unwrap();
 }
 
+/// Reads the JSON-RPC error a refused `initialize` is answered with.
+///
+/// A refusal has to arrive as the initialize response itself, addressed to that
+/// request: every later exchange on this surface is workspace-scoped, so a
+/// caller refused any other way would learn only that something failed.
+async fn refusal_error(response: Response) -> serde_json::Value {
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get(SESSION_ID_HEADER).is_none(),
+        "a refused initialize must not hand back a session"
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let message: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        message.get("id"),
+        Some(&serde_json::json!(1)),
+        "the refusal must answer the initialize request: {message}"
+    );
+    message
+        .get("error")
+        .expect("a refusal carries a JSON-RPC error")
+        .clone()
+}
+
+fn refusal_guidance(error: &serde_json::Value) -> &str {
+    error
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .expect("a refusal carries guidance text")
+}
+
+/// One RPC a workspace directory answered, and the credential it carried.
+///
+/// Which credential asked is the whole of a membership listing's meaning: the
+/// same question put on a shared unauthenticated connection returns one
+/// deployment-wide answer, so recording the authorization is what separates a
+/// per-caller admission decision from a per-deployment one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DirectoryCall {
+    rpc: &'static str,
+    authorization: Option<String>,
+}
+
+/// Every RPC one workspace directory answered, in order.
+type DirectoryCalls = Arc<std::sync::Mutex<Vec<DirectoryCall>>>;
+
+/// A workspace directory that reveals only the caller's own memberships.
+///
+/// Memberships are keyed by the bearer the request carries, as the real service
+/// scopes them to the authenticated caller. Every RPC is recorded, not only the
+/// listing, so a test can claim admission asked one question and no other: a
+/// second listing, or any question that could tell a concealed workspace from
+/// an absent one, lands in the same log.
+struct WorkspaceDirectory {
+    memberships: HashMap<String, Vec<String>>,
+    calls: DirectoryCalls,
+}
+
+impl WorkspaceDirectory {
+    fn record(&self, rpc: &'static str, metadata: &MetadataMap) -> Option<String> {
+        let authorization = metadata
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        self.calls
+            .lock()
+            .expect("record directory call")
+            .push(DirectoryCall {
+                rpc,
+                authorization: authorization.clone(),
+            });
+        authorization
+    }
+
+    /// Records a question admission has no business asking, then refuses it.
+    ///
+    /// Refusing alone would leave the attempt invisible once the caller
+    /// recovers from the error, so the log sees it first.
+    fn refuse(&self, rpc: &'static str, metadata: &MetadataMap) -> Status {
+        self.record(rpc, metadata);
+        Status::unimplemented(rpc)
+    }
+}
+
+#[tonic::async_trait]
+impl WorkspaceService for WorkspaceDirectory {
+    async fn list_workspaces(
+        &self,
+        request: GrpcRequest<ListWorkspacesRequest>,
+    ) -> Result<GrpcResponse<ListWorkspacesResponse>, Status> {
+        let memberships = self
+            .record("ListWorkspaces", request.metadata())
+            .and_then(|authorization| self.memberships.get(&authorization))
+            .into_iter()
+            .flatten()
+            .map(|name| WorkspaceMembership {
+                workspace: Some(workspace(name.as_str())),
+                role: WorkspaceRole::Owner as i32,
+            })
+            .collect();
+        Ok(GrpcResponse::new(ListWorkspacesResponse { memberships }))
+    }
+
+    async fn create_workspace(
+        &self,
+        request: GrpcRequest<CreateWorkspaceRequest>,
+    ) -> Result<GrpcResponse<CreateWorkspaceResponse>, Status> {
+        Err(self.refuse("CreateWorkspace", request.metadata()))
+    }
+
+    async fn delete_workspace(
+        &self,
+        request: GrpcRequest<DeleteWorkspaceRequest>,
+    ) -> Result<GrpcResponse<DeleteWorkspaceResponse>, Status> {
+        Err(self.refuse("DeleteWorkspace", request.metadata()))
+    }
+
+    async fn list_workspace_members(
+        &self,
+        request: GrpcRequest<ListWorkspaceMembersRequest>,
+    ) -> Result<GrpcResponse<ListWorkspaceMembersResponse>, Status> {
+        Err(self.refuse("ListWorkspaceMembers", request.metadata()))
+    }
+
+    async fn add_workspace_member(
+        &self,
+        request: GrpcRequest<AddWorkspaceMemberRequest>,
+    ) -> Result<GrpcResponse<AddWorkspaceMemberResponse>, Status> {
+        Err(self.refuse("AddWorkspaceMember", request.metadata()))
+    }
+
+    async fn remove_workspace_member(
+        &self,
+        request: GrpcRequest<RemoveWorkspaceMemberRequest>,
+    ) -> Result<GrpcResponse<RemoveWorkspaceMemberResponse>, Status> {
+        Err(self.refuse("RemoveWorkspaceMember", request.metadata()))
+    }
+}
+
+/// One workspace directory served over loopback gRPC for the length of a test.
+struct RunningDirectory {
+    endpoint: String,
+    calls: DirectoryCalls,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl RunningDirectory {
+    /// The RPCs this directory has answered so far.
+    fn calls(&self) -> Vec<DirectoryCall> {
+        self.calls.lock().expect("read directory calls").clone()
+    }
+}
+
+impl Drop for RunningDirectory {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Serves one directory whose memberships are keyed by bearer token.
+///
+/// A directory is a whole world: the workspaces it contains are exactly the
+/// ones somebody in it holds. Two directories are therefore what it takes to
+/// pose a workspace that exists but is out of reach against one that was never
+/// created at all.
+async fn serve_directory(memberships: Vec<(&str, Vec<String>)>) -> RunningDirectory {
+    let calls = DirectoryCalls::default();
+    let directory = WorkspaceDirectory {
+        memberships: memberships
+            .into_iter()
+            .map(|(token, names)| (format!("Bearer {token}"), names))
+            .collect(),
+        calls: Arc::clone(&calls),
+    };
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind workspace directory");
+    let endpoint = format!(
+        "http://{}",
+        listener.local_addr().expect("directory address")
+    );
+    let task = tokio::spawn(async move {
+        let _served = Server::builder()
+            .add_service(WorkspaceServiceServer::new(directory))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await;
+    });
+    RunningDirectory {
+        endpoint,
+        calls,
+        task,
+    }
+}
+
+/// The one question admission may ask, put on one caller's own bearer.
+fn listing_by(token: &str) -> DirectoryCall {
+    DirectoryCall {
+        rpc: "ListWorkspaces",
+        authorization: Some(format!("Bearer {token}")),
+    }
+}
+
+/// Connects one caller's own bearer-bound client, the way serving does.
+async fn bearer_client(endpoint: &str, token: &str) -> Result<AppClient, ()> {
+    let bearer = BearerToken::new(token).map_err(|_error| ())?;
+    connect_with_loopback_bearer(endpoint, bearer)
+        .await
+        .map_err(|_error| ())
+}
+
+/// A surface that names no workspace admits nobody, and says what to do.
+///
+/// The caller holds a workspace here, and it is still not substituted for the
+/// one nothing named: an unnamed workspace is a configuration answer, so no
+/// bearer-bound client is built and the directory is asked nothing at all —
+/// admission cannot pick what it never read. The unauthenticated readiness
+/// probe stays untouched too; it is not a way to find a workspace.
+#[tokio::test]
+async fn authenticated_admission_requires_a_configured_workspace() {
+    let directory = serve_directory(vec![("member", vec![TEST_WORKSPACE.to_string()])]).await;
+    let endpoint = directory.endpoint.clone();
+    let client_calls = Arc::new(AtomicUsize::new(0));
+    let counted_client_calls = Arc::clone(&client_calls);
+    let readiness_calls = Arc::new(AtomicUsize::new(0));
+    let counted_readiness_calls = Arc::clone(&readiness_calls);
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |token: String| {
+            counted_client_calls.fetch_add(1, Ordering::Relaxed);
+            let endpoint = endpoint.clone();
+            async move { bearer_client(&endpoint, &token).await }
+        },
+        McpOptions::default(),
+        move || {
+            counted_readiness_calls.fetch_add(1, Ordering::Relaxed);
+            async { Ok::<_, tonic::Code>(()) }
+        },
+    );
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+
+    let refused = send(&router, auth_request("Bearer member", None, INITIALIZE)).await;
+    let error = refusal_error(refused).await;
+
+    let guidance = refusal_guidance(&error);
+    assert!(
+        guidance.contains("no workspace configured"),
+        "guidance: {guidance}"
+    );
+    assert!(
+        guidance.contains("Reef") && guidance.contains("server.mcp_http.workspace"),
+        "guidance must name both ways out: {guidance}"
+    );
+    assert_eq!(client_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(readiness_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(
+        directory.calls(),
+        Vec::new(),
+        "with nothing configured there is no membership question to ask"
+    );
+    assert_eq!(state.sessions.len().await, 0);
+    assert_eq!(
+        state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS
+    );
+}
+
+/// Admission binds a session only to the exact workspace the caller holds, and
+/// learns that from one question asked on the caller's own connection.
+///
+/// One configured name meets three callers. The member holds it and is
+/// admitted. The outsider is in the same directory, where the workspace exists
+/// and they simply do not belong to it — they hold only a name that starts the
+/// same way, so admitting anyone's first membership would show up here. The
+/// stranger is in a directory where no such workspace was ever created. Both
+/// are refused with the identical sentence, so nothing in the answer separates
+/// a concealed workspace from an absent one — and the member's admission is
+/// what keeps that sameness from being "deny everyone".
+///
+/// The directories record every RPC, so three claims are observable rather than
+/// assumed: each admission listed exactly once, each listing carried its own
+/// caller's bearer rather than a shared one, and nothing else was ever asked.
+#[tokio::test]
+async fn authenticated_admission_binds_only_an_exact_membership() {
+    let holders = serve_directory(vec![
+        ("member", vec![TEST_WORKSPACE.to_string()]),
+        ("outsider", vec![format!("{TEST_WORKSPACE}-staging")]),
+    ])
+    .await;
+    let elsewhere = serve_directory(vec![("stranger", Vec::new())]).await;
+    let holders_endpoint = holders.endpoint.clone();
+    let elsewhere_endpoint = elsewhere.endpoint.clone();
+    let readiness_calls = Arc::new(AtomicUsize::new(0));
+    let counted_readiness_calls = Arc::clone(&readiness_calls);
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |token: String| {
+            let endpoint = if token == "stranger" {
+                elsewhere_endpoint.clone()
+            } else {
+                holders_endpoint.clone()
+            };
+            async move { bearer_client(&endpoint, &token).await }
+        },
+        workspace_named_options(),
+        move || {
+            counted_readiness_calls.fetch_add(1, Ordering::Relaxed);
+            async { Ok::<_, tonic::Code>(()) }
+        },
+    );
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+
+    let admitted = send(&router, auth_request("Bearer member", None, INITIALIZE)).await;
+    assert_eq!(admitted.status(), StatusCode::OK);
+    let session = admitted.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(state.sessions.len().await, 1);
+    assert_eq!(
+        holders.calls(),
+        vec![listing_by("member")],
+        "admission asks the caller's own connection once, and asks nothing else"
+    );
+
+    let mut ping = auth_request("Bearer member", Some(&session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&router, ping).await.status().is_success());
+    assert_eq!(
+        holders.calls().len(),
+        1,
+        "the decision is made once at admission, not again per request"
+    );
+
+    let outsider_refusal =
+        refusal_error(send(&router, auth_request("Bearer outsider", None, INITIALIZE)).await).await;
+    let stranger_refusal =
+        refusal_error(send(&router, auth_request("Bearer stranger", None, INITIALIZE)).await).await;
+
+    assert_eq!(
+        outsider_refusal, stranger_refusal,
+        "a workspace out of reach and one that does not exist must read alike"
+    );
+    let guidance = refusal_guidance(&outsider_refusal);
+    assert!(
+        guidance.contains(&format!("Workspace `{TEST_WORKSPACE}` was not found")),
+        "the answer they share must be the not-found contract: {guidance}"
+    );
+    assert_eq!(
+        holders.calls(),
+        vec![listing_by("member"), listing_by("outsider")],
+        "every admission lists once, on its own caller's bearer"
+    );
+    assert_eq!(elsewhere.calls(), vec![listing_by("stranger")]);
+    assert_eq!(
+        readiness_calls.load(Ordering::Relaxed),
+        0,
+        "the unauthenticated client stays restricted to health readiness"
+    );
+    assert_eq!(
+        state.sessions.len().await,
+        1,
+        "a refused caller opens no session"
+    );
+    assert_eq!(
+        state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS - 1,
+        "a refusal releases the admission it reserved"
+    );
+
+    state.sessions.close_all().await;
+}
+
 #[tokio::test]
 async fn authenticated_session_honors_the_declared_idle_timeout() {
     let (_temp, app_server, app) = local_app().await;
-    tokio::time::pause();
+    let options = workspace_scoped_options(&app).await;
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        workspace_named_options(),
+        options,
         || async { Ok::<_, tonic::Code>(()) },
     );
     let sessions = Arc::new(AuthenticatedSessions::new(1));
@@ -1163,6 +1555,10 @@ async fn authenticated_session_honors_the_declared_idle_timeout() {
         .to_string();
     assert_eq!(state.sessions.available_permits(), 0);
 
+    // Admission is a live gRPC exchange with the app server, so the clock is
+    // taken over only once it has finished: auto-advance can otherwise run a
+    // request's own deadline out from under it while it waits on the socket.
+    tokio::time::pause();
     tokio::task::yield_now().await;
     tokio::time::advance(SessionConfig::DEFAULT_KEEP_ALIVE + Duration::from_secs(1)).await;
     tokio::task::yield_now().await;

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -562,6 +562,7 @@ async fn readyz_reports_unready_when_the_engine_cannot_resolve_a_real_catalog() 
         options,
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
+        &[],
     )
     .expect("router scoped to a workspace");
 
@@ -659,7 +660,7 @@ async fn auth_disabled_workspace_selection_reports_zero_and_several_distinctly()
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
 
     let Err(McpHttpError::NoLocalWorkspace) =
-        start_auth_disabled(config, app.clone(), McpOptions::default()).await
+        start_auth_disabled(config.clone(), app.clone(), McpOptions::default()).await
     else {
         panic!("a local user with no workspace must be told to create one");
     };

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -2881,7 +2881,7 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
     assert_eq!(
         extension.get("workspace"),
         Some(&serde_json::json!(TEST_WORKSPACE)),
-        "the session serves the workspace its options name"
+        "the session's workspace is the URL's, not a configured default"
     );
     let sessions = authenticated_sessions(&server);
     let state = Arc::downgrade(&server.state);
@@ -2905,9 +2905,7 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
 async fn authenticated_extension_uses_its_session_app_client() {
     let (_live_temp, live_server, live_app) = local_app().await;
     let (_stopped_temp, stopped_server, stopped_app) = local_app().await;
-    // Nothing provisions a workspace any more, so the fixture creates the one
-    // the sessions serve and scopes the options to it.
-    let options = workspace_scoped_options(&live_app).await;
+    create_workspace(&live_app, TEST_WORKSPACE).await;
     stopped_server
         .shutdown()
         .await
@@ -2923,10 +2921,7 @@ async fn authenticated_extension_uses_its_session_app_client() {
             };
             std::future::ready(Ok::<_, ()>(app))
         },
-        McpOptions {
-            surface: extension_options().surface,
-            ..options
-        },
+        extension_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let server = start_authenticated(
@@ -2935,7 +2930,7 @@ async fn authenticated_extension_uses_its_session_app_client() {
     )
     .await
     .expect("start authenticated MCP HTTP server");
-    let endpoint = format!("http://{}/mcp", server.local_addr());
+    let endpoint = format!("http://{}{}", server.local_addr(), ws_path(TEST_WORKSPACE));
 
     let live_client = ()
         .serve(StreamableHttpClientTransport::from_config(
@@ -2943,12 +2938,14 @@ async fn authenticated_extension_uses_its_session_app_client() {
         ))
         .await
         .expect("initialize live MCP session");
-    let stopped_client = ()
+    // Admission lists the caller's workspaces on the session's own client, so
+    // the stopped app refuses this session at the handshake — which is itself
+    // the claim: the session reaches its own client and nobody else's.
+    let stopped_session = ()
         .serve(StreamableHttpClientTransport::from_config(
             StreamableHttpClientTransportConfig::with_uri(endpoint).auth_header("token-b"),
         ))
-        .await
-        .expect("initialize stopped MCP session");
+        .await;
 
     let live_result = live_client
         .call_tool(CallToolRequestParams::new("extension_workspace"))
@@ -2962,16 +2959,12 @@ async fn authenticated_extension_uses_its_session_app_client() {
             .and_then(serde_json::Value::as_u64)
             .is_some_and(|count| count > 0)
     );
-    stopped_client
-        .call_tool(CallToolRequestParams::new("extension_workspace"))
-        .await
-        .expect_err("stopped session must use its unavailable app client");
+    assert!(
+        stopped_session.is_err(),
+        "the stopped session must be refused through its own unavailable client"
+    );
 
     live_client.cancel().await.expect("cancel live MCP client");
-    stopped_client
-        .cancel()
-        .await
-        .expect("cancel stopped MCP client");
     server.shutdown().await.expect("shutdown MCP HTTP server");
     live_server
         .shutdown()

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -8,12 +8,14 @@ use std::time::Duration;
 use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::{Router, response::Response};
+use coral_api::v1::user_service_server::{UserService, UserServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
     AddWorkspaceMemberRequest, AddWorkspaceMemberResponse, CreateWorkspaceRequest,
     CreateWorkspaceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
+    GetCurrentUserRequest, GetCurrentUserResponse, ListUsersRequest, ListUsersResponse,
     ListWorkspaceMembersRequest, ListWorkspaceMembersResponse, ListWorkspacesRequest,
-    ListWorkspacesResponse, RemoveWorkspaceMemberRequest, RemoveWorkspaceMemberResponse,
+    ListWorkspacesResponse, RemoveWorkspaceMemberRequest, RemoveWorkspaceMemberResponse, User,
     WorkspaceMembership, WorkspaceRole,
 };
 use coral_client::local::{ServerBuilder, connect_with_loopback_bearer};
@@ -52,6 +54,9 @@ use super::{
 
 const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
 const PING: &str = r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#;
+/// The first exchange a caller would reach for after a handshake — and the
+/// first that is workspace-scoped, so the first that could only fail opaquely.
+const TOOLS_LIST: &str = r#"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#;
 
 #[rmcp::tool(description = "Return the workspace bound to this MCP session")]
 fn extension_workspace(
@@ -1218,20 +1223,29 @@ struct WorkspaceDirectory {
     calls: DirectoryCalls,
 }
 
+/// Logs one answered RPC and reports the credential it arrived on.
+fn record_call(
+    calls: &DirectoryCalls,
+    rpc: &'static str,
+    metadata: &MetadataMap,
+) -> Option<String> {
+    let authorization = metadata
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    calls
+        .lock()
+        .expect("record directory call")
+        .push(DirectoryCall {
+            rpc,
+            authorization: authorization.clone(),
+        });
+    authorization
+}
+
 impl WorkspaceDirectory {
     fn record(&self, rpc: &'static str, metadata: &MetadataMap) -> Option<String> {
-        let authorization = metadata
-            .get("authorization")
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_string);
-        self.calls
-            .lock()
-            .expect("record directory call")
-            .push(DirectoryCall {
-                rpc,
-                authorization: authorization.clone(),
-            });
-        authorization
+        record_call(&self.calls, rpc, metadata)
     }
 
     /// Records a question admission has no business asking, then refuses it.
@@ -1299,6 +1313,42 @@ impl WorkspaceService for WorkspaceDirectory {
     }
 }
 
+/// The identity half of the same directory, logging into the same record.
+///
+/// Admission has no identity question to ask: which workspaces a caller holds
+/// is answered by the caller's own connection, and the caller's name adds
+/// nothing to it. The half is served anyway — and `GetCurrentUser` is
+/// *answered* rather than refused — so that "identity was never asked" is an
+/// observation instead of an accident of wiring: an admission that asked would
+/// be answered and carry on exactly as before, and only the log would differ.
+struct IdentityDirectory {
+    calls: DirectoryCalls,
+}
+
+#[tonic::async_trait]
+impl UserService for IdentityDirectory {
+    async fn get_current_user(
+        &self,
+        request: GrpcRequest<GetCurrentUserRequest>,
+    ) -> Result<GrpcResponse<GetCurrentUserResponse>, Status> {
+        let authorization = record_call(&self.calls, "GetCurrentUser", request.metadata());
+        Ok(GrpcResponse::new(GetCurrentUserResponse {
+            user: Some(User {
+                user_id: authorization.unwrap_or_default(),
+                display_name: String::new(),
+            }),
+        }))
+    }
+
+    async fn list_users(
+        &self,
+        request: GrpcRequest<ListUsersRequest>,
+    ) -> Result<GrpcResponse<ListUsersResponse>, Status> {
+        record_call(&self.calls, "ListUsers", request.metadata());
+        Err(Status::unimplemented("ListUsers"))
+    }
+}
+
 /// One workspace directory served over loopback gRPC for the length of a test.
 struct RunningDirectory {
     endpoint: String,
@@ -1341,9 +1391,13 @@ async fn serve_directory(memberships: Vec<(&str, Vec<String>)>) -> RunningDirect
         "http://{}",
         listener.local_addr().expect("directory address")
     );
+    let identity = IdentityDirectory {
+        calls: Arc::clone(&calls),
+    };
     let task = tokio::spawn(async move {
         let _served = Server::builder()
             .add_service(WorkspaceServiceServer::new(directory))
+            .add_service(UserServiceServer::new(identity))
             .serve_with_incoming(TcpListenerStream::new(listener))
             .await;
     });
@@ -1360,6 +1414,39 @@ fn listing_by(token: &str) -> DirectoryCall {
         rpc: "ListWorkspaces",
         authorization: Some(format!("Bearer {token}")),
     }
+}
+
+/// The identity question admission has, and must have, no use for.
+fn identity_by(token: &str) -> DirectoryCall {
+    DirectoryCall {
+        rpc: "GetCurrentUser",
+        authorization: Some(format!("Bearer {token}")),
+    }
+}
+
+/// A runtime that admits against one directory and disowns one bearer.
+///
+/// The disowned bearer stands for a token the authorization server declines to
+/// vouch for. Keeping it in the same runtime as the admitted ones is what lets
+/// a test compare an authentication answer against an admission answer without
+/// changing anything else about the surface.
+fn admission_runtime(
+    endpoint: String,
+    options: McpOptions,
+    disowned: &'static str,
+) -> AuthenticatedMcpHttpRuntime {
+    AuthenticatedMcpHttpRuntime::new(
+        move |token: String| {
+            let vouched = token != disowned;
+            async move { if vouched { Ok(()) } else { Err(()) } }
+        },
+        move |token: String| {
+            let endpoint = endpoint.clone();
+            async move { bearer_client(&endpoint, &token).await }
+        },
+        options,
+        || async { Ok::<_, tonic::Code>(()) },
+    )
 }
 
 /// Connects one caller's own bearer-bound client, the way serving does.
@@ -1531,6 +1618,272 @@ async fn authenticated_admission_binds_only_an_exact_membership() {
     );
 
     state.sessions.close_all().await;
+}
+
+/// Three ways to be turned away stay three answers for whoever runs the server.
+///
+/// A caller the authorization server will not vouch for, a surface that names
+/// no workspace, and a configured name the caller does not hold are three
+/// different things to fix — a token, a config file, a membership — and an
+/// operator reading one response has to know which. Concealment is owed to the
+/// *caller* about which workspaces exist, and this is the boundary of that
+/// debt: it never obliged the surface to answer "no" the same way to questions
+/// that are not about a workspace at all.
+///
+/// The rejected bearer never reaches the directory, and the unconfigured
+/// surface never asks it anything even though the caller holds a workspace
+/// there — the configuration answer is settled before the membership question
+/// is worth asking, so neither refusal can be the other in disguise.
+#[tokio::test]
+async fn authenticated_admission_keeps_its_three_refusals_apart() {
+    let directory = serve_directory(vec![("member", vec![TEST_WORKSPACE.to_string()])]).await;
+    let (router, state) = authenticated_router(
+        authenticated_config(),
+        admission_runtime(
+            directory.endpoint.clone(),
+            workspace_named_options(),
+            "impostor",
+        ),
+    );
+
+    let unvouched = send(&router, auth_request("Bearer impostor", None, INITIALIZE)).await;
+    assert_eq!(unvouched.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        unvouched.headers().contains_key(header::WWW_AUTHENTICATE),
+        "an authentication answer sends the caller back to the authorization server"
+    );
+    assert_eq!(
+        directory.calls(),
+        Vec::new(),
+        "a bearer nobody vouches for is turned away before any membership question"
+    );
+
+    let unreachable = send(&router, auth_request("Bearer stranger", None, INITIALIZE)).await;
+    assert!(
+        !unreachable.headers().contains_key(header::WWW_AUTHENTICATE),
+        "an admission answer must not read as an authentication failure"
+    );
+    let unreachable = refusal_error(unreachable).await;
+
+    let (bare_router, bare_state) = authenticated_router(
+        authenticated_config(),
+        admission_runtime(
+            directory.endpoint.clone(),
+            McpOptions::default(),
+            "impostor",
+        ),
+    );
+    let unconfigured = send(
+        &bare_router,
+        auth_request("Bearer member", None, INITIALIZE),
+    )
+    .await;
+    assert!(
+        !unconfigured
+            .headers()
+            .contains_key(header::WWW_AUTHENTICATE),
+        "an admission answer must not read as an authentication failure"
+    );
+    let unconfigured = refusal_error(unconfigured).await;
+
+    assert!(
+        refusal_guidance(&unreachable)
+            .contains(&format!("Workspace `{TEST_WORKSPACE}` was not found")),
+        "guidance: {}",
+        refusal_guidance(&unreachable)
+    );
+    assert!(
+        refusal_guidance(&unconfigured).contains("no workspace configured"),
+        "guidance: {}",
+        refusal_guidance(&unconfigured)
+    );
+    assert_ne!(
+        refusal_guidance(&unreachable),
+        refusal_guidance(&unconfigured),
+        "an unnamed workspace and an unheld one are different things to fix"
+    );
+
+    assert_eq!(
+        directory.calls(),
+        vec![listing_by("stranger")],
+        "only the configured surface had a membership question to ask"
+    );
+    assert_eq!(state.sessions.len().await, 0);
+    assert_eq!(
+        state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS
+    );
+    assert_eq!(bare_state.sessions.len().await, 0);
+    assert_eq!(
+        bare_state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS
+    );
+}
+
+/// Admission asks one question, of the directory's membership half only.
+///
+/// The listing decides the session once and is not repeated per request, and
+/// the identity half is never consulted at all: who the caller is cannot
+/// broaden what they may reach, so asking would only invite deciding on it.
+/// Both claims are made against a log that demonstrably sees what it denies —
+/// a second admission lands a second listing in it, and the identity question
+/// this directory answers lands there too the moment anyone asks it.
+///
+/// The neighbour is the fallback's last hiding place: they hold exactly one
+/// workspace, which is precisely the shape a "resolve the caller's only
+/// workspace" rule was written for. They are refused the configured name and
+/// never offered their own.
+#[tokio::test]
+async fn authenticated_admission_asks_memberships_once_and_identity_never() {
+    let directory = serve_directory(vec![
+        ("member", vec![TEST_WORKSPACE.to_string()]),
+        ("neighbor", vec!["reporting".to_string()]),
+    ])
+    .await;
+    let (router, state) = authenticated_router(
+        authenticated_config(),
+        admission_runtime(
+            directory.endpoint.clone(),
+            workspace_named_options(),
+            "impostor",
+        ),
+    );
+
+    let admitted = send(&router, auth_request("Bearer member", None, INITIALIZE)).await;
+    assert_eq!(admitted.status(), StatusCode::OK);
+    let session = admitted.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(directory.calls(), vec![listing_by("member")]);
+
+    let mut ping = auth_request("Bearer member", Some(&session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&router, ping).await.status().is_success());
+    assert_eq!(
+        directory.calls(),
+        vec![listing_by("member")],
+        "an admitted session re-asks nothing"
+    );
+
+    let neighbor =
+        refusal_error(send(&router, auth_request("Bearer neighbor", None, INITIALIZE)).await).await;
+    let guidance = refusal_guidance(&neighbor);
+    assert!(
+        guidance.contains(&format!("Workspace `{TEST_WORKSPACE}` was not found")),
+        "guidance: {guidance}"
+    );
+    assert!(
+        !guidance.contains("reporting"),
+        "the one workspace a caller does hold is never offered in place of the configured one: {guidance}"
+    );
+    assert_eq!(
+        state.sessions.len().await,
+        1,
+        "a sole membership is refused, not resolved into a session"
+    );
+
+    assert_eq!(
+        directory.calls(),
+        vec![listing_by("member"), listing_by("neighbor")],
+        "a second admission is a second listing, so counting one earlier meant something"
+    );
+    assert!(
+        directory
+            .calls()
+            .iter()
+            .all(|call| call.rpc != "GetCurrentUser"),
+        "admission has no identity question: {:?}",
+        directory.calls()
+    );
+
+    let asker = bearer_client(&directory.endpoint, "member")
+        .await
+        .expect("bearer client");
+    asker
+        .user_client()
+        .get_current_user(GrpcRequest::new(GetCurrentUserRequest {}))
+        .await
+        .expect("this directory answers identity");
+    assert_eq!(
+        directory.calls().last(),
+        Some(&identity_by("member")),
+        "the identity question is one this log records, so its absence above was observed"
+    );
+
+    state.sessions.close_all().await;
+}
+
+/// The refusal lands on the handshake, before any session exists to misuse.
+///
+/// `initialize` is the only exchange on this surface that is not
+/// workspace-scoped, so it is the only one that can carry a sentence an
+/// operator can act on. Admitting a memberless caller and letting `tools/list`
+/// fail instead would spend that one chance: the caller would be left holding a
+/// live session and a bare not-found, with nothing saying which workspace was
+/// meant or what to change.
+///
+/// So the handshake is answered with the guidance, and the two ways a caller
+/// might still try to reach a tool — asking without a session, and inventing
+/// one — are shown to lead nowhere near a workspace.
+#[tokio::test]
+async fn authenticated_admission_refuses_the_handshake_not_the_first_tool_call() {
+    let directory = serve_directory(vec![("orphan", Vec::new())]).await;
+    let (router, state) = authenticated_router(
+        authenticated_config(),
+        admission_runtime(
+            directory.endpoint.clone(),
+            workspace_named_options(),
+            "impostor",
+        ),
+    );
+
+    let refusal =
+        refusal_error(send(&router, auth_request("Bearer orphan", None, INITIALIZE)).await).await;
+    let guidance = refusal_guidance(&refusal);
+    assert!(
+        guidance.contains(&format!("Workspace `{TEST_WORKSPACE}` was not found")),
+        "guidance: {guidance}"
+    );
+    assert!(
+        guidance.contains("server.mcp_http.workspace"),
+        "the handshake is where a way out still fits: {guidance}"
+    );
+    assert_eq!(state.sessions.len().await, 0);
+    assert_eq!(
+        state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS
+    );
+
+    let sessionless = send(&router, auth_request("Bearer orphan", None, TOOLS_LIST)).await;
+    assert_eq!(
+        sessionless.status(),
+        StatusCode::BAD_REQUEST,
+        "only a handshake opens a session, so no tool call can skip the refusal"
+    );
+
+    let invented = send(
+        &router,
+        auth_request(
+            "Bearer orphan",
+            Some("00000000-0000-0000-0000-000000000000"),
+            TOOLS_LIST,
+        ),
+    )
+    .await;
+    assert_eq!(invented.status(), StatusCode::NOT_FOUND);
+    let body = to_bytes(invented.into_body(), usize::MAX).await.unwrap();
+    assert!(
+        body.is_empty(),
+        "a session that was never opened says nothing about any workspace: {body:?}"
+    );
+
+    assert_eq!(
+        directory.calls(),
+        vec![listing_by("orphan")],
+        "the handshake asked once and nothing after it asked again"
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -163,13 +163,18 @@ const TEST_WORKSPACE: &str = "analytics";
 
 /// Creates [`TEST_WORKSPACE`] and returns options scoped to it.
 async fn workspace_scoped_options(app: &AppClient) -> McpOptions {
+    create_workspace(app, TEST_WORKSPACE).await;
+    workspace_named_options()
+}
+
+/// Creates one workspace through the same public RPC any client would use.
+async fn create_workspace(app: &AppClient, name: &str) {
     app.workspace_client()
         .create_workspace(GrpcRequest::new(CreateWorkspaceRequest {
-            workspace: Some(workspace(TEST_WORKSPACE)),
+            workspace: Some(workspace(name)),
         }))
         .await
         .expect("create test workspace");
-    workspace_named_options()
 }
 
 /// Names [`TEST_WORKSPACE`] without creating it.
@@ -529,6 +534,152 @@ async fn readyz_classifies_auth_transport_and_timeout_results() {
         readiness_status(&pending, Duration::from_millis(10)).await,
         StatusCode::SERVICE_UNAVAILABLE
     );
+}
+
+/// Reads the workspace an initialized session was scoped to.
+async fn session_workspace_line(server: &RunningMcpHttpServer) -> String {
+    let transport =
+        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
+    let client = ().serve(transport).await.expect("initialize MCP client");
+    let line = client
+        .peer_info()
+        .expect("initialize result")
+        .instructions
+        .as_deref()
+        .expect("initialize instructions")
+        .lines()
+        .find(|line| line.starts_with("Current Coral workspace:"))
+        .expect("workspace line")
+        .to_string();
+    let _cancel_result = client.cancel().await;
+    line
+}
+
+/// A configured name is used exactly, including one no workspace answers to.
+///
+/// Composition validated the name's shape already, so the adapter wraps it
+/// rather than re-deriving it, and it never consults memberships: a surface
+/// configured today has to start for a workspace created tomorrow. The unnamed
+/// second workspace here would make any membership-based choice ambiguous, so
+/// starting at all proves the configured name was taken as authoritative.
+#[tokio::test]
+async fn auth_disabled_workspace_selection_uses_the_configured_name() {
+    let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
+    create_workspace(&app, "reporting").await;
+    let config =
+        McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
+    let server = start_auth_disabled(config, app, options)
+        .await
+        .expect("start MCP HTTP server");
+
+    assert_eq!(
+        session_workspace_line(&server).await,
+        format!("Current Coral workspace: {TEST_WORKSPACE}.")
+    );
+
+    server.shutdown().await.expect("shutdown MCP HTTP server");
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// Naming none is answered by the local user's one membership.
+#[tokio::test]
+async fn auth_disabled_workspace_selection_uses_the_sole_membership() {
+    let (_temp, app_server, app) = local_app().await;
+    create_workspace(&app, "reporting").await;
+    let config =
+        McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
+    let server = start_auth_disabled(config, app, McpOptions::default())
+        .await
+        .expect("start MCP HTTP server");
+
+    assert_eq!(
+        session_workspace_line(&server).await,
+        "Current Coral workspace: reporting."
+    );
+
+    server.shutdown().await.expect("shutdown MCP HTTP server");
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// Owning nothing and owning several are different problems for the operator,
+/// so they get different guidance instead of one workspace picked for them.
+#[tokio::test]
+async fn auth_disabled_workspace_selection_reports_zero_and_several_distinctly() {
+    let (_temp, app_server, app) = local_app().await;
+    let config =
+        McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
+
+    let Err(McpHttpError::NoLocalWorkspace) =
+        start_auth_disabled(config, app.clone(), McpOptions::default()).await
+    else {
+        panic!("a local user with no workspace must be told to create one");
+    };
+
+    create_workspace(&app, TEST_WORKSPACE).await;
+    create_workspace(&app, "reporting").await;
+    let Err(McpHttpError::AmbiguousLocalWorkspace(available)) =
+        start_auth_disabled(config, app, McpOptions::default()).await
+    else {
+        panic!("a local user with several workspaces must be told to name one");
+    };
+    for name in [TEST_WORKSPACE, "reporting"] {
+        assert!(
+            available.contains(name),
+            "the guidance must name the workspaces to choose between, got {available}"
+        );
+    }
+
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// A configured name nothing answers to is a request-time not-found, not a
+/// startup failure: the surface serves, and the tool that needs the workspace
+/// reports the ordinary contract rather than reaching another workspace.
+#[tokio::test]
+async fn auth_disabled_workspace_selection_defers_a_missing_name_to_the_request() {
+    let (_temp, app_server, app) = local_app().await;
+    create_workspace(&app, "reporting").await;
+    let config =
+        McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
+    let server = start_auth_disabled(
+        config,
+        app,
+        McpOptions {
+            workspace: Some(workspace("never-created")),
+            ..McpOptions::default()
+        },
+    )
+    .await
+    .expect("a configured name is not checked for existence at startup");
+
+    let transport =
+        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
+    let client = ().serve(transport).await.expect("initialize MCP client");
+    let refused = client
+        .call_tool(CallToolRequestParams::new("start_task").with_arguments(
+            serde_json::Map::from_iter([(
+                "intent".to_string(),
+                serde_json::json!("Reach the workspace that was configured"),
+            )]),
+        ))
+        .await
+        .expect("a workspace rejection is an in-band tool result");
+
+    assert_eq!(
+        refused.is_error,
+        Some(true),
+        "a configured workspace that does not exist must be reported, not replaced"
+    );
+    let reported = format!("{:?}", refused.content);
+    assert!(
+        reported.contains("never-created"),
+        "the refusal must name the workspace that was asked for, got {reported}"
+    );
+
+    let _cancel_result = client.cancel().await;
+    server.shutdown().await.expect("shutdown MCP HTTP server");
+    app_server.shutdown().await.expect("shutdown app server");
 }
 
 #[tokio::test]

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -564,55 +564,6 @@ async fn readyz_classifies_auth_transport_and_timeout_results() {
     );
 }
 
-/// Readiness must observe the engine, not a workspace nothing provisions.
-///
-/// This is the mirror of coral-app's gRPC discriminator: an instance that owns
-/// a workspace and cannot resolve its catalog is an unready engine. The probe
-/// this replaces asked `ListCatalog` for the literal `default`; nothing creates
-/// that workspace any more, so it read `NotFound` — a code
-/// `catalog_rejection_is_reachable` deliberately treats as reachable — and
-/// answered ready here, which is exactly what this asserts it no longer does.
-///
-/// The unparseable config file is that engine: catalog resolution reads it
-/// after the workspace check and fails with an infrastructure code. The config
-/// is corrupted before the first probe so no cached answer predates it.
-#[tokio::test]
-async fn readyz_reports_unready_when_the_engine_cannot_resolve_a_real_catalog() {
-    let (temp, app_server, app) = local_app().await;
-    let options = workspace_scoped_options(&app).await;
-    std::fs::write(
-        temp.path().join("coral-config").join("config.toml"),
-        "this is not toml",
-    )
-    .expect("write unparseable config");
-    let (router, state) = auth_disabled_router(
-        app.clone(),
-        options,
-        ReadinessProbe::from_app(app),
-        IpAddr::V4(Ipv4Addr::LOCALHOST),
-        &[],
-    )
-    .expect("router scoped to a workspace");
-
-    let response = send(
-        &router,
-        Request::builder()
-            .uri("/readyz")
-            .body(Body::empty())
-            .expect("request"),
-    )
-    .await;
-
-    assert_eq!(
-        response.status(),
-        StatusCode::SERVICE_UNAVAILABLE,
-        "an engine that cannot resolve a catalog it owns must not report ready"
-    );
-    state.server.config.cancellation_token.cancel();
-    state.server.sessions.close_all().await;
-    app_server.shutdown().await.expect("shutdown app server");
-}
-
 /// Reads the workspace an initialized session was scoped to.
 async fn session_workspace_line(server: &RunningMcpHttpServer) -> String {
     let transport =

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -169,6 +169,16 @@ async fn workspace_scoped_options(app: &AppClient) -> McpOptions {
         }))
         .await
         .expect("create test workspace");
+    workspace_named_options()
+}
+
+/// Names [`TEST_WORKSPACE`] without creating it.
+///
+/// A session factory demands a *resolved* workspace, not an existing one:
+/// whether the name resolves is answered by the request that needs it. Fixtures
+/// below that never reach a workspace-scoped tool therefore only have to name
+/// one, and naming it is what keeps them from exercising a fallback.
+fn workspace_named_options() -> McpOptions {
     McpOptions {
         workspace: Some(workspace(TEST_WORKSPACE)),
         ..McpOptions::default()
@@ -275,7 +285,8 @@ async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         &["coral".to_string()],
-    );
+    )
+    .expect("router scoped to a workspace");
 
     // The baseline loopback names and the operator-listed host all initialize;
     // anything else keeps hitting the DNS-rebinding 403.
@@ -328,11 +339,12 @@ async fn raw_routes_enforce_health_and_host_contracts() {
     let advertised_ip = IpAddr::V4(Ipv4Addr::new(127, 42, 3, 9));
     let (router, state) = auth_disabled_router(
         app.clone(),
-        McpOptions::default(),
+        workspace_named_options(),
         ReadinessProbe::from_app(app),
         advertised_ip,
         &[],
-    );
+    )
+    .expect("router scoped to a workspace");
 
     for path in ["/livez", "/readyz"] {
         let response = router
@@ -407,11 +419,12 @@ async fn mcp_rejects_uninitialized_and_oversized_requests_without_leaking_sessio
     let (_temp, app_server, app) = local_app().await;
     let (router, state) = auth_disabled_router(
         app.clone(),
-        McpOptions::default(),
+        workspace_named_options(),
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         &[],
-    );
+    )
+    .expect("router scoped to a workspace");
 
     for body in [
         PING,
@@ -624,7 +637,7 @@ async fn shutdown_timeout_matches_one_second_contract() {
     let (_temp, app_server, app) = local_app().await;
     let config =
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
-    let server = start_auth_disabled(config, app, McpOptions::default())
+    let server = start_auth_disabled(config, app, workspace_named_options())
         .await
         .expect("start MCP HTTP server");
     let state = server.state.clone();
@@ -648,7 +661,7 @@ async fn dropping_server_cancels_requests_and_releases_state() {
     let (_temp, app_server, app) = local_app().await;
     let config =
         McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
-    let server = start_auth_disabled(config, app, McpOptions::default())
+    let server = start_auth_disabled(config, app, workspace_named_options())
         .await
         .expect("start MCP HTTP server");
     let transport =
@@ -703,7 +716,7 @@ async fn authenticated_session_lifecycle_is_coherent() {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
         },
-        McpOptions::default(),
+        workspace_named_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(config, runtime);
@@ -789,7 +802,7 @@ async fn authenticated_requests_are_bounded_before_and_after_initialization() {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
         },
-        McpOptions::default(),
+        workspace_named_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
@@ -844,7 +857,7 @@ async fn authenticated_sessions_remain_isolated() {
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        McpOptions::default(),
+        workspace_named_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
@@ -896,7 +909,7 @@ async fn authenticated_session_admission_rejects_before_client_creation() {
             counted_factory_calls.fetch_add(1, Ordering::Relaxed);
             std::future::ready(Ok::<_, ()>(app.clone()))
         },
-        McpOptions::default(),
+        workspace_named_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let sessions = Arc::new(AuthenticatedSessions::new(1));
@@ -935,7 +948,7 @@ async fn authenticated_session_honors_the_declared_idle_timeout() {
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        McpOptions::default(),
+        workspace_named_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let sessions = Arc::new(AuthenticatedSessions::new(1));
@@ -1087,7 +1100,7 @@ async fn authenticated_discovery_and_challenge_do_not_advertise_scopes() {
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         |_| std::future::ready(Err::<AppClient, ()>(())),
-        McpOptions::default(),
+        workspace_named_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, _state) = authenticated_router(config, runtime);

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -291,6 +291,19 @@ async fn running_local_session_count(workspaces: &WeakLocalWorkspaces) -> usize 
     count
 }
 
+/// The workspace names the auth-disabled server currently caches an entry for.
+async fn cached_workspace_names(workspaces: &WeakLocalWorkspaces) -> Vec<String> {
+    let workspaces = workspaces.upgrade().expect("workspaces");
+    let mut names: Vec<String> = workspaces
+        .read()
+        .await
+        .keys()
+        .map(|name| name.as_str().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
 fn authenticated_sessions(
     server: &RunningMcpHttpServer,
 ) -> std::sync::Weak<super::AuthenticatedSessions> {
@@ -729,6 +742,66 @@ async fn auth_disabled_delete_makes_the_url_not_found_for_new_handshakes() {
     );
 
     let _cancel_result = client.cancel().await;
+    server.shutdown().await.expect("shutdown MCP HTTP server");
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// A deleted workspace's dead cache entry is evicted, not kept forever.
+///
+/// The map would otherwise grow for the process's lifetime across create/delete
+/// cycles. Eviction runs on the next handshake and only drops entries whose
+/// workspace is gone AND holds no live session, so the surface stays bounded
+/// without disturbing a session that is still draining.
+#[tokio::test]
+async fn auth_disabled_evicts_a_deleted_workspaces_dead_cache_entry() {
+    let (_temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
+    create_workspace(&app, "reporting").await;
+    let config =
+        McpHttpConfig::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).expect("loopback config");
+    let server = start_auth_disabled(config, app.clone(), options)
+        .await
+        .expect("start MCP HTTP server");
+    let workspaces = local_workspaces(&server);
+
+    // A completed session at TEST_WORKSPACE leaves a cached entry with no live
+    // session behind it.
+    let opened = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}{}",
+        server.local_addr(),
+        ws_path(TEST_WORKSPACE)
+    ));
+    let client = ().serve(opened).await.expect("initialize MCP client");
+    client.cancel().await.expect("close the session");
+    assert_eq!(running_local_session_count(&workspaces).await, 0);
+    assert_eq!(
+        cached_workspace_names(&workspaces).await,
+        vec![TEST_WORKSPACE.to_string()],
+        "the completed handshake cached its workspace"
+    );
+
+    app.workspace_client()
+        .delete_workspace(GrpcRequest::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace(TEST_WORKSPACE)),
+        }))
+        .await
+        .expect("delete the workspace");
+
+    // A handshake for a workspace that still exists carries the current
+    // inventory, so it evicts the deleted one's dead entry.
+    let survivor = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}{}",
+        server.local_addr(),
+        ws_path("reporting")
+    ));
+    let survivor = ().serve(survivor).await.expect("initialize survivor client");
+    assert_eq!(
+        cached_workspace_names(&workspaces).await,
+        vec!["reporting".to_string()],
+        "the deleted workspace's dead entry is gone, the live one remains"
+    );
+
+    survivor.cancel().await.expect("close survivor session");
     server.shutdown().await.expect("shutdown MCP HTTP server");
     app_server.shutdown().await.expect("shutdown app server");
 }

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -536,6 +536,54 @@ async fn readyz_classifies_auth_transport_and_timeout_results() {
     );
 }
 
+/// Readiness must observe the engine, not a workspace nothing provisions.
+///
+/// This is the mirror of coral-app's gRPC discriminator: an instance that owns
+/// a workspace and cannot resolve its catalog is an unready engine. The probe
+/// this replaces asked `ListCatalog` for the literal `default`; nothing creates
+/// that workspace any more, so it read `NotFound` — a code
+/// `catalog_rejection_is_reachable` deliberately treats as reachable — and
+/// answered ready here, which is exactly what this asserts it no longer does.
+///
+/// The unparseable config file is that engine: catalog resolution reads it
+/// after the workspace check and fails with an infrastructure code. The config
+/// is corrupted before the first probe so no cached answer predates it.
+#[tokio::test]
+async fn readyz_reports_unready_when_the_engine_cannot_resolve_a_real_catalog() {
+    let (temp, app_server, app) = local_app().await;
+    let options = workspace_scoped_options(&app).await;
+    std::fs::write(
+        temp.path().join("coral-config").join("config.toml"),
+        "this is not toml",
+    )
+    .expect("write unparseable config");
+    let (router, state) = auth_disabled_router(
+        app.clone(),
+        options,
+        ReadinessProbe::from_app(app),
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+    )
+    .expect("router scoped to a workspace");
+
+    let response = send(
+        &router,
+        Request::builder()
+            .uri("/readyz")
+            .body(Body::empty())
+            .expect("request"),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "an engine that cannot resolve a catalog it owns must not report ready"
+    );
+    state.server.config.cancellation_token.cancel();
+    state.server.sessions.close_all().await;
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
 /// Reads the workspace an initialized session was scoped to.
 async fn session_workspace_line(server: &RunningMcpHttpServer) -> String {
     let transport =

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -2089,6 +2089,22 @@ async fn authenticated_admission_binds_each_caller_to_the_urls_workspace() {
         "a session opened at one workspace's URL does not exist at another's, \
          even for the bearer that owns it where it lives"
     );
+    // The discriminating case for the workspace-before-fingerprint ordering:
+    // alpha's own bearer — valid at this URL — presenting beta's foreign
+    // session id. Both the workspace and the fingerprint mismatch, so a
+    // fingerprint-first check would answer 403 and confirm the foreign id
+    // exists to a caller who belongs here; the workspace-first check answers
+    // the same 404 an invented id gets, disclosing nothing.
+    assert_eq!(
+        send(
+            &router,
+            auth_request_at(ALPHA_WORKSPACE, "Bearer alpha", Some(&beta_session), PING)
+        )
+        .await
+        .status(),
+        StatusCode::NOT_FOUND,
+        "a foreign workspace's session id is not-found even to a bearer valid at this URL"
+    );
 
     let beta_on_alpha = refusal_error(
         send(

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -204,8 +204,13 @@ async fn create_workspace(app: &AppClient, name: &str) {
 /// [`workspace_scoped_options`] instead, because admission there checks the
 /// name against the caller's memberships before opening a session.
 fn workspace_named_options() -> McpOptions {
+    options_naming(TEST_WORKSPACE)
+}
+
+/// Names one workspace for a surface, without creating it.
+fn options_naming(name: &str) -> McpOptions {
     McpOptions {
-        workspace: Some(workspace(TEST_WORKSPACE)),
+        workspace: Some(workspace(name)),
         ..McpOptions::default()
     }
 }
@@ -1196,6 +1201,93 @@ fn refusal_guidance(error: &serde_json::Value) -> &str {
         .expect("a refusal carries guidance text")
 }
 
+/// The session an admitted `initialize` opened, and the result it answered with.
+///
+/// A handshake answered as one JSON object and one answered as an event stream
+/// carry the same result, so this reads whichever framing arrived rather than
+/// pinning one — an event stream opens with an empty priming frame, so the
+/// payload is the last one carrying anything. The read is bounded, because a
+/// body that never ends is a failure to report rather than a test that hangs
+/// until something else gives up on it.
+async fn admitted_result(response: Response) -> (String, serde_json::Value) {
+    assert_eq!(response.status(), StatusCode::OK);
+    let session = response
+        .headers()
+        .get(SESSION_ID_HEADER)
+        .expect("an admitted handshake hands back a session")
+        .to_str()
+        .expect("the session id is text")
+        .to_string();
+    let body = tokio::time::timeout(
+        Duration::from_secs(5),
+        to_bytes(response.into_body(), usize::MAX),
+    )
+    .await
+    .expect("the handshake response body ends")
+    .expect("read the handshake response body");
+    let text = String::from_utf8(body.to_vec()).expect("the handshake response is text");
+    let payload = text
+        .lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(str::trim)
+        .rfind(|payload| !payload.is_empty())
+        .unwrap_or_else(|| text.trim());
+    let message: serde_json::Value = serde_json::from_str(payload)
+        .unwrap_or_else(|error| panic!("the handshake response is JSON ({error}): {text}"));
+    let result = message
+        .get("result")
+        .unwrap_or_else(|| panic!("an admitted handshake carries a result: {message}"))
+        .clone();
+    (session, result)
+}
+
+/// The instructions an admitted session opened with.
+///
+/// They carry the workspace the session was scoped to, which is the only place
+/// a caller is told what their session reaches — so it is where a session bound
+/// to a workspace nobody configured would show.
+fn admitted_instructions(result: &serde_json::Value) -> &str {
+    result
+        .get("instructions")
+        .and_then(serde_json::Value::as_str)
+        .expect("an initialize result carries the session's instructions")
+}
+
+/// Admits one caller, and says the session reaches `configured` and not `other`.
+///
+/// Returns the session, so what the caller goes on to hold is the session the
+/// workspace claim was made about.
+async fn admitted_session_scoped_to(response: Response, configured: &str, other: &str) -> String {
+    let (session, result) = admitted_result(response).await;
+    let instructions = admitted_instructions(&result);
+    assert!(
+        instructions.contains(&format!("Current Coral workspace: {configured}.")),
+        "the session opens in the workspace its surface configured: {instructions}"
+    );
+    assert!(
+        !instructions.contains(other),
+        "no part of the session mentions the other caller's workspace: {instructions}"
+    );
+    session
+}
+
+/// Refuses one caller the configured workspace without offering the one they
+/// hold.
+///
+/// `held` is the accessible workspace a fallback would reach for, so naming it
+/// here is what separates "refused" from "refused, and not quietly rerouted".
+fn assert_refused_without_a_substitute(error: &serde_json::Value, configured: &str, held: &str) {
+    let guidance = refusal_guidance(error);
+    assert!(
+        guidance.contains(&format!("Workspace `{configured}` was not found")),
+        "guidance: {guidance}"
+    );
+    assert!(
+        !guidance.contains(held),
+        "the workspace this caller does hold is never offered in place of the configured one: {guidance}"
+    );
+}
+
 /// One RPC a workspace directory answered, and the credential it carried.
 ///
 /// Which credential asked is the whole of a membership listing's meaning: the
@@ -1211,6 +1303,13 @@ struct DirectoryCall {
 /// Every RPC one workspace directory answered, in order.
 type DirectoryCalls = Arc<std::sync::Mutex<Vec<DirectoryCall>>>;
 
+/// The memberships a directory answers with, editable while it keeps serving.
+///
+/// A membership that can only change across a restart cannot tell a decision
+/// made per handshake from one cached at startup, so the map the running
+/// directory reads is the same map a test revokes from.
+type DirectoryMemberships = Arc<std::sync::Mutex<HashMap<String, Vec<String>>>>;
+
 /// A workspace directory that reveals only the caller's own memberships.
 ///
 /// Memberships are keyed by the bearer the request carries, as the real service
@@ -1219,7 +1318,7 @@ type DirectoryCalls = Arc<std::sync::Mutex<Vec<DirectoryCall>>>;
 /// second listing, or any question that could tell a concealed workspace from
 /// an absent one, lands in the same log.
 struct WorkspaceDirectory {
-    memberships: HashMap<String, Vec<String>>,
+    memberships: DirectoryMemberships,
     calls: DirectoryCalls,
 }
 
@@ -1266,7 +1365,13 @@ impl WorkspaceService for WorkspaceDirectory {
     ) -> Result<GrpcResponse<ListWorkspacesResponse>, Status> {
         let memberships = self
             .record("ListWorkspaces", request.metadata())
-            .and_then(|authorization| self.memberships.get(&authorization))
+            .and_then(|authorization| {
+                self.memberships
+                    .lock()
+                    .expect("read directory memberships")
+                    .get(&authorization)
+                    .cloned()
+            })
             .into_iter()
             .flatten()
             .map(|name| WorkspaceMembership {
@@ -1353,6 +1458,7 @@ impl UserService for IdentityDirectory {
 struct RunningDirectory {
     endpoint: String,
     calls: DirectoryCalls,
+    memberships: DirectoryMemberships,
     task: tokio::task::JoinHandle<()>,
 }
 
@@ -1360,6 +1466,27 @@ impl RunningDirectory {
     /// The RPCs this directory has answered so far.
     fn calls(&self) -> Vec<DirectoryCall> {
         self.calls.lock().expect("read directory calls").clone()
+    }
+
+    /// Takes one workspace away from one caller, on the directory now serving.
+    ///
+    /// Nothing is restarted, rebuilt or reconnected: the map this edits is the
+    /// one the running directory answers listings from, so whatever asks next
+    /// asks the changed world. The count assertion is what keeps a revocation
+    /// from silently doing nothing — a revocation that removed no membership
+    /// would leave a test green for the wrong reason.
+    fn revoke(&self, token: &str, name: &str) {
+        let mut memberships = self.memberships.lock().expect("revoke a membership");
+        let held = memberships
+            .get_mut(&format!("Bearer {token}"))
+            .expect("revoke from a caller this directory knows");
+        let before = held.len();
+        held.retain(|workspace| workspace != name);
+        assert_eq!(
+            held.len() + 1,
+            before,
+            "revoking `{name}` from `{token}` must remove exactly the named membership"
+        );
     }
 }
 
@@ -1377,11 +1504,14 @@ impl Drop for RunningDirectory {
 /// created at all.
 async fn serve_directory(memberships: Vec<(&str, Vec<String>)>) -> RunningDirectory {
     let calls = DirectoryCalls::default();
-    let directory = WorkspaceDirectory {
-        memberships: memberships
+    let memberships: DirectoryMemberships = Arc::new(std::sync::Mutex::new(
+        memberships
             .into_iter()
             .map(|(token, names)| (format!("Bearer {token}"), names))
             .collect(),
+    ));
+    let directory = WorkspaceDirectory {
+        memberships: Arc::clone(&memberships),
         calls: Arc::clone(&calls),
     };
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -1404,6 +1534,7 @@ async fn serve_directory(memberships: Vec<(&str, Vec<String>)>) -> RunningDirect
     RunningDirectory {
         endpoint,
         calls,
+        memberships,
         task,
     }
 }
@@ -1420,6 +1551,18 @@ fn listing_by(token: &str) -> DirectoryCall {
 fn identity_by(token: &str) -> DirectoryCall {
     DirectoryCall {
         rpc: "GetCurrentUser",
+        authorization: Some(format!("Bearer {token}")),
+    }
+}
+
+/// A control-plane RPC, recorded against the credential that attempted it.
+///
+/// Creating a workspace is an administrator's act, performed by a person in
+/// Reef. It is named here only so a test can say the MCP surface never reached
+/// it — and so the log can be shown to notice when something does.
+fn control_plane_by(token: &str) -> DirectoryCall {
+    DirectoryCall {
+        rpc: "CreateWorkspace",
         authorization: Some(format!("Bearer {token}")),
     }
 }
@@ -1455,6 +1598,22 @@ async fn bearer_client(endpoint: &str, token: &str) -> Result<AppClient, ()> {
     connect_with_loopback_bearer(endpoint, bearer)
         .await
         .map_err(|_error| ())
+}
+
+/// One authenticated surface, configured for one workspace of one directory.
+///
+/// Two of these over the same directory is what a deployment looks like from
+/// two people's desks: one world of workspaces, and a surface each, naming the
+/// workspace its own operator meant to serve.
+fn surface_naming(directory: &RunningDirectory, configured: &str) -> (Router, super::AuthState) {
+    authenticated_router(
+        authenticated_config(),
+        admission_runtime(
+            directory.endpoint.clone(),
+            options_naming(configured),
+            "impostor",
+        ),
+    )
 }
 
 /// A surface that names no workspace admits nobody, and says what to do.
@@ -1884,6 +2043,325 @@ async fn authenticated_admission_refuses_the_handshake_not_the_first_tool_call()
         vec![listing_by("orphan")],
         "the handshake asked once and nothing after it asked again"
     );
+}
+
+/// Two callers in one deployment, each holding a workspace the other does not.
+///
+/// Neither name contains the other, so "this answer never mentioned the other
+/// workspace" cannot be satisfied by the other name hiding inside this one.
+const ALPHA_WORKSPACE: &str = "alpha-ledger";
+const BETA_WORKSPACE: &str = "beta-ledger";
+
+/// Two callers, two surfaces, and neither is ever served the other's workspace.
+///
+/// A configured workspace belongs to the surface, not to the caller, so two
+/// people sharing one deployment reach it through two surfaces — each naming the
+/// workspace that person holds. What has to hold is that the pairing is the only
+/// one that works: each caller is admitted on their own surface, scoped to the
+/// name that surface configured, and turned away on the other's.
+///
+/// The refusals are where a fallback would surface. Both of these callers hold a
+/// workspace, and it is an accessible one — exactly the material a "serve
+/// whatever they can reach" rule needs — so being refused the name they do not
+/// hold, and never being offered the name they do, is the claim. A rule that
+/// substituted an accessible workspace would pass every test that only checks a
+/// caller can reach their own.
+///
+/// Nothing here asks the directory anything but a membership listing, and the
+/// log proves the absence rather than assuming it: one control-plane attempt at
+/// the end lands in the same log, so the RPCs an MCP credential must never
+/// reach are ones this fixture demonstrably notices.
+#[tokio::test]
+async fn authenticated_admission_binds_two_callers_to_their_own_surfaces() {
+    let directory = serve_directory(vec![
+        ("alpha", vec![ALPHA_WORKSPACE.to_string()]),
+        ("beta", vec![BETA_WORKSPACE.to_string()]),
+    ])
+    .await;
+    let (alpha_router, alpha_state) = surface_naming(&directory, ALPHA_WORKSPACE);
+    let (beta_router, beta_state) = surface_naming(&directory, BETA_WORKSPACE);
+
+    let alpha_session = admitted_session_scoped_to(
+        send(
+            &alpha_router,
+            auth_request("Bearer alpha", None, INITIALIZE),
+        )
+        .await,
+        ALPHA_WORKSPACE,
+        BETA_WORKSPACE,
+    )
+    .await;
+    let beta_session = admitted_session_scoped_to(
+        send(&beta_router, auth_request("Bearer beta", None, INITIALIZE)).await,
+        BETA_WORKSPACE,
+        ALPHA_WORKSPACE,
+    )
+    .await;
+
+    let mut ping = auth_request("Bearer alpha", Some(&alpha_session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&alpha_router, ping).await.status().is_success());
+    assert_eq!(
+        send(
+            &alpha_router,
+            auth_request("Bearer beta", Some(&alpha_session), PING)
+        )
+        .await
+        .status(),
+        StatusCode::FORBIDDEN,
+        "one caller's session is not a credential the other can present"
+    );
+    assert_eq!(
+        send(
+            &alpha_router,
+            auth_request("Bearer beta", Some(&beta_session), PING)
+        )
+        .await
+        .status(),
+        StatusCode::NOT_FOUND,
+        "a session opened on one surface does not exist on the other"
+    );
+
+    let beta_on_alpha =
+        refusal_error(send(&alpha_router, auth_request("Bearer beta", None, INITIALIZE)).await)
+            .await;
+    assert_refused_without_a_substitute(&beta_on_alpha, ALPHA_WORKSPACE, BETA_WORKSPACE);
+
+    let alpha_on_beta =
+        refusal_error(send(&beta_router, auth_request("Bearer alpha", None, INITIALIZE)).await)
+            .await;
+    assert_refused_without_a_substitute(&alpha_on_beta, BETA_WORKSPACE, ALPHA_WORKSPACE);
+
+    assert_eq!(alpha_state.sessions.len().await, 1);
+    assert_eq!(beta_state.sessions.len().await, 1);
+    assert_eq!(
+        alpha_state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS - 1,
+        "the refused caller left no admission reserved behind"
+    );
+    assert_eq!(
+        beta_state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS - 1,
+        "the refused caller left no admission reserved behind"
+    );
+
+    assert_eq!(
+        directory.calls(),
+        vec![
+            listing_by("alpha"),
+            listing_by("beta"),
+            listing_by("beta"),
+            listing_by("alpha"),
+        ],
+        "every handshake asked once, on its own caller's bearer, and nothing else asked at all"
+    );
+
+    let asker = bearer_client(&directory.endpoint, "alpha")
+        .await
+        .expect("bearer client");
+    let attempted = asker
+        .workspace_client()
+        .create_workspace(GrpcRequest::new(CreateWorkspaceRequest {
+            workspace: Some(workspace(BETA_WORKSPACE)),
+        }))
+        .await;
+    assert!(
+        attempted.is_err(),
+        "an MCP credential is not an administrator"
+    );
+    assert_eq!(
+        directory.calls().last(),
+        Some(&control_plane_by("alpha")),
+        "a control-plane RPC is one this log records, so its absence above was observed"
+    );
+
+    alpha_state.sessions.close_all().await;
+    beta_state.sessions.close_all().await;
+}
+
+/// One sentence covers every reason the configured workspace is out of reach.
+///
+/// The debt is concealment, not refusal: a caller must not be able to read an
+/// answer and learn whether the name they were configured for exists. So the
+/// three situations that could each have grown their own wording are compared
+/// against one another whole — code, message and structured data together —
+/// rather than each being checked to be *some* error, which is a check that
+/// survives exactly the leak it is supposed to catch.
+///
+/// The three differ in everything the surface could key a leak on. One caller
+/// holds a workspace and the configured one exists beside it, held by somebody
+/// else. One holds a workspace in a world where the configured name was never
+/// created. One holds nothing at all. And the caller who does hold the
+/// configured name is admitted from the same surface, so the sameness of the
+/// other three is concealment rather than a door that is simply shut.
+#[tokio::test]
+async fn authenticated_admission_conceals_why_a_workspace_is_out_of_reach() {
+    let deployment = serve_directory(vec![
+        ("alpha", vec![ALPHA_WORKSPACE.to_string()]),
+        ("beta", vec![BETA_WORKSPACE.to_string()]),
+    ])
+    .await;
+    let elsewhere = serve_directory(vec![
+        ("nomad", vec!["nomad-ledger".to_string()]),
+        ("hermit", Vec::new()),
+    ])
+    .await;
+    let deployment_endpoint = deployment.endpoint.clone();
+    let elsewhere_endpoint = elsewhere.endpoint.clone();
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |token: String| {
+            let endpoint = if token == "alpha" || token == "beta" {
+                deployment_endpoint.clone()
+            } else {
+                elsewhere_endpoint.clone()
+            };
+            async move { bearer_client(&endpoint, &token).await }
+        },
+        options_naming(BETA_WORKSPACE),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+
+    let held_by_another =
+        refusal_error(send(&router, auth_request("Bearer alpha", None, INITIALIZE)).await).await;
+    let never_created =
+        refusal_error(send(&router, auth_request("Bearer nomad", None, INITIALIZE)).await).await;
+    let holds_nothing =
+        refusal_error(send(&router, auth_request("Bearer hermit", None, INITIALIZE)).await).await;
+
+    assert_eq!(
+        held_by_another, never_created,
+        "a workspace somebody else holds must read exactly as one that was never created"
+    );
+    assert_eq!(
+        never_created, holds_nothing,
+        "holding a workspace elsewhere must not change the answer either"
+    );
+
+    let guidance = refusal_guidance(&held_by_another);
+    assert!(
+        guidance.contains(&format!("Workspace `{BETA_WORKSPACE}` was not found")),
+        "the answer they share is the not-found contract: {guidance}"
+    );
+    assert!(
+        !guidance.contains(ALPHA_WORKSPACE) && !guidance.contains("nomad-ledger"),
+        "the shared answer names only the workspace that was asked for: {guidance}"
+    );
+
+    let (_session, admitted) =
+        admitted_result(send(&router, auth_request("Bearer beta", None, INITIALIZE)).await).await;
+    let instructions = admitted_instructions(&admitted);
+    assert!(
+        instructions.contains(&format!("Current Coral workspace: {BETA_WORKSPACE}.")),
+        "one sentence for everyone else is concealment only because the holder gets in: {instructions}"
+    );
+
+    assert_eq!(
+        deployment.calls(),
+        vec![listing_by("alpha"), listing_by("beta")],
+        "each caller was answered from their own connection"
+    );
+    assert_eq!(
+        elsewhere.calls(),
+        vec![listing_by("nomad"), listing_by("hermit")],
+        "and the surface never asked the other world whether the name exists there"
+    );
+    assert_eq!(state.sessions.len().await, 1);
+    assert_eq!(
+        state.sessions.available_permits(),
+        MAX_AUTHENTICATED_SESSIONS - 1,
+        "three refusals released the admissions they reserved"
+    );
+
+    state.sessions.close_all().await;
+}
+
+/// A membership taken away lands on the next handshake, with nothing restarted.
+///
+/// The server, its session store, its runtime and the directory it asks are the
+/// same objects throughout: the only thing that changes is one entry in the
+/// directory the running surface reads. So a decision cached anywhere — at
+/// startup, per token, per process — would keep admitting the revoked caller,
+/// and this is where that shows.
+///
+/// Two things bound the claim. A colleague who still holds the workspace is
+/// still admitted afterwards, so what changed was one membership and not the
+/// world. And the session already open goes on working: admission is decided
+/// once, at the handshake, and this fixes what "affects the next session"
+/// actually buys — a revoked caller cannot open another session, while the one
+/// they hold lasts until it is closed or idles out. That is the boundary, stated
+/// rather than implied.
+#[tokio::test]
+async fn authenticated_admission_follows_a_revocation_without_a_restart() {
+    let directory = serve_directory(vec![
+        ("alpha", vec![ALPHA_WORKSPACE.to_string()]),
+        ("colleague", vec![ALPHA_WORKSPACE.to_string()]),
+        ("beta", vec![BETA_WORKSPACE.to_string()]),
+    ])
+    .await;
+    let (router, state) = surface_naming(&directory, ALPHA_WORKSPACE);
+
+    let (session, admitted) =
+        admitted_result(send(&router, auth_request("Bearer alpha", None, INITIALIZE)).await).await;
+    let instructions = admitted_instructions(&admitted);
+    assert!(
+        instructions.contains(&format!("Current Coral workspace: {ALPHA_WORKSPACE}.")),
+        "instructions: {instructions}"
+    );
+
+    directory.revoke("alpha", ALPHA_WORKSPACE);
+
+    let mut ping = auth_request("Bearer alpha", Some(&session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(
+        send(&router, ping).await.status().is_success(),
+        "the session already admitted is not re-decided per request"
+    );
+
+    let after_revocation =
+        refusal_error(send(&router, auth_request("Bearer alpha", None, INITIALIZE)).await).await;
+    let guidance = refusal_guidance(&after_revocation);
+    assert!(
+        guidance.contains(&format!("Workspace `{ALPHA_WORKSPACE}` was not found")),
+        "the same server that admitted this caller a moment ago now refuses them: {guidance}"
+    );
+
+    let never_held =
+        refusal_error(send(&router, auth_request("Bearer beta", None, INITIALIZE)).await).await;
+    assert_eq!(
+        after_revocation, never_held,
+        "a membership taken away reads exactly like one never held"
+    );
+
+    let (_colleague_session, colleague) =
+        admitted_result(send(&router, auth_request("Bearer colleague", None, INITIALIZE)).await)
+            .await;
+    let instructions = admitted_instructions(&colleague);
+    assert!(
+        instructions.contains(&format!("Current Coral workspace: {ALPHA_WORKSPACE}.")),
+        "one membership was revoked, not the workspace: {instructions}"
+    );
+
+    assert_eq!(
+        directory.calls(),
+        vec![
+            listing_by("alpha"),
+            listing_by("alpha"),
+            listing_by("beta"),
+            listing_by("colleague"),
+        ],
+        "the second handshake asked the live directory again rather than reusing the first answer"
+    );
+    assert_eq!(
+        state.sessions.len().await,
+        2,
+        "the refusals opened no sessions, and the revoked caller's first one was not closed"
+    );
+
+    state.sessions.close_all().await;
 }
 
 #[tokio::test]

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -309,9 +309,12 @@ fn allowed_hosts_must_be_valid_header_values() {
 #[tokio::test]
 async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
     let (_temp, app_server, app) = local_app().await;
+    // Host acceptance is what this asserts, but the router now resolves a
+    // workspace before it exists, so the fixture gives it one to resolve.
+    let options = workspace_scoped_options(&app).await;
     let (router, state) = auth_disabled_router(
         app.clone(),
-        McpOptions::default(),
+        options,
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
         &["coral".to_string()],

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -2031,7 +2031,10 @@ const BETA_WORKSPACE: &str = "beta-ledger";
 /// the end lands in the same log, so the RPCs an MCP credential must never
 /// reach are ones this fixture demonstrably notices.
 #[tokio::test]
-#[expect(clippy::too_many_lines, reason = "one scenario walks both workspaces end to end")]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one scenario walks both workspaces end to end"
+)]
 async fn authenticated_admission_binds_each_caller_to_the_urls_workspace() {
     let directory = serve_directory(vec![
         ("alpha", vec![ALPHA_WORKSPACE.to_string()]),

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -130,11 +130,15 @@ pub struct McpOptions {
 ///
 /// # Errors
 ///
-/// Returns [`McpError`] if the stdio server cannot complete its `MCP`
-/// lifecycle.
+/// Returns [`McpError`] if `options` names no workspace, or if the stdio server
+/// cannot complete its `MCP` lifecycle. Stdio's launcher resolves the workspace
+/// before it gets here, so the missing one is reported as the failed
+/// precondition it is rather than served against an invented name.
 pub async fn run_stdio_with_client(app: AppClient, options: McpOptions) -> Result<(), McpError> {
     options.surface.validate(options.feedback_enabled)?;
-    let handler = CoralMcpServerFactory::new(app, options).create();
+    let handler = CoralMcpServerFactory::new(app, options)
+        .map_err(|error| tonic::Status::failed_precondition(error.to_string()))?
+        .create();
     let server = Box::pin(handler.serve((tokio::io::stdin(), tokio::io::stdout()))).await?;
     let _ = server.waiting().await?;
     Ok(())

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -448,24 +448,27 @@ impl CoralToolset {
             .sources)
     }
 
-    /// Lists installed sources for a discovery surface, degrading to none when
-    /// the caller may not read source configuration.
+    /// Lists installed sources for a discovery surface, degrading to none only
+    /// when the caller may not read source configuration.
     ///
     /// Source configuration is owner-only because it carries credential setup
     /// metadata, so an MCP agent credential is refused even while acting for a
-    /// person who owns the workspace. Sources are advisory context on
-    /// discovery surfaces, so a refusal must shrink the answer rather than fail
-    /// the request.
-    async fn load_sources_for_discovery(&self) -> Vec<Source> {
+    /// person who owns the workspace. Sources are advisory context on discovery
+    /// surfaces, so that owner-only `PermissionDenied` refusal must shrink the
+    /// answer rather than fail the request. Every other status — a transient
+    /// `Unavailable`/`Internal` and the like — is a real fault the surface must
+    /// still surface, so it propagates rather than masquerading as "no sources".
+    async fn load_sources_for_discovery(&self) -> Result<Vec<Source>, tonic::Status> {
         match self.load_sources().await {
-            Ok(sources) => sources,
-            Err(status) => {
+            Ok(sources) => Ok(sources),
+            Err(status) if status.code() == tonic::Code::PermissionDenied => {
                 tracing::warn!(
                     error = %status,
-                    "failed to load sources for an MCP discovery surface"
+                    "source configuration is owner-only; omitting sources from an MCP discovery surface"
                 );
-                Vec::new()
+                Ok(Vec::new())
             }
+            Err(status) => Err(status),
         }
     }
 
@@ -576,7 +579,7 @@ impl CoralToolset {
             self.load_catalog_counts()
         );
         let (table_count, table_function_count) = counts?;
-        Ok((sources, table_count, table_function_count))
+        Ok((sources?, table_count, table_function_count))
     }
 
     async fn load_sources_and_guide_catalog(
@@ -585,7 +588,7 @@ impl CoralToolset {
         let (sources, catalog) =
             tokio::join!(self.load_sources_for_discovery(), self.load_guide_catalog());
         let (tables, table_function_schema_names) = catalog?;
-        Ok((sources, tables, table_function_schema_names))
+        Ok((sources?, tables, table_function_schema_names))
     }
 
     async fn query_rows(
@@ -1000,6 +1003,7 @@ impl CoralToolset {
         let source_names = self
             .load_sources_for_discovery()
             .await
+            .map_err(|status| status_to_error_data(&status))?
             .into_iter()
             .map(|source| source.name)
             .collect();

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1115,7 +1115,12 @@ impl ServerHandler for CoralMcpServer {
                 .enable_tools()
                 .build(),
         )
-        .with_server_info(Implementation::new("coral", env!("CARGO_PKG_VERSION")));
+        // The workspace joins the advertised name so a client connected to two
+        // workspaces shows them as two distinct connectors.
+        .with_server_info(Implementation::new(
+            format!("Coral / {}", self.core_tools.workspace().name),
+            env!("CARGO_PKG_VERSION"),
+        ));
         match &self.initialize_instructions {
             InitializeInstructions::CoralDefault => info.with_instructions(initial_instructions(
                 &self.core_tools.workspace().name,

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -381,7 +381,6 @@ impl CoralToolset {
         options: McpOptions,
         guide_block: Arc<GuideBlockState>,
     ) -> Self {
-
         let startup_context = McpStartupContext::from_options(&options);
         Self::new_with_startup_context(app, workspace, options, startup_context, guide_block)
     }

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -8,12 +8,13 @@ use coral_api::v1::{
     ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListSourcesRequest,
     PaginationRequest, QueryGuideReadContext, SearchRequest, Source, StartTaskRequest,
     SubmitFeedbackRequest, TableSummary as ProtoTableSummary,
-    TaskAttribution as ProtoTaskAttribution, TaskStatus as ProtoTaskStatus, catalog_item,
+    TaskAttribution as ProtoTaskAttribution, TaskStatus as ProtoTaskStatus, Workspace,
+    catalog_item,
 };
 use coral_client::{
     AppClient, CatalogClient, FeedbackClient, FunctionClient, QueryClient, SearchClient,
     SourceClient, TaskClient, batches_to_json_rows_json_safe_numbers, decode_execute_sql_response,
-    default_workspace, search_response_json_value, with_task_metadata,
+    search_response_json_value, with_task_metadata,
 };
 use rmcp::{
     ErrorData, ServerHandler,
@@ -249,10 +250,21 @@ fn task_context_requirement(options: &McpOptions, tool_name: ToolName) -> TaskCo
     }
 }
 
+/// A handler factory was asked for before a workspace was resolved.
+///
+/// Every MCP tool and resource is workspace-scoped, so a factory without a
+/// concrete workspace could only serve sessions that invent one. Each transport
+/// resolves its own workspace first and reports this refusal in the terms its
+/// caller understands.
+#[derive(Debug, thiserror::Error)]
+#[error("MCP sessions require a resolved workspace")]
+pub(crate) struct WorkspaceRequired;
+
 /// Cloneable factory for constructing an independent MCP handler per session.
 #[derive(Clone)]
 pub(crate) struct CoralMcpServerFactory {
     app: AppClient,
+    workspace: Workspace,
     options: McpOptions,
     guide_block: Arc<GuideBlockState>,
 }
@@ -265,13 +277,20 @@ impl CoralMcpServerFactory {
     /// those sessions share the same authorization context. An authenticated
     /// transport must use a client bound to the validated session and must not
     /// fall back to a shared unauthenticated client.
-    #[must_use]
-    pub(crate) fn new(app: AppClient, options: McpOptions) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkspaceRequired`] when `options` names no workspace. The
+    /// workspace is taken once here rather than read per request, so a live
+    /// handler can only ever reach the one it was scoped to.
+    pub(crate) fn new(app: AppClient, options: McpOptions) -> Result<Self, WorkspaceRequired> {
+        let workspace = options.workspace.clone().ok_or(WorkspaceRequired)?;
+        Ok(Self {
             app,
+            workspace,
             options,
             guide_block: Arc::new(GuideBlockState::default()),
-        }
+        })
     }
 
     /// Constructs a fresh handler for one MCP session.
@@ -281,6 +300,7 @@ impl CoralMcpServerFactory {
     pub(crate) fn create(&self) -> CoralMcpServer {
         CoralMcpServer::new(
             &self.app,
+            self.workspace.clone(),
             self.options.clone(),
             Arc::clone(&self.guide_block),
         )
@@ -293,11 +313,7 @@ impl CoralMcpServerFactory {
     /// Substituting the source client is how tests reach that refusal.
     #[cfg(test)]
     pub(crate) fn create_with_source_client(&self, source: SourceClient) -> CoralMcpServer {
-        let mut server = CoralMcpServer::new(
-            &self.app,
-            self.options.clone(),
-            Arc::clone(&self.guide_block),
-        );
+        let mut server = self.create();
         server.core_tools.source = source;
         server
     }
@@ -315,6 +331,7 @@ pub struct CoralToolset {
     task: TaskClient,
     guide_block: Arc<GuideBlockState>,
     startup_context: McpStartupContext,
+    workspace: Workspace,
     options: McpOptions,
     retained_tool_names: Option<Arc<BTreeSet<String>>>,
 }
@@ -358,13 +375,20 @@ impl McpStartupContext {
 }
 
 impl CoralToolset {
-    fn new(app: &AppClient, options: McpOptions, guide_block: Arc<GuideBlockState>) -> Self {
+    fn new(
+        app: &AppClient,
+        workspace: Workspace,
+        options: McpOptions,
+        guide_block: Arc<GuideBlockState>,
+    ) -> Self {
+
         let startup_context = McpStartupContext::from_options(&options);
-        Self::new_with_startup_context(app, options, startup_context, guide_block)
+        Self::new_with_startup_context(app, workspace, options, startup_context, guide_block)
     }
 
     fn new_with_startup_context(
         app: &AppClient,
+        workspace: Workspace,
         options: McpOptions,
         startup_context: McpStartupContext,
         guide_block: Arc<GuideBlockState>,
@@ -379,6 +403,7 @@ impl CoralToolset {
             task: app.task_client(),
             guide_block,
             startup_context,
+            workspace,
             options,
             retained_tool_names: None,
         }
@@ -396,11 +421,8 @@ impl CoralToolset {
                 .is_none_or(|names| names.contains(tool.as_str()))
     }
 
-    fn workspace(&self) -> coral_api::v1::Workspace {
-        self.options
-            .workspace
-            .clone()
-            .unwrap_or_else(default_workspace)
+    fn workspace(&self) -> Workspace {
+        self.workspace.clone()
     }
 
     /// Returns an enforced view containing only the named core tools.
@@ -1063,9 +1085,14 @@ pub(crate) struct CoralMcpServer {
 }
 
 impl CoralMcpServer {
-    fn new(app: &AppClient, options: McpOptions, guide_block: Arc<GuideBlockState>) -> Self {
+    fn new(
+        app: &AppClient,
+        workspace: Workspace,
+        options: McpOptions,
+        guide_block: Arc<GuideBlockState>,
+    ) -> Self {
         let surface = options.surface.clone();
-        let core_tools = CoralToolset::new(app, options, guide_block);
+        let core_tools = CoralToolset::new(app, workspace, options, guide_block);
         let tool_context = McpToolContext::new(core_tools.clone(), core_tools.workspace());
         let public_core_tools = surface.public_core_tool_names().map_or_else(
             || core_tools.clone(),

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -285,6 +285,22 @@ impl CoralMcpServerFactory {
             Arc::clone(&self.guide_block),
         )
     }
+
+    /// Constructs a handler whose source client is replaced.
+    ///
+    /// A shared deployment refuses owner-only source configuration to agent
+    /// credentials, which a local unauthenticated fixture cannot reproduce.
+    /// Substituting the source client is how tests reach that refusal.
+    #[cfg(test)]
+    pub(crate) fn create_with_source_client(&self, source: SourceClient) -> CoralMcpServer {
+        let mut server = CoralMcpServer::new(
+            &self.app,
+            self.options.clone(),
+            Arc::clone(&self.guide_block),
+        );
+        server.core_tools.source = source;
+        server
+    }
 }
 
 /// Session-bound implementation of Coral's built-in MCP tools.
@@ -410,6 +426,27 @@ impl CoralToolset {
             .sources)
     }
 
+    /// Lists installed sources for a discovery surface, degrading to none when
+    /// the caller may not read source configuration.
+    ///
+    /// Source configuration is owner-only because it carries credential setup
+    /// metadata, so an MCP agent credential is refused even while acting for a
+    /// person who owns the workspace. Sources are advisory context on
+    /// discovery surfaces, so a refusal must shrink the answer rather than fail
+    /// the request.
+    async fn load_sources_for_discovery(&self) -> Vec<Source> {
+        match self.load_sources().await {
+            Ok(sources) => sources,
+            Err(status) => {
+                tracing::warn!(
+                    error = %status,
+                    "failed to load sources for an MCP discovery surface"
+                );
+                Vec::new()
+            }
+        }
+    }
+
     async fn load_catalog(
         &self,
         catalog_name: Option<&str>,
@@ -512,16 +549,20 @@ impl CoralToolset {
     async fn load_sources_and_catalog_counts(
         &self,
     ) -> Result<(Vec<Source>, usize, usize), tonic::Status> {
-        let (sources, (table_count, table_function_count)) =
-            tokio::try_join!(self.load_sources(), self.load_catalog_counts())?;
+        let (sources, counts) = tokio::join!(
+            self.load_sources_for_discovery(),
+            self.load_catalog_counts()
+        );
+        let (table_count, table_function_count) = counts?;
         Ok((sources, table_count, table_function_count))
     }
 
     async fn load_sources_and_guide_catalog(
         &self,
     ) -> Result<(Vec<Source>, Vec<ProtoTableSummary>, Vec<String>), tonic::Status> {
-        let (sources, (tables, table_function_schema_names)) =
-            tokio::try_join!(self.load_sources(), self.load_guide_catalog())?;
+        let (sources, catalog) =
+            tokio::join!(self.load_sources_for_discovery(), self.load_guide_catalog());
+        let (tables, table_function_schema_names) = catalog?;
         Ok((sources, tables, table_function_schema_names))
     }
 
@@ -934,16 +975,12 @@ impl CoralToolset {
             .load_catalog_counts()
             .await
             .map_err(|status| status_to_error_data(&status))?;
-        let source_names = match self.load_sources().await {
-            Ok(sources) => sources.into_iter().map(|source| source.name).collect(),
-            Err(status) => {
-                tracing::warn!(
-                    error = %status,
-                    "failed to load source names for MCP tool descriptions"
-                );
-                Vec::new()
-            }
-        };
+        let source_names = self
+            .load_sources_for_discovery()
+            .await
+            .into_iter()
+            .map(|source| source.name)
+            .collect();
         let tool_context =
             ToolDescriptionContext::new(visible_table_count, visible_function_count, source_names);
         Ok(available_tools(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -5,10 +5,18 @@
 )]
 
 use std::fs;
+use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    CreateWorkspaceRequest, ImportSourceRequest, Workspace, import_source_response,
+    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, DeleteSourceRequest,
+    DeleteSourceResponse, DescribeSourceManifestRequest, DescribeSourceManifestResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, import_source_response,
+    source_service_server::{SourceService, SourceServiceServer},
 };
 use coral_client::{
     AppClient, SourceClient,
@@ -16,6 +24,7 @@ use coral_client::{
     workspace,
 };
 use futures::future::BoxFuture;
+use futures::stream::Empty;
 use jsonschema::Validator;
 use opentelemetry::trace::{SpanId, SpanKind, TracerProvider as _};
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
@@ -27,7 +36,8 @@ use rmcp::{
 };
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
-use tonic::Request;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status, transport::Server};
 use tracing_subscriber::Layer as _;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt as _;
@@ -361,9 +371,13 @@ fn test_workspace() -> Workspace {
 }
 
 async fn create_test_workspace(app: &AppClient) {
+    create_workspace(app, test_workspace()).await;
+}
+
+async fn create_workspace(app: &AppClient, workspace: Workspace) {
     app.workspace_client()
         .create_workspace(Request::new(CreateWorkspaceRequest {
-            workspace: Some(test_workspace()),
+            workspace: Some(workspace),
         }))
         .await
         .expect("create test workspace");
@@ -377,9 +391,17 @@ fn feedback_reports_path(root: &Path) -> PathBuf {
 }
 
 async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String) {
+    add_demo_source_to(source_client, test_workspace(), manifest_yaml).await;
+}
+
+async fn add_demo_source_to(
+    source_client: &mut SourceClient,
+    workspace: Workspace,
+    manifest_yaml: String,
+) {
     let mut stream = source_client
         .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(test_workspace()),
+            workspace: Some(workspace),
             manifest_yaml,
             variables: Vec::new(),
             secrets: Vec::new(),
@@ -2783,4 +2805,192 @@ async fn mcp_sql_returns_large_int64_as_string() {
     );
 
     session.shutdown().await;
+}
+
+/// The refusal a shared deployment returns for owner-only source configuration.
+const SOURCE_REFUSAL: &str = "workspace source configuration is owner-only";
+
+fn source_refusal<T>() -> Result<T, Status> {
+    Err(Status::permission_denied(SOURCE_REFUSAL))
+}
+
+/// A source service that refuses every call.
+///
+/// Source configuration is owner-only and `WorkspaceAuthorizer` denies `Manage`
+/// to an agent principal before any role is read, so an MCP agent credential is
+/// refused even while acting for a person who owns the workspace. A local
+/// unauthenticated fixture always speaks as an owner, so the refusal has to be
+/// served rather than provoked.
+#[derive(Clone, Copy)]
+struct RefusingSourceService;
+
+#[tonic::async_trait]
+impl SourceService for RefusingSourceService {
+    type CreateBundledSourceWithOAuthStream =
+        Empty<Result<CreateBundledSourceWithOAuthResponse, Status>>;
+    type ImportSourceStream = Empty<Result<ImportSourceResponse, Status>>;
+
+    async fn discover_sources(
+        &self,
+        _request: Request<DiscoverSourcesRequest>,
+    ) -> Result<Response<DiscoverSourcesResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn list_sources(
+        &self,
+        _request: Request<ListSourcesRequest>,
+    ) -> Result<Response<ListSourcesResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn get_source(
+        &self,
+        _request: Request<GetSourceRequest>,
+    ) -> Result<Response<GetSourceResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn get_source_info(
+        &self,
+        _request: Request<GetSourceInfoRequest>,
+    ) -> Result<Response<GetSourceInfoResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn describe_source_manifest(
+        &self,
+        _request: Request<DescribeSourceManifestRequest>,
+    ) -> Result<Response<DescribeSourceManifestResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn create_bundled_source(
+        &self,
+        _request: Request<CreateBundledSourceRequest>,
+    ) -> Result<Response<CreateBundledSourceResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn create_bundled_source_with_o_auth(
+        &self,
+        _request: Request<CreateBundledSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
+        source_refusal()
+    }
+
+    async fn import_source(
+        &self,
+        _request: Request<ImportSourceRequest>,
+    ) -> Result<Response<Self::ImportSourceStream>, Status> {
+        source_refusal()
+    }
+
+    async fn delete_source(
+        &self,
+        _request: Request<DeleteSourceRequest>,
+    ) -> Result<Response<DeleteSourceResponse>, Status> {
+        source_refusal()
+    }
+
+    async fn validate_source(
+        &self,
+        _request: Request<ValidateSourceRequest>,
+    ) -> Result<Response<ValidateSourceResponse>, Status> {
+        source_refusal()
+    }
+}
+
+/// Serves [`RefusingSourceService`] on loopback and returns a client for it.
+async fn start_refusing_source_client() -> (SourceClient, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind refusing source server");
+    let addr = listener
+        .local_addr()
+        .expect("refusing source server address");
+    let task = tokio::spawn(async move {
+        let _served = Server::builder()
+            .add_service(SourceServiceServer::new(RefusingSourceService))
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await;
+    });
+    let app = AppClient::connect(&format!("http://{addr}"))
+        .await
+        .expect("connect refusing source client");
+    (app.source_client(), task)
+}
+
+/// A refused source listing must shrink each discovery surface, not fail it.
+///
+/// `list_tools`, `list_resources`, and the `coral://guide` resource each blend
+/// installed sources with catalog contents. Sources are advisory context there,
+/// so the catalog half must still answer when source configuration is refused.
+#[tokio::test]
+async fn discovery_surfaces_degrade_when_source_listing_is_refused() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let app_server = ServerBuilder::new()
+        .with_config_dir(temp.path().join("coral-config"))
+        .with_noop_feedback_uploads()
+        .start()
+        .await
+        .expect("start server");
+    let app = AppClient::connect(app_server.endpoint_uri())
+        .await
+        .expect("connect client");
+    create_test_workspace(&app).await;
+    add_demo_source_to(
+        &mut app.source_client(),
+        test_workspace(),
+        manifest_yaml.clone(),
+    )
+    .await;
+
+    let (refusing_source, refusing_task) = start_refusing_source_client().await;
+    let factory = CoralMcpServerFactory::new(
+        app,
+        McpOptions {
+            workspace: Some(test_workspace()),
+            ..McpOptions::default()
+        },
+    );
+    let (client, mcp_task) =
+        start_mcp_session(factory.create_with_source_client(refusing_source)).await;
+
+    let tools = client
+        .list_all_tools()
+        .await
+        .expect("tools despite a refused source listing");
+    let sql_description = tool_by_name(&tools, "sql")
+        .description
+        .as_deref()
+        .expect("sql description")
+        .to_string();
+    assert!(sql_description.contains("8 table(s) are currently visible"));
+    assert!(sql_description.contains("No connected user sources are currently configured"));
+
+    let resources = client
+        .list_all_resources()
+        .await
+        .expect("resources despite a refused source listing");
+    let guide_description = resources[0]
+        .description
+        .as_deref()
+        .expect("guide description");
+    assert!(guide_description.contains("0 configured connection(s)"));
+    assert!(guide_description.contains("8 visible table(s)"));
+
+    let guide = client
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
+        .await
+        .expect("guide despite a refused source listing");
+    let guide_text = text_content(&guide);
+    assert!(guide_text.contains("Visible schemas:"));
+    assert!(guide_text.contains("- local_messages"));
+
+    shutdown_mcp_session(client, mcp_task).await;
+    refusing_task.abort();
+    app_server.shutdown().await.expect("shutdown app server");
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -12,10 +12,10 @@ use coral_api::v1::{
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, DeleteSourceRequest,
     DeleteSourceResponse, DescribeSourceManifestRequest, DescribeSourceManifestResponse,
-    DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
-    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, import_source_response,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
+    ListSourcesRequest, ListSourcesResponse, ValidateSourceRequest, ValidateSourceResponse,
+    Workspace, import_source_response,
     source_service_server::{SourceService, SourceServiceServer},
 };
 use coral_client::{
@@ -2842,6 +2842,13 @@ impl SourceService for RefusingSourceService {
         source_refusal()
     }
 
+    async fn describe_source_manifest(
+        &self,
+        _request: Request<DescribeSourceManifestRequest>,
+    ) -> Result<Response<DescribeSourceManifestResponse>, Status> {
+        source_refusal()
+    }
+
     async fn list_sources(
         &self,
         _request: Request<ListSourcesRequest>,
@@ -2860,13 +2867,6 @@ impl SourceService for RefusingSourceService {
         &self,
         _request: Request<GetSourceInfoRequest>,
     ) -> Result<Response<GetSourceInfoResponse>, Status> {
-        source_refusal()
-    }
-
-    async fn describe_source_manifest(
-        &self,
-        _request: Request<DescribeSourceManifestRequest>,
-    ) -> Result<Response<DescribeSourceManifestResponse>, Status> {
         source_refusal()
     }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -2815,19 +2815,26 @@ async fn mcp_sql_returns_large_int64_as_string() {
 /// The refusal a shared deployment returns for owner-only source configuration.
 const SOURCE_REFUSAL: &str = "workspace source configuration is owner-only";
 
-fn source_refusal<T>() -> Result<T, Status> {
-    Err(Status::permission_denied(SOURCE_REFUSAL))
-}
-
-/// A source service that refuses every call.
+/// A source service that fails every call with one configured status code.
 ///
-/// Source configuration is owner-only and `WorkspaceAuthorizer` denies `Manage`
+/// With [`tonic::Code::PermissionDenied`] it models the owner-only refusal:
+/// source configuration is owner-only and `WorkspaceAuthorizer` denies `Manage`
 /// to an agent principal before any role is read, so an MCP agent credential is
 /// refused even while acting for a person who owns the workspace. A local
 /// unauthenticated fixture always speaks as an owner, so the refusal has to be
-/// served rather than provoked.
+/// served rather than provoked. With a transient code such as
+/// [`tonic::Code::Unavailable`] it models a real backend fault that discovery
+/// surfaces must propagate rather than mistake for "no sources".
 #[derive(Clone, Copy)]
-struct RefusingSourceService;
+struct RefusingSourceService {
+    code: tonic::Code,
+}
+
+impl RefusingSourceService {
+    fn refuse<T>(self) -> Result<T, Status> {
+        Err(Status::new(self.code, SOURCE_REFUSAL))
+    }
+}
 
 #[tonic::async_trait]
 impl SourceService for RefusingSourceService {
@@ -2839,75 +2846,78 @@ impl SourceService for RefusingSourceService {
         &self,
         _request: Request<DiscoverSourcesRequest>,
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn describe_source_manifest(
         &self,
         _request: Request<DescribeSourceManifestRequest>,
     ) -> Result<Response<DescribeSourceManifestResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn list_sources(
         &self,
         _request: Request<ListSourcesRequest>,
     ) -> Result<Response<ListSourcesResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn get_source(
         &self,
         _request: Request<GetSourceRequest>,
     ) -> Result<Response<GetSourceResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn get_source_info(
         &self,
         _request: Request<GetSourceInfoRequest>,
     ) -> Result<Response<GetSourceInfoResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn create_bundled_source(
         &self,
         _request: Request<CreateBundledSourceRequest>,
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn create_bundled_source_with_o_auth(
         &self,
         _request: Request<CreateBundledSourceWithOAuthRequest>,
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn import_source(
         &self,
         _request: Request<ImportSourceRequest>,
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn delete_source(
         &self,
         _request: Request<DeleteSourceRequest>,
     ) -> Result<Response<DeleteSourceResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 
     async fn validate_source(
         &self,
         _request: Request<ValidateSourceRequest>,
     ) -> Result<Response<ValidateSourceResponse>, Status> {
-        source_refusal()
+        self.refuse()
     }
 }
 
-/// Serves [`RefusingSourceService`] on loopback and returns a client for it.
-async fn start_refusing_source_client() -> (SourceClient, tokio::task::JoinHandle<()>) {
+/// Serves a [`RefusingSourceService`] failing with `code` on loopback and
+/// returns a client for it.
+async fn start_refusing_source_client(
+    code: tonic::Code,
+) -> (SourceClient, tokio::task::JoinHandle<()>) {
     let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
         .await
         .expect("bind refusing source server");
@@ -2916,7 +2926,7 @@ async fn start_refusing_source_client() -> (SourceClient, tokio::task::JoinHandl
         .expect("refusing source server address");
     let task = tokio::spawn(async move {
         let _served = Server::builder()
-            .add_service(SourceServiceServer::new(RefusingSourceService))
+            .add_service(SourceServiceServer::new(RefusingSourceService { code }))
             .serve_with_incoming(TcpListenerStream::new(listener))
             .await;
     });
@@ -2953,7 +2963,8 @@ async fn discovery_surfaces_degrade_when_source_listing_is_refused() {
     )
     .await;
 
-    let (refusing_source, refusing_task) = start_refusing_source_client().await;
+    let (refusing_source, refusing_task) =
+        start_refusing_source_client(tonic::Code::PermissionDenied).await;
     let factory = CoralMcpServerFactory::new(
         app,
         McpOptions {
@@ -2998,6 +3009,66 @@ async fn discovery_surfaces_degrade_when_source_listing_is_refused() {
 
     shutdown_mcp_session(client, mcp_task).await;
     refusing_task.abort();
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// A transient source-listing fault must surface as an error, not empty sources.
+///
+/// Only the owner-only `PermissionDenied` refusal degrades a discovery surface
+/// to "no sources"; a transient `Unavailable`/`Internal` scoped to the source
+/// listing is a real fault that `list_tools`, `list_resources`, and the
+/// `coral://guide` resource must each propagate rather than render as an empty
+/// source list.
+#[tokio::test]
+async fn discovery_surfaces_fail_when_source_listing_hits_a_transient_fault() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let app_server = ServerBuilder::new()
+        .with_config_dir(temp.path().join("coral-config"))
+        .with_noop_feedback_uploads()
+        .start()
+        .await
+        .expect("start server");
+    let app = AppClient::connect(app_server.endpoint_uri())
+        .await
+        .expect("connect client");
+    create_test_workspace(&app).await;
+    add_demo_source_to(
+        &mut app.source_client(),
+        test_workspace(),
+        manifest_yaml.clone(),
+    )
+    .await;
+
+    let (unavailable_source, unavailable_task) =
+        start_refusing_source_client(tonic::Code::Unavailable).await;
+    let factory = CoralMcpServerFactory::new(
+        app,
+        McpOptions {
+            workspace: Some(test_workspace()),
+            ..McpOptions::default()
+        },
+    )
+    .expect("session scoped to a workspace");
+    let (client, mcp_task) =
+        start_mcp_session(factory.create_with_source_client(unavailable_source)).await;
+
+    client
+        .list_all_tools()
+        .await
+        .expect_err("a transient source fault must fail list_tools");
+    client
+        .list_all_resources()
+        .await
+        .expect_err("a transient source fault must fail list_resources");
+    client
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
+        .await
+        .expect_err("a transient source fault must fail the guide resource");
+
+    shutdown_mcp_session(client, mcp_task).await;
+    unavailable_task.abort();
     app_server.shutdown().await.expect("shutdown app server");
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -461,7 +461,7 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
         .expect("connect client");
     let options = with_created_workspace(&app, options).await;
     let source_client = app.source_client();
-    let factory = CoralMcpServerFactory::new(app, options);
+    let factory = CoralMcpServerFactory::new(app, options).expect("session scoped to a workspace");
     let (client, mcp_server_task) = start_mcp_session(factory.create()).await;
 
     TestSession {
@@ -2236,7 +2236,8 @@ async fn factory_shares_configuration_and_task_guide_state_across_sessions() {
             workspace: Some(test_workspace()),
             ..McpOptions::default()
         },
-    );
+    )
+    .expect("session scoped to a workspace");
 
     let (first_client, first_task) = start_mcp_session(factory.create()).await;
     let (second_client, second_task) = start_mcp_session(factory.create()).await;
@@ -2959,7 +2960,8 @@ async fn discovery_surfaces_degrade_when_source_listing_is_refused() {
             workspace: Some(test_workspace()),
             ..McpOptions::default()
         },
-    );
+    )
+    .expect("session scoped to a workspace");
     let (client, mcp_task) =
         start_mcp_session(factory.create_with_source_client(refusing_source)).await;
 
@@ -3032,14 +3034,16 @@ async fn workspace_scoped_sessions_read_only_their_own_workspace() {
             workspace: Some(test_workspace()),
             ..McpOptions::default()
         },
-    );
+    )
+    .expect("session scoped to a workspace");
     let sourced = CoralMcpServerFactory::new(
         app,
         McpOptions {
             workspace: Some(workspace(OTHER_TEST_WORKSPACE)),
             ..McpOptions::default()
         },
-    );
+    )
+    .expect("session scoped to a workspace");
     let (sourceless_client, sourceless_task) = start_mcp_session(sourceless.create()).await;
     let (sourced_client, sourced_task) = start_mcp_session(sourced.create()).await;
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -370,6 +370,10 @@ fn test_workspace() -> Workspace {
     workspace(TEST_WORKSPACE)
 }
 
+/// A second ordinary workspace, used to prove that a session only ever reaches
+/// the workspace it was scoped to.
+const OTHER_TEST_WORKSPACE: &str = "reporting";
+
 async fn create_test_workspace(app: &AppClient) {
     create_workspace(app, test_workspace()).await;
 }
@@ -2992,5 +2996,101 @@ async fn discovery_surfaces_degrade_when_source_listing_is_refused() {
 
     shutdown_mcp_session(client, mcp_task).await;
     refusing_task.abort();
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
+/// Every discovery surface must read the workspace the session was scoped to.
+///
+/// The fixture source is installed in one workspace only, so a session scoped
+/// to the other one must report an empty catalog and no configured sources.
+#[tokio::test]
+async fn workspace_scoped_sessions_read_only_their_own_workspace() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let app_server = ServerBuilder::new()
+        .with_config_dir(temp.path().join("coral-config"))
+        .with_noop_feedback_uploads()
+        .start()
+        .await
+        .expect("start server");
+    let app = AppClient::connect(app_server.endpoint_uri())
+        .await
+        .expect("connect client");
+    create_test_workspace(&app).await;
+    create_workspace(&app, workspace(OTHER_TEST_WORKSPACE)).await;
+    add_demo_source_to(
+        &mut app.source_client(),
+        workspace(OTHER_TEST_WORKSPACE),
+        manifest_yaml,
+    )
+    .await;
+
+    let sourceless = CoralMcpServerFactory::new(
+        app.clone(),
+        McpOptions {
+            workspace: Some(test_workspace()),
+            ..McpOptions::default()
+        },
+    );
+    let sourced = CoralMcpServerFactory::new(
+        app,
+        McpOptions {
+            workspace: Some(workspace(OTHER_TEST_WORKSPACE)),
+            ..McpOptions::default()
+        },
+    );
+    let (sourceless_client, sourceless_task) = start_mcp_session(sourceless.create()).await;
+    let (sourced_client, sourced_task) = start_mcp_session(sourced.create()).await;
+
+    for (client, expected_workspace) in [
+        (&sourceless_client, TEST_WORKSPACE),
+        (&sourced_client, OTHER_TEST_WORKSPACE),
+    ] {
+        let instructions = client
+            .peer_info()
+            .expect("initialize result")
+            .instructions
+            .clone()
+            .expect("initialize instructions");
+        assert!(instructions.contains(&format!("Current Coral workspace: {expected_workspace}.")));
+    }
+
+    let sourceless_guide_description = sourceless_client
+        .list_all_resources()
+        .await
+        .expect("resources for the source-free workspace")[0]
+        .description
+        .as_deref()
+        .expect("guide description")
+        .to_string();
+    assert!(sourceless_guide_description.contains("0 configured connection(s)"));
+    assert!(sourceless_guide_description.contains("5 visible table(s)"));
+
+    let sourced_guide_description = sourced_client
+        .list_all_resources()
+        .await
+        .expect("resources for the workspace holding the source")[0]
+        .description
+        .as_deref()
+        .expect("guide description")
+        .to_string();
+    assert!(sourced_guide_description.contains("1 configured connection(s)"));
+    assert!(sourced_guide_description.contains("8 visible table(s)"));
+
+    let sourceless_guide = sourceless_client
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
+        .await
+        .expect("guide for the source-free workspace");
+    assert!(text_content(&sourceless_guide).contains("No user schemas are currently configured."));
+
+    let sourced_guide = sourced_client
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
+        .await
+        .expect("guide for the workspace holding the source");
+    assert!(text_content(&sourced_guide).contains("- local_messages"));
+
+    shutdown_mcp_session(sourceless_client, sourceless_task).await;
+    shutdown_mcp_session(sourced_client, sourced_task).await;
     app_server.shutdown().await.expect("shutdown app server");
 }

--- a/xtask/benchmarks/src/main.rs
+++ b/xtask/benchmarks/src/main.rs
@@ -13,8 +13,10 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result, ensure};
 use clap::{Parser, Subcommand};
-use coral_api::v1::{ImportSourceRequest, import_source_response};
-use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use coral_api::v1::{
+    CreateWorkspaceRequest, ImportSourceRequest, Workspace, import_source_response,
+};
+use coral_client::{AppClient, local::ServerBuilder, workspace};
 use coral_mcp::{
     McpOptions,
     http::{McpHttpConfig, start_auth_disabled},
@@ -31,6 +33,13 @@ mod universal_search;
 const SCHEMA: &str = "benchmark_columns";
 const TABLE: &str = "wide_table";
 const COLUMN_COUNT: usize = 50;
+
+/// The workspace this benchmark creates and imports its fixture into.
+///
+/// A fresh state directory owns no workspace, so the harness has to create the
+/// one it measures against and name it on every request that follows.
+const WORKSPACE: &str = "benchmarks";
+const TASK_INTENT: &str = "Measure the token cost of list_columns";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -96,6 +105,7 @@ async fn run_list_columns_benchmark() -> Result<()> {
     let app = AppClient::connect(app_server.endpoint_uri())
         .await
         .context("connecting benchmark Coral client")?;
+    create_benchmark_workspace(&app).await?;
     import_fixture(&app, manifest_yaml).await?;
 
     let mcp_server = start_auth_disabled(
@@ -104,6 +114,7 @@ async fn run_list_columns_benchmark() -> Result<()> {
         app,
         McpOptions {
             source_names: vec![SCHEMA.to_string()],
+            workspace: Some(benchmark_workspace()),
             ..McpOptions::default()
         },
     )
@@ -112,12 +123,18 @@ async fn run_list_columns_benchmark() -> Result<()> {
     let transport =
         StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", mcp_server.local_addr()));
     let client = ().serve(transport).await.context("starting benchmark MCP client")?;
+    // `list_columns` is task-attributed, so the measurement runs inside a real
+    // task exactly as an agent's would: the attribution travels with the call
+    // rather than being measured as a special case.
+    let task_id = start_benchmark_task(&client).await?;
     let response = client
         .call_tool(
             CallToolRequestParams::new("list_columns").with_arguments(Map::from_iter([
                 ("schema".to_string(), Value::String(SCHEMA.to_string())),
                 ("table".to_string(), Value::String(TABLE.to_string())),
                 ("limit".to_string(), Value::from(COLUMN_COUNT)),
+                ("task_id".to_string(), Value::String(task_id.clone())),
+                ("intent".to_string(), Value::String(TASK_INTENT.to_string())),
             ])),
         )
         .await
@@ -166,11 +183,46 @@ async fn run_list_columns_benchmark() -> Result<()> {
     Ok(())
 }
 
+fn benchmark_workspace() -> Workspace {
+    workspace(WORKSPACE)
+}
+
+async fn start_benchmark_task(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+) -> Result<String> {
+    let started = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(Map::from_iter([(
+                "intent".to_string(),
+                Value::String(TASK_INTENT.to_string()),
+            )])),
+        )
+        .await
+        .context("starting the benchmark MCP task")?;
+    let task_id = started
+        .structured_content
+        .as_ref()
+        .and_then(|content| content.get("task_id"))
+        .and_then(Value::as_str)
+        .context("start_task response has no task ID")?;
+    Ok(task_id.to_string())
+}
+
+async fn create_benchmark_workspace(app: &AppClient) -> Result<()> {
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(benchmark_workspace()),
+        }))
+        .await
+        .context("creating the benchmark workspace")?;
+    Ok(())
+}
+
 async fn import_fixture(app: &AppClient, manifest_yaml: String) -> Result<()> {
     let mut stream = app
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
+            workspace: Some(benchmark_workspace()),
             manifest_yaml,
             variables: Vec::new(),
             secrets: Vec::new(),

--- a/xtask/benchmarks/src/main.rs
+++ b/xtask/benchmarks/src/main.rs
@@ -114,14 +114,15 @@ async fn run_list_columns_benchmark() -> Result<()> {
         app,
         McpOptions {
             source_names: vec![SCHEMA.to_string()],
-            workspace: Some(benchmark_workspace()),
             ..McpOptions::default()
         },
     )
     .await
     .context("starting benchmark MCP HTTP server")?;
-    let transport =
-        StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", mcp_server.local_addr()));
+    let transport = StreamableHttpClientTransport::from_uri(format!(
+        "http://{}/mcp/workspace/{WORKSPACE}",
+        mcp_server.local_addr()
+    ));
     let client = ().serve(transport).await.context("starting benchmark MCP client")?;
     // `list_columns` is task-attributed, so the measurement runs inside a real
     // task exactly as an agent's would: the attribution travels with the call


### PR DESCRIPTION
## Intent

A team server has more than one workspace, and its members reach different ones. Binding the MCP surface to a single configured workspace made every deployment a one-workspace deployment; this slice makes the URL name the workspace instead, per the Authenticated MCP Server PRD (Rev 11): every workspace is served at `<public_url>/workspace/{workspace}`, on both entry points, with no configuration selecting anything.

## What it enables

- **Breaking:** the legacy `/mcp` endpoint stops serving MCP (404 with a static hint naming the URL shape), tokens minted for the base `public_url` audience stop validating, and existing connectors reconnect at their workspace's URL.
- **Per-workspace URLs on both surfaces.** Auth-disabled serving exposes every existing workspace at `/mcp/workspace/{name}` as the implicit local user — existence answered per handshake and never cached, so a workspace created after startup is immediately reachable and a deleted one refuses new handshakes immediately; an unknown name is a plain not-found. There is no startup-time workspace resolution and no zero/several errors — the URL names the workspace directly.
- **Per-workspace OAuth resource identity.** Each workspace URL is its own protected resource: the route's exact resource is the token audience it admits (a bearer for `team` is `401 invalid_token` at `sandbox`, with `sandbox`'s own challenge), its RFC 9728 metadata document is served at the path-inserted well-known URL the per-route `WWW-Authenticate` challenge names, and the authorization server accepts any family member as an RFC 8707 resource. The private gRPC API accepts the family beside the configured extras; the base URL is no longer an audience anywhere.
- **Existence-blind concealment (PRD Rev 11 amendment).** Every shape-valid workspace URL presents the identical challenge and metadata surface to anonymous callers, whether or not the workspace exists — challenge and document are pure derivations of the URL, so probing enumerates nothing. Once identity is known, admission's single membership listing on the caller's own bearer produces byte-identical not-found refusals for a workspace out of reach and one never created. Malformed or non-canonical segments (including any percent-encoded spelling) are a plain 404 with no challenge and no metadata; workspace names outside the URL-safe charset are unreachable by URL by design.
- **Sessions are workspace-keyed.** A session is bound to (workspace, session id) before its bearer fingerprint, so a session replayed at another workspace's URL is a plain not-found even for the bearer that owns it where it lives; a wrong bearer for a session that does exist at the URL stays 403.
- **Distinct connectors.** Sessions advertise `Coral / {workspace}` as the server name, so a client connected to two workspaces shows two connectors.
- stdio selection is unchanged from the previous shape of this slice: `--workspace`, then `CORAL_WORKSPACE`, then sole membership, with the actionable zero/several errors; the client-side default-workspace helper stays retired.

## Known boundaries

- MCP admission is decided once per handshake. A membership revoked mid-session refuses the next handshake immediately; the already-open session's workspace-scoped calls fail at the gRPC layer (every backend RPC re-authorizes), while pure protocol exchanges (`ping`) still answer until the session closes or idles out.
- Tokens are not bound to a workspace incarnation: delete-and-recreate admits only members of the new workspace (rosters start fresh), but incarnation-scoped token invalidation (`wid` claims) remains with the authenticated-MCP mission.
- Coral UI's `CORAL_MCP_URL` advertises one operator-set URL verbatim; operators set it to one workspace's URL. Advertising several workspaces from the UI is a follow-up.

## Usage examples

```toml
[server.mcp_http]
enabled = true
public_url = "https://coral.example/mcp"   # base of the per-workspace URLs
```

```text
https://coral.example/mcp/workspace/team      → the team workspace
https://coral.example/mcp/workspace/sandbox   → the sandbox workspace
```

```bash
coral mcp-stdio --workspace analytics   # stdio selection, unchanged
```

---
Slice 4 of 5. Requires slices 1–3. Reshaped from the single-configured-workspace binding to per-workspace URLs per the Authenticated MCP Server PRD Rev 11 (concealment posture amended to existence-blind uniformity in the same revision).

