### PR TITLE
style(ui): move ScrollArea vertical scrollbar closer to the right edge

### DIFF
--- a/apps/coral-ui/app/wax/components/scroll-area/scroll-area.css.ts
+++ b/apps/coral-ui/app/wax/components/scroll-area/scroll-area.css.ts
@@ -196,6 +196,7 @@ export const scrollbar = style({
     },
     '&[data-orientation="vertical"]': {
       margin: '8px',
+      marginInlineEnd: '4px',
       width: '4px',
     },
     '&[data-orientation="vertical"]::before': {


### PR DESCRIPTION
## Summary

From 8px to 4px, to have less change of overlapping content

## Test plan

<img width="404" height="296" alt="image" src="https://github.com/user-attachments/assets/644f38a8-4e7b-4441-8a2f-f745b6d66d50" />
<img width="190" height="328" alt="image" src="https://github.com/user-attachments/assets/0c5a5cc8-63e1-4524-bd14-a29cf95d0018" />
<img width="376" height="884" alt="image" src="https://github.com/user-attachments/assets/139b005e-bb04-4c12-8540-74f501338443" />
