### PR TITLE
fix(ui): show each credential method's own hint

### DIFF
--- a/apps/coral-ui/app/views/sources/source-input-collection.tsx
+++ b/apps/coral-ui/app/views/sources/source-input-collection.tsx
@@ -161,7 +161,7 @@ function InputRow({
   const selected = methods[methodIndex]
 
   return (
-    <SourceInputField input={input} showHint={methods.length <= 1} showLabel={methods.length <= 1}>
+    <SourceInputField input={input} showHint={methods.length === 0} showLabel={methods.length <= 1}>
       {methods.length > 0 ? (
         <input type="hidden" name={`method:${input.key}`} value={methodIndex} />
       ) : null}
@@ -188,7 +188,7 @@ function InputRow({
               <div aria-hidden="true" className={styles.methodSizer} inert key={`sizer:${index}`}>
                 <CredentialMethodContent
                   disabled
-                  hint={input.hint}
+                  hint={method.hint || method.description || input.hint}
                   inputKey={input.key}
                   method={method}
                   onValueChange={onValueChange}
@@ -200,7 +200,7 @@ function InputRow({
               <Tabs.Panel className={styles.methodPanel} key={index} value={index}>
                 <CredentialMethodContent
                   disabled={disabled || index !== methodIndex}
-                  hint={input.hint}
+                  hint={method.hint || method.description || input.hint}
                   inputKey={input.key}
                   method={method}
                   onValueChange={onValueChange}
@@ -211,8 +211,9 @@ function InputRow({
           </div>
         </Tabs.Root>
       ) : (
-        <CredentialMethodFields
+        <CredentialMethodContent
           disabled={disabled}
+          hint={selected ? selected.hint || selected.description || input.hint : ''}
           inputKey={input.key}
           method={selected}
           onValueChange={onValueChange}


### PR DESCRIPTION
## Summary

Says on the tin, we should use the specific method hint (if available) as that would be more precise that the generic description

## Test plan

| Before | After |
| ------ | ------ |
| <img width="516" height="281" alt="image" src="https://github.com/user-attachments/assets/ae6b0fba-2dfb-412d-810d-cef23c02ea33" /> | <img width="519" height="308" alt="image" src="https://github.com/user-attachments/assets/0f5aa8f9-3329-4ec9-911a-5f07c11b23f2" /> |