### PR TITLE
feat(desktop): package the Windows desktop app as an NSIS installer

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -37,6 +37,11 @@ jobs:
               apps/desktop/dist/coral-desktop-*.AppImage
               apps/desktop/dist/coral-desktop-*.deb
               apps/desktop/dist/latest-linux.yml
+          # The installer alone: Windows ships no updater, and verify-dist fails
+          # the job if the build produced a feed or a blockmap.
+          - platform: win
+            os: blacksmith-4vcpu-windows-2025
+            artifacts: apps/desktop/dist/coral-desktop-*.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,11 +420,84 @@ jobs:
             apps/desktop/dist/coral-desktop-*.deb
             apps/desktop/dist/latest-linux.yml
 
+  # An unsigned preview: SmartScreen warns on install. No signing, no
+  # notarization, and no updater, so no xtask and no credentials — and unlike
+  # the Linux leg, no update feed either (see win.publish in
+  # apps/desktop/electron-builder.config.ts).
+  build-desktop-windows:
+    needs:
+      - validate-release-ref
+      - build
+    runs-on: blacksmith-4vcpu-windows-2025
+    env:
+      TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-ref.outputs.commit-sha }}
+          persist-credentials: false
+
+      # Nothing downstream carries the version — the installer filename holds
+      # only the arch — so a manual tag on a commit whose desktop version was
+      # never bumped would ship an About panel and an Add/Remove Programs entry
+      # that disagree with the release. The macOS leg gets this from xtask; see
+      # ensure_version_matches_tag in xtask/src/release.rs.
+      - name: Verify desktop version matches the release tag
+        shell: pwsh
+        run: |
+          $version = (Get-Content apps/desktop/package.json | ConvertFrom-Json).version
+          if ("v$version" -ne $env:TAG_NAME) {
+            Write-Error "desktop version v$version does not match release tag $env:TAG_NAME"
+            exit 1
+          }
+
+      - name: Download Windows CLI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: coral-x86_64-pc-windows-msvc
+          path: ${{ runner.temp }}/cli
+
+      # The `build` job already compiled this target; reuse it rather than
+      # rebuilding Rust here.
+      - name: Unpack the prebuilt Coral CLI
+        shell: pwsh
+        run: |
+          $cli = "$env:RUNNER_TEMP\cli"
+          Expand-Archive -Path "$cli\coral-x86_64-pc-windows-msvc.zip" -DestinationPath $cli -Force
+          & "$cli\coral.exe" --version
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      # No CORAL_DESKTOP_RELEASE: it bakes in the updater, and Windows has none.
+      # createConfig() rejects the flag on a win32 host for that reason.
+      - name: Package desktop app
+        env:
+          CORAL_DESKTOP_CLI_PATH: ${{ runner.temp }}/cli/coral.exe
+        run: npm run package:win --prefix apps/desktop
+
+      - name: Verify desktop package artifacts
+        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist win
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-windows
+          if-no-files-found: error
+          path: apps/desktop/dist/coral-desktop-*.exe
+
   checksums:
     needs:
       - build
       - build-desktop-linux
       - build-desktop-macos
+      - build-desktop-windows
       - sign-notarize-macos
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -448,6 +521,7 @@ jobs:
             coral-*.blockmap
             coral-desktop-*.AppImage
             coral-desktop-*.deb
+            coral-desktop-*.exe
           )
           if [ "${#archives[@]}" -eq 0 ]; then
             echo "No Coral release archives found" >&2
@@ -508,6 +582,7 @@ jobs:
             artifacts/coral-*.blockmap
             artifacts/coral-desktop-*.AppImage
             artifacts/coral-desktop-*.deb
+            artifacts/coral-desktop-*.exe
           )
           if [ "${#archives[@]}" -eq 0 ]; then
             echo "No Coral release archives found" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,14 @@ jobs:
       - validate-release-ref
       - build
     runs-on: blacksmith-4vcpu-windows-2025
+    # The Windows installer is an unsigned preview, so it must not gate the whole
+    # release. Everything downstream tolerates a missing .exe: both archive lists
+    # run under nullglob and stay non-empty from the other platforms, and the
+    # `test -s` literals are the mac and linux feeds. A failure here therefore
+    # degrades to "no Windows installer this release" instead of publishing a
+    # release with no assets at all, which would also stall macOS and AppImage
+    # auto-updates. publish-version warns when the installer is missing.
+    continue-on-error: true
     env:
       TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
     steps:
@@ -587,6 +595,12 @@ jobs:
           if [ "${#archives[@]}" -eq 0 ]; then
             echo "No Coral release archives found" >&2
             exit 1
+          fi
+          # build-desktop-windows is allowed to fail, so say so rather than
+          # shipping a quietly Windows-less release.
+          installers=(artifacts/coral-desktop-*.exe)
+          if [ "${#installers[@]}" -eq 0 ]; then
+            echo "::warning title=No Windows installer::build-desktop-windows produced no installer; ${TAG_NAME} ships without one"
           fi
           test -s artifacts/latest-mac.yml
           test -s artifacts/latest-linux.yml

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -27,13 +27,13 @@ uses `CORAL_ENDPOINT` to reach the supervised sidecar.
 - Coral UI documents rendered in-process from the staged React Router server build,
   with static assets served over the custom `coral-app://` scheme and a strict
   Content-Security-Policy
-- light and dark app icons (macOS and Linux; Windows icon assets are staged for a
-  future Windows target)
+- light and dark app icons on macOS, Linux, and Windows
 - Coral MCP configuration from Desktop Settings for supported stdio-capable
   clients, including before they are installed
 - macOS DMG and ZIP packaging via `electron-builder`, with a signed and
   notarized release mode
 - Linux AppImage and deb packaging (x64), unsigned
+- Windows NSIS installer packaging (x64), unsigned preview
 - GitHub Releases update metadata for packaged desktop auto-updates on macOS and
   on the Linux AppImage
 - macOS system theme support
@@ -89,6 +89,16 @@ which replaces its own image file on update; the deb belongs to dpkg, so
 `deb.publish` is null (which keeps it out of that feed),
 `desktopUpdatesSupported()` (`src/main/auto-update.ts`) returns false there, and
 deb users install a new release themselves.
+
+Use `npm run package:win --prefix apps/desktop` for the x64 Windows NSIS
+installer. It must run on Windows: NSIS builds its uninstaller by executing the
+freshly built installer, which off-Windows means wine. The installer is an
+unsigned preview, so SmartScreen shows an "unrecognized app" warning; ship it
+labelled as such. It installs per user under `%LOCALAPPDATA%`, needs no UAC
+prompt, and lets the user pick a directory. Windows ships no updater, so
+`win.publish` is `null` and `nsis.differentialPackage` is `false` — the first
+suppresses `latest.yml` and the embedded `app-update.yml`, the second suppresses
+the `.exe.blockmap`, and NSIS gates them independently.
 
 `CORAL_DESKTOP_RELEASE=1` selects release mode: it bakes the updater into the main
 process, so only builds made with it check for updates. On macOS it also requires a

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -95,10 +95,8 @@ installer. It must run on Windows: NSIS builds its uninstaller by executing the
 freshly built installer, which off-Windows means wine. The installer is an
 unsigned preview, so SmartScreen shows an "unrecognized app" warning; ship it
 labelled as such. It installs per user under `%LOCALAPPDATA%`, needs no UAC
-prompt, and lets the user pick a directory. Windows ships no updater, so
-`win.publish` is `null` and `nsis.differentialPackage` is `false` — the first
-suppresses `latest.yml` and the embedded `app-update.yml`, the second suppresses
-the `.exe.blockmap`, and NSIS gates them independently.
+prompt, and lets the user pick a directory. Windows ships no updater, so the
+build writes no feed and no blockmap.
 
 `CORAL_DESKTOP_RELEASE=1` selects release mode: it bakes the updater into the main
 process, so only builds made with it check for updates. On macOS it also requires a

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -94,8 +94,10 @@ Use `npm run package:win --prefix apps/desktop` for the x64 Windows NSIS
 installer. It must run on Windows: NSIS builds its uninstaller by executing the
 freshly built installer, which off-Windows means wine. The installer is an
 unsigned preview, so SmartScreen shows an "unrecognized app" warning; ship it
-labelled as such. It installs per user under `%LOCALAPPDATA%`, needs no UAC
-prompt, and lets the user pick a directory. Windows ships no updater, so the
+labelled as such. It installs per user under `%LOCALAPPDATA%` by default, needs no
+UAC prompt, and lets the user pick a directory. The install mode page also offers
+an all-users install, but `allowElevation: false` disables that choice unless the
+installer already runs elevated. Windows ships no updater, so the
 build writes no feed and no blockmap.
 
 `CORAL_DESKTOP_RELEASE=1` selects release mode: it bakes the updater into the main

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -2,6 +2,8 @@ import { accessSync, constants, statSync } from 'node:fs'
 
 import type { Configuration } from 'electron-builder'
 
+import { APP_ID } from './src/shared/app-id.ts'
+
 // Release mode ships an active updater, so it only applies where the app can
 // replace itself: the macOS app and the Linux AppImage.
 const RELEASE_PLATFORMS: NodeJS.Platform[] = ['darwin', 'linux']
@@ -58,7 +60,7 @@ export function createConfig(
   if (appleRelease) requireNotarizationCredentials(env)
 
   return {
-    appId: 'com.withcoral.desktop',
+    appId: APP_ID,
     productName: 'Coral',
     artifactName: 'coral-desktop-${os}-${arch}.${ext}',
     forceCodeSigning: appleRelease,

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -156,6 +156,39 @@ export function createConfig(
       // that reason.
       publish: null,
     },
+    win: {
+      // The file, not the directory. The .png trap the linux block works around
+      // is PNG-only: electron-builder validates that an .ico carries a >=256
+      // entry and then uses it as is, and resources/icons/icon.ico carries
+      // 16/24/32/48/64/128/256.
+      icon: 'resources/icons/icon.ico',
+      // Windows ships no updater, so desktopUpdatesSupported() is false there.
+      // `null` keeps electron-builder from writing a latest.yml feed nobody
+      // serves and from embedding app-update.yml in the package.
+      // getPublishConfigs reads this platform block before the top-level
+      // `publish`, so null short-circuits it.
+      publish: null,
+      // No executableName: the deb symlinks its executable into /usr/bin and
+      // would shadow the `coral` CLI, which is why linux renames it. The
+      // installer writes Coral.exe into its own directory, so there is nothing
+      // to collide with.
+      target: [{ target: 'nsis', arch: ['x64'] }],
+    },
+    nsis: {
+      // An assisted installer, so the user can pick a directory.
+      allowToChangeInstallationDirectory: true,
+      // A blockmap is differential-update metadata. NsisTarget gates it on
+      // `!isPortable && differentialPackage !== false` — not on `publish` — so
+      // without this a coral-desktop-win-x64.exe.blockmap lands in dist even
+      // with publish: null, and release.yml's `coral-*.blockmap` glob would
+      // sweep it into the GitHub release.
+      differentialPackage: false,
+      oneClick: false,
+      // Per-user, under %LOCALAPPDATA%. A per-machine install puts
+      // resourcesPath under C:\Program Files, which a standard user cannot
+      // write to, and costs a UAC prompt for a developer tool that needs none.
+      perMachine: false,
+    },
   }
 }
 

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -3,8 +3,7 @@ import { accessSync, constants, statSync } from 'node:fs'
 import type { Configuration } from 'electron-builder'
 
 // Release mode ships an active updater, so it only applies where the app can
-// replace itself: the macOS app and the Linux AppImage. Windows has no updater
-// and no signing story yet.
+// replace itself: the macOS app and the Linux AppImage.
 const RELEASE_PLATFORMS: NodeJS.Platform[] = ['darwin', 'linux']
 
 const API_KEY_NOTARIZATION_ENV = [
@@ -157,36 +156,27 @@ export function createConfig(
       publish: null,
     },
     win: {
-      // The file, not the directory. The .png trap the linux block works around
-      // is PNG-only: electron-builder validates that an .ico carries a >=256
-      // entry and then uses it as is, and resources/icons/icon.ico carries
-      // 16/24/32/48/64/128/256.
+      // The file, not the directory: the lone-.png trap the linux block works
+      // around is PNG-only, and electron-builder uses an .ico with a >=256
+      // entry as is.
       icon: 'resources/icons/icon.ico',
-      // Windows ships no updater, so desktopUpdatesSupported() is false there.
-      // `null` keeps electron-builder from writing a latest.yml feed nobody
-      // serves and from embedding app-update.yml in the package.
-      // getPublishConfigs reads this platform block before the top-level
-      // `publish`, so null short-circuits it.
+      // Windows ships no updater, so `null` keeps electron-builder from writing
+      // a latest.yml feed nobody serves and from embedding app-update.yml in the
+      // package. getPublishConfigs reads this block before the top-level
+      // `publish`, so it short-circuits there.
       publish: null,
-      // No executableName: the deb symlinks its executable into /usr/bin and
-      // would shadow the `coral` CLI, which is why linux renames it. The
-      // installer writes Coral.exe into its own directory, so there is nothing
-      // to collide with.
       target: [{ target: 'nsis', arch: ['x64'] }],
     },
     nsis: {
-      // An assisted installer, so the user can pick a directory.
       allowToChangeInstallationDirectory: true,
-      // A blockmap is differential-update metadata. NsisTarget gates it on
-      // `!isPortable && differentialPackage !== false` — not on `publish` — so
-      // without this a coral-desktop-win-x64.exe.blockmap lands in dist even
-      // with publish: null, and release.yml's `coral-*.blockmap` glob would
-      // sweep it into the GitHub release.
+      // Blockmaps are differential-update metadata, gated on this rather than on
+      // `publish`, so without it a .exe.blockmap lands in dist and release.yml's
+      // `coral-*.blockmap` glob sweeps it into the release.
       differentialPackage: false,
       oneClick: false,
       // Per-user, under %LOCALAPPDATA%. A per-machine install puts
-      // resourcesPath under C:\Program Files, which a standard user cannot
-      // write to, and costs a UAC prompt for a developer tool that needs none.
+      // resourcesPath under Program Files, which a standard user cannot write
+      // to, and costs a UAC prompt for a developer tool that needs none.
       perMachine: false,
     },
   }

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -168,15 +168,22 @@ export function createConfig(
       target: [{ target: 'nsis', arch: ['x64'] }],
     },
     nsis: {
+      // An assisted installer with `perMachine: false` still shows the install
+      // mode page, so the user can ask for an all-users install. Without this
+      // that choice tries to elevate, and a standard account hits a UAC prompt
+      // it cannot answer. With it the all-users radio is disabled and labelled
+      // "(must run as admin)", so only an already-elevated installer can pick
+      // Program Files.
+      allowElevation: false,
       allowToChangeInstallationDirectory: true,
       // Blockmaps are differential-update metadata, gated on this rather than on
       // `publish`, so without it a .exe.blockmap lands in dist and release.yml's
       // `coral-*.blockmap` glob sweeps it into the release.
       differentialPackage: false,
       oneClick: false,
-      // Per-user, under %LOCALAPPDATA%. A per-machine install puts
-      // resourcesPath under Program Files, which a standard user cannot write
-      // to, and costs a UAC prompt for a developer tool that needs none.
+      // Default to per-user, under %LOCALAPPDATA%: a developer tool needs no UAC
+      // prompt. Nothing writes into resourcesPath, so a per-machine install
+      // works too — it just costs the prompt.
       perMachine: false,
     },
   }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,8 @@
     "prepackage:linux": "npm run build",
     "package:linux": "npm run package:linux:prepared",
     "package:linux:prepared": "electron-builder --linux --publish never --config electron-builder.config.ts",
+    "prepackage:win": "npm run build",
+    "package:win": "electron-builder --win --publish never --config electron-builder.config.ts",
     "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
     "package:mac": "npm run package:mac:prepared",
     "package:mac:prepared": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -159,9 +159,12 @@ test('windows packages target a single NSIS installer with no updater', () => {
   // independently, so both settings are load-bearing.
   assert.equal(win?.publish, null)
   assert.equal(nsis?.differentialPackage, false)
-  // An assisted, per-user install: %LOCALAPPDATA% is writable without UAC.
+  // An assisted install that defaults to per-user: %LOCALAPPDATA% is writable
+  // without UAC. The mode page still offers all-users, so refusing elevation is
+  // what keeps a standard account off a UAC prompt it cannot answer.
   assert.equal(nsis?.oneClick, false)
   assert.equal(nsis?.perMachine, false)
+  assert.equal(nsis?.allowElevation, false)
   assert.equal(nsis?.allowToChangeInstallationDirectory, true)
   assert.equal(win?.icon, 'resources/icons/icon.ico')
   // Only the deb needs a renamed executable, because it symlinks into /usr/bin.

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import test, { after } from 'node:test'
 
 import { createConfig } from '../electron-builder.config.ts'
+import { APP_ID } from '../src/shared/app-id.ts'
 
 const tempDir = mkdtempSync(join(tmpdir(), 'coral-desktop-signing-config-'))
 const apiKeyPath = join(tempDir, 'AuthKey_TEST.p8')
@@ -169,6 +170,16 @@ test('windows packages target a single NSIS installer with no updater', () => {
   assert.equal(win?.icon, 'resources/icons/icon.ico')
   // Only the deb needs a renamed executable, because it symlinks into /usr/bin.
   assert.equal(win?.executableName, undefined)
+})
+
+test('the main process registers the app id electron-builder stamps on the shortcut', () => {
+  const main = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8')
+
+  // Windows reads two spellings of the id as two applications, so the id on the
+  // shortcut and the id the process registers have to be one string. The shared
+  // constant makes them one; this catches a re-inlined literal.
+  assert.match(main, /app\.setAppUserModelId\(APP_ID\)/)
+  assert.equal(createConfig({}, 'win32').appId, APP_ID)
 })
 
 test('deb metadata inputs that live in package.json are present', () => {

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -151,6 +151,28 @@ test('linux packages target AppImage and deb, and publish an AppImage-only feed'
   assert.equal(linux?.icon, 'resources/icons')
 })
 
+test('windows packages target a single NSIS installer with no updater', () => {
+  const { win, nsis } = createConfig({}, 'win32')
+
+  assert.deepEqual(win?.target, [{ target: 'nsis', arch: ['x64'] }])
+  // No updater on Windows, so electron-builder must write neither a latest.yml
+  // feed nor the app-update.yml the package would otherwise embed. The blockmap
+  // is gated separately: NsisTarget keys it off differentialPackage, not off
+  // publish, so `publish: null` alone still leaves one in dist.
+  assert.equal(win?.publish, null)
+  assert.equal(nsis?.differentialPackage, false)
+  // An assisted, per-user install: %LOCALAPPDATA% is writable without UAC,
+  // while a per-machine resourcesPath under Program Files is not.
+  assert.equal(nsis?.oneClick, false)
+  assert.equal(nsis?.perMachine, false)
+  assert.equal(nsis?.allowToChangeInstallationDirectory, true)
+  // The .ico file, not the icons directory: the directory form exists for the
+  // lone-.png trap on linux, and electron-builder uses a >=256-entry .ico as is.
+  assert.equal(win?.icon, 'resources/icons/icon.ico')
+  // Only the deb needs a renamed executable, because it symlinks into /usr/bin.
+  assert.equal(win?.executableName, undefined)
+})
+
 test('deb metadata inputs that live in package.json are present', () => {
   const packageJson = JSON.parse(
     readFileSync(new URL('../package.json', import.meta.url), 'utf8'),

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -155,19 +155,14 @@ test('windows packages target a single NSIS installer with no updater', () => {
   const { win, nsis } = createConfig({}, 'win32')
 
   assert.deepEqual(win?.target, [{ target: 'nsis', arch: ['x64'] }])
-  // No updater on Windows, so electron-builder must write neither a latest.yml
-  // feed nor the app-update.yml the package would otherwise embed. The blockmap
-  // is gated separately: NsisTarget keys it off differentialPackage, not off
-  // publish, so `publish: null` alone still leaves one in dist.
+  // No updater on Windows, so no feed and no blockmap. The two are gated
+  // independently, so both settings are load-bearing.
   assert.equal(win?.publish, null)
   assert.equal(nsis?.differentialPackage, false)
-  // An assisted, per-user install: %LOCALAPPDATA% is writable without UAC,
-  // while a per-machine resourcesPath under Program Files is not.
+  // An assisted, per-user install: %LOCALAPPDATA% is writable without UAC.
   assert.equal(nsis?.oneClick, false)
   assert.equal(nsis?.perMachine, false)
   assert.equal(nsis?.allowToChangeInstallationDirectory, true)
-  // The .ico file, not the icons directory: the directory form exists for the
-  // lone-.png trap on linux, and electron-builder uses a >=256-entry .ico as is.
   assert.equal(win?.icon, 'resources/icons/icon.ico')
   // Only the deb needs a renamed executable, because it symlinks into /usr/bin.
   assert.equal(win?.executableName, undefined)

--- a/apps/desktop/scripts/verify-dist.mjs
+++ b/apps/desktop/scripts/verify-dist.mjs
@@ -7,10 +7,12 @@
 //   linux  one AppImage, one deb, and latest-linux.yml. The deb has no updater
 //          and must stay out of the feed, and the AppImage carries its blockmap
 //          inside the image.
+//   win    one NSIS installer .exe, and neither a feed nor a blockmap, because
+//          Windows ships no updater.
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
-const PLATFORMS = ['mac', 'linux']
+const PLATFORMS = ['mac', 'linux', 'win']
 
 const distDir = resolve(process.argv[2] ?? 'apps/desktop/dist')
 const platform = process.argv[3] ?? 'mac'
@@ -111,6 +113,28 @@ function verifyLinux() {
   return `${appImages[0]}, ${debs[0]}, latest-linux.yml references ${referenced.join(', ')}`
 }
 
-const summary = { mac: verifyMac, linux: verifyLinux }[platform]()
+// Windows has no updater, so a feed or a blockmap here is a packaging mistake:
+// both would be published and then served to nobody. NSIS gates the blockmap on
+// `differentialPackage`, not on `publish`, so `publish: null` alone does not
+// suppress it — see the nsis block in electron-builder.config.ts.
+function verifyWindows() {
+  const installers = artifacts('.exe')
+  if (installers.length !== 1) {
+    fail(`expected exactly one desktop installer .exe, got [${installers}]`)
+  }
+
+  const feeds = entries.filter((f) => /^latest(-\w+)?\.yml$/.test(f))
+  if (feeds.length > 0) {
+    fail(`windows ships no updater, but the build produced update metadata: ${feeds.join(', ')}`)
+  }
+  const blockmaps = entries.filter((f) => f.endsWith('.blockmap'))
+  if (blockmaps.length > 0) {
+    fail(`windows ships no updater, but the build produced blockmaps: ${blockmaps.join(', ')}`)
+  }
+
+  return installers[0]
+}
+
+const summary = { mac: verifyMac, linux: verifyLinux, win: verifyWindows }[platform]()
 
 console.log(`[verify-dist] ok (${platform}): ${summary}`)

--- a/apps/desktop/scripts/verify-dist.mjs
+++ b/apps/desktop/scripts/verify-dist.mjs
@@ -113,10 +113,9 @@ function verifyLinux() {
   return `${appImages[0]}, ${debs[0]}, latest-linux.yml references ${referenced.join(', ')}`
 }
 
-// Windows has no updater, so a feed or a blockmap here is a packaging mistake:
-// both would be published and then served to nobody. NSIS gates the blockmap on
-// `differentialPackage`, not on `publish`, so `publish: null` alone does not
-// suppress it — see the nsis block in electron-builder.config.ts.
+// Windows has no updater, so a feed or a blockmap here would be published and
+// served to nobody. The two are suppressed by separate settings (see the win and
+// nsis blocks in electron-builder.config.ts), so check both.
 function verifyWindows() {
   const installers = artifacts('.exe')
   if (installers.length !== 1) {

--- a/apps/desktop/src/main/auto-update-core.ts
+++ b/apps/desktop/src/main/auto-update-core.ts
@@ -12,12 +12,11 @@ import type { DesktopUpdateState, DesktopUpdateStateListener } from '../shared/t
 export const UNSUPPORTED_UPDATE_DETAIL =
   'Coral checks for updates from the released macOS app and the Linux AppImage only.'
 
-// The image file AppImageUpdater replaces on install, read from the same
-// variable the updater reads. electron-updater only checks that it is set before
-// offering an update, then demands an absolute, NUL-free path at install time —
-// after the download. Checking here keeps a value that cannot install from
-// enabling updates at all. Left unsanitised on purpose: the updater reads
-// process.env.APPIMAGE verbatim, so trimming would validate a different string.
+// The image file AppImageUpdater replaces on install. electron-updater only
+// checks that APPIMAGE is set before offering an update, then demands an
+// absolute, NUL-free path at install time — after the download — so check it
+// here instead. Left unsanitised on purpose: the updater reads the variable
+// verbatim, and trimming would validate a different string.
 export function appImagePath(env: NodeJS.ProcessEnv): string | null {
   const path = env.APPIMAGE
   if (!path || !isAbsolute(path) || path.includes('\0')) return null

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -122,7 +122,8 @@ function createMainWindow(): BrowserWindow {
     minHeight: 520,
     title: 'Coral',
     icon: currentWindowIconPath(),
-    autoHideMenuBar: process.platform !== 'darwin',
+    // A hidden bar means the only route to About and Quit is the Alt key.
+    autoHideMenuBar: false,
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,
@@ -305,28 +306,54 @@ function installAboutPanel() {
   })
 }
 
-function installMenu() {
-  const template: Electron.MenuItemConstructorOptions[] = [
+// `role: 'about'` would label itself from app.name, the package name in dev.
+const ABOUT_ITEM: Electron.MenuItemConstructorOptions = {
+  label: 'About Coral',
+  click: () => app.showAboutPanel(),
+}
+
+function updateItems(): Electron.MenuItemConstructorOptions[] {
+  if (!desktopUpdatesSupported()) return []
+  return [
+    {
+      label: 'Check for Updates...',
+      click: () => {
+        void checkForDesktopUpdates({ interactive: true })
+      },
+    },
+  ]
+}
+
+// macOS puts About, updates, and Quit in an application menu named after the
+// app. Windows and Linux have no such menu: a top-level "Coral" entry next to
+// Edit and View is where nobody looks for either item, so those platforms get
+// the File/Help pair they do expect.
+function leadingMenus(): Electron.MenuItemConstructorOptions[] {
+  if (process.platform !== 'darwin') return [{ label: 'File', submenu: [{ role: 'quit' }] }]
+  const updates = updateItems()
+  return [
     {
       label: 'Coral',
       submenu: [
-        // `role: 'about'` would label itself from app.name, the package name in dev.
-        { label: 'About Coral', click: () => app.showAboutPanel() },
+        ABOUT_ITEM,
         { type: 'separator' },
-        ...(desktopUpdatesSupported()
-          ? ([
-              {
-                label: 'Check for Updates...',
-                click: () => {
-                  void checkForDesktopUpdates({ interactive: true })
-                },
-              },
-              { type: 'separator' },
-            ] satisfies Electron.MenuItemConstructorOptions[])
+        ...(updates.length > 0
+          ? ([...updates, { type: 'separator' }] satisfies Electron.MenuItemConstructorOptions[])
           : []),
         { role: 'quit' },
       ],
     },
+  ]
+}
+
+function trailingMenus(): Electron.MenuItemConstructorOptions[] {
+  if (process.platform === 'darwin') return []
+  return [{ label: 'Help', submenu: [...updateItems(), ABOUT_ITEM] }]
+}
+
+function installMenu() {
+  const template: Electron.MenuItemConstructorOptions[] = [
+    ...leadingMenus(),
     {
       label: 'Edit',
       submenu: [
@@ -356,11 +383,17 @@ function installMenu() {
         { role: 'zoomOut' },
       ],
     },
+    ...trailingMenus(),
   ]
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
 function startApplication(): void {
+  // Windows keys toasts, taskbar grouping, and jump lists off this id, and
+  // silently drops a notification from a process that never set one. Must run
+  // before the app is ready. It is inert on macOS and Linux.
+  app.setAppUserModelId('com.withcoral.desktop')
+
   const gotLock = app.requestSingleInstanceLock()
   if (!gotLock) {
     app.quit()

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, ipcMain, nativeTheme, shell } from 'electron'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { APP_ID } from '../shared/app-id'
 import type { DesktopUpdateState } from '../shared/types'
 import {
   configureMcpClient,
@@ -375,10 +376,10 @@ function installMenu() {
 
 function startApplication(): void {
   // Windows keys toasts, taskbar grouping, and jump lists off this id, and
-  // silently drops a notification from a process that never set one. Must match
-  // `appId` in electron-builder.config.ts, which is what the installer stamps on
-  // the shortcut, and must run before the app is ready. Inert elsewhere.
-  app.setAppUserModelId('com.withcoral.desktop')
+  // silently drops a notification from a process that never set one. Shared with
+  // electron-builder, which stamps the same id on the shortcut. Must run before
+  // the app is ready. Inert elsewhere.
+  app.setAppUserModelId(APP_ID)
 
   const gotLock = app.requestSingleInstanceLock()
   if (!gotLock) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -122,8 +122,6 @@ function createMainWindow(): BrowserWindow {
     minHeight: 520,
     title: 'Coral',
     icon: currentWindowIconPath(),
-    // A hidden bar means the only route to About and Quit is the Alt key.
-    autoHideMenuBar: false,
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,
@@ -306,54 +304,41 @@ function installAboutPanel() {
   })
 }
 
-// `role: 'about'` would label itself from app.name, the package name in dev.
-const ABOUT_ITEM: Electron.MenuItemConstructorOptions = {
-  label: 'About Coral',
-  click: () => app.showAboutPanel(),
-}
-
-function updateItems(): Electron.MenuItemConstructorOptions[] {
-  if (!desktopUpdatesSupported()) return []
-  return [
-    {
-      label: 'Check for Updates...',
-      click: () => {
-        void checkForDesktopUpdates({ interactive: true })
-      },
-    },
-  ]
-}
-
-// macOS puts About, updates, and Quit in an application menu named after the
-// app. Windows and Linux have no such menu: a top-level "Coral" entry next to
-// Edit and View is where nobody looks for either item, so those platforms get
-// the File/Help pair they do expect.
-function leadingMenus(): Electron.MenuItemConstructorOptions[] {
-  if (process.platform !== 'darwin') return [{ label: 'File', submenu: [{ role: 'quit' }] }]
-  const updates = updateItems()
-  return [
-    {
-      label: 'Coral',
-      submenu: [
-        ABOUT_ITEM,
-        { type: 'separator' },
-        ...(updates.length > 0
-          ? ([...updates, { type: 'separator' }] satisfies Electron.MenuItemConstructorOptions[])
-          : []),
-        { role: 'quit' },
-      ],
-    },
-  ]
-}
-
-function trailingMenus(): Electron.MenuItemConstructorOptions[] {
-  if (process.platform === 'darwin') return []
-  return [{ label: 'Help', submenu: [...updateItems(), ABOUT_ITEM] }]
-}
-
 function installMenu() {
+  const isMac = process.platform === 'darwin'
+  // `role: 'about'` would label itself from app.name, the package name in dev.
+  const about: Electron.MenuItemConstructorOptions = {
+    label: 'About Coral',
+    click: () => app.showAboutPanel(),
+  }
+  const updates: Electron.MenuItemConstructorOptions[] = desktopUpdatesSupported()
+    ? [
+        {
+          label: 'Check for Updates...',
+          click: () => {
+            void checkForDesktopUpdates({ interactive: true })
+          },
+        },
+      ]
+    : []
+
   const template: Electron.MenuItemConstructorOptions[] = [
-    ...leadingMenus(),
+    // macOS collects About, updates, and Quit in an application menu named
+    // after the app. Windows and Linux have no such menu, so they get the
+    // File and Help entries users look in there instead.
+    isMac
+      ? {
+          label: 'Coral',
+          submenu: [
+            about,
+            { type: 'separator' },
+            ...(updates.length > 0
+              ? ([...updates, { type: 'separator' }] satisfies Electron.MenuItemConstructorOptions[])
+              : []),
+            { role: 'quit' },
+          ],
+        }
+      : { label: 'File', submenu: [{ role: 'quit' }] },
     {
       label: 'Edit',
       submenu: [
@@ -383,15 +368,16 @@ function installMenu() {
         { role: 'zoomOut' },
       ],
     },
-    ...trailingMenus(),
+    ...(isMac ? [] : [{ label: 'Help', submenu: [...updates, about] }]),
   ]
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
 function startApplication(): void {
   // Windows keys toasts, taskbar grouping, and jump lists off this id, and
-  // silently drops a notification from a process that never set one. Must run
-  // before the app is ready. It is inert on macOS and Linux.
+  // silently drops a notification from a process that never set one. Must match
+  // `appId` in electron-builder.config.ts, which is what the installer stamps on
+  // the shortcut, and must run before the app is ready. Inert elsewhere.
   app.setAppUserModelId('com.withcoral.desktop')
 
   const gotLock = app.requestSingleInstanceLock()

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -48,9 +48,13 @@ export async function externalCoralPath(): Promise<string> {
     releaseCoralPath(),
   ]
 
+  // libuv maps X_OK to F_OK on Windows, so the executable bit is unverifiable
+  // there and the check degrades to "does the file exist". Ask for what the
+  // platform can actually answer, so the failure message below stays true.
+  const mode = process.platform === 'win32' ? constants.F_OK : constants.X_OK
   for (const candidate of candidates) {
     try {
-      await access(candidate, constants.X_OK)
+      await access(candidate, mode)
       return candidate
     } catch {
       // Try the next candidate.

--- a/apps/desktop/src/shared/app-id.ts
+++ b/apps/desktop/src/shared/app-id.ts
@@ -1,0 +1,8 @@
+// The application identity, in two places that must agree. electron-builder
+// stamps it on the Windows shortcut as the AppUserModelID, and the main process
+// registers the same string at startup. Windows keys toasts, taskbar grouping,
+// and jump lists off that id, and treats two spellings of it as two separate
+// applications: the running window gets its own taskbar button instead of
+// grouping under the pinned shortcut, and toasts from an unregistered id are
+// dropped. macOS and Linux read it as the bundle id and the reverse-DNS name.
+export const APP_ID = 'com.withcoral.desktop'

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -5,6 +5,10 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "isolatedModules": true,
+    // electron-builder.config.ts is loaded, not compiled: node's type stripping
+    // runs it in the config test and needs the extension on the relative import
+    // of the shared app id. Harmless under noEmit.
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "noEmit": true,
     "types": ["node", "electron"],


### PR DESCRIPTION
## Summary

Building an unsigned desktop app for Windows x64.

## Test plan

Manually run desktop package action ([results](https://github.com/withcoral/coral/actions/runs/32240419196/job/96029528534)).
Download installer from there.
Open it on a Windows machine (not a VM on apple silicon, but an actual windows machine).
Go through installation and then onboarding.

Since it's still unsigned, I got this message:

<img width="656" height="615" alt="image" src="https://github.com/user-attachments/assets/0d806dd8-686d-49a3-88ff-20663bff3e79" />

<img width="617" height="479" alt="image" src="https://github.com/user-attachments/assets/83c2c1d6-3aca-4985-bc47-ffc1c3e72155" />

<img width="1579" height="1063" alt="image" src="https://github.com/user-attachments/assets/3a828684-628b-41cc-871f-040628ea9226" />

<img width="1580" height="1060" alt="image" src="https://github.com/user-attachments/assets/bf0ecfaa-dcaa-40b5-a812-d8beb7f98b3c" />

I was also able to uninstall it correctly


<details>
Phase 2 of the desktop port. An unsigned x64 NSIS installer, `coral-desktop-win-x64.exe`, labelled a preview: SmartScreen shows an "unrecognized app" warning on install. Signing is a later decision.

## No updater, and that takes two settings

`desktopUpdatesSupported()` already returns `false` for win32, so nothing should ship update metadata. Two independent gates in `app-builder-lib` have to be closed for that to actually hold:

- `win.publish: null` — `getPublishConfigs` reads the platform block before the top-level `publish`, so this suppresses both the `latest.yml` feed and the `app-update.yml` the package would otherwise embed.
- `nsis.differentialPackage: false` — `NsisTarget` gates the `.exe.blockmap` on `!isPortable && differentialPackage !== false`, **not** on `publish`. Without it a blockmap lands in `dist` even with `publish: null`, and `release.yml`'s existing `coral-*.blockmap` glob would sweep it into the release with no warning.

`verify-dist.mjs` gains a `win` platform that fails on either, so this cannot regress silently.

## Deliberate asymmetries with the Linux block

- **`icon: 'resources/icons/icon.ico'`** — the file, not the directory. The lone-`.png` trap that forces `icon: 'resources/icons'` on Linux is PNG-only; the ICO branch validates a `>=256` entry and uses the file as is.
- **No `executableName`** — Linux renames the executable because the deb symlinks it into `/usr/bin` and would shadow the `coral` CLI. `WinPackager` writes `Coral.exe` into the install directory, so there is nothing to collide with.
- **`perMachine: false`** — per-user under `%LOCALAPPDATA%`, no UAC. A per-machine install puts `resourcesPath` under `C:\Program Files`, which a standard user cannot write to.

## Windows polish

- `app.setAppUserModelId('com.withcoral.desktop')` before the app is ready. Windows silently drops toasts from a process without one. Pre-emptive — only the updater uses `Notification` today and that is macOS-gated — but it is one line.
- A conventional **File / Edit / View / Help** menu off darwin, with About and updates under Help. A top-level "Coral" menu sitting next to Edit and View is not where Windows users look for either. The menu bar is now visible off darwin too, since `autoHideMenuBar` put both behind the Alt key. **This changes Linux as well**, which is intended — the same reasoning applies there.
- The sidecar probe asks for `F_OK` on win32. libuv maps `X_OK` to `F_OK` there, so the check silently degraded to "does it exist" while the error message claimed otherwise.

## CI

A `blacksmith-4vcpu-windows-2025` leg in `desktop-package.yml`, and a `build-desktop-windows` job in `release.yml` consuming the CLI artifact the `build` job already produces for `x86_64-pc-windows-msvc`. No `CORAL_DESKTOP_RELEASE` — `createConfig()` rejects it on a win32 host, since release mode means an updater.

Packaging has to run on Windows: `NsisTarget.computeScriptAndSignUninstaller` builds the uninstaller by *executing* the freshly built installer, and off-Windows it does that through wine. The only bypass is owning a custom `installer.nsi`, which is not a trade worth making.

Note the `desktop-package.yml` leg compiles the Rust CLI from source; the release job reuses the prebuilt artifact instead.

## Verification

Local, on macOS:

- `npm run check` and `npm test` in `apps/desktop` — 14 + 50 pass, including a new test asserting the NSIS/no-updater shape.
- The config passes electron-builder's own `scheme.json` validation for `win32`, `darwin`, and `linux`.
- `verify-dist … win` exercised against synthetic dists: happy path, stray blockmap, stray feed, two installers, unknown platform name.
- `electron-builder --win --dir` really packaged: the executable is `Coral.exe`, no `app-update.yml` appears in resources, and all seven ICO entries (16 → 256) are byte-present in the exe.

**Not yet verified: NSIS itself.** Nothing off Windows can cover it. Still to do on a real Windows machine, before this leaves draft:

- [ ] Installer is `coral-desktop-win-x64.exe`; `verify-dist … win` passes on a real build.
- [ ] Installs per-user under `%LOCALAPPDATA%` with no UAC prompt; the directory picker works.
- [ ] Sidecar becomes ready, UI renders over `coral-app://`, no read-only-filesystem errors.
- [ ] Quit is clean, no orphaned `coral.exe` in Task Manager, second launch succeeds immediately.
- [ ] State lands under `%APPDATA%\@withcoral\desktop\coral` via `CORAL_CONFIG_DIR`, and nothing appears in the legacy `config_dir()` location.
- [ ] Desktop Settings → MCP clients writes under `%APPDATA%` through `add-mcp`'s win32 branch.

Drive the real title-bar close, not a scripted one. Phase 1 produced a convincing false "the app does not quit on window close" under bare Xvfb; treat any Windows equivalent as suspect until a minimal control app reproduces it.

## Out of scope

- **Signing.** Azure Trusted Signing (~$10/mo, no HSM, first-class `win.azureSignOptions` support) is the recommended option when we do this. It is also what would unblock a Windows updater later.
- **`aarch64-pc-windows-msvc`.** The CLI release matrix does not build it, so there is no binary to bundle. Windows ARM runs the x64 build under emulation.
- **Graceful sidecar shutdown.** On Windows both `SIGTERM` and `SIGKILL` become `TerminateProcess`, so the five-second graceful window is dead code there. It leaks nothing: the state lock is an advisory `LockFileEx`, which the kernel releases when the handle closes. If it ever matters, the portable fix is a stdin-close handshake, not `taskkill`.
</details>