### PR TITLE
chore: remove leftover gRPC-Web references

### DIFF
--- a/apps/coral-ui/app/routes/source-oauth-install.ts
+++ b/apps/coral-ui/app/routes/source-oauth-install.ts
@@ -29,7 +29,7 @@ import { workspaceFromParams } from '@/lib/workspace-routing'
 // Resource route: normal source CRUD stays in React Router loaders/actions, but
 // interactive OAuth/device-code installs need browser-visible server-streaming
 // progress. The browser fetches this same-origin endpoint; it never imports or
-// calls Coral's gRPC-Web client directly.
+// calls Coral's gRPC client directly.
 export async function action({ context, params, request }: Route.ActionArgs): Promise<Response> {
   const formData = await request.formData()
   let name: string

--- a/apps/coral-ui/package-lock.json
+++ b/apps/coral-ui/package-lock.json
@@ -10,7 +10,6 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@connectrpc/connect-web": "^2.1.2",
         "@internationalized/date": "^3.12.2",
         "@react-router/node": "8.3.0",
         "@vanilla-extract/recipes": "^0.5.7",
@@ -869,16 +868,6 @@
       "engines": {
         "node": ">=20"
       },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2"
-      }
-    },
-    "node_modules/@connectrpc/connect-web": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
-      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
         "@connectrpc/connect": "2.1.2"

--- a/apps/coral-ui/package.json
+++ b/apps/coral-ui/package.json
@@ -24,7 +24,6 @@
     "@bufbuild/protobuf": "^2.12.1",
     "@connectrpc/connect": "^2.1.2",
     "@connectrpc/connect-node": "^2.1.2",
-    "@connectrpc/connect-web": "^2.1.2",
     "@internationalized/date": "^3.12.2",
     "@react-router/node": "8.3.0",
     "@vanilla-extract/recipes": "^0.5.7",

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -9,7 +9,7 @@ sidecar:
 coral server
 ```
 
-The sidecar owns the local gRPC-Web/API runtime. In packaged builds the main
+The sidecar owns the local gRPC/API runtime. In packaged builds the main
 process serves Coral UI through React Router's server build over a custom
 `coral-app://` scheme (no local network socket), serves static client assets from
 the same scheme, points the window at it, and handles the native shell concerns:

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -12,7 +12,6 @@
         "@bufbuild/protobuf": "2.12.1",
         "@connectrpc/connect": "2.1.2",
         "@connectrpc/connect-node": "2.1.2",
-        "@connectrpc/connect-web": "2.1.2",
         "@internationalized/date": "3.12.2",
         "@react-router/node": "8.3.0",
         "@vanilla-extract/recipes": "0.5.7",
@@ -445,16 +444,6 @@
       "engines": {
         "node": ">=20"
       },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.2"
-      }
-    },
-    "node_modules/@connectrpc/connect-web": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
-      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0",
         "@connectrpc/connect": "2.1.2"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,7 +33,6 @@
     "@bufbuild/protobuf": "2.12.1",
     "@connectrpc/connect": "2.1.2",
     "@connectrpc/connect-node": "2.1.2",
-    "@connectrpc/connect-web": "2.1.2",
     "@internationalized/date": "3.12.2",
     "@react-router/node": "8.3.0",
     "@vanilla-extract/recipes": "0.5.7",

--- a/docker/entrypoint-coral-ui.sh
+++ b/docker/entrypoint-coral-ui.sh
@@ -44,12 +44,9 @@ case "$CORAL_UI_AUTH_MODE" in
   disabled)
     echo 'coral-ui-entrypoint: WARNING: CORAL_UI_AUTH_MODE=disabled serves the Coral console with no' >&2
     echo 'coral-ui-entrypoint: login at all — anyone who can reach this port can read every source' >&2
-    echo 'coral-ui-entrypoint: and POST new source credentials. It ALSO selects Coral UI’s gRPC-Web' >&2
-    echo 'coral-ui-entrypoint: transport, while standalone `coral server` serves native gRPC.' >&2
-    echo 'coral-ui-entrypoint: Without a gRPC-Web-capable proxy in front of Coral,' >&2
-    echo 'coral-ui-entrypoint: every page this container serves will fail to load data.' >&2
-    echo 'coral-ui-entrypoint: Set CORAL_UI_AUTH_MODE=required unless you know you have both' >&2
-    echo 'coral-ui-entrypoint: a trusted network and such a proxy.' >&2
+    echo 'coral-ui-entrypoint: and POST new source credentials.' >&2
+    echo 'coral-ui-entrypoint: Set CORAL_UI_AUTH_MODE=required unless this port is reachable only' >&2
+    echo 'coral-ui-entrypoint: from a trusted network.' >&2
     ;;
   *)
     fatal 'CORAL_UI_AUTH_MODE must be required or disabled.' \


### PR DESCRIPTION
## Intent

#2199 moved the Desktop sidecar to native gRPC and #2200 removed the embedded browser UI, ending gRPC-Web support — but a few references outlived the removal. An audit swept the repo (textual variants, tests, docs/topology claims, dependencies/lockfiles/CI) and this PR cleans up everything it found.

## What it enables

Nothing in the tree claims a gRPC-Web topology anymore, so operators and contributors can't be misled by it:

- **`docker/entrypoint-coral-ui.sh`** — the `CORAL_UI_AUTH_MODE=disabled` warning claimed disabled mode "selects Coral UI's gRPC-Web transport" and that every page fails without a gRPC-Web-capable proxy. Every transport path in `coral-request.server.ts` now uses native gRPC (`createGrpcTransport`) regardless of auth mode, so that operational claim was false; the warning keeps its true security half. The Docker smoke test's grep target (`WARNING: CORAL_UI_AUTH_MODE=disabled`) is unchanged.
- **`apps/desktop/README.md`** — the sidecar owns a "gRPC/API runtime", not a "gRPC-Web/API runtime".
- **`apps/coral-ui/app/routes/source-oauth-install.ts`** — route comment referenced a gRPC-Web client that no longer exists.
- **`@connectrpc/connect-web`** — imported nowhere in coral-ui or desktop; removed from both manifests and lockfiles. (`@connectrpc/connect` / `connect-node` remain: they are the live native-gRPC transport.)

No tombstone tests needed removal: the `coral ui` CLI tests were already deleted inside #2199/#2200, and the remaining lookalikes ("Coral UI-only" auth-audience tests, FTS/CouchDB "tombstone" domain terms, the hidden-flag guard for the retired tasks feature) all test live behavior unrelated to gRPC-Web.

## Usage examples

Running the Coral UI container with auth disabled now prints only the accurate warning:

```
coral-ui-entrypoint: WARNING: CORAL_UI_AUTH_MODE=disabled serves the Coral console with no
coral-ui-entrypoint: login at all — anyone who can reach this port can read every source
coral-ui-entrypoint: and POST new source credentials.
coral-ui-entrypoint: Set CORAL_UI_AUTH_MODE=required unless this port is reachable only
coral-ui-entrypoint: from a trusted network.
```

Verified: coral-ui `npm run check` + 398/398 tests, desktop `npm run check` + 56/56 tests, `sh -n` on the entrypoint.