### PR TITLE
feat(mcp-http): allow auth-disabled non-loopback serving behind explicit opt-in

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -94,7 +94,42 @@ enabled = true
 bind = "127.0.0.1:14556"
 ```
 
-The unauthenticated MCP listener is restricted to loopback addresses.
+The unauthenticated MCP listener is restricted to loopback addresses by
+default. To serve it on other interfaces — necessary inside a Docker
+container, where a loopback bind is unreachable through published ports —
+opt in explicitly:
+
+```toml
+[server.mcp_http]
+enabled = true
+bind = "0.0.0.0:14556"
+allow_unauthenticated_non_loopback = true
+```
+
+<Warning>
+  The opted-in listener performs no authentication: anything that can reach the
+  port can read every configured source with the local user's full authority.
+  Keep it reachable only from trusted machines. In Docker, publish the port to
+  loopback only (`-p 127.0.0.1:14556:14556` — a bare `-p 14556:14556` exposes
+  it on every host interface), or keep it unpublished on an internal network.
+  For anything beyond a single trusted machine, configure Coral's
+  authenticated serving mode (the `[auth]` section) instead.
+</Warning>
+
+The listener accepts requests whose `Host` header names `localhost`,
+`127.0.0.1`, `::1`, or the bind IP; other values are rejected to block
+DNS-rebinding attacks. When clients reach the listener under another name —
+for example a Docker Compose service name or the machine's LAN address —
+list the extra names explicitly:
+
+```toml
+[server.mcp_http]
+allowed_hosts = ["coral"]
+```
+
+Both keys are rejected when `[auth]` is configured: remote binds then need
+no opt-in, and accepted hosts derive from `public_url` plus the loopback
+names.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -128,8 +128,8 @@ allowed_hosts = ["coral"]
 ```
 
 Both keys are rejected when `[auth]` is configured: remote binds then need
-no opt-in, and accepted hosts derive from `public_url` plus the loopback
-names.
+no opt-in, and accepted hosts derive from `public_url`, the bind IP, plus the
+loopback names.
 
 ## Runtime features
 

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -182,6 +182,8 @@ struct RawMcpHttpSettings {
     enabled: bool,
     bind: SocketAddr,
     public_url: Option<String>,
+    allow_unauthenticated_non_loopback: bool,
+    allowed_hosts: Vec<String>,
 }
 
 impl Default for RawMcpHttpSettings {
@@ -190,6 +192,8 @@ impl Default for RawMcpHttpSettings {
             enabled: false,
             bind: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
             public_url: None,
+            allow_unauthenticated_non_loopback: false,
+            allowed_hosts: Vec::new(),
         }
     }
 }
@@ -204,9 +208,13 @@ impl RawMcpHttpSettings {
         }
 
         let Some(authorization_server) = authorization_server else {
-            if !is_loopback_ip(self.bind.ip()) {
+            let expose_non_loopback = !is_loopback_ip(self.bind.ip());
+            if expose_non_loopback && !self.allow_unauthenticated_non_loopback {
                 return Err(AppError::FailedPrecondition(
-                    "auth-disabled server.mcp_http.bind must be loopback".to_string(),
+                    "auth-disabled server.mcp_http.bind must be loopback; set \
+                     server.mcp_http.allow_unauthenticated_non_loopback = true to expose \
+                     the unauthenticated listener deliberately"
+                        .to_string(),
                 ));
             }
             if self.public_url.is_some() {
@@ -216,9 +224,25 @@ impl RawMcpHttpSettings {
             }
             return Ok(Some(McpHttpServeConfig::AuthDisabled {
                 bind_addr: self.bind,
+                expose_non_loopback,
+                allowed_hosts: validated_mcp_allowed_hosts(&self.allowed_hosts)?,
             }));
         };
 
+        if self.allow_unauthenticated_non_loopback {
+            return Err(AppError::FailedPrecondition(
+                "server.mcp_http.allow_unauthenticated_non_loopback has no effect with [auth] \
+                 configured; remove it"
+                    .to_string(),
+            ));
+        }
+        if !self.allowed_hosts.is_empty() {
+            return Err(AppError::FailedPrecondition(
+                "server.mcp_http.allowed_hosts is only supported without [auth]; the \
+                 authenticated listener derives its accepted hosts from public_url"
+                    .to_string(),
+            ));
+        }
         let public_url =
             required_oauth_url("server.mcp_http.public_url", self.public_url.as_deref())?;
         let authorization_server = authorization_server.to_string();
@@ -231,13 +255,45 @@ impl RawMcpHttpSettings {
     }
 }
 
+/// Validates operator-supplied MCP HTTP Host allowlist entries.
+///
+/// Entries are Host header values (`host` or `host:port`), so a scheme, path,
+/// userinfo, or embedded whitespace means the operator pasted a URL — reject it
+/// with the field name rather than letting the listener 403 the requests the
+/// entry was meant to admit.
+fn validated_mcp_allowed_hosts(hosts: &[String]) -> Result<Vec<String>, AppError> {
+    for host in hosts {
+        let valid = !host.is_empty()
+            && !host.contains(|character: char| {
+                character.is_whitespace() || matches!(character, '/' | '@')
+            });
+        if !valid {
+            return Err(AppError::FailedPrecondition(format!(
+                "server.mcp_http.allowed_hosts entry {host:?} is not a bare host or host:port"
+            )));
+        }
+    }
+    Ok(hosts.to_vec())
+}
+
 /// Resolved MCP HTTP configuration prepared independently from gRPC startup.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum McpHttpServeConfig {
-    /// Loopback-only MCP HTTP backed by an unauthenticated local client.
+    /// MCP HTTP backed by an unauthenticated local client.
+    ///
+    /// Loopback-only unless the operator opted into deliberate exposure with
+    /// `server.mcp_http.allow_unauthenticated_non_loopback`.
     AuthDisabled {
         /// Address for the MCP HTTP listener.
         bind_addr: SocketAddr,
+        /// Operator consent to serve unauthenticated off loopback.
+        ///
+        /// Set only when `bind_addr` is non-loopback and the config opted in;
+        /// a loopback bind never carries consent it does not need.
+        expose_non_loopback: bool,
+        /// Extra Host header values accepted beside the loopback defaults,
+        /// e.g. a Docker Compose service name.
+        allowed_hosts: Vec<String>,
     },
     /// Session-authenticated MCP HTTP backed by per-session clients.
     Authenticated {
@@ -255,7 +311,9 @@ impl McpHttpServeConfig {
     #[must_use]
     pub fn bind_addr(&self) -> SocketAddr {
         match self {
-            Self::AuthDisabled { bind_addr } | Self::Authenticated { bind_addr, .. } => *bind_addr,
+            Self::AuthDisabled { bind_addr, .. } | Self::Authenticated { bind_addr, .. } => {
+                *bind_addr
+            }
         }
     }
 
@@ -513,12 +571,17 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
         )
         .expect("config file");
 
-        let Some(McpHttpServeConfig::AuthDisabled { bind_addr }) =
-            McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
+        let Some(McpHttpServeConfig::AuthDisabled {
+            bind_addr,
+            expose_non_loopback,
+            allowed_hosts,
+        }) = McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
         else {
             panic!("loopback MCP must be explicitly auth-disabled");
         };
         assert_eq!(bind_addr, SocketAddr::from((Ipv6Addr::LOCALHOST, 14556)));
+        assert!(!expose_non_loopback);
+        assert!(allowed_hosts.is_empty());
     }
 
     #[test]
@@ -536,6 +599,131 @@ redirect_uri = 'https://auth.example.test/auth/oidc/callback'
             McpHttpServeConfig::load(&layout).expect_err("public auth-disabled bind must fail");
 
         assert!(error.to_string().contains("must be loopback"));
+        // The rejection is also where the operator learns the deliberate way out.
+        assert!(
+            error
+                .to_string()
+                .contains("allow_unauthenticated_non_loopback")
+        );
+    }
+
+    #[test]
+    fn opted_in_auth_disabled_mcp_http_accepts_a_public_bind() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nbind = '0.0.0.0:14556'\n\
+             allow_unauthenticated_non_loopback = true\nallowed_hosts = ['coral']\n",
+        )
+        .expect("config file");
+
+        let Some(McpHttpServeConfig::AuthDisabled {
+            bind_addr,
+            expose_non_loopback,
+            allowed_hosts,
+        }) = McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
+        else {
+            panic!("opted-in non-loopback MCP must stay auth-disabled");
+        };
+        assert_eq!(bind_addr, SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14556)));
+        assert!(expose_non_loopback);
+        assert_eq!(allowed_hosts, vec!["coral".to_string()]);
+    }
+
+    #[test]
+    fn opt_in_on_a_loopback_bind_carries_no_exposure() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:14556'\n\
+             allow_unauthenticated_non_loopback = true\n",
+        )
+        .expect("config file");
+
+        let Some(McpHttpServeConfig::AuthDisabled {
+            expose_non_loopback,
+            ..
+        }) = McpHttpServeConfig::load(&layout).expect("MCP HTTP config")
+        else {
+            panic!("loopback MCP must resolve auth-disabled");
+        };
+        assert!(
+            !expose_non_loopback,
+            "a loopback bind must not carry consent it does not need"
+        );
+    }
+
+    #[test]
+    fn opted_in_auth_disabled_mcp_http_still_rejects_public_url() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nbind = '0.0.0.0:14556'\n\
+             allow_unauthenticated_non_loopback = true\n\
+             public_url = 'https://coral.example/mcp'\n",
+        )
+        .expect("config file");
+
+        let error = McpHttpServeConfig::load(&layout)
+            .expect_err("exposure consent must not unlock OAuth metadata");
+        assert!(error.to_string().contains("OAuth metadata"));
+    }
+
+    #[test]
+    fn mcp_http_exposure_opt_in_conflicts_with_auth() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        write_authenticated_config(
+            &layout,
+            "[server.mcp_http]\nenabled = true\nbind = '0.0.0.0:14556'\n\
+             public_url = 'https://coral.example/mcp'\n\
+             allow_unauthenticated_non_loopback = true\n",
+        );
+
+        let error = McpHttpServeConfig::load(&layout)
+            .expect_err("a stale unauthenticated opt-in must not survive enabling [auth]");
+        assert!(
+            error
+                .to_string()
+                .contains("allow_unauthenticated_non_loopback has no effect")
+        );
+    }
+
+    #[test]
+    fn mcp_http_allowed_hosts_conflict_with_auth() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        write_authenticated_config(
+            &layout,
+            "[server.mcp_http]\nenabled = true\nbind = '0.0.0.0:14556'\n\
+             public_url = 'https://coral.example/mcp'\nallowed_hosts = ['coral']\n",
+        );
+
+        let error = McpHttpServeConfig::load(&layout)
+            .expect_err("authenticated hosts derive from public_url");
+        assert!(error.to_string().contains("allowed_hosts"));
+    }
+
+    #[test]
+    fn mcp_http_allowed_hosts_reject_pasted_urls() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nallowed_hosts = ['http://coral:14556']\n",
+        )
+        .expect("config file");
+
+        let error =
+            McpHttpServeConfig::load(&layout).expect_err("a URL is not a Host header value");
+        assert!(error.to_string().contains("not a bare host"));
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -764,7 +764,10 @@ async fn run_server(
     if let Some(address) = server.mcp_http_addr() {
         let mcp_endpoint = format!("http://{address}/mcp");
         if server_requires_security_warning(address) {
-            eprintln!("{}", mcp_http_exposure_warning(&mcp_endpoint));
+            eprintln!(
+                "{}",
+                mcp_http_exposure_warning(&mcp_endpoint, server.mcp_http_authentication_enabled())
+            );
         }
         println!("Coral MCP HTTP server listening on {mcp_endpoint}");
     }
@@ -802,20 +805,21 @@ fn server_endpoint_address(endpoint: &str) -> Option<SocketAddr> {
 /// Reports whether the operator should be told the listener at `address` is exposed.
 ///
 /// Binding off loopback is the operator's decision: nothing gates the gRPC
-/// listener, and configuration lets MCP HTTP bind remotely once `[auth]` is set.
-/// So this line on stderr is the only notice they get — which is why it fires
-/// whether or not authentication is configured. Coral terminates no TLS: without
+/// listener, and configuration lets MCP HTTP bind remotely once `[auth]` is set
+/// or the operator opts in with `allow_unauthenticated_non_loopback`. So this
+/// line on stderr is the only notice they get — which is why it fires whether
+/// or not authentication is configured. Coral terminates no TLS: without
 /// `[auth]` anyone reachable gets in, and with it the bearer tokens cross the wire
-/// in cleartext. Both served surfaces run this check because both carry those
-/// tokens; [`grpc_exposure_warning`] and [`mcp_http_exposure_warning`] word each
+/// in cleartext. Both served surfaces run this check because both can end up
+/// exposed; [`grpc_exposure_warning`] and [`mcp_http_exposure_warning`] word each
 /// listener's case.
 ///
 /// Loopback is judged by coral-app's [`is_loopback_ip`] rather than by a rule
 /// restated here, IPv4-mapped IPv6 included. That is the same helper the
-/// auth-disabled `server.mcp_http.bind` guard rejects a remote bind with — an
-/// authenticated listener may bind remotely, which is precisely the case this
-/// warning exists to report — so a bind bootstrap accepts as local is never
-/// reported as exposed, and the notice cannot drift out of step with the
+/// auth-disabled `server.mcp_http.bind` guard rejects an unconsented remote
+/// bind with — the remote binds that survive resolution are precisely the ones
+/// this warning exists to report — so a bind bootstrap accepts as local is
+/// never reported as exposed, and the notice cannot drift out of step with the
 /// rejection.
 fn server_requires_security_warning(address: SocketAddr) -> bool {
     !is_loopback_ip(address.ip())
@@ -836,15 +840,28 @@ fn grpc_exposure_warning(endpoint: &str, authentication_enabled: bool) -> String
 
 /// The exposure warning for a non-loopback MCP HTTP listener.
 ///
-/// This one has no unauthenticated case to word: configuration rejects a
-/// non-loopback `server.mcp_http.bind` unless `[auth]` is configured, so a
-/// listener that reaches this warning is one clients hand bearer tokens to.
-fn mcp_http_exposure_warning(endpoint: &str) -> String {
-    format!(
-        "Warning: the MCP HTTP server at {endpoint} is not bound to loopback and it serves \
-         cleartext HTTP, so the bearer tokens clients send can be read off the wire. Terminate \
-         TLS in front of Coral and keep untrusted clients off the listener."
-    )
+/// The unauthenticated case exists only through the explicit
+/// `server.mcp_http.allow_unauthenticated_non_loopback` opt-in, so the warning
+/// restates what the operator signed up for rather than asking them to stop:
+/// with no credential check on the listener, reachability is the whole access
+/// control, and narrowing reachability (a loopback-only Docker port publish,
+/// a trusted network boundary) is the only thing left to get right.
+fn mcp_http_exposure_warning(endpoint: &str, authentication_enabled: bool) -> String {
+    if authentication_enabled {
+        format!(
+            "Warning: the MCP HTTP server at {endpoint} is not bound to loopback and it serves \
+             cleartext HTTP, so the bearer tokens clients send can be read off the wire. Terminate \
+             TLS in front of Coral and keep untrusted clients off the listener."
+        )
+    } else {
+        format!(
+            "Warning: the MCP HTTP server at {endpoint} is not bound to loopback and does not \
+             authenticate clients, so anything that can reach it can access Coral and its \
+             configured sources with the local user's full authority. Keep the listener \
+             reachable only from trusted machines — in Docker, publish the port to loopback \
+             only (-p 127.0.0.1:PORT:PORT) — or configure [auth] instead."
+        )
+    }
 }
 
 #[cfg(unix)]
@@ -1854,12 +1871,15 @@ mod tests {
         );
         let authenticated = grpc_exposure_warning("http://0.0.0.0:14555", true);
         assert!(authenticated.contains("bearer tokens"), "{authenticated}");
-        // A remote MCP bind is always the authenticated variant, so its warning
-        // has one case: cleartext HTTP carrying those tokens.
-        let mcp = mcp_http_exposure_warning("http://0.0.0.0:14556/mcp");
+        let mcp = mcp_http_exposure_warning("http://0.0.0.0:14556/mcp", true);
         assert!(mcp.contains("MCP HTTP server"), "{mcp}");
         assert!(mcp.contains("cleartext"), "{mcp}");
         assert!(mcp.contains("bearer tokens"), "{mcp}");
+        // The opted-in unauthenticated bind warns about open access, not tokens
+        // no client sends.
+        let mcp = mcp_http_exposure_warning("http://0.0.0.0:14556/mcp", false);
+        assert!(mcp.contains("does not authenticate clients"), "{mcp}");
+        assert!(mcp.contains("127.0.0.1:PORT"), "{mcp}");
     }
 
     #[cfg(feature = "embedded-ui")]

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -123,6 +123,7 @@ pub(crate) struct RunningServer {
     oauth: Option<RunningCoralAuthorizationServer>,
     mcp_http: Option<RunningMcpHttpServer>,
     grpc_authentication_enabled: bool,
+    mcp_http_authentication_enabled: bool,
 }
 
 impl RunningServer {
@@ -136,6 +137,10 @@ impl RunningServer {
 
     pub(crate) fn grpc_authentication_enabled(&self) -> bool {
         self.grpc_authentication_enabled
+    }
+
+    pub(crate) fn mcp_http_authentication_enabled(&self) -> bool {
+        self.mcp_http_authentication_enabled
     }
 
     #[cfg(test)]
@@ -155,6 +160,7 @@ impl RunningServer {
             oauth,
             mcp_http,
             grpc_authentication_enabled: _,
+            mcp_http_authentication_enabled: _,
         } = self;
         shutdown_components(grpc, oauth, mcp_http)
             .await
@@ -177,6 +183,8 @@ pub(crate) async fn start(
     let mcp_config = settings.mcp_http().cloned();
     let session_auth = settings.take_session_auth();
     let grpc_authentication_enabled = session_auth.is_some();
+    let mcp_http_authentication_enabled =
+        matches!(mcp_config, Some(McpHttpServeConfig::Authenticated { .. }));
     let (builder, mcp_principal_provider) =
         compose_session_policies(builder, session_auth.as_ref(), mcp_config.as_ref());
     // Built after the providers, which only borrow the settings; this consumes them.
@@ -219,6 +227,7 @@ pub(crate) async fn start(
         oauth,
         mcp_http,
         grpc_authentication_enabled,
+        mcp_http_authentication_enabled,
     })
 }
 
@@ -287,8 +296,20 @@ async fn start_mcp_http(
     };
     let grpc_endpoint_uri = loopback_grpc_endpoint_uri(grpc_addr)?;
     let server = match settings {
-        McpHttpServeConfig::AuthDisabled { bind_addr } => {
-            let config = McpHttpConfig::new(bind_addr)?;
+        McpHttpServeConfig::AuthDisabled {
+            bind_addr,
+            expose_non_loopback,
+            allowed_hosts,
+        } => {
+            // Configuration resolution only sets `expose_non_loopback` for a
+            // non-loopback bind the operator opted into, so a loopback bind
+            // keeps flowing through the constructor that enforces it.
+            let config = if expose_non_loopback {
+                McpHttpConfig::allow_unauthenticated_non_loopback(bind_addr)
+            } else {
+                McpHttpConfig::new(bind_addr)?
+            };
+            let config = config.with_allowed_hosts(allowed_hosts)?;
             let app = AppClient::connect(&grpc_endpoint_uri).await?;
             start_auth_disabled(config, app, mcp_options).await?
         }

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -398,6 +398,7 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     .expect("start composite server");
     let grpc_addr = grpc_addr(&server);
     assert!(!server.grpc_authentication_enabled());
+    assert!(!server.mcp_http_authentication_enabled());
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
     assert!(server.oauth_addr().is_none());
     assert_catalog_tool(format!("http://{mcp_addr}/mcp"), None).await;
@@ -405,6 +406,57 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC port must be released");
     let mcp_rebound = TcpListener::bind(mcp_addr).expect("MCP port must be released");
     drop((grpc_rebound, mcp_rebound));
+}
+
+/// Configuration resolution already rejects an unconsented non-loopback bind,
+/// so no config file can reach this arm with one. This hand-built settings
+/// value pins the second fail-closed layer's wiring anyway: without consent,
+/// serve must route through the constructor that enforces loopback.
+#[tokio::test]
+async fn unconsented_non_loopback_settings_fail_closed_in_serve() {
+    let settings = McpHttpServeConfig::AuthDisabled {
+        bind_addr: SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 0)),
+        expose_non_loopback: false,
+        allowed_hosts: Vec::new(),
+    };
+    let result = start_mcp_http(
+        Some(settings),
+        None,
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 1)),
+        McpOptions::default(),
+    )
+    .await;
+    match result {
+        Err(McpStartError::Http(McpHttpError::NonLoopbackBind(_))) => {}
+        Err(other) => panic!("expected the loopback rejection, got: {other}"),
+        Ok(_) => panic!("an unconsented non-loopback bind must not start"),
+    }
+}
+
+#[tokio::test]
+async fn opted_in_auth_disabled_companion_serves_off_loopback() {
+    let temp = TempDir::new().expect("temp dir");
+    write_config(
+        &temp,
+        "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\n\
+         bind = '0.0.0.0:0'\nallow_unauthenticated_non_loopback = true\n",
+    );
+    let server = start(
+        ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(temp.path())
+            .with_noop_feedback_uploads(),
+        McpOptions::default(),
+    )
+    .await
+    .expect("start composite server with the exposure opt-in");
+    assert!(!server.mcp_http_authentication_enabled());
+    let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
+    assert!(mcp_addr.ip().is_unspecified(), "bind must leave loopback");
+    // Dial through loopback: the point here is that the listener started and
+    // serves; reachability from other interfaces is the operator's affair.
+    let dial = SocketAddr::from((Ipv4Addr::LOCALHOST, mcp_addr.port()));
+    assert_catalog_tool(format!("http://{dial}/mcp"), None).await;
+    server.shutdown().await.expect("shutdown composite server");
 }
 
 #[tokio::test]
@@ -560,6 +612,7 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
         oauth,
         mcp_http,
         grpc_authentication_enabled: _,
+        mcp_http_authentication_enabled: _,
     } = server;
     grpc.shutdown().await.expect("shutdown gRPC server");
     let unready = reqwest::get(format!("{base}/readyz"))

--- a/crates/coral-mcp/AGENTS.md
+++ b/crates/coral-mcp/AGENTS.md
@@ -34,12 +34,16 @@ and Streamable HTTP transport adapters.
 - Keep HTTP tools and resources in the shared MCP surface. The HTTP adapter owns
   routing, host protection, health, and lifecycle; keep `/livez` process-only,
   while `/readyz` may probe reachability without requiring authentication.
-- In auth-disabled loopback mode, an HTTP transport may share an unauthenticated
-  local `AppClient` across sessions. In auth-required serving mode, validate the
-  bearer presented on initialize, construct a per-session `AppClient` that
-  forwards it for gRPC to validate again, and require the same bearer on later
-  requests; never fall back to a shared unauthenticated client. Stdio may also
-  use its unauthenticated local client.
+- In auth-disabled mode, an HTTP transport may share an unauthenticated local
+  `AppClient` across sessions. That mode binds loopback only, except through
+  the constructor that names the exposure
+  (`McpHttpConfig::allow_unauthenticated_non_loopback`), which exists solely to
+  honor an explicit operator opt-in from configuration — never call it on any
+  other authority. In auth-required serving mode, validate the bearer presented
+  on initialize, construct a per-session `AppClient` that forwards it for gRPC
+  to validate again, and require the same bearer on later requests; never fall
+  back to a shared unauthenticated client. Stdio may also use its
+  unauthenticated local client.
 - Prefer typed discovery from app/query APIs over scraping SQL metadata when a
   direct RPC already exists.
 - Decode query payloads through `coral-client`; do not fork Arrow IPC handling

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -1,8 +1,12 @@
 //! Streamable HTTP transport for Coral's MCP surface.
 //!
-//! [`start_auth_disabled`] is intentionally limited to loopback. It shares an
-//! unauthenticated local [`coral_client::AppClient`] across sessions and is not
-//! a safe construction path for a long-running, non-loopback server.
+//! [`start_auth_disabled`] is limited to loopback by default. It shares an
+//! unauthenticated local [`coral_client::AppClient`] across sessions, so
+//! network reachability is its entire access control. The only way off
+//! loopback without authentication is
+//! [`McpHttpConfig::allow_unauthenticated_non_loopback`], the constructor
+//! that configuration deliberately routes operator consent through; any
+//! other non-loopback serving must use the authenticated construction path.
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -326,10 +330,11 @@ impl SessionManager for AuthenticatedSessionManager {
     }
 }
 
-/// Configuration for the auth-disabled loopback MCP HTTP server.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Configuration for the auth-disabled MCP HTTP server.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct McpHttpConfig {
     bind_addr: SocketAddr,
+    extra_allowed_hosts: Vec<String>,
 }
 
 impl McpHttpConfig {
@@ -342,12 +347,56 @@ impl McpHttpConfig {
         if !is_loopback(bind_addr.ip()) {
             return Err(McpHttpError::NonLoopbackBind(bind_addr));
         }
-        Ok(Self { bind_addr })
+        Ok(Self {
+            bind_addr,
+            extra_allowed_hosts: Vec::new(),
+        })
+    }
+
+    /// Creates server configuration that may bind off loopback.
+    ///
+    /// Skipping the loopback check is this constructor's entire purpose, and
+    /// what its name exists to make callers say: every session still shares
+    /// one unauthenticated client, so whoever can reach the listener holds
+    /// the local user's full authority. Call this only to honor an explicit,
+    /// fail-closed operator opt-in (`allow_unauthenticated_non_loopback` in
+    /// the server configuration) — never as a convenience.
+    #[must_use]
+    pub fn allow_unauthenticated_non_loopback(bind_addr: SocketAddr) -> Self {
+        Self {
+            bind_addr,
+            extra_allowed_hosts: Vec::new(),
+        }
+    }
+
+    /// Accepts additional Host header values beside the loopback defaults.
+    ///
+    /// The Host allowlist is the DNS-rebinding defense, so entries must name
+    /// only hosts the operator expects legitimate clients to use — e.g. a
+    /// Docker Compose service name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`McpHttpError::InvalidAuthConfig`] when an entry is not a
+    /// valid header value.
+    pub fn with_allowed_hosts(
+        mut self,
+        hosts: impl IntoIterator<Item = String>,
+    ) -> Result<Self, McpHttpError> {
+        let hosts: Vec<String> = hosts.into_iter().collect();
+        if hosts
+            .iter()
+            .any(|host| HeaderValue::from_str(host).is_err())
+        {
+            return Err(McpHttpError::InvalidAuthConfig("invalid allowed Host"));
+        }
+        self.extra_allowed_hosts = hosts;
+        Ok(self)
     }
 
     /// Returns the configured bind address.
     #[must_use]
-    pub fn bind_addr(self) -> SocketAddr {
+    pub fn bind_addr(&self) -> SocketAddr {
         self.bind_addr
     }
 }
@@ -470,11 +519,12 @@ fn is_loopback(ip: IpAddr) -> bool {
 /// MCP HTTP startup or shutdown failure.
 #[derive(Debug, thiserror::Error)]
 pub enum McpHttpError {
-    /// Auth-disabled serving is restricted to the local machine.
+    /// Auth-disabled serving is restricted to the local machine unless the
+    /// operator consented via [`McpHttpConfig::allow_unauthenticated_non_loopback`].
     #[error("auth-disabled MCP HTTP bind must be loopback, got {0}")]
     NonLoopbackBind(SocketAddr),
-    /// Authenticated serving configuration is invalid.
-    #[error("invalid authenticated MCP HTTP configuration: {0}")]
+    /// MCP HTTP serving configuration is invalid.
+    #[error("invalid MCP HTTP configuration: {0}")]
     InvalidAuthConfig(&'static str),
     /// The TCP listener could not bind.
     #[error("failed to bind MCP HTTP server to {address}")]
@@ -566,11 +616,13 @@ fn join_server(
         .map_err(McpHttpError::Server)
 }
 
-/// Starts the loopback-only, authentication-disabled MCP HTTP server.
+/// Starts the authentication-disabled MCP HTTP server.
 ///
 /// The supplied unauthenticated client is shared across independent MCP
-/// sessions. Auth-required serving must use a distinct construction path that
-/// creates a bearer-bound client after validating each incoming session.
+/// sessions, so the listener is loopback-only unless the config was built
+/// with [`McpHttpConfig::allow_unauthenticated_non_loopback`]. Auth-required
+/// serving must use a distinct construction path that creates a bearer-bound
+/// client after validating each incoming session.
 ///
 /// # Errors
 ///
@@ -588,7 +640,13 @@ pub async fn start_auth_disabled(
         })?;
     let local_addr = listener.local_addr().map_err(McpHttpError::Server)?;
     let readiness = ReadinessProbe::from_app(app.clone());
-    let (router, state) = auth_disabled_router(app, options, readiness, local_addr.ip());
+    let (router, state) = auth_disabled_router(
+        app,
+        options,
+        readiness,
+        local_addr.ip(),
+        &config.extra_allowed_hosts,
+    );
     Ok(spawn_http_server(
         listener,
         local_addr,
@@ -677,10 +735,22 @@ fn auth_disabled_router(
     options: McpOptions,
     readiness: ReadinessProbe,
     advertised_ip: IpAddr,
+    extra_allowed_hosts: &[String],
 ) -> (Router, Arc<HttpState>) {
     let factory = CoralMcpServerFactory::new(app, options);
-    let config =
-        StreamableHttpServerConfig::default().with_allowed_hosts([advertised_ip.to_string()]);
+    // These are the same loopback names the authenticated listener accepts, so
+    // a client dialing `localhost` is not rejected for the bind being
+    // `127.0.0.1`. The allowlist stays exact beyond that baseline: it is the
+    // DNS-rebinding defense for originless requests, so only operator-listed
+    // hosts join it.
+    let mut allowed_hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+        advertised_ip.to_string(),
+    ];
+    allowed_hosts.extend(extra_allowed_hosts.iter().cloned());
+    let config = StreamableHttpServerConfig::default().with_allowed_hosts(allowed_hosts);
     let sessions = Arc::new(LocalSessionManager::default());
     let server = Arc::new(ServerState {
         sessions: SessionOwner::Local(sessions.clone()),

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -202,6 +202,81 @@ fn auth_disabled_config_accepts_only_real_loopback_binds() {
     }
 }
 
+#[test]
+fn exposure_consent_constructor_accepts_non_loopback_binds() {
+    for ip in ["0.0.0.0", "192.0.2.1", "::"] {
+        let address = SocketAddr::new(ip.parse().expect("IP"), 8080);
+        let config = McpHttpConfig::allow_unauthenticated_non_loopback(address);
+        assert_eq!(config.bind_addr(), address);
+    }
+}
+
+#[test]
+fn allowed_hosts_must_be_valid_header_values() {
+    let config = McpHttpConfig::new(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+        .expect("loopback");
+    assert!(matches!(
+        config.with_allowed_hosts(["bad\nhost".to_string()]),
+        Err(McpHttpError::InvalidAuthConfig(_))
+    ));
+}
+
+#[tokio::test]
+async fn auth_disabled_router_accepts_loopback_names_and_configured_hosts() {
+    let (_temp, app_server, app) = local_app().await;
+    let (router, state) = auth_disabled_router(
+        app.clone(),
+        McpOptions::default(),
+        ReadinessProbe::from_app(app),
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        &["coral".to_string()],
+    );
+
+    // The baseline loopback names and the operator-listed host all initialize;
+    // anything else keeps hitting the DNS-rebinding 403.
+    for host in [
+        "localhost:14556",
+        "127.0.0.1:14556",
+        "[::1]:14556",
+        "coral:14556",
+    ] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header(header::HOST, host)
+                    .header(header::ACCEPT, "application/json, text/event-stream")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(INITIALIZE))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK, "Host {host}");
+    }
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/mcp")
+                .header(header::HOST, "coral.example")
+                .header(header::ACCEPT, "application/json, text/event-stream")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(INITIALIZE))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    state.server.config.cancellation_token.cancel();
+    state.server.sessions.close_all().await;
+    app_server.shutdown().await.expect("shutdown app server");
+}
+
 #[tokio::test]
 async fn raw_routes_enforce_health_and_host_contracts() {
     let (_temp, app_server, app) = local_app().await;
@@ -211,6 +286,7 @@ async fn raw_routes_enforce_health_and_host_contracts() {
         McpOptions::default(),
         ReadinessProbe::from_app(app),
         advertised_ip,
+        &[],
     );
 
     for path in ["/livez", "/readyz"] {
@@ -289,6 +365,7 @@ async fn mcp_rejects_uninitialized_and_oversized_requests_without_leaking_sessio
         McpOptions::default(),
         ReadinessProbe::from_app(app),
         IpAddr::V4(Ipv4Addr::LOCALHOST),
+        &[],
     );
 
     for body in [

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -9,7 +9,8 @@
 //!   existing [`coral_client::AppClient`], typically bootstrapped by
 //!   `coral-cli`.
 //! - [`http::start_auth_disabled`] serves the same MCP surface over
-//!   loopback-only Streamable HTTP.
+//!   Streamable HTTP, loopback-only unless configuration routed operator
+//!   consent through [`http::McpHttpConfig::allow_unauthenticated_non_loopback`].
 //!
 //! The exposed MCP surface is intentionally small:
 //!


### PR DESCRIPTION
## Intent

The auth-disabled MCP Streamable HTTP listener is hard-restricted to loopback binds (#1626), which makes it unusable inside a Docker container: a loopback bind is unreachable through published ports, and the only sanctioned alternative — the authenticated listener — requires the full `[auth]` OIDC stack, disproportionate for a local single-user container. This PR adds a deliberate, fail-closed way out.

## What it enables

HTTP MCP from a Dockerized Coral with auth disabled, without weakening anyone who does not opt in:

- New `server.mcp_http.allow_unauthenticated_non_loopback` config key, default `false`. Without it, non-loopback binds keep failing closed at both existing layers (config resolution and `McpHttpConfig::new`), and the rejection now names the key.
- Consent flows from config resolution into coral-mcp through a constructor whose name states the exposure (`McpHttpConfig::allow_unauthenticated_non_loopback`); serve calls it only when resolution marked a consented non-loopback bind, so the loopback-enforcing constructor remains the default path.
- Every other hardening stays: 403 on any `Origin` header, the Host-header allowlist (DNS-rebinding defense), and the 1 MiB body cap. The allowlist baseline becomes `localhost` / `127.0.0.1` / `::1` / bind IP — also fixing a papercut where a loopback listener rejected clients dialing `localhost` — and the new `server.mcp_http.allowed_hosts` key adds operator-listed names such as a Docker Compose service name.
- An exposed unauthenticated listener prints its own stderr warning (with no credential check, reachability is the entire access control). Both new keys are rejected when `[auth]` is configured, so a stale opt-in cannot survive enabling authentication.

## Usage examples

Container config (via `CORAL_SEED_CONFIG` or the mounted `config.toml`):

```toml
[server]
bind_addr = "0.0.0.0:14555"

[server.mcp_http]
enabled = true
bind = "0.0.0.0:14556"
allow_unauthenticated_non_loopback = true
```

Publish to loopback only and connect a client on the host:

```sh
docker run -p 127.0.0.1:14556:14556 ... ghcr.io/withcoral/coral
claude mcp add --transport http coral http://localhost:14556/mcp
```

Reach it from a sibling container by service name instead of publishing the port:

```toml
[server.mcp_http]
allowed_hosts = ["coral"]
```

## Notes

- Verified with focused suites (MCP HTTP router/config, serve end-to-end on `0.0.0.0`, warning wordings) plus repo-wide `make rust-checks`.
- Follow-up: the deployment guide in #2204 documents MCP HTTP as unavailable in the auth-disabled Docker topology; once this merges it should show this opt-in instead of routing everyone to `[auth]`.
