### PR TITLE
refactor(coral-ui): remove onboarding button from sidebar

### DIFF
--- a/apps/coral-ui/app/components/sidebar/sidebar.tsx
+++ b/apps/coral-ui/app/components/sidebar/sidebar.tsx
@@ -122,19 +122,6 @@ export function Sidebar({
     </>
   )
 
-  // Temporary: re-entry point into the onboarding flow.
-  const onboardingButton = (
-    <SidebarButton
-      aria-label="Onboarding"
-      as={Link}
-      icon="Sparkles"
-      isMinimized={isMinimized}
-      to={routePath('onboarding')}
-    >
-      Onboarding
-    </SidebarButton>
-  )
-
   const handleToggleSidebar = (event: KeyboardEvent) => {
     event.preventDefault()
     toggleSidebar()
@@ -316,13 +303,6 @@ export function Sidebar({
           )
         })}
       </div>
-      {isMinimized ? (
-        <Tooltip content="Onboarding" side="right">
-          {onboardingButton}
-        </Tooltip>
-      ) : (
-        onboardingButton
-      )}
       {updateState.status !== 'idle' && updateState.status !== 'unsupported' && (
         <DesktopUpdateIndicator
           isMinimized={isMinimized}


### PR DESCRIPTION
## Summary

Now that onboarding completion is stored in the DB, we can remove this button.

UX flow: first time you use Coral, you land in the onboarding; once completed, we mark that in the DB (for your user id). Next time you open Coral, you won't see the onboarding.

## Test plan

Load UI, button is gone.