### PR TITLE
fix(coral-ui): use unstyled react-toastify components

### DIFF
--- a/apps/coral-ui/app/__tests__/architecture.test.ts
+++ b/apps/coral-ui/app/__tests__/architecture.test.ts
@@ -252,6 +252,21 @@ describe('architecture', () => {
     ).toEqual([])
   })
 
+  it('takes react-toastify from the entry point that ships no styles', () => {
+    const importers = filesUnder(appDir, (name) => /\.tsx?$/.test(name)).filter((file) =>
+      importsFrom(fs.readFileSync(file, 'utf8')).includes('react-toastify'),
+    )
+
+    expect(
+      importers.map((file) => path.relative(appDir, file)),
+      "react-toastify has to come from 'react-toastify/unstyled'. The default entry point " +
+        'appends its stylesheet to the head as an inline style element when ToastContainer ' +
+        'mounts. Those rules are unlayered, an unlayered rule beats every layer whatever its ' +
+        'specificity, and they silently outrank both the vendor import in ' +
+        'app/wax/components/toast/toastify.css and the wax rules written to restyle them.',
+    ).toEqual([])
+  })
+
   it('states one layer order for the whole app', () => {
     const globals = fs.readFileSync(path.join(appDir, 'styles', 'globals.css'), 'utf8')
     const layers = fs.readFileSync(path.join(appDir, 'wax', 'theme', 'layers.css.ts'), 'utf8')

--- a/apps/coral-ui/app/wax/components/toast/toast-container.tsx
+++ b/apps/coral-ui/app/wax/components/toast/toast-container.tsx
@@ -1,4 +1,4 @@
-import { Bounce, ToastContainer as ToastContainerComponent } from 'react-toastify'
+import { Bounce, ToastContainer as ToastContainerComponent } from 'react-toastify/unstyled'
 import './toastify.css'
 
 import * as styles from './toast-container.css'

--- a/apps/coral-ui/app/wax/components/toast/toast.tsx
+++ b/apps/coral-ui/app/wax/components/toast/toast.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 
-import { Bounce, toast, type ToastOptions } from 'react-toastify'
+import { Bounce, toast, type ToastOptions } from 'react-toastify/unstyled'
 
 import { ToastContent } from './toast-content'
 

--- a/apps/coral-ui/app/wax/components/toast/toastify.css
+++ b/apps/coral-ui/app/wax/components/toast/toastify.css
@@ -1,5 +1,8 @@
-/* react-toastify ships unlayered rules for the same classes that
-   toast-container.css.ts restyles. An unlayered rule beats every layer whatever
-   its specificity, so the defaults have to be in a layer of their own, below wax.
+/* react-toastify ships its rules unlayered, and an unlayered rule beats every layer
+   whatever its specificity, so the toast-container.css.ts overrides would lose. The
+   package stylesheet comes in here, in a layer below wax, instead. The components
+   import react-toastify/unstyled: the default entry point appends the same rules to
+   the head as an inline style element when ToastContainer mounts, which is unlayered
+   again and beats this import.
    app/styles/globals.css and ../../theme/layers.css.ts state the layer order. */
 @import 'react-toastify/dist/ReactToastify.css' layer(vendor);


### PR DESCRIPTION
## Summary

Using normal toastify elements appends an unlayered stylesheet when ToastContainer mounts; that would override our styles (unlayered takes precedence over layered).
Instead, import the same components from the `/unstyled` path to avoid that stylesheet injection.

## Test plan

Toast now have our styles

<img width="357" height="114" alt="image" src="https://github.com/user-attachments/assets/bf092e2d-1874-4650-b315-2e7d16992cb8" />
