### PR TITLE
feat(mcp): add host-owned MCP surfaces

### DIFF
--- a/crates/coral-cli/AGENTS.md
+++ b/crates/coral-cli/AGENTS.md
@@ -29,8 +29,9 @@
   transport startup, shutdown, and the compatible `run_from_env` default in
   this crate.
 - Forward host engine providers to every local `ServerBuilder` after the OSS
-  providers. Resolve MCP providers only for MCP stdio or an enabled MCP HTTP
-  runtime; help and unrelated commands must not require them.
+  providers. Resolve the optional `McpSurfaceProvider` once, only for MCP stdio
+  or an enabled MCP HTTP runtime; help and unrelated commands must not require
+  it.
 - Server and transport lifecycles remain in their owning components (`coral-app`
   for gRPC, `coral-mcp::http` for MCP HTTP).
 - Keep CLI-owned process environment access purpose-specific and locally

--- a/crates/coral-cli/AGENTS.md
+++ b/crates/coral-cli/AGENTS.md
@@ -24,6 +24,13 @@
 - Keep server orchestration internal to this crate while CLI commands are its
   only consumers (see the root `AGENTS.md` for when it may move to a shared
   crate).
+- Sibling host binaries compose Coral through `CoralExtensions` and
+  `run_from_env_with_extensions`. Keep argument parsing, command routing,
+  transport startup, shutdown, and the compatible `run_from_env` default in
+  this crate.
+- Forward host engine providers to every local `ServerBuilder` after the OSS
+  providers. Resolve MCP providers only for MCP stdio or an enabled MCP HTTP
+  runtime; help and unrelated commands must not require them.
 - Server and transport lifecycles remain in their owning components (`coral-app`
   for gRPC, `coral-mcp::http` for MCP HTTP).
 - Keep CLI-owned process environment access purpose-specific and locally

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -8,7 +8,7 @@ use coral_client::{
     AppClient, ClientError,
     local::{LocalServerError, RunningServer as AppRunningServer, ServerBuilder},
 };
-use coral_mcp::McpOptions;
+use coral_mcp::{McpExtensionsProvider, McpOptions};
 
 pub(crate) struct Bootstrap {
     pub(crate) app: AppClient,
@@ -64,6 +64,7 @@ pub(crate) async fn bootstrap(
 pub(crate) async fn start_standalone_server(
     feature_overrides: FeatureOverrides,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    mcp_extensions_providers: Vec<Arc<dyn McpExtensionsProvider>>,
 ) -> Result<crate::serve::RunningServer, BootstrapError> {
     let features = FeatureStore::discover(None)?.load_with_overrides(&feature_overrides)?;
     let mcp_options = McpOptions {
@@ -79,7 +80,7 @@ pub(crate) async fn start_standalone_server(
         },
         engine_extensions_providers,
     );
-    crate::serve::start(builder, mcp_options)
+    crate::serve::start(builder, mcp_options, mcp_extensions_providers)
         .await
         .map_err(Into::into)
 }

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use coral_app::{
-    AwsEngineExtensionsProvider,
+    AwsEngineExtensionsProvider, EngineExtensionsProvider,
     features::{Feature, FeatureOverrides, FeatureStore},
 };
 use coral_client::{
@@ -39,7 +39,10 @@ pub(crate) enum BootstrapError {
     Serve(#[from] crate::serve::ServeError),
 }
 
-pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, BootstrapError> {
+pub(crate) async fn bootstrap(
+    options: BootstrapOptions,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+) -> Result<Bootstrap, BootstrapError> {
     if let Some(endpoint) = bootstrap_endpoint() {
         return Ok(Bootstrap {
             app: AppClient::connect(&endpoint).await?,
@@ -47,9 +50,10 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
         });
     }
 
-    let server = configure_server_builder(ServerBuilder::new(), options)
-        .start()
-        .await?;
+    let server =
+        configure_server_builder(ServerBuilder::new(), options, engine_extensions_providers)
+            .start()
+            .await?;
     let app = AppClient::connect(server.endpoint_uri()).await?;
     Ok(Bootstrap {
         app,
@@ -59,6 +63,7 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
 
 pub(crate) async fn start_standalone_server(
     feature_overrides: FeatureOverrides,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
 ) -> Result<crate::serve::RunningServer, BootstrapError> {
     let features = FeatureStore::discover(None)?.load_with_overrides(&feature_overrides)?;
     let mcp_options = McpOptions {
@@ -72,17 +77,27 @@ pub(crate) async fn start_standalone_server(
             feature_overrides,
             ..BootstrapOptions::default()
         },
+        engine_extensions_providers,
     );
     crate::serve::start(builder, mcp_options)
         .await
         .map_err(Into::into)
 }
 
-fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
-    builder
+fn configure_server_builder(
+    builder: ServerBuilder,
+    options: BootstrapOptions,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+) -> ServerBuilder {
+    let builder = builder
         .with_stderr_logs(options.enable_stderr_logs)
         .with_feature_overrides(options.feature_overrides)
-        .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
+        .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider));
+    engine_extensions_providers
+        .into_iter()
+        .fold(builder, |builder, provider| {
+            builder.add_engine_extensions_provider(provider)
+        })
 }
 
 #[cfg(feature = "cli-test-server")]

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -110,3 +110,66 @@ fn bootstrap_endpoint() -> Option<String> {
 fn bootstrap_endpoint() -> Option<String> {
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use coral_api::v1::ExecuteSqlRequest;
+    use coral_app::{EngineExtensions, QuerySource};
+    use coral_client::default_workspace;
+    use tempfile::TempDir;
+    use tonic::Request;
+
+    use super::*;
+
+    struct RecordingProvider {
+        name: &'static str,
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl EngineExtensionsProvider for RecordingProvider {
+        fn extensions_for(&self, _selected_sources: &[QuerySource]) -> EngineExtensions {
+            self.calls.lock().expect("calls lock").push(self.name);
+            EngineExtensions::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn configured_builder_runs_host_engine_providers_in_order() {
+        let temp = TempDir::new().expect("temp dir");
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let providers = ["first", "second"]
+            .map(|name| {
+                Arc::new(RecordingProvider {
+                    name,
+                    calls: Arc::clone(&calls),
+                }) as Arc<dyn EngineExtensionsProvider>
+            })
+            .into();
+        let server = configure_server_builder(
+            ServerBuilder::new().with_config_dir(temp.path()),
+            BootstrapOptions::default(),
+            providers,
+        )
+        .start()
+        .await
+        .expect("start server");
+        let app = AppClient::connect(server.endpoint_uri())
+            .await
+            .expect("connect client");
+
+        app.query_client()
+            .execute_sql(Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: "SELECT 1".to_string(),
+                guide_read_context: None,
+                task_attribution: None,
+            }))
+            .await
+            .expect("execute query");
+
+        assert_eq!(*calls.lock().expect("calls lock"), ["first", "second"]);
+        server.shutdown().await.expect("stop server");
+    }
+}

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -8,7 +8,7 @@ use coral_client::{
     AppClient, ClientError,
     local::{LocalServerError, RunningServer as AppRunningServer, ServerBuilder},
 };
-use coral_mcp::{McpExtensionsProvider, McpOptions};
+use coral_mcp::{McpOptions, McpSurfaceProvider};
 
 pub(crate) struct Bootstrap {
     pub(crate) app: AppClient,
@@ -64,7 +64,7 @@ pub(crate) async fn bootstrap(
 pub(crate) async fn start_standalone_server(
     feature_overrides: FeatureOverrides,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    mcp_extensions_providers: Vec<Arc<dyn McpExtensionsProvider>>,
+    mcp_surface_provider: Option<Arc<dyn McpSurfaceProvider>>,
 ) -> Result<crate::serve::RunningServer, BootstrapError> {
     let features = FeatureStore::discover(None)?.load_with_overrides(&feature_overrides)?;
     let mcp_options = McpOptions {
@@ -80,7 +80,7 @@ pub(crate) async fn start_standalone_server(
         },
         engine_extensions_providers,
     );
-    crate::serve::start(builder, mcp_options, mcp_extensions_providers)
+    crate::serve::start(builder, mcp_options, mcp_surface_provider)
         .await
         .map_err(Into::into)
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -42,7 +42,7 @@ use coral_client::{
     format_batches_table, format_search_response_json, format_search_response_text,
     manifest_input_from_proto, workspace as workspace_resource,
 };
-use coral_mcp::McpExtensionsProvider;
+use coral_mcp::{McpSurface, McpSurfaceProvider};
 use dialoguer::console::measure_text_width;
 use tonic::Request;
 
@@ -615,7 +615,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
 #[derive(Default)]
 pub struct CoralExtensions {
     engine_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    mcp_providers: Vec<Arc<dyn McpExtensionsProvider>>,
+    mcp_surface_provider: Option<Arc<dyn McpSurfaceProvider>>,
 }
 
 impl CoralExtensions {
@@ -629,10 +629,10 @@ impl CoralExtensions {
         self
     }
 
-    /// Adds a static MCP extension provider.
+    /// Sets the host-owned MCP surface provider.
     #[must_use]
-    pub fn add_mcp_extensions_provider(mut self, provider: Arc<dyn McpExtensionsProvider>) -> Self {
-        self.mcp_providers.push(provider);
+    pub fn with_mcp_surface_provider(mut self, provider: Arc<dyn McpSurfaceProvider>) -> Self {
+        self.mcp_surface_provider = Some(provider);
         self
     }
 }
@@ -658,7 +658,7 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
     };
     let CoralExtensions {
         engine_providers,
-        mcp_providers,
+        mcp_surface_provider,
     } = extensions;
 
     match command.required_runtime() {
@@ -686,7 +686,7 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
                     Some(&ctx),
                     &feature_overrides,
                     &workspace,
-                    &mcp_providers,
+                    mcp_surface_provider.as_deref(),
                 )
                 .await
             } else {
@@ -698,7 +698,7 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
                         None,
                         &feature_overrides,
                         &workspace,
-                        &mcp_providers,
+                        mcp_surface_provider.as_deref(),
                     )),
                 )
                 .await
@@ -714,7 +714,7 @@ pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result
                     &feature_overrides,
                     CoralExtensions {
                         engine_providers,
-                        mcp_providers,
+                        mcp_surface_provider,
                     },
                 )),
             )
@@ -740,7 +740,7 @@ async fn run_server(
     let server = bootstrap::start_standalone_server(
         feature_overrides,
         extensions.engine_providers,
-        extensions.mcp_providers,
+        extensions.mcp_surface_provider,
     )
     .await?;
     let endpoint = server.endpoint_uri().to_string();
@@ -919,7 +919,7 @@ async fn run_app_command(
     ctx: Option<&coral_app::RunContext>,
     feature_overrides: &coral_app::features::FeatureOverrides,
     workspace: &Workspace,
-    mcp_extensions_providers: &[Arc<dyn McpExtensionsProvider>],
+    mcp_surface_provider: Option<&dyn McpSurfaceProvider>,
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
@@ -1001,8 +1001,10 @@ async fn run_app_command(
                     source_names,
                     query_examples,
                     workspace: Some(workspace.clone()),
-                    extensions: coral_mcp::McpExtensions::from_providers(mcp_extensions_providers)
-                        .map_err(anyhow::Error::from)?,
+                    surface: match mcp_surface_provider {
+                        Some(provider) => provider.surface().map_err(anyhow::Error::from_boxed)?,
+                        None => McpSurface::default(),
+                    },
                 },
             ))
             .await

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -42,6 +42,7 @@ use coral_client::{
     format_batches_table, format_search_response_json, format_search_response_text,
     manifest_input_from_proto, workspace as workspace_resource,
 };
+use coral_mcp::McpExtensionsProvider;
 use dialoguer::console::measure_text_width;
 use tonic::Request;
 
@@ -607,19 +608,43 @@ where
 /// Returns an error if runtime startup, command execution, or output
 /// formatting fails.
 pub async fn run_from_env() -> Result<(), CliError> {
-    Box::pin(run_from_env_with_engine_extensions(Vec::new())).await
+    Box::pin(run_from_env_with_extensions(CoralExtensions::default())).await
 }
 
-/// Parses CLI arguments and runs the selected command with additional engine
-/// extensions providers.
+/// Typed extensions supplied by a sibling Coral host binary.
+#[derive(Default)]
+pub struct CoralExtensions {
+    engine_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    mcp_providers: Vec<Arc<dyn McpExtensionsProvider>>,
+}
+
+impl CoralExtensions {
+    /// Adds an app-owned engine extension provider.
+    #[must_use]
+    pub fn add_engine_extensions_provider(
+        mut self,
+        provider: Arc<dyn EngineExtensionsProvider>,
+    ) -> Self {
+        self.engine_providers.push(provider);
+        self
+    }
+
+    /// Adds a static MCP extension provider.
+    #[must_use]
+    pub fn add_mcp_extensions_provider(mut self, provider: Arc<dyn McpExtensionsProvider>) -> Self {
+        self.mcp_providers.push(provider);
+        self
+    }
+}
+
+/// Parses CLI arguments and runs the selected command with host-supplied
+/// Coral extensions.
 ///
 /// # Errors
 ///
 /// Returns an error if runtime startup, command execution, or output
 /// formatting fails.
-pub async fn run_from_env_with_engine_extensions(
-    providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-) -> Result<(), CliError> {
+pub async fn run_from_env_with_extensions(extensions: CoralExtensions) -> Result<(), CliError> {
     let Cli {
         feature_overrides,
         workspace_selection,
@@ -631,6 +656,10 @@ pub async fn run_from_env_with_engine_extensions(
     let ctx = coral_app::RunContext {
         trace_parent: env::trace_parent(),
     };
+    let CoralExtensions {
+        engine_providers,
+        mcp_providers,
+    } = extensions;
 
     match command.required_runtime() {
         RequiredRuntime::AppClient => {
@@ -645,13 +674,21 @@ pub async fn run_from_env_with_engine_extensions(
                     enable_stderr_logs: command.enables_stderr_logs(),
                     feature_overrides: feature_overrides.clone(),
                 },
-                providers,
+                engine_providers,
             )
             .await
             .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
             let result = if is_mcp_stdio {
-                run_app_command(app, command, Some(&ctx), &feature_overrides, &workspace).await
+                run_app_command(
+                    app,
+                    command,
+                    Some(&ctx),
+                    &feature_overrides,
+                    &workspace,
+                    &mcp_providers,
+                )
+                .await
             } else {
                 coral_app::run_with_context(
                     &ctx,
@@ -661,6 +698,7 @@ pub async fn run_from_env_with_engine_extensions(
                         None,
                         &feature_overrides,
                         &workspace,
+                        &mcp_providers,
                     )),
                 )
                 .await
@@ -674,7 +712,10 @@ pub async fn run_from_env_with_engine_extensions(
                 Box::pin(run_no_runtime_command(
                     command,
                     &feature_overrides,
-                    providers,
+                    CoralExtensions {
+                        engine_providers,
+                        mcp_providers,
+                    },
                 )),
             )
             .await
@@ -694,10 +735,14 @@ fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<
 
 async fn run_server(
     feature_overrides: coral_app::features::FeatureOverrides,
-    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    extensions: CoralExtensions,
 ) -> Result<(), anyhow::Error> {
-    let server =
-        bootstrap::start_standalone_server(feature_overrides, engine_extensions_providers).await?;
+    let server = bootstrap::start_standalone_server(
+        feature_overrides,
+        extensions.engine_providers,
+        extensions.mcp_providers,
+    )
+    .await?;
     let endpoint = server.endpoint_uri().to_string();
 
     // An endpoint that does not parse back to an address is treated as exposed:
@@ -842,7 +887,7 @@ async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
 async fn run_no_runtime_command(
     command: Command,
     feature_overrides: &coral_app::features::FeatureOverrides,
-    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    extensions: CoralExtensions,
 ) -> Result<(), CliError> {
     match command {
         Command::Completion(args) => {
@@ -852,12 +897,9 @@ async fn run_no_runtime_command(
             Ok(())
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
-        Command::Server => Box::pin(run_server(
-            feature_overrides.clone(),
-            engine_extensions_providers,
-        ))
-        .await
-        .map_err(Into::into),
+        Command::Server => Box::pin(run_server(feature_overrides.clone(), extensions))
+            .await
+            .map_err(Into::into),
         Command::Sql(_)
         | Command::Search(_)
         | Command::SearchIndex(_)
@@ -877,6 +919,7 @@ async fn run_app_command(
     ctx: Option<&coral_app::RunContext>,
     feature_overrides: &coral_app::features::FeatureOverrides,
     workspace: &Workspace,
+    mcp_extensions_providers: &[Arc<dyn McpExtensionsProvider>],
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
@@ -958,6 +1001,8 @@ async fn run_app_command(
                     source_names,
                     query_examples,
                     workspace: Some(workspace.clone()),
+                    extensions: coral_mcp::McpExtensions::from_providers(mcp_extensions_providers)
+                        .map_err(anyhow::Error::from)?,
                 },
             ))
             .await

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -21,6 +21,7 @@ use std::fmt::Write as _;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::{
     Arg, ArgAction, ArgGroup, ArgMatches, Args, CommandFactory, Error as ClapError, FromArgMatches,
@@ -35,7 +36,7 @@ use coral_api::v1::{
     SearchProvider, SearchRequest, Workspace, function, search_clear_target,
     search_maintenance_result,
 };
-use coral_app::bootstrap::is_loopback_ip;
+use coral_app::{EngineExtensionsProvider, bootstrap::is_loopback_ip};
 use coral_client::{
     AppClient, DEFAULT_WORKSPACE_ID, decode_execute_sql_response, format_batches_json,
     format_batches_table, format_search_response_json, format_search_response_text,
@@ -606,6 +607,19 @@ where
 /// Returns an error if runtime startup, command execution, or output
 /// formatting fails.
 pub async fn run_from_env() -> Result<(), CliError> {
+    Box::pin(run_from_env_with_engine_extensions(Vec::new())).await
+}
+
+/// Parses CLI arguments and runs the selected command with additional engine
+/// extensions providers.
+///
+/// # Errors
+///
+/// Returns an error if runtime startup, command execution, or output
+/// formatting fails.
+pub async fn run_from_env_with_engine_extensions(
+    providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+) -> Result<(), CliError> {
     let Cli {
         feature_overrides,
         workspace_selection,
@@ -626,10 +640,13 @@ pub async fn run_from_env() -> Result<(), CliError> {
                 workspace_resource(DEFAULT_WORKSPACE_ID)
             };
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
-            let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
-                enable_stderr_logs: command.enables_stderr_logs(),
-                feature_overrides: feature_overrides.clone(),
-            })
+            let bootstrap = bootstrap::bootstrap(
+                bootstrap::BootstrapOptions {
+                    enable_stderr_logs: command.enables_stderr_logs(),
+                    feature_overrides: feature_overrides.clone(),
+                },
+                providers,
+            )
             .await
             .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
@@ -654,7 +671,11 @@ pub async fn run_from_env() -> Result<(), CliError> {
         RequiredRuntime::None => {
             coral_app::run_with_context(
                 &ctx,
-                Box::pin(run_no_runtime_command(command, &feature_overrides)),
+                Box::pin(run_no_runtime_command(
+                    command,
+                    &feature_overrides,
+                    providers,
+                )),
             )
             .await
         }
@@ -673,8 +694,10 @@ fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<
 
 async fn run_server(
     feature_overrides: coral_app::features::FeatureOverrides,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
 ) -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_standalone_server(feature_overrides).await?;
+    let server =
+        bootstrap::start_standalone_server(feature_overrides, engine_extensions_providers).await?;
     let endpoint = server.endpoint_uri().to_string();
 
     // An endpoint that does not parse back to an address is treated as exposed:
@@ -819,6 +842,7 @@ async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
 async fn run_no_runtime_command(
     command: Command,
     feature_overrides: &coral_app::features::FeatureOverrides,
+    engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
 ) -> Result<(), CliError> {
     match command {
         Command::Completion(args) => {
@@ -828,9 +852,12 @@ async fn run_no_runtime_command(
             Ok(())
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
-        Command::Server => Box::pin(run_server(feature_overrides.clone()))
-            .await
-            .map_err(Into::into),
+        Command::Server => Box::pin(run_server(
+            feature_overrides.clone(),
+            engine_extensions_providers,
+        ))
+        .await
+        .map_err(Into::into),
         Command::Sql(_)
         | Command::Search(_)
         | Command::SearchIndex(_)

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -13,7 +13,7 @@ use coral_client::{
     },
 };
 use coral_mcp::{
-    McpExtensions, McpExtensionsProvider, McpOptions,
+    McpOptions, McpSurfaceProvider, McpSurfaceProviderError,
     http::{
         AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, McpHttpConfig, McpHttpError,
         RunningMcpHttpServer, start_auth_disabled, start_authenticated,
@@ -112,8 +112,8 @@ enum McpStartError {
     UnsafeGrpcAddress(SocketAddr),
     #[error("authenticated MCP HTTP requires a session authenticator")]
     MissingSessionProvider,
-    #[error(transparent)]
-    Extensions(#[from] coral_mcp::McpExtensionsError),
+    #[error("failed to build MCP surface: {0}")]
+    SurfaceProvider(#[source] McpSurfaceProviderError),
     #[error(transparent)]
     Client(#[from] ClientError),
     #[error(transparent)]
@@ -177,8 +177,8 @@ impl RunningServer {
 /// enforces, happens here — where the transports' lifecycles are already owned.
 pub(crate) async fn start(
     builder: ServerBuilder,
-    mcp_options: McpOptions,
-    mcp_extensions_providers: Vec<Arc<dyn McpExtensionsProvider>>,
+    mut mcp_options: McpOptions,
+    mcp_surface_provider: Option<Arc<dyn McpSurfaceProvider>>,
 ) -> Result<RunningServer, ServeError> {
     let mut settings = builder
         .serve_settings()
@@ -188,6 +188,15 @@ pub(crate) async fn start(
     let grpc_authentication_enabled = session_auth.is_some();
     let mcp_http_authentication_enabled =
         matches!(mcp_config, Some(McpHttpServeConfig::Authenticated { .. }));
+    if mcp_config.is_some()
+        && let Some(provider) = mcp_surface_provider
+    {
+        mcp_options.surface = provider.surface().map_err(|error| {
+            ServeError(ServeErrorKind::McpStart(McpStartError::SurfaceProvider(
+                error,
+            )))
+        })?;
+    }
     let (builder, mcp_principal_provider) =
         compose_session_policies(builder, session_auth.as_ref(), mcp_config.as_ref());
     // Built after the providers, which only borrow the settings; this consumes them.
@@ -219,7 +228,6 @@ pub(crate) async fn start(
         mcp_principal_provider,
         grpc_addr,
         mcp_options,
-        &mcp_extensions_providers,
     ))
     .await
     {
@@ -299,13 +307,11 @@ async fn start_mcp_http(
     settings: Option<McpHttpServeConfig>,
     mcp_principal_provider: Option<Arc<dyn BearerAuthenticator>>,
     grpc_addr: SocketAddr,
-    mut mcp_options: McpOptions,
-    mcp_extensions_providers: &[Arc<dyn McpExtensionsProvider>],
+    mcp_options: McpOptions,
 ) -> Result<Option<RunningMcpHttpServer>, McpStartError> {
     let Some(settings) = settings else {
         return Ok(None);
     };
-    mcp_options.extensions = McpExtensions::from_providers(mcp_extensions_providers)?;
     let grpc_endpoint_uri = loopback_grpc_endpoint_uri(grpc_addr)?;
     let server = match settings {
         McpHttpServeConfig::AuthDisabled {

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -13,7 +13,7 @@ use coral_client::{
     },
 };
 use coral_mcp::{
-    McpOptions,
+    McpExtensions, McpExtensionsProvider, McpOptions,
     http::{
         AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, McpHttpConfig, McpHttpError,
         RunningMcpHttpServer, start_auth_disabled, start_authenticated,
@@ -113,6 +113,8 @@ enum McpStartError {
     #[error("authenticated MCP HTTP requires a session authenticator")]
     MissingSessionProvider,
     #[error(transparent)]
+    Extensions(#[from] coral_mcp::McpExtensionsError),
+    #[error(transparent)]
     Client(#[from] ClientError),
     #[error(transparent)]
     Http(#[from] McpHttpError),
@@ -176,6 +178,7 @@ impl RunningServer {
 pub(crate) async fn start(
     builder: ServerBuilder,
     mcp_options: McpOptions,
+    mcp_extensions_providers: Vec<Arc<dyn McpExtensionsProvider>>,
 ) -> Result<RunningServer, ServeError> {
     let mut settings = builder
         .serve_settings()
@@ -211,17 +214,24 @@ pub(crate) async fn start(
             return Err(ServeError(error));
         }
     };
-    let mcp_http =
-        match start_mcp_http(mcp_config, mcp_principal_provider, grpc_addr, mcp_options).await {
-            Ok(server) => server,
-            Err(mcp) => {
-                let error = match shutdown_components(grpc, oauth, None).await {
-                    Ok(()) => ServeErrorKind::McpStart(mcp),
-                    Err(cleanup) => ServeErrorKind::McpStartCleanup { mcp, cleanup },
-                };
-                return Err(ServeError(error));
-            }
-        };
+    let mcp_http = match Box::pin(start_mcp_http(
+        mcp_config,
+        mcp_principal_provider,
+        grpc_addr,
+        mcp_options,
+        &mcp_extensions_providers,
+    ))
+    .await
+    {
+        Ok(server) => server,
+        Err(mcp) => {
+            let error = match shutdown_components(grpc, oauth, None).await {
+                Ok(()) => ServeErrorKind::McpStart(mcp),
+                Err(cleanup) => ServeErrorKind::McpStartCleanup { mcp, cleanup },
+            };
+            return Err(ServeError(error));
+        }
+    };
     Ok(RunningServer {
         grpc,
         oauth,
@@ -289,11 +299,13 @@ async fn start_mcp_http(
     settings: Option<McpHttpServeConfig>,
     mcp_principal_provider: Option<Arc<dyn BearerAuthenticator>>,
     grpc_addr: SocketAddr,
-    mcp_options: McpOptions,
+    mut mcp_options: McpOptions,
+    mcp_extensions_providers: &[Arc<dyn McpExtensionsProvider>],
 ) -> Result<Option<RunningMcpHttpServer>, McpStartError> {
     let Some(settings) = settings else {
         return Ok(None);
     };
+    mcp_options.extensions = McpExtensions::from_providers(mcp_extensions_providers)?;
     let grpc_endpoint_uri = loopback_grpc_endpoint_uri(grpc_addr)?;
     let server = match settings {
         McpHttpServeConfig::AuthDisabled {

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -1,8 +1,10 @@
 use std::net::TcpListener;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
 use coral_client::default_workspace;
+use coral_mcp::McpExtensions;
 use jsonwebtoken::jwk::{Jwk, ThumbprintHash};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::header::WWW_AUTHENTICATE;
@@ -23,6 +25,14 @@ const OAUTH_RESOURCE: &str = "http://localhost:1457";
 const SESSION_ISSUER: &str = "https://auth.example";
 const SESSION_RESOURCE: &str = "https://coral.example/mcp";
 const CORAL_UI_RESOURCE: &str = "https://coral-ui.example";
+
+struct TestMcpProvider;
+
+impl McpExtensionsProvider for TestMcpProvider {
+    fn extensions(&self) -> McpExtensions {
+        McpExtensions::default().retain_tools(["start_task", "list_catalog", "end_task"])
+    }
+}
 
 fn write_config(temp: &TempDir, config: &str) {
     std::fs::write(temp.path().join("config.toml"), config).expect("write config");
@@ -94,6 +104,20 @@ async fn assert_feedback_tool(endpoint: String) {
             .expect("initialize MCP client");
     let tools = client.list_all_tools().await.expect("list MCP tools");
     assert!(tools.iter().any(|tool| tool.name == "feedback"));
+    client.cancel().await.expect("stop MCP client");
+}
+
+async fn assert_cli_extension_filter(endpoint: String) {
+    let client =
+        ().serve(StreamableHttpClientTransport::from_uri(endpoint))
+            .await
+            .expect("initialize MCP client");
+    let tools = client.list_all_tools().await.expect("list MCP tools");
+    assert_eq!(tools.len(), 3);
+    assert!(tools.iter().all(|tool| matches!(
+        tool.name.as_ref(),
+        "start_task" | "list_catalog" | "end_task"
+    )));
     client.cancel().await.expect("stop MCP client");
 }
 
@@ -393,6 +417,7 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        vec![Arc::new(TestMcpProvider)],
     )
     .await
     .expect("start composite server");
@@ -402,6 +427,7 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
     assert!(server.oauth_addr().is_none());
     assert_catalog_tool(format!("http://{mcp_addr}/mcp"), None).await;
+    assert_cli_extension_filter(format!("http://{mcp_addr}/mcp")).await;
     server.shutdown().await.expect("shutdown composite server");
     let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC port must be released");
     let mcp_rebound = TcpListener::bind(mcp_addr).expect("MCP port must be released");
@@ -424,6 +450,7 @@ async fn unconsented_non_loopback_settings_fail_closed_in_serve() {
         None,
         SocketAddr::from((Ipv4Addr::LOCALHOST, 1)),
         McpOptions::default(),
+        &[],
     )
     .await;
     match result {
@@ -446,6 +473,7 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await
     .expect("start composite server with the exposure opt-in");
@@ -474,6 +502,7 @@ async fn companion_uses_supplied_mcp_options() {
             feedback_enabled: true,
             ..McpOptions::default()
         },
+        Vec::new(),
     )
     .await
     .expect("start composite server");
@@ -499,6 +528,7 @@ async fn oauth_and_mcp_companions_serve_and_release_all_listeners() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await
     .expect("start composite server");
@@ -541,6 +571,7 @@ async fn oauth_start_failure_releases_the_started_grpc_listener() {
             .with_noop_feedback_uploads()
             .with_prebound_grpc_listener(grpc_listener),
         McpOptions::default(),
+        Vec::new(),
     )
     .await;
     let Err(error) = result else {
@@ -567,6 +598,7 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await
     .expect("start authenticated composite server");
@@ -648,6 +680,7 @@ async fn coral_ui_only_audience_authenticates_private_grpc_without_mcp_http() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await
     .expect("start Coral UI-only authenticated server");
@@ -709,6 +742,7 @@ async fn session_failures_and_restart_are_fail_closed() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await
     .expect("start authenticated composite server");
@@ -734,6 +768,7 @@ async fn session_failures_and_restart_are_fail_closed() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await
     .expect("restart authenticated composite server");
@@ -762,6 +797,7 @@ async fn mcp_start_failure_releases_started_oauth_and_grpc_listeners() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
+        Vec::new(),
     )
     .await;
     let Err(error) = result else {

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
 use coral_client::default_workspace;
-use coral_mcp::McpExtensions;
+use coral_mcp::{McpSurface, McpSurfaceProvider, McpSurfaceProviderError, McpToolRoute};
 use jsonwebtoken::jwk::{Jwk, ThumbprintHash};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::header::WWW_AUTHENTICATE;
@@ -28,9 +28,21 @@ const CORAL_UI_RESOURCE: &str = "https://coral-ui.example";
 
 struct TestMcpProvider;
 
-impl McpExtensionsProvider for TestMcpProvider {
-    fn extensions(&self) -> McpExtensions {
-        McpExtensions::default().retain_tools(["start_task", "list_catalog", "end_task"])
+impl McpSurfaceProvider for TestMcpProvider {
+    fn surface(&self) -> Result<McpSurface, McpSurfaceProviderError> {
+        Ok(McpSurface::replace(
+            std::iter::empty::<McpToolRoute>(),
+            ["start_task", "list_catalog", "end_task"],
+            Some("Use the available Coral catalog tools.".to_string()),
+        )?)
+    }
+}
+
+struct UnexpectedMcpProvider;
+
+impl McpSurfaceProvider for UnexpectedMcpProvider {
+    fn surface(&self) -> Result<McpSurface, McpSurfaceProviderError> {
+        Err(std::io::Error::other("MCP provider ran while MCP HTTP was disabled").into())
     }
 }
 
@@ -417,7 +429,7 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        vec![Arc::new(TestMcpProvider)],
+        Some(Arc::new(TestMcpProvider)),
     )
     .await
     .expect("start composite server");
@@ -450,7 +462,6 @@ async fn unconsented_non_loopback_settings_fail_closed_in_serve() {
         None,
         SocketAddr::from((Ipv4Addr::LOCALHOST, 1)),
         McpOptions::default(),
-        &[],
     )
     .await;
     match result {
@@ -473,7 +484,7 @@ async fn opted_in_auth_disabled_companion_serves_off_loopback() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await
     .expect("start composite server with the exposure opt-in");
@@ -502,7 +513,7 @@ async fn companion_uses_supplied_mcp_options() {
             feedback_enabled: true,
             ..McpOptions::default()
         },
-        Vec::new(),
+        None,
     )
     .await
     .expect("start composite server");
@@ -528,7 +539,7 @@ async fn oauth_and_mcp_companions_serve_and_release_all_listeners() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await
     .expect("start composite server");
@@ -571,7 +582,7 @@ async fn oauth_start_failure_releases_the_started_grpc_listener() {
             .with_noop_feedback_uploads()
             .with_prebound_grpc_listener(grpc_listener),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await;
     let Err(error) = result else {
@@ -598,7 +609,7 @@ async fn session_authenticated_companion_gates_grpc_and_mcp() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await
     .expect("start authenticated composite server");
@@ -680,7 +691,7 @@ async fn coral_ui_only_audience_authenticates_private_grpc_without_mcp_http() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        Some(Arc::new(UnexpectedMcpProvider)),
     )
     .await
     .expect("start Coral UI-only authenticated server");
@@ -742,7 +753,7 @@ async fn session_failures_and_restart_are_fail_closed() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await
     .expect("start authenticated composite server");
@@ -768,7 +779,7 @@ async fn session_failures_and_restart_are_fail_closed() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await
     .expect("restart authenticated composite server");
@@ -797,7 +808,7 @@ async fn mcp_start_failure_releases_started_oauth_and_grpc_listeners() {
             .with_config_dir(temp.path())
             .with_noop_feedback_uploads(),
         McpOptions::default(),
-        Vec::new(),
+        None,
     )
     .await;
     let Err(error) = result else {

--- a/crates/coral-mcp/AGENTS.md
+++ b/crates/coral-mcp/AGENTS.md
@@ -31,6 +31,15 @@ and Streamable HTTP transport adapters.
   per protocol session. Keep standalone process launch outside this crate.
 - Configure tool availability through `McpOptions` consistently across stdio
   and alternate transports; transport choice is not a capability boundary.
+- Compose host tools once at MCP runtime startup through
+  `McpExtensionsProvider`. Reject core-name and duplicate extension collisions,
+  intersect retained-name sets, and keep the selected public tool surface
+  fixed for that runtime. A hidden tool must be absent from discovery and
+  dispatch.
+- Give each extension route an `McpToolContext` built from that session's
+  authorized `AppClient`. Its `CoralToolset` is the core-only projection before
+  public additions and filtering. Do not expose bearer tokens or let extension
+  routes enter that private core projection.
 - Keep HTTP tools and resources in the shared MCP surface. The HTTP adapter owns
   routing, host protection, health, and lifecycle; keep `/livez` process-only,
   while `/readyz` may probe reachability without requiring authentication.

--- a/crates/coral-mcp/AGENTS.md
+++ b/crates/coral-mcp/AGENTS.md
@@ -31,11 +31,12 @@ and Streamable HTTP transport adapters.
   per protocol session. Keep standalone process launch outside this crate.
 - Configure tool availability through `McpOptions` consistently across stdio
   and alternate transports; transport choice is not a capability boundary.
-- Compose host tools once at MCP runtime startup through
-  `McpExtensionsProvider`. Reject core-name and duplicate extension collisions,
-  intersect retained-name sets, and keep the selected public tool surface
-  fixed for that runtime. A hidden tool must be absent from discovery and
-  dispatch.
+- Build one host-owned `McpSurface` at MCP runtime startup through
+  `McpSurfaceProvider`. Use `extend` for the complete OSS surface plus host
+  tools, or `replace` for exact host tools, named core tools, and initialize
+  instructions. Reject reserved, duplicate, unknown, and unavailable tool
+  names before the MCP listener starts. Keep the selected surface fixed for
+  that runtime; a hidden tool must be absent from discovery and dispatch.
 - Give each extension route an `McpToolContext` built from that session's
   authorized `AppClient`. Its `CoralToolset` is the core-only projection before
   public additions and filtering. Do not expose bearer tokens or let extension

--- a/crates/coral-mcp/src/error.rs
+++ b/crates/coral-mcp/src/error.rs
@@ -5,7 +5,7 @@
 pub enum McpError {
     /// Static MCP extension composition was invalid.
     #[error(transparent)]
-    Extensions(#[from] crate::McpExtensionsError),
+    Surface(#[from] crate::McpSurfaceError),
     /// Building or using the Coral client failed.
     #[error(transparent)]
     Client(#[from] coral_client::ClientError),

--- a/crates/coral-mcp/src/error.rs
+++ b/crates/coral-mcp/src/error.rs
@@ -3,6 +3,9 @@
 /// Errors surfaced by the `MCP` stdio server.
 #[derive(Debug, thiserror::Error)]
 pub enum McpError {
+    /// Static MCP extension composition was invalid.
+    #[error(transparent)]
+    Extensions(#[from] crate::McpExtensionsError),
     /// Building or using the Coral client failed.
     #[error(transparent)]
     Client(#[from] coral_client::ClientError),

--- a/crates/coral-mcp/src/extensions.rs
+++ b/crates/coral-mcp/src/extensions.rs
@@ -1,14 +1,19 @@
-//! Static MCP extension composition and per-session tool context.
+//! Static MCP surface composition and per-session tool context.
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{collections::BTreeSet, error::Error, sync::Arc};
 
 use coral_api::v1::Workspace;
-use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::router::tool::{ToolRoute, ToolRouter};
 
 use crate::{server::CoralToolset, surface::ToolName};
 
-/// RMCP router used for tools supplied by an MCP extension provider.
-pub type McpToolRouter = ToolRouter<McpToolContext>;
+/// RMCP route used for one host-supplied tool.
+pub type McpToolRoute = ToolRoute<McpToolContext>;
+
+pub(crate) type McpToolRouter = ToolRouter<McpToolContext>;
+
+/// Error returned by a host while it builds its MCP surface.
+pub type McpSurfaceProviderError = Box<dyn Error + Send + Sync + 'static>;
 
 /// Session-bound context supplied to extension tool handlers.
 #[derive(Clone)]
@@ -38,119 +43,149 @@ impl McpToolContext {
     }
 }
 
-/// Supplies static MCP contributions when an MCP runtime starts.
-pub trait McpExtensionsProvider: Send + Sync {
-    /// Returns this provider's static MCP contributions.
-    fn extensions(&self) -> McpExtensions;
-}
-
-/// Static tools and public tool-name projection supplied by one or more hosts.
-#[derive(Clone, Debug, Default)]
-pub struct McpExtensions(Arc<McpExtensionsInner>);
-
-#[derive(Clone, Debug, Default)]
-struct McpExtensionsInner {
-    added_tools: McpToolRouter,
-    retained_tool_names: Option<BTreeSet<String>>,
-    duplicate_tool_names: BTreeSet<String>,
-}
-
-impl McpExtensions {
-    /// Adds extension tool routes.
-    #[must_use]
-    pub fn add_tools(mut self, tools: McpToolRouter) -> Self {
-        let extensions = Arc::make_mut(&mut self.0);
-        for route in tools {
-            let name = route.name().to_string();
-            if extensions.added_tools.has_route(&name) {
-                extensions.duplicate_tool_names.insert(name);
-            } else {
-                extensions.added_tools.add_route(route);
-            }
-        }
-        self
-    }
-
-    /// Retains only the named tools in the public MCP surface.
-    ///
-    /// Repeated calls intersect their name sets. Core tool projections obtained
-    /// through [`McpToolContext::core_tools`] are not affected.
-    #[must_use]
-    pub fn retain_tools(mut self, names: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        let names = names.into_iter().map(Into::into).collect::<BTreeSet<_>>();
-        let retained_tool_names = &mut Arc::make_mut(&mut self.0).retained_tool_names;
-        match retained_tool_names {
-            Some(retained) => retained.retain(|name| names.contains(name)),
-            None => *retained_tool_names = Some(names),
-        }
-        self
-    }
-
-    /// Evaluates and deterministically merges static provider contributions.
+/// Builds one static MCP surface when an MCP runtime starts.
+pub trait McpSurfaceProvider: Send + Sync {
+    /// Returns the complete host-owned MCP surface contribution.
     ///
     /// # Errors
     ///
-    /// Returns an error when an extension uses a reserved core name or when
-    /// more than one extension route has the same name.
-    pub fn from_providers(
-        providers: &[Arc<dyn McpExtensionsProvider>],
-    ) -> Result<Self, McpExtensionsError> {
-        let mut merged = Self::default();
-        for provider in providers {
-            let extensions = provider.extensions();
-            Arc::make_mut(&mut merged.0)
-                .duplicate_tool_names
-                .extend(extensions.0.duplicate_tool_names.iter().cloned());
-            merged = merged.add_tools(extensions.0.added_tools.clone());
-            if let Some(names) = &extensions.0.retained_tool_names {
-                merged = merged.retain_tools(names.clone());
-            }
-        }
-        merged.finalize()?;
-        Ok(merged)
+    /// Returns an error when host configuration cannot produce a surface.
+    fn surface(&self) -> Result<McpSurface, McpSurfaceProviderError>;
+}
+
+/// Static public MCP tool surface and initialize instructions.
+#[derive(Clone, Debug)]
+pub struct McpSurface(Arc<McpSurfaceInner>);
+
+#[derive(Clone, Debug)]
+struct McpSurfaceInner {
+    extension_tools: McpToolRouter,
+    public_core_tool_names: Option<BTreeSet<String>>,
+    initialize_instructions: InitializeInstructions,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum InitializeInstructions {
+    CoralDefault,
+    Replace(Option<String>),
+}
+
+impl Default for McpSurface {
+    fn default() -> Self {
+        Self(Arc::new(McpSurfaceInner {
+            extension_tools: McpToolRouter::new(),
+            public_core_tool_names: None,
+            initialize_instructions: InitializeInstructions::CoralDefault,
+        }))
+    }
+}
+
+impl McpSurface {
+    /// Keeps the complete OSS Coral surface and adds host tool routes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for duplicate routes or a route that uses a reserved
+    /// Coral tool name.
+    pub fn extend(routes: impl IntoIterator<Item = McpToolRoute>) -> Result<Self, McpSurfaceError> {
+        Self::build(routes, None, InitializeInstructions::CoralDefault)
     }
 
-    pub(crate) fn added_tools(&self) -> &McpToolRouter {
-        &self.0.added_tools
-    }
-
-    pub(crate) fn retained_tool_names(&self) -> Option<&BTreeSet<String>> {
-        self.0.retained_tool_names.as_ref()
-    }
-
-    pub(crate) fn finalize(&mut self) -> Result<(), McpExtensionsError> {
-        if let Some(name) = self.0.duplicate_tool_names.iter().next() {
-            return Err(McpExtensionsError::DuplicateToolName(name.clone()));
-        }
-        if let Some(name) = self
-            .0
-            .added_tools
-            .list_all()
+    /// Replaces the public surface with exact host routes and named core tools.
+    ///
+    /// `initialize_instructions` replaces Coral's default instructions. `None`
+    /// omits initialize instructions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for duplicate routes, a route that uses a reserved
+    /// Coral tool name, or an unknown core tool name.
+    pub fn replace(
+        routes: impl IntoIterator<Item = McpToolRoute>,
+        public_core_tool_names: impl IntoIterator<Item = impl Into<String>>,
+        initialize_instructions: Option<String>,
+    ) -> Result<Self, McpSurfaceError> {
+        let public_core_tool_names = public_core_tool_names
             .into_iter()
-            .map(|tool| tool.name.to_string())
-            .find(|name| name.parse::<ToolName>().is_ok())
+            .map(Into::into)
+            .collect::<BTreeSet<_>>();
+        if let Some(name) = public_core_tool_names
+            .iter()
+            .find(|name| name.parse::<ToolName>().is_err())
         {
-            return Err(McpExtensionsError::ReservedToolName(name));
+            return Err(McpSurfaceError::UnknownCoreToolName(name.clone()));
         }
-        let extensions = Arc::make_mut(&mut self.0);
-        if let Some(retained) = &extensions.retained_tool_names {
-            for tool in extensions.added_tools.list_all() {
-                if !retained.contains(tool.name.as_ref()) {
-                    extensions.added_tools.disable_route(tool.name);
-                }
+        Self::build(
+            routes,
+            Some(public_core_tool_names),
+            InitializeInstructions::Replace(initialize_instructions),
+        )
+    }
+
+    fn build(
+        routes: impl IntoIterator<Item = McpToolRoute>,
+        public_core_tool_names: Option<BTreeSet<String>>,
+        initialize_instructions: InitializeInstructions,
+    ) -> Result<Self, McpSurfaceError> {
+        let mut extension_tools = McpToolRouter::new();
+        for route in routes {
+            let name = route.name().to_string();
+            if name.parse::<ToolName>().is_ok() {
+                return Err(McpSurfaceError::ReservedToolName(name));
             }
+            if extension_tools.has_route(&name) {
+                return Err(McpSurfaceError::DuplicateToolName(name));
+            }
+            extension_tools.add_route(route);
+        }
+        Ok(Self(Arc::new(McpSurfaceInner {
+            extension_tools,
+            public_core_tool_names,
+            initialize_instructions,
+        })))
+    }
+
+    pub(crate) fn extension_tools(&self) -> &McpToolRouter {
+        &self.0.extension_tools
+    }
+
+    pub(crate) fn public_core_tool_names(&self) -> Option<&BTreeSet<String>> {
+        self.0.public_core_tool_names.as_ref()
+    }
+
+    pub(crate) fn initialize_instructions(&self) -> &InitializeInstructions {
+        &self.0.initialize_instructions
+    }
+
+    pub(crate) fn validate(&self, feedback_enabled: bool) -> Result<(), McpSurfaceError> {
+        if !feedback_enabled
+            && self
+                .0
+                .public_core_tool_names
+                .as_ref()
+                .is_some_and(|names| names.contains(ToolName::Feedback.as_str()))
+        {
+            return Err(McpSurfaceError::UnavailableCoreToolName(
+                ToolName::Feedback.as_str().to_string(),
+            ));
         }
         Ok(())
     }
 }
 
-/// Invalid static MCP extension composition.
+/// Invalid static MCP surface composition.
 #[derive(Debug, thiserror::Error)]
-pub enum McpExtensionsError {
-    /// An extension tried to register a reserved core Coral tool name.
+pub enum McpSurfaceError {
+    /// A host route tried to use a reserved core Coral tool name.
     #[error("MCP extension tool name '{0}' is reserved by Coral")]
     ReservedToolName(String),
-    /// More than one extension tool used the same name.
+    /// More than one host route used the same name.
     #[error("duplicate MCP extension tool name '{0}'")]
     DuplicateToolName(String),
+    /// A replacement surface named a core tool that Coral does not define.
+    #[error("unknown core MCP tool name '{0}'")]
+    UnknownCoreToolName(String),
+    /// A replacement surface selected a core tool that is not enabled.
+    #[error("core MCP tool '{0}' is not available")]
+    UnavailableCoreToolName(String),
 }

--- a/crates/coral-mcp/src/extensions.rs
+++ b/crates/coral-mcp/src/extensions.rs
@@ -1,0 +1,156 @@
+//! Static MCP extension composition and per-session tool context.
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use coral_api::v1::Workspace;
+use rmcp::handler::server::router::tool::ToolRouter;
+
+use crate::{server::CoralToolset, surface::ToolName};
+
+/// RMCP router used for tools supplied by an MCP extension provider.
+pub type McpToolRouter = ToolRouter<McpToolContext>;
+
+/// Session-bound context supplied to extension tool handlers.
+#[derive(Clone)]
+pub struct McpToolContext {
+    core_tools: CoralToolset,
+    workspace: Workspace,
+}
+
+impl McpToolContext {
+    pub(crate) fn new(core_tools: CoralToolset, workspace: Workspace) -> Self {
+        Self {
+            core_tools,
+            workspace,
+        }
+    }
+
+    /// Core Coral tools bound to this authenticated MCP session.
+    #[must_use]
+    pub fn core_tools(&self) -> &CoralToolset {
+        &self.core_tools
+    }
+
+    /// Workspace selected for this MCP session.
+    #[must_use]
+    pub fn workspace(&self) -> &Workspace {
+        &self.workspace
+    }
+}
+
+/// Supplies static MCP contributions when an MCP runtime starts.
+pub trait McpExtensionsProvider: Send + Sync {
+    /// Returns this provider's static MCP contributions.
+    fn extensions(&self) -> McpExtensions;
+}
+
+/// Static tools and public tool-name projection supplied by one or more hosts.
+#[derive(Clone, Debug, Default)]
+pub struct McpExtensions(Arc<McpExtensionsInner>);
+
+#[derive(Clone, Debug, Default)]
+struct McpExtensionsInner {
+    added_tools: McpToolRouter,
+    retained_tool_names: Option<BTreeSet<String>>,
+    duplicate_tool_names: BTreeSet<String>,
+}
+
+impl McpExtensions {
+    /// Adds extension tool routes.
+    #[must_use]
+    pub fn add_tools(mut self, tools: McpToolRouter) -> Self {
+        let extensions = Arc::make_mut(&mut self.0);
+        for route in tools {
+            let name = route.name().to_string();
+            if extensions.added_tools.has_route(&name) {
+                extensions.duplicate_tool_names.insert(name);
+            } else {
+                extensions.added_tools.add_route(route);
+            }
+        }
+        self
+    }
+
+    /// Retains only the named tools in the public MCP surface.
+    ///
+    /// Repeated calls intersect their name sets. Core tool projections obtained
+    /// through [`McpToolContext::core_tools`] are not affected.
+    #[must_use]
+    pub fn retain_tools(mut self, names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let names = names.into_iter().map(Into::into).collect::<BTreeSet<_>>();
+        let retained_tool_names = &mut Arc::make_mut(&mut self.0).retained_tool_names;
+        match retained_tool_names {
+            Some(retained) => retained.retain(|name| names.contains(name)),
+            None => *retained_tool_names = Some(names),
+        }
+        self
+    }
+
+    /// Evaluates and deterministically merges static provider contributions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an extension uses a reserved core name or when
+    /// more than one extension route has the same name.
+    pub fn from_providers(
+        providers: &[Arc<dyn McpExtensionsProvider>],
+    ) -> Result<Self, McpExtensionsError> {
+        let mut merged = Self::default();
+        for provider in providers {
+            let extensions = provider.extensions();
+            Arc::make_mut(&mut merged.0)
+                .duplicate_tool_names
+                .extend(extensions.0.duplicate_tool_names.iter().cloned());
+            merged = merged.add_tools(extensions.0.added_tools.clone());
+            if let Some(names) = &extensions.0.retained_tool_names {
+                merged = merged.retain_tools(names.clone());
+            }
+        }
+        merged.finalize()?;
+        Ok(merged)
+    }
+
+    pub(crate) fn added_tools(&self) -> &McpToolRouter {
+        &self.0.added_tools
+    }
+
+    pub(crate) fn retained_tool_names(&self) -> Option<&BTreeSet<String>> {
+        self.0.retained_tool_names.as_ref()
+    }
+
+    pub(crate) fn finalize(&mut self) -> Result<(), McpExtensionsError> {
+        if let Some(name) = self.0.duplicate_tool_names.iter().next() {
+            return Err(McpExtensionsError::DuplicateToolName(name.clone()));
+        }
+        if let Some(name) = self
+            .0
+            .added_tools
+            .list_all()
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .find(|name| name.parse::<ToolName>().is_ok())
+        {
+            return Err(McpExtensionsError::ReservedToolName(name));
+        }
+        let extensions = Arc::make_mut(&mut self.0);
+        if let Some(retained) = &extensions.retained_tool_names {
+            for tool in extensions.added_tools.list_all() {
+                if !retained.contains(tool.name.as_ref()) {
+                    extensions.added_tools.disable_route(tool.name);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Invalid static MCP extension composition.
+#[derive(Debug, thiserror::Error)]
+pub enum McpExtensionsError {
+    /// An extension tried to register a reserved core Coral tool name.
+    #[error("MCP extension tool name '{0}' is reserved by Coral")]
+    ReservedToolName(String),
+    /// More than one extension tool used the same name.
+    #[error("duplicate MCP extension tool name '{0}'")]
+    DuplicateToolName(String),
+}

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -519,6 +519,9 @@ fn is_loopback(ip: IpAddr) -> bool {
 /// MCP HTTP startup or shutdown failure.
 #[derive(Debug, thiserror::Error)]
 pub enum McpHttpError {
+    /// Static MCP extension composition was invalid.
+    #[error(transparent)]
+    Extensions(#[from] crate::McpExtensionsError),
     /// Auth-disabled serving is restricted to the local machine unless the
     /// operator consented via [`McpHttpConfig::allow_unauthenticated_non_loopback`].
     #[error("auth-disabled MCP HTTP bind must be loopback, got {0}")]
@@ -630,8 +633,9 @@ fn join_server(
 pub async fn start_auth_disabled(
     config: McpHttpConfig,
     app: AppClient,
-    options: McpOptions,
+    mut options: McpOptions,
 ) -> Result<RunningMcpHttpServer, McpHttpError> {
+    options.extensions.finalize()?;
     let listener = TcpListener::bind(config.bind_addr())
         .await
         .map_err(|source| McpHttpError::Bind {
@@ -660,8 +664,9 @@ pub async fn start_auth_disabled(
 /// Returns an error when the listener cannot bind.
 pub async fn start_authenticated(
     config: AuthenticatedMcpHttpConfig,
-    runtime: AuthenticatedMcpHttpRuntime,
+    mut runtime: AuthenticatedMcpHttpRuntime,
 ) -> Result<RunningMcpHttpServer, McpHttpError> {
+    runtime.options.extensions.finalize()?;
     let listener = TcpListener::bind(config.bind_addr)
         .await
         .map_err(|source| McpHttpError::Bind {

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -521,7 +521,7 @@ fn is_loopback(ip: IpAddr) -> bool {
 pub enum McpHttpError {
     /// Static MCP extension composition was invalid.
     #[error(transparent)]
-    Extensions(#[from] crate::McpExtensionsError),
+    Surface(#[from] crate::McpSurfaceError),
     /// Auth-disabled serving is restricted to the local machine unless the
     /// operator consented via [`McpHttpConfig::allow_unauthenticated_non_loopback`].
     #[error("auth-disabled MCP HTTP bind must be loopback, got {0}")]
@@ -633,9 +633,9 @@ fn join_server(
 pub async fn start_auth_disabled(
     config: McpHttpConfig,
     app: AppClient,
-    mut options: McpOptions,
+    options: McpOptions,
 ) -> Result<RunningMcpHttpServer, McpHttpError> {
-    options.extensions.finalize()?;
+    options.surface.validate(options.feedback_enabled)?;
     let listener = TcpListener::bind(config.bind_addr())
         .await
         .map_err(|source| McpHttpError::Bind {
@@ -664,9 +664,12 @@ pub async fn start_auth_disabled(
 /// Returns an error when the listener cannot bind.
 pub async fn start_authenticated(
     config: AuthenticatedMcpHttpConfig,
-    mut runtime: AuthenticatedMcpHttpRuntime,
+    runtime: AuthenticatedMcpHttpRuntime,
 ) -> Result<RunningMcpHttpServer, McpHttpError> {
-    runtime.options.extensions.finalize()?;
+    runtime
+        .options
+        .surface
+        .validate(runtime.options.feedback_enabled)?;
     let listener = TcpListener::bind(config.bind_addr)
         .await
         .map_err(|source| McpHttpError::Bind {

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -8,8 +8,7 @@ use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::{Router, response::Response};
 use coral_client::{AppClient, local::ServerBuilder};
-use futures::poll;
-use rmcp::ServiceExt as _;
+use futures::{future::BoxFuture, poll};
 use rmcp::model::{CallToolRequestParams, ClientJsonRpcMessage};
 use rmcp::transport::{
     StreamableHttpClientTransport,
@@ -19,12 +18,13 @@ use rmcp::transport::{
         local::{SessionConfig, create_local_session},
     },
 };
+use rmcp::{ErrorData, Json, ServiceExt as _};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpStream;
 use tower::ServiceExt as _;
 
-use crate::McpOptions;
+use crate::{McpExtensions, McpOptions, McpToolContext, McpToolRouter};
 
 use super::{
     AUTHENTICATED_SESSION_IDLE_TIMEOUT, AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime,
@@ -37,6 +37,26 @@ use super::{
 
 const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
 const PING: &str = r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#;
+
+#[rmcp::tool(description = "Return the workspace bound to this MCP session")]
+fn extension_workspace(
+    context: &McpToolContext,
+) -> BoxFuture<'_, Result<Json<serde_json::Value>, ErrorData>> {
+    Box::pin(async move {
+        Ok(Json(serde_json::json!({
+            "workspace": context.workspace().name,
+        })))
+    })
+}
+
+fn extension_options() -> McpOptions {
+    McpOptions {
+        extensions: McpExtensions::default().add_tools(
+            McpToolRouter::new().with_route((extension_workspace_tool_attr(), extension_workspace)),
+        ),
+        ..McpOptions::default()
+    }
+}
 
 fn raw_mcp_request(body: impl Into<Body>) -> Request<Body> {
     Request::builder()
@@ -1092,7 +1112,7 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        McpOptions::default(),
+        extension_options(),
         || async { Ok::<_, tonic::Code>(()) },
     );
     let server = start_authenticated(
@@ -1109,6 +1129,16 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
         .auth_header("token-a"),
     );
     let client = ().serve(transport).await.expect("initialize MCP client");
+    let extension = client
+        .call_tool(CallToolRequestParams::new("extension_workspace"))
+        .await
+        .expect("call authenticated extension tool")
+        .structured_content
+        .expect("extension structured content");
+    assert_eq!(
+        extension.get("workspace"),
+        Some(&serde_json::json!("default"))
+    );
     let sessions = authenticated_sessions(&server);
     let state = Arc::downgrade(&server.state);
     assert_eq!(sessions.upgrade().expect("sessions").len().await, 1);

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -9,6 +9,7 @@ use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::{Router, response::Response};
 use coral_client::{AppClient, local::ServerBuilder};
 use futures::{future::BoxFuture, poll};
+use rmcp::handler::server::router::tool::IntoToolRoute;
 use rmcp::model::{CallToolRequestParams, ClientJsonRpcMessage};
 use rmcp::transport::{
     StreamableHttpClientTransport,
@@ -24,7 +25,7 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpStream;
 use tower::ServiceExt as _;
 
-use crate::{McpExtensions, McpOptions, McpToolContext, McpToolRouter};
+use crate::{McpOptions, McpSurface, McpToolContext};
 
 use super::{
     AUTHENTICATED_SESSION_IDLE_TIMEOUT, AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime,
@@ -45,15 +46,17 @@ fn extension_workspace(
     Box::pin(async move {
         Ok(Json(serde_json::json!({
             "workspace": context.workspace().name,
+            "core_tool_count": context.core_tools().definitions().await?.len(),
         })))
     })
 }
 
 fn extension_options() -> McpOptions {
     McpOptions {
-        extensions: McpExtensions::default().add_tools(
-            McpToolRouter::new().with_route((extension_workspace_tool_attr(), extension_workspace)),
-        ),
+        surface: McpSurface::extend([
+            (extension_workspace_tool_attr(), extension_workspace).into_tool_route()
+        ])
+        .expect("build MCP surface"),
         ..McpOptions::default()
     }
 }
@@ -1155,4 +1158,76 @@ async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
 
     let _cancel_result = client.cancel().await;
     app_server.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn authenticated_extension_uses_its_session_app_client() {
+    let (_live_temp, live_server, live_app) = local_app().await;
+    let (_stopped_temp, stopped_server, stopped_app) = local_app().await;
+    stopped_server
+        .shutdown()
+        .await
+        .expect("stop second app server");
+
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |token| {
+            let app = if token == "token-a" {
+                live_app.clone()
+            } else {
+                stopped_app.clone()
+            };
+            std::future::ready(Ok::<_, ()>(app))
+        },
+        extension_options(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let server = start_authenticated(
+        authenticated_config_at("127.0.0.1:0".parse().unwrap()),
+        runtime,
+    )
+    .await
+    .expect("start authenticated MCP HTTP server");
+    let endpoint = format!("http://{}/mcp", server.local_addr());
+
+    let live_client = ()
+        .serve(StreamableHttpClientTransport::from_config(
+            StreamableHttpClientTransportConfig::with_uri(endpoint.clone()).auth_header("token-a"),
+        ))
+        .await
+        .expect("initialize live MCP session");
+    let stopped_client = ()
+        .serve(StreamableHttpClientTransport::from_config(
+            StreamableHttpClientTransportConfig::with_uri(endpoint).auth_header("token-b"),
+        ))
+        .await
+        .expect("initialize stopped MCP session");
+
+    let live_result = live_client
+        .call_tool(CallToolRequestParams::new("extension_workspace"))
+        .await
+        .expect("live session extension call")
+        .structured_content
+        .expect("live session structured result");
+    assert!(
+        live_result
+            .get("core_tool_count")
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|count| count > 0)
+    );
+    stopped_client
+        .call_tool(CallToolRequestParams::new("extension_workspace"))
+        .await
+        .expect_err("stopped session must use its unavailable app client");
+
+    live_client.cancel().await.expect("cancel live MCP client");
+    stopped_client
+        .cancel()
+        .await
+        .expect("cancel stopped MCP client");
+    server.shutdown().await.expect("shutdown MCP HTTP server");
+    live_server
+        .shutdown()
+        .await
+        .expect("shutdown live app server");
 }

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -12,7 +12,7 @@
 //!   Streamable HTTP, loopback-only unless configuration routed operator
 //!   consent through [`http::McpHttpConfig::allow_unauthenticated_non_loopback`].
 //!
-//! The exposed MCP surface is intentionally small:
+//! The default MCP surface is intentionally small:
 //!
 //! - tools: `start_task`, `sql`, `search`, paginated `list_catalog`,
 //!   `describe`, `list_columns`, `end_task`, and optionally `feedback`
@@ -41,8 +41,10 @@ use coral_client::AppClient;
 use rmcp::ServiceExt;
 
 pub use error::McpError;
+pub(crate) use extensions::McpToolRouter;
 pub use extensions::{
-    McpExtensions, McpExtensionsError, McpExtensionsProvider, McpToolContext, McpToolRouter,
+    McpSurface, McpSurfaceError, McpSurfaceProvider, McpSurfaceProviderError, McpToolContext,
+    McpToolRoute,
 };
 pub(crate) use server::CoralMcpServerFactory;
 pub use server::CoralToolset;
@@ -120,8 +122,8 @@ pub struct McpOptions {
     pub query_examples: Vec<McpQueryExample>,
     /// Workspace scoped to this MCP server instance.
     pub workspace: Option<coral_api::v1::Workspace>,
-    /// Static MCP tool additions and public tool-name projection.
-    pub extensions: McpExtensions,
+    /// Static public MCP tool surface and initialize instructions.
+    pub surface: McpSurface,
 }
 
 /// Runs the `MCP` stdio server using an existing Coral client.
@@ -130,11 +132,8 @@ pub struct McpOptions {
 ///
 /// Returns [`McpError`] if the stdio server cannot complete its `MCP`
 /// lifecycle.
-pub async fn run_stdio_with_client(
-    app: AppClient,
-    mut options: McpOptions,
-) -> Result<(), McpError> {
-    options.extensions.finalize()?;
+pub async fn run_stdio_with_client(app: AppClient, options: McpOptions) -> Result<(), McpError> {
+    options.surface.validate(options.feedback_enabled)?;
     let handler = CoralMcpServerFactory::new(app, options).create();
     let server = Box::pin(handler.serve((tokio::io::stdin(), tokio::io::stdout()))).await?;
     let _ = server.waiting().await?;

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -27,6 +27,7 @@
 )]
 
 mod error;
+mod extensions;
 mod guide_block;
 pub mod http;
 mod server;
@@ -40,7 +41,11 @@ use coral_client::AppClient;
 use rmcp::ServiceExt;
 
 pub use error::McpError;
+pub use extensions::{
+    McpExtensions, McpExtensionsError, McpExtensionsProvider, McpToolContext, McpToolRouter,
+};
 pub(crate) use server::CoralMcpServerFactory;
+pub use server::CoralToolset;
 
 /// A successful SQL query example for MCP initialize instructions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -115,6 +120,8 @@ pub struct McpOptions {
     pub query_examples: Vec<McpQueryExample>,
     /// Workspace scoped to this MCP server instance.
     pub workspace: Option<coral_api::v1::Workspace>,
+    /// Static MCP tool additions and public tool-name projection.
+    pub extensions: McpExtensions,
 }
 
 /// Runs the `MCP` stdio server using an existing Coral client.
@@ -123,7 +130,11 @@ pub struct McpOptions {
 ///
 /// Returns [`McpError`] if the stdio server cannot complete its `MCP`
 /// lifecycle.
-pub async fn run_stdio_with_client(app: AppClient, options: McpOptions) -> Result<(), McpError> {
+pub async fn run_stdio_with_client(
+    app: AppClient,
+    mut options: McpOptions,
+) -> Result<(), McpError> {
+    options.extensions.finalize()?;
     let handler = CoralMcpServerFactory::new(app, options).create();
     let server = Box::pin(handler.serve((tokio::io::stdin(), tokio::io::stdout()))).await?;
     let _ = server.waiting().await?;

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,6 +1,6 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use coral_api::v1::{
     AddFunctionRequest, CatalogItemKind as ProtoCatalogItemKind, DescribeCatalogSurfaceRequest,
@@ -17,10 +17,11 @@ use coral_client::{
 };
 use rmcp::{
     ErrorData, ServerHandler,
+    handler::server::tool::ToolCallContext,
     model::{
         CallToolRequestParams, CallToolResult, Implementation, ListResourcesResult,
         ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult,
-        ResourceContents, ServerCapabilities, ServerInfo,
+        ResourceContents, ServerCapabilities, ServerInfo, Tool,
     },
     service::{RequestContext, RoleServer},
 };
@@ -33,7 +34,7 @@ use tonic::{
 use tracing::Instrument as _;
 
 use crate::{
-    McpOptions, McpQueryExample,
+    McpOptions, McpQueryExample, McpToolContext, McpToolRouter,
     guide_block::GuideBlockState,
     surface::{
         AddFunctionArguments, CatalogToolKind, EndTaskArguments, FeedbackStoredValue,
@@ -276,7 +277,7 @@ impl CoralMcpServerFactory {
     ///
     /// Handlers from this factory share task-scoped guide-block state.
     #[must_use]
-    pub(crate) fn create(&self) -> impl ServerHandler + Clone + use<> {
+    pub(crate) fn create(&self) -> CoralMcpServer {
         CoralMcpServer::new(
             &self.app,
             self.options.clone(),
@@ -285,8 +286,9 @@ impl CoralMcpServerFactory {
     }
 }
 
+/// Session-bound implementation of Coral's built-in MCP tools.
 #[derive(Clone)]
-pub(crate) struct CoralMcpServer {
+pub struct CoralToolset {
     source: SourceClient,
     catalog: CatalogClient,
     query: QueryClient,
@@ -297,6 +299,7 @@ pub(crate) struct CoralMcpServer {
     guide_block: Arc<GuideBlockState>,
     startup_context: McpStartupContext,
     options: McpOptions,
+    retained_tool_names: Option<Arc<BTreeSet<String>>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -337,7 +340,7 @@ impl McpStartupContext {
     }
 }
 
-impl CoralMcpServer {
+impl CoralToolset {
     fn new(app: &AppClient, options: McpOptions, guide_block: Arc<GuideBlockState>) -> Self {
         let startup_context = McpStartupContext::from_options(&options);
         Self::new_with_startup_context(app, options, startup_context, guide_block)
@@ -360,14 +363,20 @@ impl CoralMcpServer {
             guide_block,
             startup_context,
             options,
+            retained_tool_names: None,
         }
     }
 
     fn tool_allowed(&self, tool: ToolName) -> bool {
-        match tool {
+        let feature_allows = match tool {
             ToolName::Feedback => self.options.feedback_enabled,
             _ => true,
-        }
+        };
+        feature_allows
+            && self
+                .retained_tool_names
+                .as_ref()
+                .is_none_or(|names| names.contains(tool.as_str()))
     }
 
     fn workspace(&self) -> coral_api::v1::Workspace {
@@ -375,6 +384,18 @@ impl CoralMcpServer {
             .workspace
             .clone()
             .unwrap_or_else(default_workspace)
+    }
+
+    /// Returns an enforced view containing only the named core tools.
+    #[must_use]
+    pub fn retain(&self, names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let mut retained = names.into_iter().map(Into::into).collect::<BTreeSet<_>>();
+        if let Some(current) = &self.retained_tool_names {
+            retained.retain(|name| current.contains(name));
+        }
+        let mut projected = self.clone();
+        projected.retained_tool_names = Some(Arc::new(retained));
+        projected
     }
 
     async fn load_sources(&self) -> Result<Vec<Source>, tonic::Status> {
@@ -893,86 +914,81 @@ impl CoralMcpServer {
             }),
         }
     }
-}
 
-impl ServerHandler for CoralMcpServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
-            ServerCapabilities::builder()
-                .enable_resources()
-                .enable_tools()
-                .build(),
+    /// Returns the definitions for the tools in this core-tool projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an MCP error when the current catalog description cannot be
+    /// loaded.
+    pub async fn definitions(&self) -> Result<Vec<Tool>, ErrorData> {
+        let (visible_table_count, visible_function_count) = self
+            .load_catalog_counts()
+            .await
+            .map_err(|status| status_to_error_data(&status))?;
+        let source_names = match self.load_sources().await {
+            Ok(sources) => sources.into_iter().map(|source| source.name).collect(),
+            Err(status) => {
+                tracing::warn!(
+                    error = %status,
+                    "failed to load source names for MCP tool descriptions"
+                );
+                Vec::new()
+            }
+        };
+        let tool_context =
+            ToolDescriptionContext::new(visible_table_count, visible_function_count, source_names);
+        Ok(available_tools(
+            &tool_context,
+            ToolAvailability {
+                feedback_enabled: self.options.feedback_enabled,
+                observed_values_search_enabled: self.options.observed_values_search_enabled,
+            },
         )
-        .with_server_info(Implementation::new("coral", env!("CARGO_PKG_VERSION")))
-        .with_instructions(initial_instructions(
-            &self.workspace().name,
-            self.startup_context.source_names(),
-            self.startup_context.query_examples(),
-            self.options.observed_values_search_enabled,
-        ))
-    }
-
-    async fn list_tools(
-        &self,
-        _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ListToolsResult, ErrorData> {
-        let span = telemetry::list_tools_span(self.options.trace_parent.as_deref());
-        telemetry::instrument_protocol(span, async {
-            let (visible_table_count, visible_function_count) = self
-                .load_catalog_counts()
-                .await
-                .map_err(|status| status_to_error_data(&status))?;
-            let source_names = match self.load_sources().await {
-                Ok(sources) => sources.into_iter().map(|source| source.name).collect(),
-                Err(status) => {
-                    tracing::warn!(
-                        error = %status,
-                        "failed to load source names for MCP tool descriptions"
-                    );
-                    Vec::new()
-                }
-            };
-            let tool_context = ToolDescriptionContext::new(
-                visible_table_count,
-                visible_function_count,
-                source_names,
-            );
-            let tools = available_tools(
-                &tool_context,
-                ToolAvailability {
-                    feedback_enabled: self.options.feedback_enabled,
-                    observed_values_search_enabled: self.options.observed_values_search_enabled,
-                },
-            );
-            Ok(ListToolsResult::with_all_items(tools))
+        .into_iter()
+        .filter(|tool| {
+            self.retained_tool_names
+                .as_ref()
+                .is_none_or(|names| names.contains(tool.name.as_ref()))
         })
-        .await
+        .collect())
     }
 
-    async fn call_tool(
-        &self,
-        request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    /// Calls one tool in this core-tool projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns the normal MCP tool error when the tool is hidden, unknown, or
+    /// called with invalid arguments.
+    pub async fn call(&self, request: CallToolRequestParams) -> Result<CallToolResult, ErrorData> {
         let tool_name = request.name.as_ref().parse::<ToolName>().ok();
         let span = telemetry::call_tool_span(
+            tool_name.map_or("", |_| request.name.as_ref()),
             tool_name,
             &self.workspace().name,
             self.options.trace_parent.as_deref(),
         );
+        self.call_with_span(request, tool_name, &span).await
+    }
+
+    async fn call_with_span(
+        &self,
+        request: CallToolRequestParams,
+        tool_name: Option<ToolName>,
+        span: &tracing::Span,
+    ) -> Result<CallToolResult, ErrorData> {
         let inject_task_metadata = !matches!(
             tool_name,
             Some(ToolName::StartTask | ToolName::EndTask | ToolName::Sql)
         );
         let task_context = TaskCallContext::from_tool_request(
             &self.options,
-            tool_name,
+            tool_name.filter(|tool| self.tool_allowed(*tool)),
             request.arguments.as_ref(),
         );
         match task_context {
             Ok(task_context) => {
-                task_context.record_telemetry(&span);
+                task_context.record_telemetry(span);
                 let task_id_metadata = if inject_task_metadata {
                     task_context.task_id_metadata()
                 } else {
@@ -986,10 +1002,102 @@ impl ServerHandler for CoralMcpServer {
                     ),
                 )
                 .await;
-                finish_tool_call(&span, outcome)
+                finish_tool_call(span, outcome)
             }
-            Err(error) => finish_tool_call(&span, Err(error)),
+            Err(error) => finish_tool_call(span, Err(error)),
         }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CoralMcpServer {
+    core_tools: CoralToolset,
+    extension_tools: McpToolRouter,
+    tool_context: McpToolContext,
+}
+
+impl CoralMcpServer {
+    fn new(app: &AppClient, mut options: McpOptions, guide_block: Arc<GuideBlockState>) -> Self {
+        let extensions = std::mem::take(&mut options.extensions);
+        let core_tools = CoralToolset::new(app, options, guide_block);
+        let tool_context = McpToolContext::new(core_tools.clone(), core_tools.workspace());
+        let public_core_tools = extensions.retained_tool_names().map_or_else(
+            || core_tools.clone(),
+            |names| core_tools.retain(names.clone()),
+        );
+        Self {
+            core_tools: public_core_tools,
+            extension_tools: extensions.added_tools().clone(),
+            tool_context,
+        }
+    }
+}
+
+impl ServerHandler for CoralMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_resources()
+                .enable_tools()
+                .build(),
+        )
+        .with_server_info(Implementation::new("coral", env!("CARGO_PKG_VERSION")))
+        .with_instructions(initial_instructions(
+            &self.core_tools.workspace().name,
+            self.core_tools.startup_context.source_names(),
+            self.core_tools.startup_context.query_examples(),
+            self.core_tools.options.observed_values_search_enabled,
+        ))
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let span = telemetry::list_tools_span(self.core_tools.options.trace_parent.as_deref());
+        telemetry::instrument_protocol(span, async {
+            let mut tools = self.core_tools.definitions().await?;
+            tools.extend(self.extension_tools.list_all());
+            Ok(ListToolsResult::with_all_items(tools))
+        })
+        .await
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let tool_name = request.name.as_ref().parse::<ToolName>().ok();
+        let requested_tool_name =
+            if tool_name.is_some() || self.extension_tools.has_route(request.name.as_ref()) {
+                request.name.as_ref()
+            } else {
+                ""
+            };
+        let span = telemetry::call_tool_span(
+            requested_tool_name,
+            tool_name,
+            &self.core_tools.workspace().name,
+            self.core_tools.options.trace_parent.as_deref(),
+        );
+        if tool_name.is_some_and(|tool| self.core_tools.tool_allowed(tool)) {
+            return self
+                .core_tools
+                .call_with_span(request, tool_name, &span)
+                .await;
+        }
+        if self.extension_tools.has_route(request.name.as_ref()) {
+            let tool_context = ToolCallContext::new(&self.tool_context, request, context);
+            let result =
+                telemetry::instrument(span.clone(), self.extension_tools.call(tool_context)).await;
+            telemetry::record_protocol_result(&span, &result);
+            return result;
+        }
+        let error = ErrorData::invalid_params(format!("tool '{}' not found", request.name), None);
+        telemetry::record_protocol_error(&span, &error);
+        Err(error)
     }
 
     async fn list_resources(
@@ -997,9 +1105,10 @@ impl ServerHandler for CoralMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
-        let span = telemetry::list_resources_span(self.options.trace_parent.as_deref());
+        let span = telemetry::list_resources_span(self.core_tools.options.trace_parent.as_deref());
         telemetry::instrument_protocol(span, async {
             let (sources, visible_table_count, visible_function_count) = self
+                .core_tools
                 .load_sources_and_catalog_counts()
                 .await
                 .map_err(|status| status_to_error_data(&status))?;
@@ -1018,12 +1127,13 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<ReadResourceResult, ErrorData> {
         let span = telemetry::read_resource_span(
             request.uri.as_str(),
-            self.options.trace_parent.as_deref(),
+            self.core_tools.options.trace_parent.as_deref(),
         );
         telemetry::instrument_protocol(span, async {
             match request.uri.as_str() {
                 "coral://guide" => {
                     let (sources, tables, table_function_schema_names) = self
+                        .core_tools
                         .load_sources_and_guide_catalog()
                         .await
                         .map_err(|status| status_to_error_data(&status))?;
@@ -1033,7 +1143,7 @@ impl ServerHandler for CoralMcpServer {
                                 &sources,
                                 &tables,
                                 &table_function_schema_names,
-                                self.options.observed_values_search_enabled,
+                                self.core_tools.options.observed_values_search_enabled,
                             ),
                             request.uri,
                         )
@@ -1042,6 +1152,7 @@ impl ServerHandler for CoralMcpServer {
                 }
                 "coral://tables" => {
                     let tables = self
+                        .core_tools
                         .load_all_table_summaries()
                         .await
                         .map_err(|status| status_to_error_data(&status))?;
@@ -1303,7 +1414,8 @@ mod tool_call_telemetry_tests {
         let Err(error) = list_catalog_arguments(Some(&arguments)) else {
             panic!("unknown list_catalog kind should fail argument parsing");
         };
-        let span = telemetry::call_tool_span(Some(ToolName::ListCatalog), "default", None);
+        let span =
+            telemetry::call_tool_span("list_catalog", Some(ToolName::ListCatalog), "default", None);
         let returned = finish_tool_call(&span, Err(error))
             .expect_err("invalid list_catalog kind should remain a caller-visible protocol error");
         assert!(returned.message.contains(sentinel));

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -35,6 +35,7 @@ use tracing::Instrument as _;
 
 use crate::{
     McpOptions, McpQueryExample, McpToolContext, McpToolRouter,
+    extensions::InitializeInstructions,
     guide_block::GuideBlockState,
     surface::{
         AddFunctionArguments, CatalogToolKind, EndTaskArguments, FeedbackStoredValue,
@@ -922,6 +923,13 @@ impl CoralToolset {
     /// Returns an MCP error when the current catalog description cannot be
     /// loaded.
     pub async fn definitions(&self) -> Result<Vec<Tool>, ErrorData> {
+        if self
+            .retained_tool_names
+            .as_ref()
+            .is_some_and(|names| names.is_empty())
+        {
+            return Ok(Vec::new());
+        }
         let (visible_table_count, visible_function_count) = self
             .load_catalog_counts()
             .await
@@ -1014,40 +1022,48 @@ pub(crate) struct CoralMcpServer {
     core_tools: CoralToolset,
     extension_tools: McpToolRouter,
     tool_context: McpToolContext,
+    initialize_instructions: InitializeInstructions,
 }
 
 impl CoralMcpServer {
-    fn new(app: &AppClient, mut options: McpOptions, guide_block: Arc<GuideBlockState>) -> Self {
-        let extensions = std::mem::take(&mut options.extensions);
+    fn new(app: &AppClient, options: McpOptions, guide_block: Arc<GuideBlockState>) -> Self {
+        let surface = options.surface.clone();
         let core_tools = CoralToolset::new(app, options, guide_block);
         let tool_context = McpToolContext::new(core_tools.clone(), core_tools.workspace());
-        let public_core_tools = extensions.retained_tool_names().map_or_else(
+        let public_core_tools = surface.public_core_tool_names().map_or_else(
             || core_tools.clone(),
             |names| core_tools.retain(names.clone()),
         );
         Self {
             core_tools: public_core_tools,
-            extension_tools: extensions.added_tools().clone(),
+            extension_tools: surface.extension_tools().clone(),
             tool_context,
+            initialize_instructions: surface.initialize_instructions().clone(),
         }
     }
 }
 
 impl ServerHandler for CoralMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(
+        let info = ServerInfo::new(
             ServerCapabilities::builder()
                 .enable_resources()
                 .enable_tools()
                 .build(),
         )
-        .with_server_info(Implementation::new("coral", env!("CARGO_PKG_VERSION")))
-        .with_instructions(initial_instructions(
-            &self.core_tools.workspace().name,
-            self.core_tools.startup_context.source_names(),
-            self.core_tools.startup_context.query_examples(),
-            self.core_tools.options.observed_values_search_enabled,
-        ))
+        .with_server_info(Implementation::new("coral", env!("CARGO_PKG_VERSION")));
+        match &self.initialize_instructions {
+            InitializeInstructions::CoralDefault => info.with_instructions(initial_instructions(
+                &self.core_tools.workspace().name,
+                self.core_tools.startup_context.source_names(),
+                self.core_tools.startup_context.query_examples(),
+                self.core_tools.options.observed_values_search_enabled,
+            )),
+            InitializeInstructions::Replace(Some(instructions)) => {
+                info.with_instructions(instructions.clone())
+            }
+            InitializeInstructions::Replace(None) => info,
+        }
     }
 
     async fn list_tools(
@@ -1092,7 +1108,7 @@ impl ServerHandler for CoralMcpServer {
             let tool_context = ToolCallContext::new(&self.tool_context, request, context);
             let result =
                 telemetry::instrument(span.clone(), self.extension_tools.call(tool_context)).await;
-            telemetry::record_protocol_result(&span, &result);
+            telemetry::record_tool_result(&span, &result);
             return result;
         }
         let error = ErrorData::invalid_params(format!("tool '{}' not found", request.name), None);

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -254,13 +254,13 @@ mod tests {
         let (exporter, provider, subscriber) = telemetry_fixture();
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        for tool_name in [
-            Some(ToolName::Sql),
-            Some(ToolName::Search),
-            Some(ToolName::ListCatalog),
-            None,
+        for (requested_tool_name, tool_name) in [
+            ("sql", Some(ToolName::Sql)),
+            ("search", Some(ToolName::Search)),
+            ("list_catalog", Some(ToolName::ListCatalog)),
+            (UNKNOWN_TOOL_NAME, None),
+            ("extension_tool", None),
         ] {
-            let requested_tool_name = tool_name.map_or(UNKNOWN_TOOL_NAME, ToolName::as_str);
             let span = call_tool_span(requested_tool_name, tool_name, "alpha", None);
             span.in_scope(|| {});
         }
@@ -272,6 +272,7 @@ mod tests {
             ("search", coral_telemetry::QUERY_STREAM_KIND_SEARCH),
             ("list_catalog", coral_telemetry::QUERY_STREAM_KIND_TOOL),
             (UNKNOWN_TOOL_NAME, coral_telemetry::QUERY_STREAM_KIND_TOOL),
+            ("extension_tool", coral_telemetry::QUERY_STREAM_KIND_TOOL),
         ];
         for (tool_name, expected_kind) in expected {
             let tool_call = spans
@@ -292,6 +293,10 @@ mod tests {
             assert_eq!(
                 string_attribute(tool_call, "mcp.method").as_deref(),
                 Some("tools/call")
+            );
+            assert_eq!(
+                string_attribute(tool_call, "mcp.tool.name").as_deref(),
+                Some(tool_name)
             );
         }
 

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -51,12 +51,17 @@ pub(crate) fn list_tools_span(trace_parent: Option<&str>) -> tracing::Span {
 }
 
 pub(crate) fn call_tool_span(
+    requested_tool_name: &str,
     tool_name: Option<ToolName>,
     workspace: &str,
     trace_parent: Option<&str>,
 ) -> tracing::Span {
     let operation_kind = query_stream_kind_for_tool(tool_name);
-    let tool_name = tool_name.map_or(UNKNOWN_TOOL_NAME, ToolName::as_str);
+    let tool_name = if requested_tool_name.is_empty() {
+        UNKNOWN_TOOL_NAME
+    } else {
+        requested_tool_name
+    };
     let span = tracing::info_span!(
         target: "coral_mcp::server",
         "coral.mcp.call_tool",
@@ -202,7 +207,7 @@ mod tests {
         let (exporter, provider, subscriber) = telemetry_fixture();
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let span = call_tool_span(Some(ToolName::ListCatalog), "alpha", None);
+        let span = call_tool_span("list_catalog", Some(ToolName::ListCatalog), "alpha", None);
         span.in_scope(|| {});
         drop(span);
 
@@ -255,7 +260,8 @@ mod tests {
             Some(ToolName::ListCatalog),
             None,
         ] {
-            let span = call_tool_span(tool_name, "alpha", None);
+            let requested_tool_name = tool_name.map_or(UNKNOWN_TOOL_NAME, ToolName::as_str);
+            let span = call_tool_span(requested_tool_name, tool_name, "alpha", None);
             span.in_scope(|| {});
         }
 
@@ -298,7 +304,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
         let sentinel = "SENSITIVE_TONIC_ERROR_MARKER";
 
-        let span = call_tool_span(Some(ToolName::ListCatalog), "default", None);
+        let span = call_tool_span("list_catalog", Some(ToolName::ListCatalog), "default", None);
         record_tonic_status(
             &span,
             &tonic::Status::invalid_argument(format!("invalid kind: {sentinel}")),
@@ -345,7 +351,7 @@ mod tests {
             ))],
         );
 
-        let span = call_tool_span(Some(ToolName::ListCatalog), "default", None);
+        let span = call_tool_span("list_catalog", Some(ToolName::ListCatalog), "default", None);
         record_tonic_status(&span, &status);
         drop(span);
 

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -6,7 +6,10 @@ use coral_api::grpc_response_status_code;
 use coral_client::{DecodedStatusError, decode_status_error};
 use coral_telemetry::record_failure;
 use opentelemetry::trace::Status as OtelStatus;
-use rmcp::{ErrorData, model::ErrorCode};
+use rmcp::{
+    ErrorData,
+    model::{CallToolResult, ErrorCode},
+};
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -142,6 +145,16 @@ pub(crate) fn record_protocol_result<T>(span: &tracing::Span, result: &Result<T,
     }
 }
 
+pub(crate) fn record_tool_result(span: &tracing::Span, result: &Result<CallToolResult, ErrorData>) {
+    match result {
+        Ok(result) if result.is_error == Some(true) => {
+            record_failure(span, "MCP_TOOL_ERROR", MCP_TOOL_ERROR_MESSAGE);
+        }
+        Ok(_) => record_success(span),
+        Err(error) => record_protocol_error(span, error),
+    }
+}
+
 pub(crate) fn record_protocol_error(span: &tracing::Span, error: &ErrorData) {
     record_failure(span, mcp_error_type(error.code), MCP_PROTOCOL_ERROR_MESSAGE);
 }
@@ -198,7 +211,7 @@ mod tests {
 
     use super::{
         MCP_TOOL_ERROR_MESSAGE, UNKNOWN_TOOL_NAME, call_tool_span, list_resources_span,
-        list_tools_span, read_resource_span, record_tonic_status,
+        list_tools_span, read_resource_span, record_tonic_status, record_tool_result,
     };
     use crate::surface::ToolName;
 
@@ -333,6 +346,35 @@ mod tests {
         );
         assert_eq!(tool_call.status, OtelStatus::error(MCP_TOOL_ERROR_MESSAGE));
         assert!(!format!("{tool_call:?}").contains(sentinel));
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn structured_extension_error_marks_the_tool_span_as_failed() {
+        let (exporter, provider, subscriber) = telemetry_fixture();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = call_tool_span("extension_tool", None, "default", None);
+        record_tool_result(
+            &span,
+            &Ok(rmcp::model::CallToolResult::structured_error(
+                serde_json::json!({"message": "failed"}),
+            )),
+        );
+        drop(span);
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let tool_call = spans
+            .iter()
+            .find(|span| span.name == "coral.mcp.call_tool")
+            .expect("tool call span");
+        assert_eq!(
+            string_attribute(tool_call, "error.type"),
+            Some("MCP_TOOL_ERROR".to_string())
+        );
+        assert_eq!(tool_call.status, OtelStatus::error(MCP_TOOL_ERROR_MESSAGE));
 
         provider.shutdown().expect("provider shutdown");
     }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -4,10 +4,8 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use coral_api::v1::{ImportSourceRequest, Workspace, import_source_response};
 use coral_client::{
@@ -20,7 +18,7 @@ use opentelemetry::trace::{SpanId, SpanKind, TracerProvider as _};
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
 use rmcp::{
     ErrorData, Json, RoleClient, ServerHandler, ServiceExt,
-    handler::server::router::tool::ToolRouter,
+    handler::server::router::tool::IntoToolRoute,
     model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, Tool},
     service::RunningService,
 };
@@ -32,8 +30,7 @@ use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt as _;
 
 use crate::{
-    CoralMcpServerFactory, McpExtensions, McpExtensionsError, McpExtensionsProvider, McpOptions,
-    McpToolContext,
+    CoralMcpServerFactory, McpOptions, McpSurface, McpSurfaceError, McpToolContext, McpToolRoute,
     telemetry::{MCP_PROTOCOL_ERROR_MESSAGE, UNKNOWN_TOOL_NAME},
 };
 
@@ -82,58 +79,38 @@ fn core_probe(context: &McpToolContext) -> BoxFuture<'_, Result<Json<Value>, Err
     })
 }
 
-#[derive(Clone)]
-struct StaticMcpExtensionsProvider(McpExtensions);
-
-impl McpExtensionsProvider for StaticMcpExtensionsProvider {
-    fn extensions(&self) -> McpExtensions {
-        self.0.clone()
-    }
+fn core_probe_surface() -> McpSurface {
+    McpSurface::replace(
+        [core_probe_route("core_probe")],
+        std::iter::empty::<String>(),
+        Some("Use `core_probe` for Coral work.".to_string()),
+    )
+    .expect("build MCP surface")
 }
 
-fn core_probe_extensions() -> McpExtensions {
-    let router = core_probe_router("core_probe");
-    McpExtensions::default()
-        .add_tools(router)
-        .retain_tools(["core_probe"])
-}
-
-fn core_probe_router(name: &'static str) -> ToolRouter<McpToolContext> {
+fn core_probe_route(name: &'static str) -> McpToolRoute {
     let mut tool = core_probe_tool_attr();
     tool.name = name.into();
-    ToolRouter::new().with_route((tool, core_probe))
-}
-
-fn extension_provider(extensions: McpExtensions) -> Arc<dyn McpExtensionsProvider> {
-    Arc::new(StaticMcpExtensionsProvider(extensions))
+    (tool, core_probe).into_tool_route()
 }
 
 #[test]
-fn extension_registry_rejects_collisions_and_intersects_retain_sets() {
-    let first = extension_provider(McpExtensions::default().retain_tools(["a", "b"]));
-    let second = extension_provider(McpExtensions::default().retain_tools(["b", "c"]));
-    for providers in [
-        vec![Arc::clone(&first), Arc::clone(&second)],
-        vec![Arc::clone(&second), Arc::clone(&first)],
-    ] {
-        let merged = McpExtensions::from_providers(&providers).expect("merge extensions");
-        assert_eq!(
-            merged.retained_tool_names(),
-            Some(&BTreeSet::from(["b".to_string()]))
-        );
-    }
-
-    let reserved = extension_provider(McpExtensions::default().add_tools(core_probe_router("sql")));
+fn mcp_surface_rejects_invalid_names_and_duplicates() {
     assert!(matches!(
-        McpExtensions::from_providers(&[reserved]),
-        Err(McpExtensionsError::ReservedToolName(name)) if name == "sql"
+        McpSurface::extend([core_probe_route("sql")]),
+        Err(McpSurfaceError::ReservedToolName(name)) if name == "sql"
     ));
-
-    let duplicate =
-        || extension_provider(McpExtensions::default().add_tools(core_probe_router("extra")));
     assert!(matches!(
-        McpExtensions::from_providers(&[duplicate(), duplicate()]),
-        Err(McpExtensionsError::DuplicateToolName(name)) if name == "extra"
+        McpSurface::extend([core_probe_route("extra"), core_probe_route("extra")]),
+        Err(McpSurfaceError::DuplicateToolName(name)) if name == "extra"
+    ));
+    assert!(matches!(
+        McpSurface::replace(
+            std::iter::empty::<McpToolRoute>(),
+            ["not_a_core_tool"],
+            None,
+        ),
+        Err(McpSurfaceError::UnknownCoreToolName(name)) if name == "not_a_core_tool"
     ));
 }
 
@@ -455,11 +432,10 @@ async fn start_mcp_session(
 #[tokio::test]
 async fn extension_surface_filters_public_tools_but_keeps_session_core_tools() {
     let temp = TempDir::new().expect("temp dir");
-    let provider = extension_provider(core_probe_extensions());
     let session = start_session_with_options(
         &temp,
         McpOptions {
-            extensions: McpExtensions::from_providers(&[provider]).expect("merge extensions"),
+            surface: core_probe_surface(),
             ..McpOptions::default()
         },
     )
@@ -479,6 +455,16 @@ async fn extension_surface_filters_public_tools_but_keeps_session_core_tools() {
         .await
         .expect_err("hidden core tool should not be callable");
     assert!(hidden.to_string().contains("tool 'sql' not found"));
+
+    assert_eq!(
+        session
+            .client
+            .peer_info()
+            .expect("initialize result")
+            .instructions
+            .as_deref(),
+        Some("Use `core_probe` for Coral work.")
+    );
 
     let result = session
         .client

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -4,19 +4,23 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use coral_api::v1::{ImportSourceRequest, Workspace, import_source_response};
 use coral_client::{
     AppClient, SourceClient, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
+use futures::future::BoxFuture;
 use jsonschema::Validator;
 use opentelemetry::trace::{SpanId, SpanKind, TracerProvider as _};
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
 use rmcp::{
-    RoleClient, ServerHandler, ServiceExt,
+    ErrorData, Json, RoleClient, ServerHandler, ServiceExt,
+    handler::server::router::tool::ToolRouter,
     model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, Tool},
     service::RunningService,
 };
@@ -28,11 +32,110 @@ use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt as _;
 
 use crate::{
-    CoralMcpServerFactory, McpOptions,
+    CoralMcpServerFactory, McpExtensions, McpExtensionsError, McpExtensionsProvider, McpOptions,
+    McpToolContext,
     telemetry::{MCP_PROTOCOL_ERROR_MESSAGE, UNKNOWN_TOOL_NAME},
 };
 
 type McpServerTask = tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>;
+
+#[rmcp::tool(description = "Prove that an extension can use its session-bound core Coral tools")]
+fn core_probe(context: &McpToolContext) -> BoxFuture<'_, Result<Json<Value>, ErrorData>> {
+    Box::pin(async move {
+        let inner_tools = context.core_tools().retain(["start_task", "sql"]);
+        let core_tool_names = inner_tools
+            .definitions()
+            .await?
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .collect::<Vec<_>>();
+        let started = inner_tools
+            .call(
+                CallToolRequestParams::new("start_task").with_arguments(raw_json_object(&json!({
+                    "intent": "Test the session-bound core tool set"
+                }))),
+            )
+            .await?
+            .structured_content
+            .ok_or_else(|| ErrorData::internal_error("start_task returned no content", None))?;
+        let task_id = started["task_id"]
+            .as_str()
+            .ok_or_else(|| ErrorData::internal_error("start_task returned no task id", None))?;
+        let query = inner_tools
+            .call(
+                CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                    task_id,
+                    &json!({"queries": ["select 7 as value"]}),
+                )),
+            )
+            .await?
+            .structured_content
+            .ok_or_else(|| ErrorData::internal_error("sql returned no content", None))?;
+        let query_value = query["results"][0]["rows"][0]["value"]
+            .as_str()
+            .ok_or_else(|| ErrorData::internal_error("sql returned no value", None))?
+            .to_string();
+        Ok(Json(json!({
+            "core_tool_names": core_tool_names,
+            "query_value": query_value,
+        })))
+    })
+}
+
+#[derive(Clone)]
+struct StaticMcpExtensionsProvider(McpExtensions);
+
+impl McpExtensionsProvider for StaticMcpExtensionsProvider {
+    fn extensions(&self) -> McpExtensions {
+        self.0.clone()
+    }
+}
+
+fn core_probe_extensions() -> McpExtensions {
+    let router = core_probe_router("core_probe");
+    McpExtensions::default()
+        .add_tools(router)
+        .retain_tools(["core_probe"])
+}
+
+fn core_probe_router(name: &'static str) -> ToolRouter<McpToolContext> {
+    let mut tool = core_probe_tool_attr();
+    tool.name = name.into();
+    ToolRouter::new().with_route((tool, core_probe))
+}
+
+fn extension_provider(extensions: McpExtensions) -> Arc<dyn McpExtensionsProvider> {
+    Arc::new(StaticMcpExtensionsProvider(extensions))
+}
+
+#[test]
+fn extension_registry_rejects_collisions_and_intersects_retain_sets() {
+    let first = extension_provider(McpExtensions::default().retain_tools(["a", "b"]));
+    let second = extension_provider(McpExtensions::default().retain_tools(["b", "c"]));
+    for providers in [
+        vec![Arc::clone(&first), Arc::clone(&second)],
+        vec![Arc::clone(&second), Arc::clone(&first)],
+    ] {
+        let merged = McpExtensions::from_providers(&providers).expect("merge extensions");
+        assert_eq!(
+            merged.retained_tool_names(),
+            Some(&BTreeSet::from(["b".to_string()]))
+        );
+    }
+
+    let reserved = extension_provider(McpExtensions::default().add_tools(core_probe_router("sql")));
+    assert!(matches!(
+        McpExtensions::from_providers(&[reserved]),
+        Err(McpExtensionsError::ReservedToolName(name)) if name == "sql"
+    ));
+
+    let duplicate =
+        || extension_provider(McpExtensions::default().add_tools(core_probe_router("extra")));
+    assert!(matches!(
+        McpExtensions::from_providers(&[duplicate(), duplicate()]),
+        Err(McpExtensionsError::DuplicateToolName(name)) if name == "extra"
+    ));
+}
 
 fn span_string_attribute(span: &SpanData, name: &str) -> Option<String> {
     span.attributes
@@ -347,6 +450,52 @@ async fn start_mcp_session(
     });
     let client = ().serve(client_transport).await.expect("start rmcp client");
     (client, mcp_server_task)
+}
+
+#[tokio::test]
+async fn extension_surface_filters_public_tools_but_keeps_session_core_tools() {
+    let temp = TempDir::new().expect("temp dir");
+    let provider = extension_provider(core_probe_extensions());
+    let session = start_session_with_options(
+        &temp,
+        McpOptions {
+            extensions: McpExtensions::from_providers(&[provider]).expect("merge extensions"),
+            ..McpOptions::default()
+        },
+    )
+    .await;
+
+    let tools = session.client.list_all_tools().await.expect("list tools");
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["core_probe"]
+    );
+    let hidden = session
+        .client
+        .call_tool(CallToolRequestParams::new("sql"))
+        .await
+        .expect_err("hidden core tool should not be callable");
+    assert!(hidden.to_string().contains("tool 'sql' not found"));
+
+    let result = session
+        .client
+        .call_tool(CallToolRequestParams::new("core_probe"))
+        .await
+        .expect("call extension tool")
+        .structured_content
+        .expect("extension structured result");
+    assert_eq!(result["query_value"], "7");
+    let core_names = result["core_tool_names"]
+        .as_array()
+        .expect("core tool names");
+    assert!(core_names.iter().any(|name| name == "start_task"));
+    assert!(core_names.iter().any(|name| name == "sql"));
+    assert!(!core_names.iter().any(|name| name == "core_probe"));
+
+    session.shutdown().await;
 }
 
 async fn shutdown_mcp_session(client: RunningService<RoleClient, ()>, task: McpServerTask) {


### PR DESCRIPTION
## Intent

Let a sibling Coral binary supply typed startup extensions while `coral-cli` keeps command parsing, command routing, server startup, transport lifecycle, and shutdown.

For MCP, one host owns one final startup surface. This supports a complete replacement such as one Cloud tool, without a second MCP server or a raw bearer-token seam.

## What Changed

- Added `CoralExtensions` and `run_from_env_with_extensions` in `coral-cli`.
- Kept `run_from_env` as the compatible default entry point.
- Added one optional, lazy `McpSurfaceProvider` to `CoralExtensions`.
- Added `McpSurface` with two composition choices:
  - `extend(routes)` keeps all OSS core tools and current initialize instructions, then adds host routes.
  - `replace(routes, core_names, instructions)` exposes all supplied host routes, exactly the named core tools, and the supplied initialize instructions. `None` omits initialize instructions.
- Accepts individual RMCP `ToolRoute<McpToolContext>` values, so Coral rejects duplicate extension names before RMCP can replace an existing route.
- Rejects reserved core names, unknown core names, unavailable optional core names, and duplicate host routes before the MCP listener starts.
- Extracted the existing built-in definitions and dispatch into a session-bound `CoralToolset`.
- Added `McpToolContext`, which gives a host tool the selected workspace and exact session-bound core tool set.
- Applied the same surface to MCP stdio, authentication-disabled HTTP, and authenticated HTTP.
- Forwarded supplied engine providers to every local `ServerBuilder` after the existing OSS provider setup.
- Fixed extension-only discovery so an empty public core projection does not make hidden catalog RPCs.
- Records an extension `CallToolResult` with `is_error: true` as failed telemetry.

## Surface Rules

- The provider is evaluated once, only when an MCP runtime is selected.
- The resolved surface is fixed for the MCP runtime lifetime.
- Built-in names stay reserved even when a replacement surface hides them.
- Hidden core tools are absent from `list_tools` and return the normal tool-not-found error from `call_tool`.
- `McpToolContext::core_tools()` contains only built-in Coral tools. It does not contain extension routes or the public core projection, so a host tool cannot recurse through itself.
- Authenticated HTTP builds each context from that session bearer-bound `AppClient`. The host does not receive the bearer token.

## Ownership / Boundaries

- `coral-cli` still owns all CLI and server lifecycle behavior. `serve.rs` stays private.
- `coral-mcp` owns MCP surface validation and dispatch.
- There is no new protobuf RPC, app manager interface, engine interface, dependency, transport abstraction, Cloud type, Tide type, or product mode.
- MCP resources and guides remain unchanged in this change. The new replacement controls tools and initialize instructions only.
- Contributor guidance now states that sibling binaries use one lazy MCP surface provider and that CLI lifecycle ownership stays in `coral-cli`.

## Compatibility

- `CoralExtensions::default()` preserves the current OSS MCP tools, instructions, AWS engine provider, CLI behavior, and server behavior.
- `--help` and unrelated commands do not evaluate the optional MCP provider.
- There are no CLI flag, persisted-data, protobuf, or user documentation changes.

## Validation

- `cargo test -p coral-mcp --all-features`
- `cargo test -p coral-cli --all-features`
- `cargo clippy -p coral-mcp -p coral-cli --all-targets --all-features -- -D warnings`
- `make rust-checks`
  - 2,687 tests passed; 13 skipped.
- `make perf-check`
  - `coral.tables` mean: 216 ms against the 750 ms limit.
- `git diff --check`

Focused coverage includes default compatibility, exact replacement discovery and dispatch, replacement initialize instructions, hidden core calls, duplicate and reserved-name rejection, private core projection, a real constant SQL query through `CoralToolset`, authenticated per-session `AppClient` selection, shared HTTP propagation, disabled-MCP lazy resolution, engine-provider forwarding order, and extension error telemetry.