### PR TITLE
feat(engine): observe values from file-backed sources

### DIFF
--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -9,6 +9,8 @@
 mod catalog_discovery_tests;
 #[path = "grpc/feature_service_tests.rs"]
 mod feature_service_tests;
+#[path = "grpc/file_source_observed_values_tests.rs"]
+mod file_source_observed_values_tests;
 #[path = "grpc/function_lifecycle_tests.rs"]
 mod function_lifecycle_tests;
 #[path = "grpc/gui_onboarding_tests.rs"]

--- a/crates/coral-app/tests/grpc/file_source_observed_values_tests.rs
+++ b/crates/coral-app/tests/grpc/file_source_observed_values_tests.rs
@@ -1,0 +1,266 @@
+//! End-to-end proof that file-backed sources contribute observed values.
+//!
+//! The engine tests prove the file backend publishes scan batches. These prove
+//! the published rows survive the whole app path — collector, writer queue,
+//! store, search retrieval — and that source removal and edit take them back
+//! out again.
+
+use std::path::Path;
+use std::time::Duration;
+
+use coral_api::v1::{DeleteSourceRequest, DrainSearchQueueRequest, SearchProvider, SearchRequest};
+use coral_client::default_workspace;
+use serde_json::json;
+use tonic::Request;
+
+use super::harness::{GrpcHarness, manifest_yaml};
+
+const SOURCE_NAME: &str = "file_observed_fixture";
+const OBSERVED_TERM: &str = "kestrel";
+
+fn write_events_fixture(dir: &Path, kind: &str) {
+    std::fs::create_dir_all(dir).expect("fixture dir");
+    std::fs::write(
+        dir.join("events.jsonl"),
+        format!("{{\"id\":1,\"kind\":\"{kind}\"}}\n"),
+    )
+    .expect("jsonl fixture");
+}
+
+fn file_source_manifest_yaml(dir: &Path) -> String {
+    manifest_yaml(&json!({
+        "name": SOURCE_NAME,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "Observed-value file fixture",
+            "format": "jsonl",
+            "source": {
+                "location": format!("file://{}/", dir.display()),
+                "glob": "**/*.jsonl",
+            },
+            "columns": [
+                {"name": "id", "type": "Int64"},
+                {"name": "kind", "type": "Utf8"},
+            ],
+        }],
+    }))
+}
+
+fn search_sqlite_path(harness: &GrpcHarness) -> std::path::PathBuf {
+    harness
+        .config_dir()
+        .join("workspaces/default/search/search.sqlite3")
+}
+
+fn observed_value_count(harness: &GrpcHarness, source_name: &str) -> i64 {
+    rusqlite::Connection::open(search_sqlite_path(harness))
+        .expect("open search sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM observed_values WHERE workspace = 'default' AND source_name = ?1",
+            [source_name],
+            |row| row.get(0),
+        )
+        .expect("observed value count")
+}
+
+fn source_generation(harness: &GrpcHarness, source_name: &str) -> i64 {
+    rusqlite::Connection::open(search_sqlite_path(harness))
+        .expect("open search sqlite")
+        .query_row(
+            "SELECT generation FROM observed_source_generations WHERE workspace = 'default' AND source_name = ?1",
+            [source_name],
+            |row| row.get(0),
+        )
+        .expect("observed source generation")
+}
+
+/// Runs the fixture query and settles every observed row into the store.
+async fn capture_observed_values(harness: &GrpcHarness) {
+    harness
+        .execute_sql_rows(&format!("SELECT kind FROM {SOURCE_NAME}.events"))
+        .await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            harness
+                .search_client()
+                .drain_search_queue(Request::new(DrainSearchQueueRequest {
+                    workspace: Some(default_workspace()),
+                    budget_ms: 1_000,
+                }))
+                .await
+                .expect("drain observed-value search queue");
+            if observed_value_count(harness, SOURCE_NAME) > 0 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the file scan should reach the observed-values store");
+}
+
+async fn search_hits_for(harness: &GrpcHarness, query: &str) -> Vec<coral_api::v1::SearchResult> {
+    harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: query.to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect("search")
+        .into_inner()
+        .results
+}
+
+fn observed_hit_count(results: &[coral_api::v1::SearchResult], source_name: &str) -> usize {
+    results
+        .iter()
+        .filter(|result| {
+            result
+                .providers
+                .contains(&(SearchProvider::ObservedValues as i32))
+                && result
+                    .surface
+                    .as_ref()
+                    .is_some_and(|surface| surface.schema_name == source_name)
+        })
+        .count()
+}
+
+async fn install_file_source(harness: &GrpcHarness, dir: &Path) {
+    harness
+        .import_source(file_source_manifest_yaml(dir), Vec::new(), Vec::new())
+        .await;
+}
+
+async fn delete_file_source(harness: &GrpcHarness) {
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: SOURCE_NAME.to_string(),
+        }))
+        .await
+        .expect("delete file source");
+}
+
+#[tokio::test]
+async fn file_source_values_reach_observed_search() {
+    let harness = GrpcHarness::new_with_observed_values_search().await;
+    let fixture_dir = harness.temp_path().join("events");
+    write_events_fixture(&fixture_dir, OBSERVED_TERM);
+    install_file_source(&harness, &fixture_dir).await;
+
+    capture_observed_values(&harness).await;
+
+    let results = search_hits_for(&harness, OBSERVED_TERM).await;
+    let hit = results
+        .iter()
+        .find(|result| {
+            result.surface.as_ref().is_some_and(|surface| {
+                surface.schema_name == SOURCE_NAME && surface.name == "events"
+            })
+        })
+        .expect("the file source's observed value should elect its table");
+    assert!(
+        hit.providers
+            .contains(&(SearchProvider::ObservedValues as i32)),
+        "the hit must come from the observed-values provider"
+    );
+    assert!(
+        hit.matching_values.iter().any(|values| {
+            values.field == "kind" && values.values.iter().any(|value| value == OBSERVED_TERM)
+        }),
+        "the observed value should be the scanned cell"
+    );
+}
+
+#[tokio::test]
+async fn removing_a_file_source_drops_its_observed_values() {
+    let harness = GrpcHarness::new_with_observed_values_search().await;
+    let fixture_dir = harness.temp_path().join("events");
+    write_events_fixture(&fixture_dir, OBSERVED_TERM);
+    install_file_source(&harness, &fixture_dir).await;
+    capture_observed_values(&harness).await;
+    let generation_before = source_generation(&harness, SOURCE_NAME);
+
+    delete_file_source(&harness).await;
+
+    assert_eq!(
+        observed_value_count(&harness, SOURCE_NAME),
+        0,
+        "removing a file source must clear its observed values"
+    );
+    assert_eq!(
+        source_generation(&harness, SOURCE_NAME),
+        generation_before + 1,
+        "removing a file source must advance its observed-values epoch"
+    );
+    assert_eq!(
+        observed_hit_count(&search_hits_for(&harness, OBSERVED_TERM).await, SOURCE_NAME),
+        0
+    );
+}
+
+#[tokio::test]
+async fn editing_a_file_source_drops_its_observed_values() {
+    let harness = GrpcHarness::new_with_observed_values_search().await;
+    let fixture_dir = harness.temp_path().join("events");
+    write_events_fixture(&fixture_dir, OBSERVED_TERM);
+    install_file_source(&harness, &fixture_dir).await;
+    capture_observed_values(&harness).await;
+    let generation_before = source_generation(&harness, SOURCE_NAME);
+
+    // Point the same source at a different location: a runtime-contract
+    // change, which is the edit shape that must invalidate captured values.
+    let moved_dir = harness.temp_path().join("moved-events");
+    write_events_fixture(&moved_dir, "petrel");
+    install_file_source(&harness, &moved_dir).await;
+
+    assert_eq!(
+        observed_value_count(&harness, SOURCE_NAME),
+        0,
+        "editing a file source must clear its observed values"
+    );
+    assert_eq!(
+        source_generation(&harness, SOURCE_NAME),
+        generation_before + 1,
+        "editing a file source must advance its observed-values epoch"
+    );
+    assert_eq!(
+        observed_hit_count(&search_hits_for(&harness, OBSERVED_TERM).await, SOURCE_NAME),
+        0,
+        "the pre-edit value must not be retrievable under the stale scope"
+    );
+}
+
+/// Removing a source while observed-value search is off skips the store-side
+/// clear, so rows linger on disk until eviction. Retrieval must still refuse
+/// them: `live_scopes` only admits scopes of currently installed sources.
+#[tokio::test]
+async fn a_file_source_removed_with_the_flag_off_cannot_resurface() {
+    let harness = GrpcHarness::new_with_observed_values_search().await;
+    let fixture_dir = harness.temp_path().join("events");
+    write_events_fixture(&fixture_dir, OBSERVED_TERM);
+    install_file_source(&harness, &fixture_dir).await;
+    capture_observed_values(&harness).await;
+
+    let harness = Box::pin(harness.restart_with_observed_values_search(false)).await;
+    delete_file_source(&harness).await;
+    assert!(
+        observed_value_count(&harness, SOURCE_NAME) > 0,
+        "this test is only meaningful while a flag-off removal leaves rows behind; \
+         close that gap and the assertion below stops proving the live-scope filter"
+    );
+
+    let harness = Box::pin(harness.restart_with_observed_values_search(true)).await;
+    assert_eq!(
+        observed_hit_count(&search_hits_for(&harness, OBSERVED_TERM).await, SOURCE_NAME),
+        0,
+        "a removed source's values must not be retrievable, however they were left on disk"
+    );
+}

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -46,6 +46,27 @@ impl GrpcHarness {
         Self::start_with_parts(temp_dir, config_dir, feature_overrides).await
     }
 
+    /// Restarts the server on the same config dir with observed-value search
+    /// flipped.
+    ///
+    /// A feature override only reaches `active` on the next server start, so
+    /// tests that need capture on for one phase and off for the next have to
+    /// restart rather than toggle in place.
+    pub(crate) async fn restart_with_observed_values_search(self, enabled: bool) -> Self {
+        let Self {
+            temp_dir,
+            config_dir,
+            app,
+            _server: server,
+            ..
+        } = self;
+        drop(app);
+        server.shutdown().await.expect("shutdown server");
+        let mut feature_overrides = FeatureOverrides::default();
+        feature_overrides.set(Feature::ObservedValuesSearch, enabled);
+        Self::start_with_parts(temp_dir, config_dir, feature_overrides).await
+    }
+
     pub(crate) async fn start_with_config_dir(config_dir: PathBuf) -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
         Self::start_with_parts(temp_dir, config_dir, FeatureOverrides::default()).await

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -22,6 +22,11 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
+use crate::SourceObservationSurfaceKind;
+use crate::backends::shared::observing_provider::observed_table_provider;
+use crate::backends::shared::source_observation::{
+    SourceObservationConfig, SourceObservationPublishers, source_observation_publishers,
+};
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
@@ -35,12 +40,13 @@ use coral_spec::backends::file::{FileFormat, FileSourceManifest, FileTableSpec};
 use self::json::JsonFileTableProvider;
 use self::provider::FileTableProvider;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct FileCompiledSource {
     manifest: FileSourceManifest,
     home_dir: Option<PathBuf>,
     source_secrets: BTreeMap<String, String>,
     source_variables: BTreeMap<String, String>,
+    source_observation_publishers: SourceObservationPublishers,
 }
 
 pub(crate) fn compile_source(
@@ -48,12 +54,14 @@ pub(crate) fn compile_source(
     home_dir: Option<PathBuf>,
     source_secrets: BTreeMap<String, String>,
     source_variables: BTreeMap<String, String>,
+    source_observation_publishers: SourceObservationPublishers,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(FileCompiledSource {
         manifest,
         home_dir,
         source_secrets,
         source_variables,
+        source_observation_publishers,
     })
 }
 
@@ -66,6 +74,7 @@ pub(crate) fn compile_manifest(
         request.runtime_context.home_dir.clone(),
         request.source_secrets.clone(),
         request.source_variables.clone(),
+        source_observation_publishers(request.source_observation_publishers),
     )
 }
 
@@ -132,9 +141,19 @@ impl CompiledBackendSource for FileCompiledSource {
                 }
             };
             let schema = provider.schema();
-            let table_name = table.name().to_string();
             let metadata = registered_table(table, &schema);
-            tables.insert(table_name, provider);
+            tables.insert(
+                table.name().to_string(),
+                observed_table_provider(
+                    provider,
+                    &self.manifest.common.name,
+                    table.name(),
+                    SourceObservationConfig::new(
+                        SourceObservationSurfaceKind::Table,
+                        Arc::clone(&self.source_observation_publishers),
+                    ),
+                ),
+            );
             table_infos.push(metadata);
         }
 

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -4,19 +4,23 @@ use super::partitions::{
     PartitionColumns, partition_filter_constraints, partition_values_for_path,
 };
 use super::provider::FileTableProvider;
-use crate::backends::compile_source_manifest;
+use crate::backends::shared::source_observation::test_support::{
+    RecordedSourceObservation, RecordingSourceObservationPublisher,
+};
+use crate::backends::{BackendCompileRequest, compile_source_manifest, compile_validated_manifest};
 use crate::runtime::catalog;
 use crate::runtime::registry::{CompiledQuerySource, register_sources_blocking};
-use crate::{QueryRuntimeContext, QuerySource};
+use crate::{QueryRuntimeContext, QuerySource, SourceObservationPublisher};
 use coral_spec::backends::file::{
     FilePartitionDataType, FileTableSpec, PartitionColumnSpec, PartitionPathSpec,
 };
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_value};
 use datafusion::arrow::array::{
-    DictionaryArray, Float64Array, Int64Array, StringArray, UInt16Array,
+    Array as _, DictionaryArray, Float64Array, Int64Array, StringArray, UInt16Array,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, UInt16Type};
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::common::ScalarValue;
 use datafusion::datasource::listing::ListingTableUrl;
@@ -26,7 +30,7 @@ use object_store::ObjectMeta;
 use object_store::path::Path as ObjectPath;
 use parquet::arrow::ArrowWriter;
 use serde_json::json;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -912,6 +916,312 @@ async fn partition_column_in_file_schema_is_stripped_and_data_is_queryable() {
         rendered.contains("abc-123"),
         "_part_id value from hive directory should be visible"
     );
+}
+
+/// Compiles sources the way the engine does when observed-value capture is on.
+///
+/// `compile_sources` above is the capture-off path: it leaves the publisher
+/// list empty, so nothing wraps the file providers.
+fn compile_sources_with_observation_publishers(
+    manifests: Vec<ValidatedSourceManifest>,
+    publishers: &[Arc<dyn SourceObservationPublisher>],
+) -> Vec<CompiledQuerySource> {
+    let runtime_context = QueryRuntimeContext::default();
+    let request_authenticators = HashMap::new();
+    let request_identity_http_authenticators = HashMap::new();
+    manifests
+        .into_iter()
+        .map(|manifest| {
+            let source = QuerySource::new(manifest.clone(), BTreeMap::new(), BTreeMap::new());
+            let compiled = compile_validated_manifest(
+                &manifest,
+                &BackendCompileRequest {
+                    source: &source,
+                    runtime_context: &runtime_context,
+                    database_pool_registry: Arc::new(crate::DatabasePoolRegistry::new()),
+                    source_secrets: BTreeMap::new(),
+                    source_variables: BTreeMap::new(),
+                    request_authenticators: &request_authenticators,
+                    source_input_resolver: None,
+                    source_observation_publishers: publishers,
+                    request_identity_http_authenticators: &request_identity_http_authenticators,
+                },
+            )
+            .expect("manifest should compile");
+            CompiledQuerySource { source, compiled }
+        })
+        .collect()
+}
+
+/// Registers `manifest` with observed-value capture on, runs `sql`, and
+/// returns the rendered rows next to what the scan published.
+async fn observed_query(
+    manifest: ValidatedSourceManifest,
+    sql: &str,
+) -> (String, Vec<RecordedSourceObservation>) {
+    let ctx = SessionContext::new();
+    let publisher = Arc::new(RecordingSourceObservationPublisher::default());
+    register_sources_blocking(
+        &ctx,
+        compile_sources_with_observation_publishers(
+            vec![manifest],
+            &[Arc::clone(&publisher) as Arc<dyn SourceObservationPublisher>],
+        ),
+    )
+    .expect("observed file source should register");
+
+    let batches = ctx
+        .sql(sql)
+        .await
+        .expect("query should plan")
+        .collect()
+        .await
+        .expect("query should execute");
+    let rendered = pretty_format_batches(&batches)
+        .expect("batches should render")
+        .to_string();
+    (rendered, publisher.observations())
+}
+
+fn observed_rows(observations: &[RecordedSourceObservation]) -> usize {
+    observations
+        .iter()
+        .map(|observation| observation.row_count)
+        .sum()
+}
+
+fn observed_values(observations: &[RecordedSourceObservation], column: &str) -> Vec<String> {
+    observations
+        .iter()
+        .flat_map(|observation| {
+            let batch = &observation.batch;
+            let index = batch.schema().index_of(column).expect("observed column");
+            let values = batch.column(index);
+            let formatter = ArrayFormatter::try_new(values.as_ref(), &FormatOptions::default())
+                .expect("observed column should render");
+            (0..values.len())
+                .map(|row| formatter.value(row).to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn parquet_scan_publishes_observations_for_the_projected_columns() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    write_metrics_fixture(fixture_dir.path());
+    let location = file_url_from_directory_path(fixture_dir.path());
+
+    let (rendered, observations) = observed_query(
+        parquet_manifest(&location),
+        "SELECT metric FROM otel.metrics ORDER BY metric",
+    )
+    .await;
+
+    assert!(rendered.contains("cpu.usage"));
+    assert!(!observations.is_empty(), "the parquet scan should publish");
+    for observation in &observations {
+        assert_eq!(observation.source_name, "otel");
+        assert_eq!(observation.surface_name, "metrics");
+        assert_eq!(observation.column_names, vec!["metric".to_string()]);
+    }
+    let mut observed = observed_values(&observations, "metric");
+    observed.sort();
+    assert_eq!(observed, vec!["cpu.usage", "memory.usage"]);
+}
+
+#[tokio::test]
+async fn csv_scan_publishes_observations() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    fs::write(
+        fixture_dir.path().join("events.csv"),
+        "id|kind\n1|user\n2|assistant\n",
+    )
+    .expect("csv fixture should be written");
+    let location = file_url_from_directory_path(fixture_dir.path());
+    let manifest = file_manifest_with_columns(
+        "csv_demo",
+        "csv",
+        &location,
+        "**/*.csv",
+        &[
+            json!({ "name": "id", "type": "Int64" }),
+            json!({ "name": "kind", "type": "Utf8" }),
+        ],
+        Some(json!({ "has_header": true, "delimiter": "|" })),
+    );
+
+    let (_, observations) = observed_query(manifest, "SELECT kind FROM csv_demo.events").await;
+
+    assert_eq!(observed_rows(&observations), 2);
+    let mut observed = observed_values(&observations, "kind");
+    observed.sort();
+    assert_eq!(observed, vec!["assistant", "user"]);
+}
+
+#[tokio::test]
+async fn custom_json_provider_scan_publishes_observations() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    let partition_dir = fixture_dir.path().join("day=2026-03-10");
+    fs::create_dir_all(&partition_dir).expect("partition dir should exist");
+    fs::write(
+        partition_dir.join("events.jsonl"),
+        "{\"id\":1,\"kind\":\"user\"}\n{\"id\":2,\"kind\":\"assistant\"}\n",
+    )
+    .expect("jsonl fixture should be written");
+    let location = file_url_from_directory_path(fixture_dir.path());
+
+    let (_, observations) = observed_query(
+        partitioned_jsonl_manifest(&location),
+        "SELECT kind FROM jsonl_partitioned.events",
+    )
+    .await;
+
+    assert_eq!(observed_rows(&observations), 2);
+    let mut observed = observed_values(&observations, "kind");
+    observed.sort();
+    assert_eq!(observed, vec!["assistant", "user"]);
+}
+
+#[tokio::test]
+async fn partition_pruned_scan_publishes_only_the_surviving_files() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    write_metrics_fixture_for_day(
+        fixture_dir.path(),
+        "2026-03-10",
+        &[("cpu.usage", 0.42)],
+        "metrics.parquet",
+    );
+    write_metrics_fixture_for_day(
+        fixture_dir.path(),
+        "2026-03-11",
+        &[("disk.usage", 7.5)],
+        "metrics.parquet",
+    );
+    let location = file_url_from_directory_path(fixture_dir.path());
+
+    let (rendered, observations) = observed_query(
+        parquet_manifest(&location),
+        "SELECT metric FROM otel.metrics WHERE date = '2026-03-10'",
+    )
+    .await;
+
+    assert!(rendered.contains("cpu.usage"));
+    assert!(!rendered.contains("disk.usage"));
+    assert_eq!(
+        observed_values(&observations, "metric"),
+        vec!["cpu.usage"],
+        "the pruned partition's file must not be observed"
+    );
+}
+
+#[tokio::test]
+async fn a_predicate_over_the_table_selects_what_is_observed() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    write_metrics_fixture(fixture_dir.path());
+    let location = file_url_from_directory_path(fixture_dir.path());
+    let sql = "SELECT metric, value FROM otel.metrics WHERE metric = 'cpu.usage'";
+
+    let (observed_rendered, observations) = observed_query(parquet_manifest(&location), sql).await;
+
+    assert_eq!(
+        observed_values(&observations, "metric"),
+        vec!["cpu.usage"],
+        "only the rows the predicate selects should be observed"
+    );
+
+    let ctx = SessionContext::new();
+    register_sources_blocking(&ctx, compile_sources(vec![parquet_manifest(&location)]))
+        .expect("file source should register");
+    let batches = ctx
+        .sql(sql)
+        .await
+        .expect("query should plan")
+        .collect()
+        .await
+        .expect("query should execute");
+    let plain_rendered = pretty_format_batches(&batches)
+        .expect("batches should render")
+        .to_string();
+    assert_eq!(
+        observed_rendered, plain_rendered,
+        "observation must not change what the query returns"
+    );
+}
+
+#[tokio::test]
+async fn without_observation_publishers_file_providers_are_registered_unwrapped() {
+    let fixture_dir = tempdir().expect("tempdir should be created");
+    write_metrics_fixture(fixture_dir.path());
+    let location = file_url_from_directory_path(fixture_dir.path());
+
+    let plain_ctx = SessionContext::new();
+    register_sources_blocking(
+        &plain_ctx,
+        compile_sources(vec![parquet_manifest(&location)]),
+    )
+    .expect("file source should register");
+    let observed_ctx = SessionContext::new();
+    register_sources_blocking(
+        &observed_ctx,
+        compile_sources_with_observation_publishers(
+            vec![parquet_manifest(&location)],
+            &[Arc::new(RecordingSourceObservationPublisher::default())],
+        ),
+    )
+    .expect("observed file source should register");
+
+    assert!(
+        registered_metrics_provider(&plain_ctx)
+            .await
+            .downcast_ref::<FileTableProvider>()
+            .is_some(),
+        "capture off must register the file provider itself, not a wrapper"
+    );
+    assert!(
+        registered_metrics_provider(&observed_ctx)
+            .await
+            .downcast_ref::<FileTableProvider>()
+            .is_none(),
+        "capture on must register the observing wrapper"
+    );
+}
+
+async fn registered_metrics_provider(
+    ctx: &SessionContext,
+) -> Arc<dyn datafusion::catalog::TableProvider> {
+    ctx.catalog("datafusion")
+        .expect("catalog should exist")
+        .schema("otel")
+        .expect("schema should exist")
+        .table("metrics")
+        .await
+        .expect("table lookup should succeed")
+        .expect("table should exist")
+}
+
+fn partitioned_jsonl_manifest(location: &str) -> ValidatedSourceManifest {
+    parse_source_manifest_value(json!({
+        "dsl_version": 3,
+        "name": "jsonl_partitioned",
+        "version": "0.1.0",
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "events",
+            "format": "jsonl",
+            "source": {
+                "location": location,
+                "glob": "**/*.jsonl",
+                "partitions": [{ "name": "day", "type": "Utf8" }],
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" },
+                { "name": "kind", "type": "Utf8" },
+            ],
+        }]
+    }))
+    .expect("partitioned jsonl manifest should parse")
 }
 
 fn parquet_table_spec(location: &str) -> FileTableSpec {

--- a/crates/coral-engine/src/backends/shared/observing_provider.rs
+++ b/crates/coral-engine/src/backends/shared/observing_provider.rs
@@ -22,14 +22,6 @@
 //!   scan from every rule that downcasts to `DataSourceExec`, costing filter
 //!   pushdown, limit pushdown, and file-group repartitioning.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired by the file backend in the next PR of this stack"
-    )
-)]
-
 use std::any::Any;
 use std::borrow::Cow;
 use std::fmt;


### PR DESCRIPTION
> **Stack 2 of 2**, on top of #2220, which adds the decorator this wires up.

Wire the file backend to the observing table-provider decorator, so values in
parquet, csv, jsonl, and json tables reach `observed_values` and surface in
`coral search` under the `observed_values` provider. Until now the backend
received `source_observation_publishers` and dropped them.

`compile_manifest` keeps the publishers on `FileCompiledSource` and `register()`
wraps each provider, whether it is a DataFusion `ListingTable` behind
`FileTableProvider` or the custom `JsonFileTableProvider`. Wrapping at the
provider boundary covers both without touching either. This retires the staged
`dead_code` expectation the decorator carried.

Capture stays gated on `observed_values_search`. With the flag off the publisher
list is empty, `SourceObservationConfig::new` returns `None`, and `register()`
hands back the provider itself rather than a passthrough wrapper. Anyone already
running with the flag on will start capturing values from their file sources.

No app-side change was needed, verified rather than assumed:
`source_surface_scopes` already enumerates file table surfaces, `QueryManager`
builds publishers for every selected source with no backend filter, and
`credential_revision` is stably nil for credential-less sources, so scope ids
match between capture and retrieval.

Engine tests cover parquet, csv, and the custom JSON provider publishing under
the right source and surface names, a partition-pruned scan publishing only the
surviving file's rows, a predicate selecting what is observed while the query
result stays identical to an unwrapped scan's, and capture-off registering
`FileTableProvider` itself.

App tests carry the lifecycle requirements: a file source's value reaches
`coral search`, removing the source clears its rows and advances its epoch,
editing its location does the same, and a source removed while the flag was off
cannot resurface, because retrieval filters to live scopes. That last test
asserts the rows really do linger on disk first, so it fails rather than passes
vacuously if the flag-off clear gap is ever closed. Each of the four fails if
this wiring is removed.

`FileCompiledSource` loses an unused `#[derive(Debug)]`; the publisher trait is
not `Debug`, and the sibling `HttpCompiledSource` holding the same field derives
only `Clone`.


## Behaviour change

**Anyone already running with `observed_values_search` on starts capturing values
from their file sources when this lands.** No separate flag, no per-source
opt-out; a per-backend opt-out is not worth the surface area until someone asks.
Off by default, unchanged.

File values also enter the same ranking path (`search/observed/ranking.rs`) that
the observed-ranking rework is changing. A large file corpus may crowd out
API-source hits until that lands. Not a blocker, but worth knowing before this
is enabled anywhere real.

## What gets observed

This table's rows that satisfy the query's predicates on it, roughly its
contribution to the result. Deliberately not a post-pushdown scan head: an HTTP
response is shaped by the user's request, the first rows of a parquet file are
not, so a head would index query-irrelevant noise. Two accepted approximations:
rows that match this table's predicates but are dropped by a later join are
observed anyway, and a predicate spanning tables narrows this table only where
DataFusion can infer an equivalent single-table predicate from an equijoin.

There is no engine-side budget and no new config key. Inflow is contained by
machinery that already exists: the per-publish collector caps, the bounded writer
queue that sheds load by dropping with a warn, and store eviction. Consequence
accepted knowingly: an unfiltered scan of a large file publishes every batch, so
collector CPU rides on the query for its duration, and a very large scan's
coverage is whatever survived the queue.

Observation is strictly query-driven. Installing a file source never triggers a
scan — verified by hand below.

## Verification

Draft PRs report every real check as `skipping`, so CI says nothing. Locally on
this branch:

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets
  --all-features -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc` all clean
- `cargo nextest run --workspace --all-targets --all-features` — 2680 passed
- each of the four app tests fails if this wiring is reverted (checked by
  reverting it, not assumed)

Driven by hand with the real CLI against a real `.jsonl`, in an isolated
`CORAL_CONFIG_DIR`:

| step | result |
| --- | --- |
| install source, no query yet | `observed_values: eligible 0` — no install-time scan |
| `coral sql "SELECT id, species, habitat …"` | 3 rows, normal output |
| `coral search kestrel` | `results_found` → `birdlog.sightings`, `matched species = kestrel`, eligible 9 (3 rows × 3 cols) |
| `… WHERE species = 'osprey'` | eligible 2 (1 row × 2 projected cols); `kestrel` **not** captured though it is in the same file |
| `coral source remove birdlog` | store 9 rows → 0, search returns nothing |
| same query, flag off | 0 observed values, 0 queue jobs, provider reports `not_enabled` |

Not run locally: `make docs-check`, `make schema-check`.

## Follow-ups, not in this PR

- Removing a source while `observed_values_search` is off skips the store-side
  clear, so rows linger until eviction. Pre-existing and not file-specific; the
  live-scope filter keeps them unretrievable and the last test here pins that.
- Merge pushed partition-filter *values* into observations, as
  `http/provider.rs::merge_filter_values` does.
- Wrap the `database` backend's providers with the same decorator.
- Rate-limit the writer queue's "dropped" warn if a large scan turns out to spam
  logs. Nothing pre-emptive.
