### PR TITLE
feat(coral-ui): Add CSS @layers to WAX

### DIFF
--- a/apps/coral-ui/.oxlintrc.json
+++ b/apps/coral-ui/.oxlintrc.json
@@ -21,6 +21,27 @@
       }
     },
     {
+      "files": ["app/wax/**/*.{ts,tsx}"],
+      "excludeFiles": ["app/wax/css.ts", "app/wax/theme/layers.css.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@vanilla-extract/css",
+                "message": "Import from '@/wax/css' instead, so wax rules land in the wax cascade layer."
+              },
+              {
+                "name": "@vanilla-extract/recipes",
+                "message": "Import from '@/wax/css' instead, so wax rules land in the wax cascade layer."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "files": ["app/routes/**/*.{ts,tsx}"],
       "plugins": ["eslint", "typescript", "unicorn", "oxc", "react", "react-hooks", "import"],
       "rules": {

--- a/apps/coral-ui/app/__tests__/architecture.test.ts
+++ b/apps/coral-ui/app/__tests__/architecture.test.ts
@@ -122,6 +122,11 @@ function hookArguments(source: string, hook: string): string[] {
   return calls
 }
 
+/** A stylesheet that comes from a package rather than from app code. */
+function isPackageStylesheet(specifier: string): boolean {
+  return specifier.endsWith('.css') && !/^[.~]|^@\//.test(specifier)
+}
+
 function isVisualTsx(name: string): boolean {
   return (
     name.endsWith('.tsx') &&
@@ -224,6 +229,45 @@ describe('architecture', () => {
       'allowedTests names a test file that no longer exists. Drop the entry so the list keeps ' +
         'describing the suite.',
     ).toEqual([])
+  })
+
+  it('keeps third party stylesheets in a layer', () => {
+    const importedRaw = filesUnder(appDir, (name) => /\.tsx?$/.test(name)).flatMap((file) =>
+      importsFrom(fs.readFileSync(file, 'utf8'))
+        .filter(isPackageStylesheet)
+        .map((specifier) => `${path.relative(appDir, file)} -> import '${specifier}'`),
+    )
+    const importedUnlayered = filesUnder(appDir, (name) => name.endsWith('.css')).flatMap((file) =>
+      [...fs.readFileSync(file, 'utf8').matchAll(/@import\s+([^;]+);/g)]
+        .filter((match) => !match[1].includes('layer('))
+        .map((match) => `${path.relative(appDir, file)} -> @import ${match[1].trim()}`),
+    )
+
+    expect(
+      [...importedRaw, ...importedUnlayered],
+      'a third party stylesheet has to arrive through an @import that names a layer, the way ' +
+        'app/wax/components/toast/toastify.css imports react-toastify. Imported straight from ' +
+        'the package its rules are unlayered, an unlayered rule beats every layer whatever its ' +
+        'specificity, and it silently outranks the wax rules written to restyle it.',
+    ).toEqual([])
+  })
+
+  it('states one layer order for the whole app', () => {
+    const globals = fs.readFileSync(path.join(appDir, 'styles', 'globals.css'), 'utf8')
+    const layers = fs.readFileSync(path.join(appDir, 'wax', 'theme', 'layers.css.ts'), 'utf8')
+    const stated = /@layer ([^;]+);/
+      .exec(globals)?.[1]
+      .split(',')
+      .map((name) => name.trim())
+    const declared = [...layers.matchAll(/globalLayer\('([^']+)'\)/g)].map((match) => match[1])
+
+    expect(
+      stated,
+      'app/styles/globals.css states the layer order for the app and ' +
+        'app/wax/theme/layers.css.ts declares the same layers for Vanilla Extract. Both have to ' +
+        'name the same layers in the same order. A layer left out of the statement is created ' +
+        'the first time a rule uses it, which puts it above everything already there.',
+    ).toEqual(declared)
   })
 
   it('does not depend on Tailwind packages', () => {

--- a/apps/coral-ui/app/styles/globals.css
+++ b/apps/coral-ui/app/styles/globals.css
@@ -1,3 +1,10 @@
+/* Layer order for the whole app, lowest priority first. Wax rules go in the wax
+   layer (see app/wax/theme/layers.css.ts); the reset below goes in the reset layer,
+   so a component rule wins over an element default whatever the load order. App code
+   outside app/wax stays unlayered, which puts it above both. This is the first
+   stylesheet the app loads, so the order is settled before any rule arrives. */
+@layer reset, wax;
+
 /* Encode Sans Semi Expanded — latin */
 @font-face {
   font-family: 'Encode Sans Semi Expanded';
@@ -117,145 +124,147 @@
     U+A720-A7FF;
 }
 
-/* CSS reset (replaces Tailwind preflight) */
-*,
-::after,
-::before {
-  box-sizing: border-box;
-  border-width: 0;
-  border-style: solid;
-}
-
-html,
-:host {
-  line-height: 1.5;
-  -webkit-text-size-adjust: 100%;
-  tab-size: 4;
-}
-
-/* Remove default margins */
-blockquote,
-dl,
-dd,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-hr,
-figure,
-p,
-pre {
-  margin: 0;
-}
-
-/* Reset heading font-size/weight so they don't override component styles */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
-}
-
-/* Reset lists */
-ol,
-ul,
-menu {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-/* Form elements inherit font */
-button,
-input,
-optgroup,
-select,
-textarea {
-  font-family: inherit;
-  font-feature-settings: inherit;
-  font-variation-settings: inherit;
-  font-size: 100%;
-  font-weight: inherit;
-  line-height: inherit;
-  letter-spacing: inherit;
-  color: inherit;
-  margin: 0;
-  padding: 0;
-}
-
-/* Button / clickable cursor */
-button,
-[role='button'] {
-  cursor: pointer;
-}
-
-/* Textarea defaults */
-textarea {
-  resize: vertical;
-}
-
-/* Placeholder opacity normalization */
-input::placeholder,
-textarea::placeholder {
-  opacity: 1;
-}
-
-/* Table reset */
-table {
-  text-indent: 0;
-  border-color: inherit;
-  border-collapse: collapse;
-}
-
-/* HR reset */
-hr {
-  height: 0;
-  color: inherit;
-  border-top-width: 1px;
-}
-
-/* Media defaults */
-img,
-svg,
-video,
-canvas,
-audio,
-iframe,
-embed,
-object {
-  display: block;
-  vertical-align: middle;
-}
-
-img,
-video {
-  max-width: 100%;
-  height: auto;
-}
-
-/* Summary cursor */
-summary {
-  cursor: pointer;
-}
-
-a {
-  color: inherit;
-  text-decoration: inherit;
-}
-
-/* @starting-style is not supported by vanilla-extract */
-dialog {
-  @starting-style {
-    opacity: 0;
+@layer reset {
+  /* CSS reset (replaces Tailwind preflight) */
+  *,
+  ::after,
+  ::before {
+    box-sizing: border-box;
+    border-width: 0;
+    border-style: solid;
   }
-}
-dialog::backdrop {
-  @starting-style {
-    opacity: 0;
+
+  html,
+  :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+  }
+
+  /* Remove default margins */
+  blockquote,
+  dl,
+  dd,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hr,
+  figure,
+  p,
+  pre {
+    margin: 0;
+  }
+
+  /* Reset heading font-size/weight so they don't override component styles */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /* Reset lists */
+  ol,
+  ul,
+  menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Form elements inherit font */
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    font-size: 100%;
+    font-weight: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Button / clickable cursor */
+  button,
+  [role='button'] {
+    cursor: pointer;
+  }
+
+  /* Textarea defaults */
+  textarea {
+    resize: vertical;
+  }
+
+  /* Placeholder opacity normalization */
+  input::placeholder,
+  textarea::placeholder {
+    opacity: 1;
+  }
+
+  /* Table reset */
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* HR reset */
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /* Media defaults */
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+    vertical-align: middle;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* Summary cursor */
+  summary {
+    cursor: pointer;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /* @starting-style is not supported by vanilla-extract */
+  dialog {
+    @starting-style {
+      opacity: 0;
+    }
+  }
+  dialog::backdrop {
+    @starting-style {
+      opacity: 0;
+    }
   }
 }

--- a/apps/coral-ui/app/styles/globals.css
+++ b/apps/coral-ui/app/styles/globals.css
@@ -1,9 +1,10 @@
-/* Layer order for the whole app, lowest priority first. Wax rules go in the wax
-   layer (see app/wax/theme/layers.css.ts); the reset below goes in the reset layer,
-   so a component rule wins over an element default whatever the load order. App code
-   outside app/wax stays unlayered, which puts it above both. This is the first
-   stylesheet the app loads, so the order is settled before any rule arrives. */
-@layer reset, wax;
+/* Layer order for the whole app, lowest priority first. The reset below goes in the
+   reset layer, third party stylesheets go in vendor, and wax component rules go in
+   wax (see app/wax/theme/layers.css.ts), so a component rule wins over an element
+   default or a vendor default whatever the load order. App code outside app/wax
+   stays unlayered, which puts it above all three. This is the first stylesheet the
+   app loads, so the order is settled before any rule arrives. */
+@layer reset, vendor, wax;
 
 /* Encode Sans Semi Expanded — latin */
 @font-face {

--- a/apps/coral-ui/app/wax/animations/animations.css.ts
+++ b/apps/coral-ui/app/wax/animations/animations.css.ts
@@ -1,5 +1,5 @@
-import { keyframes, style } from '@vanilla-extract/css'
-import type { StyleRule } from '@vanilla-extract/css'
+import { keyframes, style } from '@/wax/css'
+import type { StyleRule } from '@/wax/css'
 
 const reducedMotion = {
   '@media': {

--- a/apps/coral-ui/app/wax/components/avatar/avatar.css.ts
+++ b/apps/coral-ui/app/wax/components/avatar/avatar.css.ts
@@ -1,6 +1,5 @@
-import { style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
+import { recipe, style } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/banner/banner.css.ts
+++ b/apps/coral-ui/app/wax/components/banner/banner.css.ts
@@ -1,5 +1,4 @@
-import { style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
+import { recipe, style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/breadcrumbs/breadcrumbs.css.ts
+++ b/apps/coral-ui/app/wax/components/breadcrumbs/breadcrumbs.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/button/button.css.ts
+++ b/apps/coral-ui/app/wax/components/button/button.css.ts
@@ -1,7 +1,5 @@
-import { assignVars, createThemeContract, style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
-
+import { assignVars, createThemeContract, recipe, style } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 import { animation, theme } from '@/wax/theme/theme.css'
 
 // Class to mark button as disabled (used for styling child elements)

--- a/apps/coral-ui/app/wax/components/button/icon.css.ts
+++ b/apps/coral-ui/app/wax/components/button/icon.css.ts
@@ -1,6 +1,5 @@
-import { keyframes, style } from '@vanilla-extract/css'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
-import { recipe } from '@vanilla-extract/recipes'
+import { keyframes, recipe, style } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 
 import { staticUtilities, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/button/text.css.ts
+++ b/apps/coral-ui/app/wax/components/button/text.css.ts
@@ -1,6 +1,5 @@
-import { createVar } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
+import { createVar, recipe } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 
 import { animation, staticUtilities, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/card/card-list/card-list.css.ts
+++ b/apps/coral-ui/app/wax/components/card/card-list/card-list.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 export const container = style({
   display: 'grid',

--- a/apps/coral-ui/app/wax/components/card/card.css.ts
+++ b/apps/coral-ui/app/wax/components/card/card.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { utils } from '@/styles/utils'
 import { theme } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/charts/bar-chart/bar-chart.css.ts
+++ b/apps/coral-ui/app/wax/components/charts/bar-chart/bar-chart.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/charts/line-chart/line-chart.css.ts
+++ b/apps/coral-ui/app/wax/components/charts/line-chart/line-chart.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/charts/sparkline/sparkline.css.ts
+++ b/apps/coral-ui/app/wax/components/charts/sparkline/sparkline.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 export const container = style({
   display: 'inline-block',

--- a/apps/coral-ui/app/wax/components/combobox/combobox.css.ts
+++ b/apps/coral-ui/app/wax/components/combobox/combobox.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { keyframes, style } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 import { zIndex } from '@/wax/theme/z-index'

--- a/apps/coral-ui/app/wax/components/date-picker/calendar.css.ts
+++ b/apps/coral-ui/app/wax/components/date-picker/calendar.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/date-picker/popover.css.ts
+++ b/apps/coral-ui/app/wax/components/date-picker/popover.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/dialog/dialog.css.ts
+++ b/apps/coral-ui/app/wax/components/dialog/dialog.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css'
+import { style, styleVariants } from '@/wax/css'
 
 import { utils } from '@/styles/utils'
 import { staticUtilities, theme, zIndex } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/duration-picker/duration-picker.css.ts
+++ b/apps/coral-ui/app/wax/components/duration-picker/duration-picker.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { keyframes, style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/error-message/error-message.css.ts
+++ b/apps/coral-ui/app/wax/components/error-message/error-message.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 export const container = style({
   alignItems: 'flex-start',

--- a/apps/coral-ui/app/wax/components/icon/icon.css.ts
+++ b/apps/coral-ui/app/wax/components/icon/icon.css.ts
@@ -1,5 +1,5 @@
-import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
+import { recipe } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/inputs/base-input.css.ts
+++ b/apps/coral-ui/app/wax/components/inputs/base-input.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/inputs/secrets/secrets-input.css.ts
+++ b/apps/coral-ui/app/wax/components/inputs/secrets/secrets-input.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { baseInput } from '@/wax/components/inputs/base-input.css'
 import { theme } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/inputs/switch/switch.css.ts
+++ b/apps/coral-ui/app/wax/components/inputs/switch/switch.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { animation, staticUtilities, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/inputs/text/text-area.css.ts
+++ b/apps/coral-ui/app/wax/components/inputs/text/text-area.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { input } from '@/wax/components/inputs/base-input.css'
 import { animation, theme } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/keyboard-hint/keyboard-hint.css.ts
+++ b/apps/coral-ui/app/wax/components/keyboard-hint/keyboard-hint.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/list/list.css.ts
+++ b/apps/coral-ui/app/wax/components/list/list.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { breakpoints } from '@/styles/theme.css'
 import { utils } from '@/styles/utils'

--- a/apps/coral-ui/app/wax/components/menu/menu.css.ts
+++ b/apps/coral-ui/app/wax/components/menu/menu.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { keyframes, style } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 import { zIndex } from '@/wax/theme/z-index'

--- a/apps/coral-ui/app/wax/components/page-layout/page-layout.css.ts
+++ b/apps/coral-ui/app/wax/components/page-layout/page-layout.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { breakpoints } from '@/styles/theme.css'
 import { theme } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/picker/picker.css.ts
+++ b/apps/coral-ui/app/wax/components/picker/picker.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 export const label = style({
   paddingBlockEnd: '6px',

--- a/apps/coral-ui/app/wax/components/pill/pill.css.ts
+++ b/apps/coral-ui/app/wax/components/pill/pill.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css'
+import { style, styleVariants } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/radio/radio.css.ts
+++ b/apps/coral-ui/app/wax/components/radio/radio.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { animation, theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/scroll-area/scroll-area.css.ts
+++ b/apps/coral-ui/app/wax/components/scroll-area/scroll-area.css.ts
@@ -1,4 +1,4 @@
-import { style, styleVariants } from '@vanilla-extract/css'
+import { style, styleVariants } from '@/wax/css'
 
 import { theme, zIndex } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/sidebar-button/sidebar-button.css.ts
+++ b/apps/coral-ui/app/wax/components/sidebar-button/sidebar-button.css.ts
@@ -1,6 +1,5 @@
-import { style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
+import { recipe, style } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 
 import { breakpoints } from '@/styles/theme.css'
 import { animation, theme } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/skeleton/skeleton.css.ts
+++ b/apps/coral-ui/app/wax/components/skeleton/skeleton.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { keyframes, style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/table/table.css.ts
+++ b/apps/coral-ui/app/wax/components/table/table.css.ts
@@ -1,5 +1,4 @@
-import { createVar, fallbackVar, style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
+import { createVar, fallbackVar, recipe, style } from '@/wax/css'
 
 import { theme, zIndex } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/tabs/tabs.css.ts
+++ b/apps/coral-ui/app/wax/components/tabs/tabs.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { breakpoints } from '@/styles/theme.css'
 import { theme, zIndex } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/components/toast/toast-container.css.ts
+++ b/apps/coral-ui/app/wax/components/toast/toast-container.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@/wax/css'
 
 export const toastContainer = style({})
 

--- a/apps/coral-ui/app/wax/components/toast/toast-container.tsx
+++ b/apps/coral-ui/app/wax/components/toast/toast-container.tsx
@@ -1,5 +1,5 @@
 import { Bounce, ToastContainer as ToastContainerComponent } from 'react-toastify'
-import 'react-toastify/dist/ReactToastify.css'
+import './toastify.css'
 
 import * as styles from './toast-container.css'
 

--- a/apps/coral-ui/app/wax/components/toast/toast-content.css.ts
+++ b/apps/coral-ui/app/wax/components/toast/toast-content.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { style } from '@/wax/css'
 
 import { theme } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/toast/toastify.css
+++ b/apps/coral-ui/app/wax/components/toast/toastify.css
@@ -1,0 +1,5 @@
+/* react-toastify ships unlayered rules for the same classes that
+   toast-container.css.ts restyles. An unlayered rule beats every layer whatever
+   its specificity, so the defaults have to be in a layer of their own, below wax.
+   app/styles/globals.css and ../../theme/layers.css.ts state the layer order. */
+@import 'react-toastify/dist/ReactToastify.css' layer(vendor);

--- a/apps/coral-ui/app/wax/components/tooltip/tooltip.css.ts
+++ b/apps/coral-ui/app/wax/components/tooltip/tooltip.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css'
+import { keyframes, style } from '@/wax/css'
 
 import { theme, zIndex } from '@/wax/theme/theme.css'
 

--- a/apps/coral-ui/app/wax/components/typography/typography.css.ts
+++ b/apps/coral-ui/app/wax/components/typography/typography.css.ts
@@ -1,6 +1,5 @@
-import { style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
-import type { RecipeVariants } from '@vanilla-extract/recipes'
+import { recipe, style } from '@/wax/css'
+import type { RecipeVariants } from '@/wax/css'
 
 import { utils } from '@/styles/utils'
 import { theme } from '@/wax/theme/theme.css'

--- a/apps/coral-ui/app/wax/css.ts
+++ b/apps/coral-ui/app/wax/css.ts
@@ -1,0 +1,112 @@
+import {
+  globalStyle as vanillaGlobalStyle,
+  style as vanillaStyle,
+  styleVariants as vanillaStyleVariants,
+} from '@vanilla-extract/css'
+import type { ComplexStyleRule, GlobalStyleRule, StyleRule } from '@vanilla-extract/css'
+import { recipe as vanillaRecipe } from '@vanilla-extract/recipes'
+import type { RuntimeFn } from '@vanilla-extract/recipes'
+
+import { resetLayer, waxLayer } from '@/wax/theme/layers.css'
+
+/**
+ * Instead of relying on bundlers, we want our CSS to follow a specific order:
+ * - Reset styles
+ * - WAX styles
+ * - Everything else (e.g. components)
+ *
+ * To achieve that, we use `@layer`: one for reset and one for WAX. Everything that's
+ * outside a layer will take precedence (given it has the same specificity). That's the C in CSS :P
+ */
+export * from '@vanilla-extract/css'
+export type { RecipeVariants, RuntimeFn } from '@vanilla-extract/recipes'
+
+type VariantGroups = NonNullable<Parameters<typeof vanillaRecipe>[0]['variants']>
+type RecipeOptions<Variants extends VariantGroups> = Parameters<typeof vanillaRecipe<Variants>>[0]
+
+function inWaxLayer(rule: StyleRule): StyleRule {
+  return { '@layer': { [waxLayer]: rule } }
+}
+
+export function globalStyle(selector: string, rule: GlobalStyleRule): void {
+  vanillaGlobalStyle(selector, { '@layer': { [waxLayer]: rule } })
+}
+
+/** `globalStyle` for an element or pseudo element default. See layers.css.ts. */
+export function resetStyle(selector: string, rule: GlobalStyleRule): void {
+  vanillaGlobalStyle(selector, { '@layer': { [resetLayer]: rule } })
+}
+
+/**
+ * `inWaxLayer` for anything the style APIs accept. Class names in a composition
+ * pass through: they name rules that already sit in the layer they belong to.
+ */
+function inWaxLayerRule<Rule extends ComplexStyleRule | string>(rule: Rule): Rule {
+  if (typeof rule === 'string') return rule
+  if (Array.isArray(rule)) {
+    return rule.map((entry) =>
+      typeof entry === 'string' || Array.isArray(entry) ? entry : inWaxLayer(entry),
+    ) as Rule
+  }
+  return inWaxLayer(rule) as Rule
+}
+
+export function style(rule: ComplexStyleRule, debugId?: string): string {
+  return vanillaStyle(inWaxLayerRule(rule), debugId)
+}
+
+export function styleVariants<StyleMap extends Record<number | string, ComplexStyleRule>>(
+  styleMap: StyleMap,
+  debugId?: string,
+): Record<keyof StyleMap, string>
+export function styleVariants<
+  Data extends Record<number | string, unknown>,
+  Key extends keyof Data,
+>(
+  data: Data,
+  mapData: (value: Data[Key], key: Key) => ComplexStyleRule,
+  debugId?: string,
+): Record<keyof Data, string>
+export function styleVariants(
+  data: Record<number | string, unknown>,
+  mapDataOrDebugId?: ((value: unknown, key: unknown) => ComplexStyleRule) | string,
+  debugId?: string,
+): Record<number | string, string> {
+  const mapData = typeof mapDataOrDebugId === 'function' ? mapDataOrDebugId : undefined
+
+  return vanillaStyleVariants(
+    data,
+    (value, key) => inWaxLayerRule(mapData ? mapData(value, key) : (value as ComplexStyleRule)),
+    typeof mapDataOrDebugId === 'string' ? mapDataOrDebugId : debugId,
+  )
+}
+
+export function recipe<Variants extends VariantGroups>(
+  options: RecipeOptions<Variants>,
+  debugId?: string,
+): RuntimeFn<Variants> {
+  const { base, compoundVariants, variants } = options
+
+  return vanillaRecipe<Variants>(
+    {
+      ...options,
+      base: base === undefined ? undefined : inWaxLayerRule(base),
+      compoundVariants: compoundVariants?.map((compound) => ({
+        ...compound,
+        style: inWaxLayerRule(compound.style),
+      })),
+      variants:
+        variants === undefined
+          ? undefined
+          : (Object.fromEntries(
+              Object.entries(variants).map(([group, values]) => [
+                group,
+                Object.fromEntries(
+                  Object.entries(values).map(([value, rule]) => [value, inWaxLayerRule(rule)]),
+                ),
+              ]),
+            ) as Variants),
+    },
+    debugId,
+  )
+}

--- a/apps/coral-ui/app/wax/css.ts
+++ b/apps/coral-ui/app/wax/css.ts
@@ -1,4 +1,6 @@
 import {
+  createGlobalTheme as vanillaCreateGlobalTheme,
+  createTheme as vanillaCreateTheme,
   globalStyle as vanillaGlobalStyle,
   style as vanillaStyle,
   styleVariants as vanillaStyleVariants,
@@ -50,6 +52,37 @@ function inWaxLayerRule<Rule extends ComplexStyleRule | string>(rule: Rule): Rul
   }
   return inWaxLayer(rule) as Rule
 }
+
+/**
+ * The token block of a theme goes in the wax layer too. The theme class sits on the
+ * body, so an app rule that redeclares a token on the body is one class wide just
+ * like the theme rule, and unlayered, which used to leave the winner to the order
+ * the bundler linked the chunks in. Vanilla Extract takes the layer as an `@layer`
+ * key in the token map, which is always the last object argument.
+ */
+function inWaxLayerTokens(args: readonly unknown[]): unknown[] {
+  const withLayer = [...args]
+
+  for (let index = withLayer.length - 1; index >= 0; index -= 1) {
+    const argument = withLayer[index]
+    if (typeof argument === 'object' && argument !== null) {
+      withLayer[index] = { ...argument, '@layer': waxLayer }
+      break
+    }
+  }
+
+  return withLayer
+}
+
+export const createTheme = ((...args: readonly unknown[]) =>
+  (vanillaCreateTheme as (...rest: unknown[]) => unknown)(
+    ...inWaxLayerTokens(args),
+  )) as typeof vanillaCreateTheme
+
+export const createGlobalTheme = ((...args: readonly unknown[]) =>
+  (vanillaCreateGlobalTheme as (...rest: unknown[]) => unknown)(
+    ...inWaxLayerTokens(args),
+  )) as typeof vanillaCreateGlobalTheme
 
 export function style(rule: ComplexStyleRule, debugId?: string): string {
   return vanillaStyle(inWaxLayerRule(rule), debugId)

--- a/apps/coral-ui/app/wax/theme/global.css.ts
+++ b/apps/coral-ui/app/wax/theme/global.css.ts
@@ -1,9 +1,9 @@
-import { globalStyle } from '@vanilla-extract/css'
+import { resetStyle } from '@/wax/css'
 
 import '@/wax/theme/font.css'
 import { theme } from '@/wax/theme/theme.css'
 
-globalStyle('body', {
+resetStyle('body', {
   backgroundColor: theme.surface.mainContent,
   color: theme.content.primary,
   fontFamily: theme.typography.body.fontFamily,
@@ -13,30 +13,30 @@ globalStyle('body', {
   minHeight: '100vh',
 })
 
-globalStyle('::selection', {
+resetStyle('::selection', {
   backgroundColor: theme.content.selection,
   color: theme.content.primary,
 })
 
-globalStyle('::-webkit-scrollbar', {
+resetStyle('::-webkit-scrollbar', {
   height: '8px',
   width: '8px',
 })
 
-globalStyle('::-webkit-scrollbar-track', {
+resetStyle('::-webkit-scrollbar-track', {
   backgroundColor: theme.surface.main,
 })
 
-globalStyle('::-webkit-scrollbar-corner', {
+resetStyle('::-webkit-scrollbar-corner', {
   backgroundColor: theme.surface.main,
   borderRadius: '0 0 8px 0',
 })
 
-globalStyle('::-webkit-scrollbar-thumb', {
+resetStyle('::-webkit-scrollbar-thumb', {
   backgroundColor: theme.surface.onMainContent,
   borderRadius: '8px',
 })
 
-globalStyle('::-webkit-scrollbar-thumb:hover', {
+resetStyle('::-webkit-scrollbar-thumb:hover', {
   backgroundColor: theme.surface.onMainContentHover,
 })

--- a/apps/coral-ui/app/wax/theme/layers.css.ts
+++ b/apps/coral-ui/app/wax/theme/layers.css.ts
@@ -12,6 +12,12 @@ import { globalLayer } from '@vanilla-extract/css'
 // wax components of everything the reset names. It goes in the first layer.
 export const resetLayer = globalLayer('reset')
 
+// Third party stylesheets, currently react-toastify. They are unlayered as shipped,
+// which puts them above every wax rule, so app/wax/components/toast/toastify.css
+// imports them into this layer instead. Nothing writes to it from TypeScript; the
+// name is declared here so that the order is stated in one place.
+export const vendorLayer = globalLayer('vendor')
+
 // Wax component styles. Wax rules and consumer overrides are both single class
 // selectors, so which one wins used to depend on the order the bundler linked the
 // CSS chunks, and dev and production disagreed. A layer settles it by construction.

--- a/apps/coral-ui/app/wax/theme/layers.css.ts
+++ b/apps/coral-ui/app/wax/theme/layers.css.ts
@@ -1,0 +1,18 @@
+import { globalLayer } from '@vanilla-extract/css'
+
+// Declaration order is layer order, and later layers win. App code outside app/wax
+// stays unlayered, so it beats both of these whatever its specificity.
+// app/styles/globals.css states the same order, because it is the first stylesheet
+// the app loads. Keep the two in step.
+//
+// Element and pseudo element defaults: the reset in app/styles/globals.css, the page
+// background, the selection colour, the scrollbars. `button { padding: 0 }` is a
+// weaker selector than any wax rule but it is unlayered, and an unlayered rule beats
+// every layer whatever its specificity, so leaving the reset out of a layer strips
+// wax components of everything the reset names. It goes in the first layer.
+export const resetLayer = globalLayer('reset')
+
+// Wax component styles. Wax rules and consumer overrides are both single class
+// selectors, so which one wins used to depend on the order the bundler linked the
+// CSS chunks, and dev and production disagreed. A layer settles it by construction.
+export const waxLayer = globalLayer('wax')

--- a/apps/coral-ui/app/wax/theme/theme-dark.css.ts
+++ b/apps/coral-ui/app/wax/theme/theme-dark.css.ts
@@ -1,4 +1,4 @@
-import { createTheme } from '@vanilla-extract/css'
+import { createTheme } from '@/wax/css'
 
 import { utils } from '@/styles/utils'
 import { paletteDark } from '@/wax/base/palette/palette-dark'

--- a/apps/coral-ui/app/wax/theme/theme-light.css.ts
+++ b/apps/coral-ui/app/wax/theme/theme-light.css.ts
@@ -1,4 +1,4 @@
-import { createTheme } from '@vanilla-extract/css'
+import { createTheme } from '@/wax/css'
 
 import { utils } from '@/styles/utils'
 import { paletteLight } from '@/wax/base/palette/palette-light'

--- a/apps/coral-ui/app/wax/theme/theme.css.ts
+++ b/apps/coral-ui/app/wax/theme/theme.css.ts
@@ -1,4 +1,4 @@
-import { createThemeContract } from '@vanilla-extract/css'
+import { createThemeContract } from '@/wax/css'
 
 /**
  * Static tokens are not affected by the theme, they are always the same.


### PR DESCRIPTION
## Summary

I noticed a CSS bug which only appeared in prod. 
Turns out a component (WorkspaceSelector) was using a CSS rule with 0,1,0 specificity, same as our WAX button.
In prod, the WAX stylesheet came after, overriding the style added by WorkspaceSelector.

Rather than fixing that one occurrence, I'm adding layers to enforce the order of styles in a predictable manner:
1. Reset css first (so they are always overridden)
2. Vendor-specific stylesheets (only toast atm)
3. WAX components next
4. Everything else (so they always take precedence)

Also add a lint rule to help with the migration and prevent diverging in the future

## Test plan

Ask Claude to review the outputs of dev and build, before and after this change. Styles are now always emitted in the correct order.