### PR TITLE
Make Windows installer routing honor browser platform hints

### DIFF
--- a/apps/coral-ui/app/components/mcp-clients-list/mcp-client-install-list.tsx
+++ b/apps/coral-ui/app/components/mcp-clients-list/mcp-client-install-list.tsx
@@ -13,6 +13,7 @@ export type McpClientInstallListItem =
   | (McpClientInstallListItemBase & {
       readonly installCommand: string
       readonly workspaceInstallCommand?: string
+      readonly workspaceInstallShell?: 'posix' | 'powershell'
     })
   | (McpClientInstallListItemBase & { readonly setupInstructions: string })
 
@@ -46,7 +47,7 @@ export function McpClientInstallList({
                 'workspaceInstallCommand' in client && client.workspaceInstallCommand
               const installCommand =
                 'workspaceInstallCommand' in client && client.workspaceInstallCommand && workspace
-                  ? `${client.workspaceInstallCommand} --args ${quotePosix(`--workspace=${workspace}`)}`
+                  ? `${client.workspaceInstallCommand} --args ${quoteShell(`--workspace=${workspace}`, client.workspaceInstallShell)}`
                   : 'installCommand' in client
                     ? client.installCommand
                     : undefined
@@ -121,6 +122,8 @@ export function McpClientInstallList({
   )
 }
 
-function quotePosix(value: string): string {
-  return `'${value.replaceAll("'", "'\"'\"'")}'`
+function quoteShell(value: string, shell: 'posix' | 'powershell' = 'posix'): string {
+  return shell === 'powershell'
+    ? `'${value.replaceAll("'", "''")}'`
+    : `'${value.replaceAll("'", "'\"'\"'")}'`
 }

--- a/apps/coral-ui/app/lib/mcp-platform.test.ts
+++ b/apps/coral-ui/app/lib/mcp-platform.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWindowsRequest } from './mcp-platform'
+
+function requestWithHeaders(headers: HeadersInit): Request {
+  // Browsers strip protected headers from constructed Request instances; the
+  // loader receives them from the actual HTTP request, so model that boundary.
+  return { headers: new Headers(headers) } as Request
+}
+
+describe('isWindowsRequest', () => {
+  it('prefers the browser platform client hint', () => {
+    expect(
+      isWindowsRequest(
+        requestWithHeaders({
+          'sec-ch-ua-platform': '"Windows"',
+          'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)',
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      isWindowsRequest(
+        requestWithHeaders({
+          'sec-ch-ua-platform': '"macOS"',
+          'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('falls back to the user agent when client hints are unavailable', () => {
+    expect(
+      isWindowsRequest(
+        requestWithHeaders({ 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('does not select PowerShell for other platforms', () => {
+    expect(isWindowsRequest(requestWithHeaders({ 'sec-ch-ua-platform': '"macOS"' }))).toBe(false)
+  })
+})

--- a/apps/coral-ui/app/lib/mcp-platform.ts
+++ b/apps/coral-ui/app/lib/mcp-platform.ts
@@ -1,0 +1,6 @@
+export function isWindowsRequest(request: Request): boolean {
+  const clientHint = request.headers.get('sec-ch-ua-platform')?.replaceAll('"', '')
+  if (clientHint) return clientHint === 'Windows'
+
+  return /Windows NT/i.test(request.headers.get('user-agent') ?? '')
+}

--- a/apps/coral-ui/app/routes/settings-loader.ts
+++ b/apps/coral-ui/app/routes/settings-loader.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/coral-desktop'
 import { remoteMcpClientInstructions, webMcpClients } from '@/lib/mcp-clients'
 import { mcpConnectionFromEnv } from '@/lib/mcp-connection'
+import { isWindowsRequest } from '@/lib/mcp-platform'
 import type { McpClientInstallListItem } from '@/components/mcp-clients-list'
 import { addToast } from '@/wax/components/toast'
 
@@ -29,8 +30,9 @@ export interface DesktopMcpClientData {
   readonly error?: string
 }
 
-export function loader(): WebSettingsLoaderData {
+export function loader({ request }: Route.LoaderArgs): WebSettingsLoaderData {
   const connection = mcpConnectionFromEnv()
+  const windows = isWindowsRequest(request)
   return {
     runtime: 'web',
     usesRemoteMcp: connection.mode === 'remote',
@@ -46,10 +48,15 @@ export function loader(): WebSettingsLoaderData {
             installCommand:
               connection.mode === 'remote'
                 ? `npx -y add-mcp@1.11.0 ${connection.url} --global --agent ${client.id} --name coral --transport http --yes`
-                : `npx --yes add-mcp@1.11.0 "$(command -v coral)" --global --agent ${client.id} --name coral --args mcp-stdio --yes`,
+                : windows
+                  ? `npx --yes add-mcp@1.11.0 (Get-Command coral).Source --global --agent ${client.id} --name coral --args mcp-stdio --yes`
+                  : `npx --yes add-mcp@1.11.0 "$(command -v coral)" --global --agent ${client.id} --name coral --args mcp-stdio --yes`,
             ...(connection.mode === 'local'
               ? {
-                  workspaceInstallCommand: `npx --yes add-mcp@1.11.0 "$(command -v coral)" --global --agent ${client.id} --name coral --args mcp-stdio --yes`,
+                  workspaceInstallCommand: windows
+                    ? `npx --yes add-mcp@1.11.0 (Get-Command coral).Source --global --agent ${client.id} --name coral --args mcp-stdio --yes`
+                    : `npx --yes add-mcp@1.11.0 "$(command -v coral)" --global --agent ${client.id} --name coral --args mcp-stdio --yes`,
+                  workspaceInstallShell: windows ? 'powershell' : 'posix',
                 }
               : {}),
           }

--- a/apps/coral-ui/app/routes/settings.server.test.ts
+++ b/apps/coral-ui/app/routes/settings.server.test.ts
@@ -7,7 +7,7 @@ describe('settings loader', () => {
   afterEach(() => vi.unstubAllEnvs())
 
   it('loads local install commands with workspace support', () => {
-    expect(loader()).toEqual({
+    expect(loader(request())).toEqual({
       runtime: 'web',
       usesRemoteMcp: false,
       mcpClients: expect.arrayContaining([
@@ -26,7 +26,7 @@ describe('settings loader', () => {
     vi.stubEnv('CORAL_MCP_MODE', 'remote')
     vi.stubEnv('CORAL_MCP_URL', 'https://coral.example.com/mcp')
 
-    const result = loader()
+    const result = loader(request())
     expect(result.usesRemoteMcp).toBe(true)
     expect(result.mcpClients).toContainEqual({
       id: 'claude-desktop',
@@ -40,11 +40,38 @@ describe('settings loader', () => {
     vi.stubEnv('CORAL_MCP_MODE', 'remote')
     vi.stubEnv('CORAL_MCP_URL', 'https://coral.example.com/mcp')
 
-    expect(loader().mcpClients).toContainEqual({
+    expect(loader(request()).mcpClients).toContainEqual({
       id: 'codex',
       installCommand:
         'npx -y add-mcp@1.11.0 https://coral.example.com/mcp --global --agent codex --name coral --transport http --yes',
       name: 'Codex',
     })
   })
+
+  it('loads PowerShell commands for Windows requests', () => {
+    expect(
+      loader({
+        request: new Request('https://reef.example/settings', {
+          headers: { 'sec-ch-ua-platform': '"Windows"' },
+        }),
+      } as Parameters<typeof loader>[0]),
+    ).toEqual({
+      runtime: 'web',
+      usesRemoteMcp: false,
+      mcpClients: expect.arrayContaining([
+        expect.objectContaining({
+          id: 'codex',
+          installCommand:
+            'npx --yes add-mcp@1.11.0 (Get-Command coral).Source --global --agent codex --name coral --args mcp-stdio --yes',
+          workspaceInstallShell: 'powershell',
+        }),
+      ]),
+    })
+  })
 })
+
+function request(headers?: HeadersInit): Parameters<typeof loader>[0] {
+  return { request: new Request('https://reef.example/settings', { headers }) } as Parameters<
+    typeof loader
+  >[0]
+}


### PR DESCRIPTION
\nConstraint: A browser client hint is more specific than the user agent and public installer routes must remain explicitly allowlisted.\nRejected: Falling through after a non-Windows hint | it offered PowerShell to conflicting Windows user agents.\nConfidence: high\nScope-risk: narrow\nDirective: Treat a present platform hint as authoritative and keep every public installer route in the auth-boundary test.\nTested: npm run typecheck; targeted platform, route, and installer tests; npm run build; targeted format and lint\nNot-tested: Full npm run check is blocked by pre-existing unformatted .omx runtime-state files.