### PR TITLE
feat(desktop): package the Linux desktop app as AppImage and deb

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -1,4 +1,4 @@
-name: Desktop macOS package
+name: Desktop package
 
 on:
   workflow_call:
@@ -7,8 +7,10 @@ on:
 permissions:
   contents: read
 
+# Workflow-level, so it bounds the whole run: the matrix legs share one slot and
+# never cancel each other.
 concurrency:
-  group: desktop-package-macos-${{ github.event_name }}-${{ github.ref }}
+  group: desktop-package-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -17,8 +19,16 @@ env:
 
 jobs:
   package:
-    name: Build unsigned package
-    runs-on: blacksmith-6vcpu-macos-26
+    name: Build unsigned ${{ matrix.platform }} package
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: mac
+            os: blacksmith-6vcpu-macos-26
+          - platform: linux
+            os: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -30,7 +40,7 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: coral-desktop-macos-universal
+          shared-key: coral-desktop-${{ matrix.platform }}
           cache-on-failure: true
           save-if: ${{ github.event_name == 'workflow_dispatch' }}
 
@@ -53,25 +63,33 @@ jobs:
         run: npm ci --prefix apps/desktop
 
       - name: Validate macOS entitlements
+        if: ${{ matrix.platform == 'mac' }}
         run: |
           plutil -lint \
             apps/desktop/resources/entitlements.mac.plist \
             apps/desktop/resources/entitlements.mac.inherit.plist
 
+      # fpm shells out to `ar` (binutils) to assemble the .deb and to `xz` for
+      # its control tarball. Both ship in the runner image; installing them
+      # explicitly keeps the dependency visible instead of implicit.
+      - name: Install deb packaging tools
+        if: ${{ matrix.platform == 'linux' }}
+        run: sudo apt-get install -y --no-install-recommends binutils xz-utils
+
       - name: Package desktop app
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: npm run package:mac --prefix apps/desktop
+        run: npm run package:${{ matrix.platform }} --prefix apps/desktop
 
       - name: Verify desktop package artifacts
-        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist
+        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist ${{ matrix.platform }}
 
       # PR and manual builds are available for inspection for one week.
-      - name: Upload desktop package artifact
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+      - name: Upload macOS package artifact
+        if: ${{ matrix.platform == 'mac' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: coral-desktop-macos-unsigned
+          name: coral-desktop-mac-unsigned
           if-no-files-found: error
           retention-days: 7
           path: |
@@ -79,3 +97,14 @@ jobs:
             apps/desktop/dist/coral-desktop-*.zip
             apps/desktop/dist/coral-desktop-*.blockmap
             apps/desktop/dist/latest-mac.yml
+
+      - name: Upload Linux package artifact
+        if: ${{ matrix.platform == 'linux' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-linux-unsigned
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            apps/desktop/dist/coral-desktop-*.AppImage
+            apps/desktop/dist/coral-desktop-*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,9 +332,86 @@ jobs:
             apps/desktop/dist/coral-desktop-*.blockmap
             apps/desktop/dist/latest-mac.yml
 
+  # Far simpler than the macOS leg: no universal binary, no signing, no
+  # notarization, and no updater, so no xtask and no credentials.
+  build-desktop-linux:
+    needs:
+      - validate-release-ref
+      - build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-ref.outputs.commit-sha }}
+          persist-credentials: false
+
+      # A manual tag on a commit whose desktop version was never bumped would
+      # otherwise ship an AppImage labelled with the wrong version. The macOS
+      # leg gets this from xtask; see ensure_version_matches_tag in
+      # xtask/src/release.rs.
+      - name: Verify desktop version matches the release tag
+        run: |
+          set -euo pipefail
+          version="$(jq -r .version apps/desktop/package.json)"
+          if [ "v${version}" != "$TAG_NAME" ]; then
+            echo "desktop version v${version} does not match release tag ${TAG_NAME}" >&2
+            exit 1
+          fi
+
+      - name: Download Linux CLI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: coral-x86_64-unknown-linux-gnu
+          path: ${{ runner.temp }}/cli
+
+      # The `build` job already compiled this target; reuse it rather than
+      # rebuilding Rust here.
+      - name: Unpack the prebuilt Coral CLI
+        run: |
+          set -euo pipefail
+          tar xzf "$RUNNER_TEMP/cli/coral-x86_64-unknown-linux-gnu.tar.gz" -C "$RUNNER_TEMP/cli"
+          "$RUNNER_TEMP/cli/coral" --version
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      # fpm shells out to `ar` (binutils) to assemble the .deb and to `xz` for
+      # its control tarball. Both ship in the runner image; installing them
+      # explicitly keeps the dependency visible instead of implicit.
+      - name: Install deb packaging tools
+        run: sudo apt-get install -y --no-install-recommends binutils xz-utils
+
+      # No CORAL_DESKTOP_RELEASE: release mode is the Apple signing path, and
+      # Linux ships without an updater.
+      - name: Package desktop app
+        env:
+          CORAL_DESKTOP_CLI_PATH: ${{ runner.temp }}/cli/coral
+        run: npm run package:linux --prefix apps/desktop
+
+      - name: Verify desktop package artifacts
+        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist linux
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-linux
+          if-no-files-found: error
+          path: |
+            apps/desktop/dist/coral-desktop-*.AppImage
+            apps/desktop/dist/coral-desktop-*.deb
+
   checksums:
     needs:
       - build
+      - build-desktop-linux
       - build-desktop-macos
       - sign-notarize-macos
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -352,7 +429,14 @@ jobs:
           cd artifacts
           # Only the globs decide "did any archive arrive?"; latest-mac.yml is a
           # literal that would always survive nullglob and mask an empty set.
-          archives=(coral-*.tar.gz coral-*.zip coral-*.dmg coral-*.blockmap)
+          archives=(
+            coral-*.tar.gz
+            coral-*.zip
+            coral-*.dmg
+            coral-*.blockmap
+            coral-desktop-*.AppImage
+            coral-desktop-*.deb
+          )
           if [ "${#archives[@]}" -eq 0 ]; then
             echo "No Coral release archives found" >&2
             exit 1
@@ -409,6 +493,8 @@ jobs:
             artifacts/coral-*.zip
             artifacts/coral-*.dmg
             artifacts/coral-*.blockmap
+            artifacts/coral-desktop-*.AppImage
+            artifacts/coral-desktop-*.deb
           )
           if [ "${#archives[@]}" -eq 0 ]; then
             echo "No Coral release archives found" >&2

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -27,13 +27,14 @@ uses `CORAL_ENDPOINT` to reach the supervised sidecar.
 - Coral UI documents rendered in-process from the staged React Router server build,
   with static assets served over the custom `coral-app://` scheme and a strict
   Content-Security-Policy
-- light and dark app icons (macOS; Windows icon assets are staged for a future
-  Windows target)
+- light and dark app icons (macOS and Linux; Windows icon assets are staged for a
+  future Windows target)
 - Coral MCP configuration from Desktop Settings for supported stdio-capable
   clients, including before they are installed
 - macOS DMG and ZIP packaging via `electron-builder`, with a signed and
   notarized release mode
-- GitHub Releases update metadata for packaged desktop auto-updates
+- Linux AppImage and deb packaging (x64), unsigned
+- GitHub Releases update metadata for packaged desktop auto-updates on macOS only
 - macOS system theme support
 
 ## Development
@@ -80,10 +81,18 @@ Use `npm run package:dmg --prefix apps/desktop` for the macOS drag-and-drop DMG.
 Use `npm run package:mac --prefix apps/desktop` to build the release-shaped
 universal macOS DMG and ZIP with updater metadata.
 
+Use `npm run package:linux --prefix apps/desktop` for the x64 Linux AppImage and
+deb. The deb needs `ar` (binutils) and `xz` on PATH — `fpm` shells out to both.
+Linux packages are unsigned and carry no update feed: `desktopUpdatesSupported()`
+(`src/main/auto-update.ts`) is macOS-only, so the Linux config sets `publish: null`
+and electron-builder writes no `latest-linux.yml`. Linux users download a new
+release manually.
+
 `CORAL_DESKTOP_RELEASE=1` selects release mode. It requires a complete App Store
 Connect API key credential set, forces Developer ID signing, enables the hardened
-runtime with minimal Electron entitlements, and notarizes the app. Without that
-flag, packaging is deterministically unsigned.
+runtime with minimal Electron entitlements, and notarizes the app. Because it is
+the Apple path, it fails on any platform other than macOS. Without that flag,
+packaging is deterministically unsigned.
 
 > Run the `--prefix apps/desktop` commands from the repo root. If you are already in
 > `apps/desktop/`, drop the flag (e.g. `npm run package:dir`).

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -36,9 +36,21 @@ function requireNotarizationCredentials(env: NodeJS.ProcessEnv): void {
   }
 }
 
-export function createConfig(env: NodeJS.ProcessEnv = process.env): Configuration {
+export function createConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): Configuration {
   const releaseBuild = env.CORAL_DESKTOP_RELEASE === '1'
-  if (releaseBuild) requireNotarizationCredentials(env)
+  if (releaseBuild) {
+    // Release mode is the Apple signing and notarization path, and macOS is the
+    // only platform with an update feed. Reject it on any other host so the
+    // build fails on the flag rather than on a credential preflight it could
+    // never satisfy.
+    if (platform !== 'darwin') {
+      throw new Error('CORAL_DESKTOP_RELEASE=1 is macOS-only; it drives Apple signing and notarization')
+    }
+    requireNotarizationCredentials(env)
+  }
 
   return {
     appId: 'com.withcoral.desktop',
@@ -96,6 +108,42 @@ export function createConfig(env: NodeJS.ProcessEnv = process.env): Configuratio
       identity: releaseBuild ? undefined : null,
       notarize: releaseBuild,
       target: ['dmg', 'zip'],
+    },
+    linux: {
+      category: 'Development',
+      // `coral` is the CLI's name. Claiming it for the Electron executable would
+      // put a /usr/bin/coral symlink to the desktop app in the deb payload and
+      // shadow the CLI the user installed.
+      executableName: 'coral-desktop',
+      // The directory, not icon.png. electron-builder returns a lone .png
+      // source verbatim (iconConverter.js `set: source is already a .png`), so
+      // naming the file installs a single 1024x1024 icon — a size hicolor's
+      // index.theme does not declare, leaving launchers with no icon at all.
+      // A directory routes icon.png through the generator and yields a real set.
+      icon: 'resources/icons',
+      // Debian requires a contact address for the Maintainer field, and fpm
+      // refuses to build without one — `author` carries no email.
+      maintainer: 'Coral Eng Team <eng@withcoral.com>',
+      // Linux has no updater (see desktopUpdatesSupported in src/main/auto-update.ts).
+      // `null` keeps electron-builder from writing a latest-linux.yml feed nobody
+      // serves and from embedding app-update.yml in the package.
+      publish: null,
+      synopsis: 'Coral desktop app',
+      // Electron sets the window's WM_CLASS from `desktopName` in package.json,
+      // and electron-builder writes StartupWMClass from the same value. Without
+      // it the two disagree — WM_CLASS is `withcoral-desktop`, derived from the
+      // package name, while StartupWMClass would be `Coral` — and no desktop
+      // environment can link a running window to the installed launcher.
+      syncDesktopName: true,
+      target: [
+        { target: 'AppImage', arch: ['x64'] },
+        { target: 'deb', arch: ['x64'] },
+      ],
+    },
+    deb: {
+      // Without this the package name falls back to the product name, `coral`,
+      // which would collide with a future CLI package.
+      packageName: 'coral-desktop',
     },
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,6 +4,9 @@
   "version": "0.13.0",
   "description": "Coral desktop app",
   "author": "With Coral",
+  "license": "Apache-2.0",
+  "homepage": "https://withcoral.com",
+  "desktopName": "coral-desktop.desktop",
   "type": "module",
   "main": "./out/main/index.js",
   "scripts": {
@@ -23,6 +26,8 @@
     "package:dir": "electron-builder --dir --config electron-builder.config.ts",
     "prepackage:dmg": "npm run build",
     "package:dmg": "electron-builder --mac dmg --publish never --config electron-builder.config.ts",
+    "prepackage:linux": "npm run build",
+    "package:linux": "electron-builder --linux --publish never --config electron-builder.config.ts",
     "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
     "package:mac": "npm run package:mac:prepared",
     "package:mac:prepared": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -42,10 +42,13 @@ test('non-release packages are explicitly unsigned', () => {
 })
 
 test('release packages enable strict signing and notarization', () => {
-  const config = createConfig({
-    CORAL_DESKTOP_RELEASE: '1',
-    ...apiKeyCredentials,
-  })
+  const config = createConfig(
+    {
+      CORAL_DESKTOP_RELEASE: '1',
+      ...apiKeyCredentials,
+    },
+    'darwin',
+  )
 
   assert.equal(config.forceCodeSigning, true)
   assert.equal(config.mac?.identity, undefined)
@@ -60,17 +63,20 @@ test('release packages reject every missing or blank notarization input', () => 
     const missing = { ...apiKeyCredentials }
     delete missing[name]
     assert.throws(
-      () => createConfig({ CORAL_DESKTOP_RELEASE: '1', ...missing }),
+      () => createConfig({ CORAL_DESKTOP_RELEASE: '1', ...missing }, 'darwin'),
       new RegExp(`missing ${name}`),
     )
 
     assert.throws(
       () =>
-        createConfig({
-          CORAL_DESKTOP_RELEASE: '1',
-          ...apiKeyCredentials,
-          [name]: ' \t ',
-        }),
+        createConfig(
+          {
+            CORAL_DESKTOP_RELEASE: '1',
+            ...apiKeyCredentials,
+            [name]: ' \t ',
+          },
+          'darwin',
+        ),
       new RegExp(`missing ${name}`),
     )
   }
@@ -84,12 +90,62 @@ test('release packages require a readable, non-empty API key file', async () => 
   for (const invalidPath of [missingPath, emptyPath, tempDir]) {
     assert.throws(
       () =>
-        createConfig({
-          CORAL_DESKTOP_RELEASE: '1',
-          ...apiKeyCredentials,
-          APPLE_API_KEY: invalidPath,
-        }),
+        createConfig(
+          {
+            CORAL_DESKTOP_RELEASE: '1',
+            ...apiKeyCredentials,
+            APPLE_API_KEY: invalidPath,
+          },
+          'darwin',
+        ),
       /APPLE_API_KEY must point to a readable, non-empty regular file/,
     )
   }
+})
+
+test('release mode is rejected off macOS before any credential preflight', () => {
+  for (const platform of ['linux', 'win32']) {
+    assert.throws(
+      () => createConfig({ CORAL_DESKTOP_RELEASE: '1', ...apiKeyCredentials }, platform),
+      /CORAL_DESKTOP_RELEASE=1 is macOS-only/,
+    )
+  }
+})
+
+test('non-release packaging config is identical on every host platform', () => {
+  const linuxHost = createConfig({}, 'linux')
+
+  assert.deepEqual(linuxHost, createConfig({}, 'darwin'))
+  assert.deepEqual(linuxHost, createConfig({}, 'win32'))
+})
+
+test('linux packages target AppImage and deb without an update feed', () => {
+  const { linux, deb } = createConfig({}, 'linux')
+
+  assert.deepEqual(linux?.target, [
+    { target: 'AppImage', arch: ['x64'] },
+    { target: 'deb', arch: ['x64'] },
+  ])
+  // Linux has no updater, so electron-builder must not emit latest-linux.yml
+  // or embed app-update.yml.
+  assert.equal(linux?.publish, null)
+  // Neither the executable nor the deb may claim the `coral` name; the deb
+  // symlinks its executable into /usr/bin and would shadow the CLI.
+  assert.equal(linux?.executableName, 'coral-desktop')
+  assert.equal(deb?.packageName, 'coral-desktop')
+  // fpm refuses to build a deb without a maintainer contact.
+  assert.match(linux?.maintainer ?? '', /^.+ <.+@.+>$/)
+  // A directory, so electron-builder generates a multi-size hicolor set;
+  // naming a single .png would install only the 1024x1024 source.
+  assert.equal(linux?.icon, 'resources/icons')
+})
+
+test('deb metadata inputs that live in package.json are present', () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  )
+
+  // fpm requires a project URL and reads the license from package metadata.
+  assert.match(packageJson.homepage, /^https:\/\//)
+  assert.equal(packageJson.license, 'Apache-2.0')
 })

--- a/apps/desktop/scripts/verify-dist.mjs
+++ b/apps/desktop/scripts/verify-dist.mjs
@@ -1,55 +1,91 @@
 #!/usr/bin/env node
-// Verifies a release-shaped desktop dist directory. Shared by the Validate
-// workflow's Desktop macOS package job and the release workflow so the two
-// checks cannot drift: exactly one DMG and one ZIP, non-empty update
-// metadata, every file latest-mac.yml references present, and a blockmap
-// next to the ZIP (electron-updater fetches <file>.blockmap for
-// differential updates).
+// Verifies a release-shaped desktop dist directory. Shared by the Desktop
+// package workflow and the release workflow so the two checks cannot drift.
+//
+// The artifact shape is per platform, and only macOS publishes an update feed
+// (see desktopUpdatesSupported in src/main/auto-update.ts):
+//
+//   mac    exactly one DMG and one ZIP, a blockmap next to the ZIP
+//          (electron-updater fetches <file>.blockmap for differential
+//          updates), and a non-empty latest-mac.yml whose every referenced
+//          file is present.
+//   linux  at least one AppImage and one deb, and no update feed.
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
+const PLATFORMS = ['mac', 'linux']
+
 const distDir = resolve(process.argv[2] ?? 'apps/desktop/dist')
+const platform = process.argv[3] ?? 'mac'
 
 function fail(message) {
   console.error(`[verify-dist] ${message}`)
   process.exit(1)
 }
 
+if (!PLATFORMS.includes(platform)) {
+  fail(`unknown platform '${platform}'; expected one of ${PLATFORMS.join(', ')}`)
+}
 if (!existsSync(distDir)) fail(`missing dist directory: ${distDir}`)
 const entries = readdirSync(distDir)
 
-const dmgs = entries.filter((f) => f.startsWith('coral-desktop-') && f.endsWith('.dmg'))
-const zips = entries.filter((f) => f.startsWith('coral-desktop-') && f.endsWith('.zip'))
-if (dmgs.length !== 1 || zips.length !== 1) {
-  fail(
-    `expected exactly one desktop DMG and one desktop ZIP, got DMGs: [${dmgs}] ZIPs: [${zips}]`,
-  )
+function artifacts(extension) {
+  return entries.filter((f) => f.startsWith('coral-desktop-') && f.endsWith(extension))
 }
 
-const metadataPath = join(distDir, 'latest-mac.yml')
-if (!existsSync(metadataPath)) fail('missing latest-mac.yml')
-const metadata = readFileSync(metadataPath, 'utf8')
-if (!metadata.trim()) fail('latest-mac.yml is empty')
+function verifyMac() {
+  const dmgs = artifacts('.dmg')
+  const zips = artifacts('.zip')
+  if (dmgs.length !== 1 || zips.length !== 1) {
+    fail(
+      `expected exactly one desktop DMG and one desktop ZIP, got DMGs: [${dmgs}] ZIPs: [${zips}]`,
+    )
+  }
 
-// latest-mac.yml lists its update assets as `url:` entries plus a legacy
-// top-level `path:`; a file the metadata references but the dist lacks would
-// 404 for every updater in the wild.
-const referenced = [
-  ...new Set(
-    [...metadata.matchAll(/^\s*(?:-\s*)?(?:url|path):\s*(\S+)\s*$/gm)].map((match) => match[1]),
-  ),
-]
-if (referenced.length === 0) fail('latest-mac.yml references no update assets')
-if (!referenced.includes(zips[0])) fail(`latest-mac.yml does not reference ${zips[0]}`)
-for (const file of referenced) {
-  if (!entries.includes(file)) fail(`latest-mac.yml references a missing file: ${file}`)
+  const metadataPath = join(distDir, 'latest-mac.yml')
+  if (!existsSync(metadataPath)) fail('missing latest-mac.yml')
+  const metadata = readFileSync(metadataPath, 'utf8')
+  if (!metadata.trim()) fail('latest-mac.yml is empty')
+
+  // latest-mac.yml lists its update assets as `url:` entries plus a legacy
+  // top-level `path:`; a file the metadata references but the dist lacks would
+  // 404 for every updater in the wild.
+  const referenced = [
+    ...new Set(
+      [...metadata.matchAll(/^\s*(?:-\s*)?(?:url|path):\s*(\S+)\s*$/gm)].map((match) => match[1]),
+    ),
+  ]
+  if (referenced.length === 0) fail('latest-mac.yml references no update assets')
+  if (!referenced.includes(zips[0])) fail(`latest-mac.yml does not reference ${zips[0]}`)
+  for (const file of referenced) {
+    if (!entries.includes(file)) fail(`latest-mac.yml references a missing file: ${file}`)
+  }
+
+  const zipBlockmap = `${zips[0]}.blockmap`
+  if (!entries.includes(zipBlockmap)) {
+    fail(`missing ${zipBlockmap}; differential updates need the ZIP blockmap`)
+  }
+
+  return `${dmgs[0]}, ${zips[0]} (+${zipBlockmap}), latest-mac.yml references ${referenced.join(', ')}`
 }
 
-const zipBlockmap = `${zips[0]}.blockmap`
-if (!entries.includes(zipBlockmap)) {
-  fail(`missing ${zipBlockmap}; differential updates need the ZIP blockmap`)
+function verifyLinux() {
+  const appImages = artifacts('.AppImage')
+  const debs = artifacts('.deb')
+  if (appImages.length === 0 || debs.length === 0) {
+    fail(
+      `expected at least one desktop AppImage and one desktop deb, got AppImages: [${appImages}] debs: [${debs}]`,
+    )
+  }
+  // Linux has no updater, so a feed here would be published and then served to
+  // nobody. Treat one as a packaging mistake.
+  const feeds = entries.filter((f) => /^latest(-\w+)?\.yml$/.test(f))
+  if (feeds.length > 0) {
+    fail(`linux ships no updater, but the build produced update metadata: ${feeds.join(', ')}`)
+  }
+  return [...appImages, ...debs].join(', ')
 }
 
-console.log(
-  `[verify-dist] ok: ${dmgs[0]}, ${zips[0]} (+${zipBlockmap}), latest-mac.yml references ${referenced.join(', ')}`,
-)
+const summary = { mac: verifyMac, linux: verifyLinux }[platform]()
+
+console.log(`[verify-dist] ok (${platform}): ${summary}`)

--- a/apps/desktop/src/main/sidecar.test.ts
+++ b/apps/desktop/src/main/sidecar.test.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from 'node:events'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  getPath: vi.fn(),
+  ensureDesktopCoralConfig: vi.fn(),
+}))
+
+vi.mock('node:child_process', () => ({ spawn: mocks.spawn }))
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: mocks.getPath,
+  },
+}))
+// Stubbed so the test never creates a real config directory on disk.
+vi.mock('./coral-config', () => ({
+  ensureDesktopCoralConfig: mocks.ensureDesktopCoralConfig,
+}))
+
+import { startCoralSidecar } from './sidecar'
+
+// Enough of a ChildProcess to drive the startup handshake: startCoralSidecar
+// resolves on the ready line, which also clears the packaged startup timeout.
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: () => void
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
+describe('packaged sidecar spawn', () => {
+  const userData = '/home/coral/.config/Coral'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getPath.mockReturnValue(userData)
+    mocks.ensureDesktopCoralConfig.mockResolvedValue(`${userData}/coral`)
+    // Electron defines resourcesPath; plain Node does not, and bundledCoralPath
+    // joins it to locate the binary.
+    Object.defineProperty(process, 'resourcesPath', {
+      value: '/tmp/.mount_Coral/usr/lib/coral-desktop/resources',
+      configurable: true,
+    })
+  })
+
+  // An AppImage mounts resourcesPath as a read-only squashfs, so anything the
+  // sidecar resolves relative to cwd has to land somewhere writable instead.
+  it('runs in the writable userData directory, not the read-only resources path', async () => {
+    const child = fakeChild()
+    mocks.spawn.mockReturnValue(child)
+
+    const starting = startCoralSidecar()
+    // The config directory is prepared before the spawn, so wait for the spawn
+    // rather than emitting the ready line into a listener that does not exist.
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled())
+    child.stdout.emit(
+      'data',
+      Buffer.from('Coral gRPC server listening on http://127.0.0.1:8778\n'),
+    )
+
+    const sidecar = await starting
+    expect(sidecar.url).toBe('http://127.0.0.1:8778')
+
+    const [, , options] = mocks.spawn.mock.calls[0]
+    expect(options.cwd).toBe(userData)
+  })
+})

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -81,7 +81,11 @@ function packagedSidecarCommand(): { command: string; args: string[]; cwd: strin
   return {
     command: bundledCoralPath(),
     args: ['server'],
-    cwd: process.resourcesPath,
+    // The binary is addressed absolutely and its state directory arrives as
+    // CORAL_CONFIG_DIR, so cwd only decides where stray relative work lands.
+    // `resourcesPath` is a read-only squashfs mount inside an AppImage;
+    // userData is writable on every platform.
+    cwd: app.getPath('userData'),
   }
 }
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -181,11 +181,12 @@ pub(crate) fn desktop_macos_package(args: &DesktopMacosPackageArgs) -> Result<bo
             .arg(&app_bundle),
         "validating desktop notarization staple",
     )?;
-    // Same artifact assertions as the Validate workflow's package job.
+    // Same artifact assertions as the Desktop package workflow's mac leg.
     run_command(
         Command::new("node")
             .arg("apps/desktop/scripts/verify-dist.mjs")
-            .arg(dist_dir),
+            .arg(dist_dir)
+            .arg("mac"),
         "verifying desktop dist artifacts",
     )?;
 


### PR DESCRIPTION
## Summary

Ships Coral Desktop on x64 Linux as an AppImage and a deb. The Rust CLI already builds for Linux and the main process was already platform-branched, so this is packaging plus one runtime fix.

- **Auto-update stays macOS-only.** `desktopUpdatesSupported()` already returns `false` off darwin, so `linux.publish: null` stops electron-builder from writing a `latest-linux.yml` feed nothing serves, or embedding `app-update.yml` in the package.
- **One runtime fix:** the packaged sidecar ran with `cwd: process.resourcesPath`, a read-only squashfs mount inside an AppImage. Now `app.getPath('userData')`.
- **`CORAL_DESKTOP_RELEASE=1` is rejected off macOS** — it's the Apple signing path. `createConfig()` takes the platform as an argument so the config tests stay host-independent (`desktop-checks` runs on Ubuntu).
- **`verify-dist.mjs` takes a platform argument** (`mac` | `linux`) and asserts the per-platform artifact shape, including that Linux produces no update metadata.
- CI: `desktop-package.yml` becomes a mac+linux matrix; `release.yml` gains `build-desktop-linux`, which reuses the CLI artifact the `build` job already produced — no Rust rebuild, no signing, no xtask.

User-facing docs (the Install and Upgrade tabs in `installation.mdx`) are deferred to a follow-up so this PR.

Four config details are load-bearing and not obvious:

| Setting | Why |
|---|---|
| `executableName` / `deb.packageName` avoid `coral` | The deb symlinks its executable into `/usr/bin`; the default would install `/usr/bin/coral` pointing at the Electron app and **shadow the CLI**. |
| `linux.icon` names the **directory**, not `icon.png` | electron-builder returns a lone `.png` verbatim instead of generating a set, and hicolor's `index.theme` declares nothing above `512x512` — so naming the file installs a single 1024×1024 icon launchers can't find. The directory yields 8 sizes, 16→512. |
| `desktopName` + `syncDesktopName` | Otherwise `WM_CLASS` is `withcoral-desktop` (from the package name) while the desktop entry declares `Coral`, and no desktop environment can associate a running window with the installed launcher. |
| `homepage` + `maintainer` | fpm refuses to build a deb without a project URL or contact address; `author` carries no email. |

## Test plan

Verified against a `coral-cli` built from the main, in an `ubuntu:24.04` container (Apple `container`) matching the CI runner's distro.

- [x] `npm run check` (12 config tests) and `npm test` (49 vitest) pass; `actionlint` clean; `cargo build -p xtask` clean
- [x] `npm run package:linux` produces `coral-desktop-linux-x86_64.AppImage` + `coral-desktop-linux-amd64.deb`; `verify-dist … linux` passes and `… mac` correctly fails
- [x] No `latest-linux.yml` and no embedded `app-update.yml`
- [x] deb: `Package: coral-desktop`, `Architecture: amd64`, `Maintainer: With Coral <eng@withcoral.com>`, `Homepage`/`License` set, `StartupWMClass=coral-desktop`, icons at 8 hicolor sizes, postinst symlinks `/usr/bin/coral-desktop`
- [x] Bundled CLI is `-rwxr-xr-x` in **both** the deb payload and the AppImage squashfs — no `afterPack` re-chmod needed
- [x] App launched (arm64 build, native in the VM): sidecar reached ready on the new `Coral gRPC server listening on` line, Coral UI rendered over `coral-app://`, window `WM_CLASS` measured as `coral-desktop` via `xprop`
- [x] Sidecar `cwd` read off `/proc/<pid>/cwd` → userData, not resourcesPath; Coral state landed in the isolated `CORAL_CONFIG_DIR` under userData
- [x] Closing the window (under a real WM) quits app + sidecar; relaunch reaches ready, so the state lock was released

Not covered: Desktop Settings → MCP clients (needs UI interaction), and `desktop-package.yml` via `workflow_dispatch` plus a release dry-run, which need CI.

