### PR TITLE
refactor(search): add a dual-backend storage seam

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,6 +53,7 @@ use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
+use crate::search::store::SearchStorage;
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
@@ -354,14 +355,12 @@ impl ServerBuilder {
         let (telemetry_config, active_trace_store) =
             init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
-        let credential_config = CredentialStorageConfig::load(&layout)?;
-        let credential_store =
-            CredentialStore::with_preference(layout.clone(), credential_config.storage);
-        let credential_manager = CredentialManager::new(credential_store);
+        let credential_manager = init_credential_manager(&layout)?;
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let workspace_pool_registry = Arc::new(WorkspacePoolRegistry::default());
         let diagnostic_reporter = SourceDiagnosticReporter::default();
         let database_sources_enabled = features.enabled(Feature::DatabaseSources);
+        let search_storage = SearchStorage::sqlite(layout.clone());
         let source_manager = SourceManager::with_diagnostic_reporter(
             config_store.clone(),
             credential_manager.clone(),
@@ -370,7 +369,8 @@ impl ServerBuilder {
             diagnostic_reporter.clone(),
         )
         .with_pool_registry(Arc::clone(&workspace_pool_registry))
-        .with_database_sources_enabled(database_sources_enabled);
+        .with_database_sources_enabled(database_sources_enabled)
+        .with_search_storage(search_storage.clone());
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
@@ -409,6 +409,7 @@ impl ServerBuilder {
         let search_observations =
             observed_values_search_enabled.then(|| SearchObservationHandle::new(layout.clone()));
         let search_manager = SearchManager::with_diagnostic_reporter(
+            search_storage,
             layout,
             &config_store,
             workspace_manager.clone(),
@@ -477,6 +478,13 @@ fn trace_components_for_store(
             ))),
         }
     })
+}
+
+fn init_credential_manager(layout: &AppStateLayout) -> Result<CredentialManager, AppError> {
+    let credential_config = CredentialStorageConfig::load(layout)?;
+    let credential_store =
+        CredentialStore::with_preference(layout.clone(), credential_config.storage);
+    Ok(CredentialManager::new(credential_store))
 }
 
 async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {

--- a/crates/coral-app/src/search/catalog/index.rs
+++ b/crates/coral-app/src/search/catalog/index.rs
@@ -1,0 +1,178 @@
+//! Backend-neutral catalog projection types and index semantics.
+//!
+//! Every search backend stores the same projection documents and answers the
+//! same retrieval questions. The types here are the contract both sides of the
+//! storage seam share; the term normalization and searchable-text composition
+//! define what "matches" means independently of the engine that indexes it.
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogIndexSnapshot {
+    pub(crate) documents: Vec<CatalogIndexDocument>,
+    pub(crate) fingerprint: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogIndexDocument {
+    pub(crate) doc_id: String,
+    pub(crate) doc_kind: CatalogIndexDocumentKind,
+    pub(crate) source_name: String,
+    pub(crate) catalog_name: Option<String>,
+    pub(crate) surface_kind: String,
+    pub(crate) surface_name: String,
+    pub(crate) field_name: String,
+    pub(crate) field_role: String,
+    pub(crate) qualified_name: String,
+    pub(crate) title: String,
+    pub(crate) description: String,
+    pub(crate) searchable_text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogIndexDocumentKind {
+    CatalogTable,
+    CatalogTableFunction,
+    ColumnHint,
+}
+
+impl CatalogIndexDocumentKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::CatalogTable => "catalog_table",
+            Self::CatalogTableFunction => "catalog_table_function",
+            Self::ColumnHint => "column_hint",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogRefreshResult {
+    pub(crate) refreshed: bool,
+    pub(crate) document_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogRebuildResult {
+    pub(crate) old_document_count: u32,
+    pub(crate) new_document_count: u32,
+    pub(crate) projection_changed: bool,
+    pub(crate) rebuild_performed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogClearResult {
+    pub(crate) deleted_document_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogSearchHits {
+    pub(crate) hits: Vec<CatalogSearchHit>,
+    /// Whether the candidate window cut the result short. Surfaced so callers
+    /// can report `has_more` rather than implying the index held nothing else.
+    pub(crate) retrieval_limited: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogSearchHit {
+    /// Storage identity of the matched document. Retrieval keys on the entry
+    /// it resolves to, so this is carried for diagnostics rather than ranking.
+    #[cfg_attr(not(test), expect(dead_code, reason = "read by index tests only"))]
+    pub(crate) doc_id: String,
+    pub(crate) source_name: String,
+    pub(crate) catalog_name: Option<String>,
+    pub(crate) surface_kind: String,
+    pub(crate) surface_name: String,
+    pub(crate) field_name: String,
+    pub(crate) field_role: String,
+}
+
+/// Which population of documents a retriever is asking for.
+///
+/// Entry documents and field documents share an index, but not a candidate
+/// window. Measured: in a 50-document window over one shared list, 45 slots go
+/// to field documents and only 7 distinct entries survive — wide tables crowd
+/// everything else out. Separate windows are what keep entry recall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogDocumentClass {
+    Entries,
+    Fields,
+}
+
+impl CatalogDocumentClass {
+    /// Fixed SQL fragment over the `d` alias of `catalog_documents` — never
+    /// built from caller input. Both backends share the vocabulary.
+    pub(crate) fn doc_kind_predicate(self) -> &'static str {
+        match self {
+            Self::Entries => "d.doc_kind IN ('catalog_table', 'catalog_table_function')",
+            Self::Fields => "d.doc_kind = 'column_hint'",
+        }
+    }
+}
+
+/// Lowercases, trims, and de-duplicates query terms, adding the compact
+/// identifier variant of each term so `deploy_url` and `deployurl` meet.
+pub(crate) fn normalized_search_terms(terms: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for term in terms {
+        let term = term.trim().to_lowercase();
+        if term.is_empty() {
+            continue;
+        }
+        push_search_term(&mut normalized, term.clone());
+        if let Some(compact) = compact_identifier_variant(&term) {
+            push_search_term(&mut normalized, compact);
+        }
+    }
+    normalized
+}
+
+fn push_search_term(terms: &mut Vec<String>, term: String) {
+    if !terms.iter().any(|existing| existing == &term) {
+        terms.push(term);
+    }
+}
+
+/// The text a backend indexes as the document's searchable body: the
+/// snapshot's searchable text plus compact identifier variants of every name.
+pub(crate) fn indexed_searchable_text(document: &CatalogIndexDocument) -> String {
+    let mut parts = vec![document.searchable_text.clone()];
+    for value in [
+        document.source_name.as_str(),
+        document.surface_name.as_str(),
+        document.field_name.as_str(),
+        document.qualified_name.as_str(),
+        document.title.as_str(),
+    ] {
+        if let Some(compact) = compact_identifier_variant(value) {
+            parts.push(compact);
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn compact_identifier_variant(value: &str) -> Option<String> {
+    let normalized = value.trim().to_lowercase();
+    let compact = normalized
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .collect::<String>();
+    (!compact.is_empty() && compact != normalized).then_some(compact)
+}
+
+/// Fetches one row past the limit so the caller can tell "exactly full" from
+/// "cut short" without a second count query.
+pub(crate) fn probe_limit(limit: usize) -> usize {
+    limit.saturating_add(1).max(1)
+}
+
+pub(crate) fn truncate_probe_hits(hits: &mut Vec<CatalogSearchHit>, limit: usize) -> bool {
+    if hits.len() > limit {
+        hits.truncate(limit);
+        true
+    } else {
+        false
+    }
+}

--- a/crates/coral-app/src/search/catalog/mod.rs
+++ b/crates/coral-app/src/search/catalog/mod.rs
@@ -1,5 +1,6 @@
 //! Catalog metadata search provider.
 
+pub(crate) mod index;
 pub(crate) mod provider;
 pub(crate) mod snapshot;
 pub(crate) mod sqlite_index;

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -7,16 +7,14 @@ use coral_engine::{CatalogInfo, TableFunctionInfo, TableInfo};
 use crate::bootstrap::AppError;
 use crate::catalog::model::CatalogResolution;
 use crate::query::manager::QueryManagerError;
+use crate::search::catalog::index::{CatalogDocumentClass, CatalogRefreshResult, CatalogSearchHit};
 use crate::search::catalog::snapshot::{
     CatalogSearchSnapshot, field_role_from_str, surface_kind_from_str,
-};
-use crate::search::catalog::sqlite_index::{
-    CatalogDocumentClass, CatalogRefreshResult, CatalogSearchHit,
 };
 use crate::search::maintenance::{
     CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult, SearchClearTarget,
     SearchDataScope, SearchMaintenanceDetail, SearchMaintenanceResult, SearchMaintenanceState,
-    SearchProviderClearOutcome, SearchProviderClearRequest, SearchStorageCleanupResult,
+    SearchProviderClearOutcome, SearchProviderClearRequest,
 };
 use crate::search::provider::{
     LocalSearchWriteCoordinator, PreparedRetrievers, ProviderFailure, Retriever, RetrieverError,
@@ -27,10 +25,9 @@ use crate::search::result::{
     SearchManagerError, SearchProviderKind, SearchProviderState, SearchRequest, SearchResult,
     SearchSurfaceId, SearchSurfaceKind, SurfaceMatch, SurfaceShape,
 };
-use crate::search::sqlite_store::{
-    SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
+use crate::search::store::{
+    CatalogStore, SearchStorage, SearchStore, SearchStoreError, search_maintenance_app_error,
 };
-use crate::state::AppStateLayout;
 
 const CATALOG_PROVIDER_RETRIEVAL_MULTIPLIER: usize = 5;
 const CATALOG_PROVIDER_MIN_RETRIEVAL_LIMIT: usize = 25;
@@ -50,7 +47,7 @@ impl SearchProvider for CatalogMetadataProvider {
 }
 
 struct CatalogProjection {
-    store: SqliteSearchStore,
+    store: SearchStore,
     refresh: CatalogRefreshResult,
     stale_index: bool,
     refresh_lock_error: Option<String>,
@@ -66,17 +63,17 @@ struct CatalogProjectionState {
 
 #[derive(Clone)]
 pub(crate) struct CatalogMetadataProvider {
-    layout: AppStateLayout,
+    storage: SearchStorage,
     write_coordinator: LocalSearchWriteCoordinator,
 }
 
 impl CatalogMetadataProvider {
     pub(crate) fn with_write_coordinator(
-        layout: AppStateLayout,
+        storage: SearchStorage,
         write_coordinator: LocalSearchWriteCoordinator,
     ) -> Self {
         Self {
-            layout,
+            storage,
             write_coordinator,
         }
     }
@@ -141,25 +138,26 @@ impl CatalogMetadataProvider {
         &self,
         request: &SearchRequest,
         resolution: &CatalogResolution,
-    ) -> Result<CatalogProjection, SqliteSearchError> {
+    ) -> Result<CatalogProjection, SearchStoreError> {
         let catalog_fingerprint = CatalogSearchSnapshot::fingerprint_catalog(&resolution.catalog);
-        let store = SqliteSearchStore::open_workspace(&self.layout, &request.workspace_name)?;
-        let capabilities = store.capabilities();
+        let store = self.storage.open_workspace(&request.workspace_name)?;
         tracing::debug!(
             workspace = %request.workspace_name,
-            sqlite_version = %capabilities.sqlite_version,
-            fts5 = capabilities.fts5,
-            trigram = capabilities.trigram,
-            "using SQLite catalog search store"
+            backend = store.backend_name(),
+            "using catalog search store"
         );
-        let state =
-            Self::prepare_projection_state(request, resolution, &store, &catalog_fingerprint)?;
+        let state = Self::prepare_projection_state(
+            request,
+            resolution,
+            store.catalog(),
+            &catalog_fingerprint,
+        )?;
         tracing::debug!(
             workspace = %request.workspace_name,
             refreshed = state.refresh.refreshed,
             document_count = state.refresh.document_count,
             stale_index = state.stale_index,
-            "prepared SQLite catalog search projection"
+            "prepared catalog search projection"
         );
         Ok(CatalogProjection {
             store,
@@ -173,11 +171,11 @@ impl CatalogMetadataProvider {
     fn prepare_projection_state(
         request: &SearchRequest,
         resolution: &CatalogResolution,
-        store: &SqliteSearchStore,
+        store: &dyn CatalogStore,
         catalog_fingerprint: &str,
-    ) -> Result<CatalogProjectionState, SqliteSearchError> {
-        if store.catalog_projection_is_current(catalog_fingerprint)? {
-            let document_count = store.catalog_document_count()?;
+    ) -> Result<CatalogProjectionState, SearchStoreError> {
+        if store.projection_is_current(catalog_fingerprint)? {
+            let document_count = store.document_count()?;
             return Ok(CatalogProjectionState {
                 refresh: CatalogRefreshResult {
                     refreshed: false,
@@ -192,7 +190,7 @@ impl CatalogMetadataProvider {
         let snapshot = CatalogSearchSnapshot::from_catalog(&resolution.catalog);
         let expected_document_count = u32::try_from(snapshot.documents.len()).unwrap_or(u32::MAX);
         let index_snapshot = snapshot.index_snapshot();
-        match store.refresh_catalog_projection(&index_snapshot) {
+        match store.refresh_projection(&index_snapshot) {
             Ok(refresh) => Ok(CatalogProjectionState {
                 refresh,
                 stale_index: false,
@@ -203,9 +201,9 @@ impl CatalogMetadataProvider {
                 tracing::debug!(
                     workspace = %request.workspace_name,
                     error = %error,
-                    "using cached SQLite catalog search projection after refresh lock contention"
+                    "using cached catalog search projection after refresh lock contention"
                 );
-                let document_count = store.catalog_document_count()?;
+                let document_count = store.document_count()?;
                 Ok(CatalogProjectionState {
                     refresh: CatalogRefreshResult {
                         refreshed: false,
@@ -229,11 +227,14 @@ impl CatalogMetadataProvider {
         force: bool,
     ) -> Result<SearchMaintenanceResult, SearchManagerError> {
         let snapshot = CatalogSearchSnapshot::from_catalog(&resolution.catalog).index_snapshot();
-        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)
-            .map_err(|error| search_sqlite_app_error(&error))?;
+        let store = self
+            .storage
+            .open_workspace(workspace_name)
+            .map_err(|error| search_maintenance_app_error(&error))?;
         let result = store
-            .rebuild_catalog_projection(&snapshot, force)
-            .map_err(|error| search_sqlite_app_error(&error))?;
+            .catalog()
+            .rebuild_projection(&snapshot, force)
+            .map_err(|error| search_maintenance_app_error(&error))?;
         Ok(catalog_rebuild_provider_result(
             result.old_document_count,
             result.new_document_count,
@@ -253,36 +254,23 @@ impl CatalogMetadataProvider {
             )
             .into());
         }
-        match request.target {
-            SearchClearTarget::Workspace => {
-                let store = SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
-                    .map_err(|error| search_sqlite_app_error(&error))?;
-                let result = store
-                    .clear_catalog_workspace()
-                    .map_err(|error| search_sqlite_app_error(&error))?;
-                Ok(SearchProviderClearOutcome {
-                    result: catalog_clear_provider_result(result.deleted_document_count),
-                    storage_cleanup: request.compact_after_clear.then(|| {
-                        let compaction = store.compact_after_clear();
-                        search_storage_cleanup_result(&compaction)
-                    }),
-                })
-            }
+        let store = self
+            .storage
+            .open_workspace(request.workspace_name)
+            .map_err(|error| search_maintenance_app_error(&error))?;
+        let result = match request.target {
+            SearchClearTarget::Workspace => store.catalog().clear_workspace(),
             SearchClearTarget::Source(source_name) => {
-                let store = SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
-                    .map_err(|error| search_sqlite_app_error(&error))?;
-                let result = store
-                    .clear_catalog_source(source_name.as_str())
-                    .map_err(|error| search_sqlite_app_error(&error))?;
-                Ok(SearchProviderClearOutcome {
-                    result: catalog_clear_provider_result(result.deleted_document_count),
-                    storage_cleanup: request.compact_after_clear.then(|| {
-                        let compaction = store.compact_after_clear();
-                        search_storage_cleanup_result(&compaction)
-                    }),
-                })
+                store.catalog().clear_source(source_name.as_str())
             }
         }
+        .map_err(|error| search_maintenance_app_error(&error))?;
+        Ok(SearchProviderClearOutcome {
+            result: catalog_clear_provider_result(result.deleted_document_count),
+            storage_cleanup: request
+                .compact_after_clear
+                .then(|| store.compact_after_clear()),
+        })
     }
 }
 
@@ -339,56 +327,6 @@ pub(crate) fn catalog_clear_provider_result(
     }
 }
 
-fn search_storage_cleanup_result(
-    result: &SqliteSearchCompactionResult,
-) -> SearchStorageCleanupResult {
-    let (state, note) = match (
-        result.wal_checkpoint_truncate_completed,
-        result.vacuum_completed,
-    ) {
-        (true, true) => (
-            SearchMaintenanceState::Completed,
-            "local search storage cleanup completed",
-        ),
-        (true, false) | (false, true) => (
-            SearchMaintenanceState::Partial,
-            "local search storage cleanup partially completed",
-        ),
-        (false, false) => (
-            SearchMaintenanceState::Failed,
-            "local search storage cleanup did not complete",
-        ),
-    };
-    if state != SearchMaintenanceState::Completed {
-        tracing::warn!(
-            wal_checkpoint_truncate_completed = result.wal_checkpoint_truncate_completed,
-            vacuum_completed = result.vacuum_completed,
-            detail = %result.note,
-            "local search storage cleanup did not fully complete"
-        );
-    }
-    SearchStorageCleanupResult {
-        state,
-        note: note.to_string(),
-    }
-}
-
-fn search_sqlite_app_error(error: &SqliteSearchError) -> AppError {
-    if error.is_lock_contention() {
-        AppError::Unavailable(format!("search maintenance storage is busy: {error}"))
-    } else if error.is_storage_exhaustion() {
-        AppError::ResourceExhausted(format!("search maintenance storage is exhausted: {error}"))
-    } else if matches!(
-        error,
-        SqliteSearchError::UnsupportedCapability { .. }
-            | SqliteSearchError::UnsupportedSchemaVersion { .. }
-    ) {
-        AppError::FailedPrecondition(format!("search maintenance is not supported: {error}"))
-    } else {
-        AppError::Internal(format!("search maintenance storage failed: {error}"))
-    }
-}
-
 fn missing_cached_projection_failure(projection: &CatalogProjection) -> Option<ProviderFailure> {
     if !(projection.stale_index
         && projection.refresh.document_count == 0
@@ -399,7 +337,7 @@ fn missing_cached_projection_failure(projection: &CatalogProjection) -> Option<P
     Some(ProviderFailure {
         state: SearchProviderState::Error,
         note: format!(
-            "Catalog metadata search index is unavailable: refresh could not acquire the SQLite writer lock and no cached projection exists{}",
+            "Catalog metadata search index is unavailable: refresh could not acquire the search store writer lock and no cached projection exists{}",
             projection
                 .refresh_lock_error
                 .as_deref()
@@ -447,7 +385,7 @@ fn failed_sources_note(failed_source_names: &BTreeSet<String>) -> String {
 /// documents starves them: measured, a 50-document shared window holds 45 field
 /// documents and yields 7 distinct entries.
 struct EntryRetriever {
-    store: SqliteSearchStore,
+    store: SearchStore,
     limit: usize,
 }
 
@@ -459,7 +397,8 @@ impl Retriever for EntryRetriever {
     fn retrieve(&self, request: &SearchRequest) -> Result<RetrieverOutcome, RetrieverError> {
         let hits = self
             .store
-            .search_catalog(&request.terms, self.limit, CatalogDocumentClass::Entries)
+            .catalog()
+            .search(&request.terms, self.limit, CatalogDocumentClass::Entries)
             .map_err(|error| retriever_error(&error))?;
         let matches = hits
             .hits
@@ -480,7 +419,7 @@ impl Retriever for EntryRetriever {
 /// Ranks entries by their best-matching field, and carries the matching field
 /// names up as evidence for the entry that owns them.
 struct FieldRetriever {
-    store: SqliteSearchStore,
+    store: SearchStore,
     limit: usize,
 }
 
@@ -492,7 +431,8 @@ impl Retriever for FieldRetriever {
     fn retrieve(&self, request: &SearchRequest) -> Result<RetrieverOutcome, RetrieverError> {
         let hits = self
             .store
-            .search_catalog(&request.terms, self.limit, CatalogDocumentClass::Fields)
+            .catalog()
+            .search(&request.terms, self.limit, CatalogDocumentClass::Fields)
             .map_err(|error| retriever_error(&error))?;
         // Scoring reorders the lane, so an entry takes the position of its
         // best-scoring field rather than its first-retrieved one.
@@ -562,7 +502,7 @@ fn surface_id(hit: &CatalogSearchHit) -> Option<SearchSurfaceId> {
     })
 }
 
-fn retriever_error(error: &SqliteSearchError) -> RetrieverError {
+fn retriever_error(error: &SearchStoreError) -> RetrieverError {
     RetrieverError {
         note: error.to_string(),
     }
@@ -790,7 +730,7 @@ fn catalog_query_failure(error: &QueryManagerError) -> ProviderFailure {
     }
 }
 
-fn catalog_index_failure(error: &SqliteSearchError) -> ProviderFailure {
+fn catalog_index_failure(error: &SearchStoreError) -> ProviderFailure {
     ProviderFailure {
         state: SearchProviderState::Error,
         note: format!("catalog metadata search index is unavailable: {error}"),

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -7,7 +7,7 @@ use coral_engine::{
 use coral_spec::SourceTableFunctionKind;
 use sha2::{Digest as _, Sha256};
 
-use crate::search::catalog::sqlite_index::{
+use crate::search::catalog::index::{
     CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
 };
 use crate::search::result::{FieldRole, SearchSurfaceKind};

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -4,6 +4,11 @@ use rusqlite::{
     Connection, OptionalExtension as _, Transaction, TransactionBehavior, params, types::Type,
 };
 
+use crate::search::catalog::index::{
+    CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
+    CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits, indexed_searchable_text,
+    normalized_search_terms, probe_limit, truncate_probe_hits,
+};
 use crate::search::sqlite_store::SqliteSearchError;
 use crate::workspaces::WorkspaceName;
 
@@ -194,86 +199,6 @@ fn rebuild_catalog_documents(
     })
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogIndexSnapshot {
-    pub(crate) documents: Vec<CatalogIndexDocument>,
-    pub(crate) fingerprint: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogIndexDocument {
-    pub(crate) doc_id: String,
-    pub(crate) doc_kind: CatalogIndexDocumentKind,
-    pub(crate) source_name: String,
-    pub(crate) catalog_name: Option<String>,
-    pub(crate) surface_kind: String,
-    pub(crate) surface_name: String,
-    pub(crate) field_name: String,
-    pub(crate) field_role: String,
-    pub(crate) qualified_name: String,
-    pub(crate) title: String,
-    pub(crate) description: String,
-    pub(crate) searchable_text: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CatalogIndexDocumentKind {
-    CatalogTable,
-    CatalogTableFunction,
-    ColumnHint,
-}
-
-impl CatalogIndexDocumentKind {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::CatalogTable => "catalog_table",
-            Self::CatalogTableFunction => "catalog_table_function",
-            Self::ColumnHint => "column_hint",
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogRefreshResult {
-    pub(crate) refreshed: bool,
-    pub(crate) document_count: u32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CatalogRebuildResult {
-    pub(crate) old_document_count: u32,
-    pub(crate) new_document_count: u32,
-    pub(crate) projection_changed: bool,
-    pub(crate) rebuild_performed: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CatalogClearResult {
-    pub(crate) deleted_document_count: u32,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogSearchHits {
-    pub(crate) hits: Vec<CatalogSearchHit>,
-    /// Whether the candidate window cut the result short. Surfaced so callers
-    /// can report `has_more` rather than implying the index held nothing else.
-    pub(crate) retrieval_limited: bool,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogSearchHit {
-    /// Storage identity of the matched document. Retrieval keys on the entry
-    /// it resolves to, so this is carried for diagnostics rather than ranking.
-    #[cfg_attr(not(test), expect(dead_code, reason = "read by index tests only"))]
-    pub(crate) doc_id: String,
-    pub(crate) source_name: String,
-    pub(crate) catalog_name: Option<String>,
-    pub(crate) surface_kind: String,
-    pub(crate) surface_name: String,
-    pub(crate) field_name: String,
-    pub(crate) field_role: String,
-}
-
 fn replace_catalog_documents(
     transaction: &Transaction<'_>,
     workspace_name: &WorkspaceName,
@@ -326,7 +251,7 @@ fn insert_catalog_snapshot_documents(
     )?;
 
     for document in &snapshot.documents {
-        let searchable_text = fts_searchable_text(document);
+        let searchable_text = indexed_searchable_text(document);
         document_insert.execute(params![
             workspace_name.as_str(),
             &document.doc_id,
@@ -506,28 +431,6 @@ fn catalog_document_count(
     Ok(u32::try_from(count).unwrap_or(u32::MAX))
 }
 
-/// Which population of documents a retriever is asking for.
-///
-/// Entry documents and field documents share an index, but not a candidate
-/// window. Measured: in a 50-document window over one shared list, 45 slots go
-/// to field documents and only 7 distinct entries survive — wide tables crowd
-/// everything else out. Separate windows are what keep entry recall.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CatalogDocumentClass {
-    Entries,
-    Fields,
-}
-
-impl CatalogDocumentClass {
-    /// Fixed SQL fragment — never built from caller input.
-    fn doc_kind_predicate(self) -> &'static str {
-        match self {
-            Self::Entries => "d.doc_kind IN ('catalog_table', 'catalog_table_function')",
-            Self::Fields => "d.doc_kind = 'column_hint'",
-        }
-    }
-}
-
 fn fts_search(
     connection: &Connection,
     workspace_name: &WorkspaceName,
@@ -565,19 +468,6 @@ fn fts_search(
     )?;
 
     collect_hits(rows)
-}
-
-fn probe_limit(limit: usize) -> usize {
-    limit.saturating_add(1).max(1)
-}
-
-fn truncate_probe_hits(hits: &mut Vec<CatalogSearchHit>, limit: usize) -> bool {
-    if hits.len() > limit {
-        hits.truncate(limit);
-        true
-    } else {
-        false
-    }
 }
 
 fn hit_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CatalogSearchHit> {
@@ -661,56 +551,6 @@ fn fts_match_query(terms: &[String]) -> Option<String> {
     } else {
         Some(phrases.join(" OR "))
     }
-}
-
-fn normalized_search_terms(terms: &[String]) -> Vec<String> {
-    let mut normalized = Vec::new();
-    for term in terms {
-        let term = term.trim().to_lowercase();
-        if term.is_empty() {
-            continue;
-        }
-        push_search_term(&mut normalized, term.clone());
-        if let Some(compact) = compact_identifier_variant(&term) {
-            push_search_term(&mut normalized, compact);
-        }
-    }
-    normalized
-}
-
-fn push_search_term(terms: &mut Vec<String>, term: String) {
-    if !terms.iter().any(|existing| existing == &term) {
-        terms.push(term);
-    }
-}
-
-fn fts_searchable_text(document: &CatalogIndexDocument) -> String {
-    let mut parts = vec![document.searchable_text.clone()];
-    for value in [
-        document.source_name.as_str(),
-        document.surface_name.as_str(),
-        document.field_name.as_str(),
-        document.qualified_name.as_str(),
-        document.title.as_str(),
-    ] {
-        if let Some(compact) = compact_identifier_variant(value) {
-            parts.push(compact);
-        }
-    }
-    parts
-        .into_iter()
-        .filter(|part| !part.trim().is_empty())
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn compact_identifier_variant(value: &str) -> Option<String> {
-    let normalized = value.trim().to_lowercase();
-    let compact = normalized
-        .chars()
-        .filter(|ch| ch.is_alphanumeric())
-        .collect::<String>();
-    (!compact.is_empty() && compact != normalized).then_some(compact)
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -1,8 +1,8 @@
 use tempfile::{TempDir, tempdir};
 
-use super::{
+use super::{SqliteCatalogIndex, refresh_catalog_documents_after_stale_check};
+use crate::search::catalog::index::{
     CatalogDocumentClass, CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
-    SqliteCatalogIndex, refresh_catalog_documents_after_stale_check,
 };
 use crate::search::sqlite_store::SqliteSearchStore;
 use crate::workspaces::WorkspaceName;

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -33,9 +33,7 @@ use crate::search::provider::{
 use crate::search::result::{
     SearchManagerError, SearchProviderKind, SearchRequest, SearchResponse,
 };
-use crate::search::sqlite_store::{
-    SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
-};
+use crate::search::store::{SearchStorage, search_maintenance_app_error};
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
@@ -48,13 +46,15 @@ use crate::workspaces::{
 pub(crate) struct SearchManager {
     catalog_discovery: CatalogDiscovery,
     catalog: CatalogMetadataProvider,
-    observed: ObservedValuesProvider,
+    /// `None` when the search backend keeps no observed values; the feature
+    /// flag then has nothing to enable.
+    observed: Option<ObservedValuesProvider>,
     observed_scope_loader: ObservedValuesLiveScopeLoader,
     observed_values_search_enabled: bool,
     engine: UniversalSearchEngine,
     workspaces: WorkspaceManager,
     lifecycle_lock: WorkspaceLifecycleLock,
-    layout: AppStateLayout,
+    storage: SearchStorage,
 }
 
 const DEFAULT_MANUAL_DRAIN_BUDGET_MS: u32 = 1_000;
@@ -88,6 +88,7 @@ impl SearchManager {
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
         Self::with_diagnostic_reporter(
+            SearchStorage::sqlite(layout.clone()),
             layout,
             config_store,
             workspace_manager,
@@ -98,7 +99,12 @@ impl SearchManager {
         )
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "server bootstrap wires every collaborator once; a builder would only move the same list"
+    )]
     pub(crate) fn with_diagnostic_reporter(
+        storage: SearchStorage,
         layout: AppStateLayout,
         config_store: &ConfigStore,
         workspace_manager: WorkspaceManager,
@@ -109,16 +115,14 @@ impl SearchManager {
     ) -> Self {
         let write_coordinator = LocalSearchWriteCoordinator::default();
         let catalog = CatalogMetadataProvider::with_write_coordinator(
-            layout.clone(),
+            storage.clone(),
             write_coordinator.clone(),
         );
-        let observed =
-            ObservedValuesProvider::with_write_coordinator(layout.clone(), write_coordinator);
-        let observed_scope_loader = ObservedValuesLiveScopeLoader::new(
-            layout.clone(),
-            config_store.clone(),
-            diagnostic_reporter,
-        );
+        let observed = storage
+            .observed_values()
+            .map(|store| ObservedValuesProvider::from_store(store, write_coordinator));
+        let observed_scope_loader =
+            ObservedValuesLiveScopeLoader::new(layout, config_store.clone(), diagnostic_reporter);
         Self {
             catalog_discovery,
             catalog: catalog.clone(),
@@ -127,11 +131,22 @@ impl SearchManager {
             observed_values_search_enabled,
             engine: UniversalSearchEngine::new(SearchProviderRegistry::local(
                 catalog,
-                observed_values_search_enabled.then(|| observed.clone()),
+                observed_values_search_enabled.then_some(observed).flatten(),
             )),
             workspaces: workspace_manager,
             lifecycle_lock,
-            layout,
+            storage,
+        }
+    }
+
+    /// The observed provider, or the maintenance result explaining why the
+    /// requested observed-values work cannot run.
+    fn observed_provider(&self) -> Result<&ObservedValuesProvider, SearchMaintenanceResult> {
+        match &self.observed {
+            Some(observed) => Ok(observed),
+            None => Err(observed_values_search_unavailable_maintenance_result(
+                self.storage.backend_name(),
+            )),
         }
     }
 
@@ -361,9 +376,21 @@ impl SearchManager {
                 }
             };
         }
+        let observed = match self.observed_provider() {
+            Ok(observed) => observed,
+            Err(unavailable) => {
+                return Ok(ClearSearchDataResponse {
+                    results: vec![unavailable],
+                    storage_cleanup: SearchStorageCleanupResult {
+                        state: SearchMaintenanceState::Noop,
+                        note: "no search storage cleanup was needed".to_string(),
+                    },
+                });
+            }
+        };
         let provider_outcomes = match request.scope {
             SearchDataScope::ObservedValues => {
-                vec![self.observed.clear_data(SearchProviderClearRequest {
+                vec![observed.clear_data(SearchProviderClearRequest {
                     workspace_name: &request.workspace_name,
                     scope: request.scope,
                     target: &request.target,
@@ -378,7 +405,7 @@ impl SearchManager {
                         target: &request.target,
                         compact_after_clear: false,
                     })?,
-                    self.observed.clear_data(SearchProviderClearRequest {
+                    observed.clear_data(SearchProviderClearRequest {
                         workspace_name: &request.workspace_name,
                         scope: request.scope,
                         target: &request.target,
@@ -414,18 +441,19 @@ impl SearchManager {
         workspace_name: &WorkspaceName,
         source_name: &crate::sources::SourceName,
     ) -> Result<ClearSearchDataResponse, SearchManagerError> {
-        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)
-            .map_err(|error| search_clear_sqlite_app_error(&error))?;
-        let (catalog, observed) = store
+        let store = self
+            .storage
+            .open_workspace(workspace_name)
+            .map_err(|error| search_maintenance_app_error(&error))?;
+        let cleared = store
             .clear_source_all(source_name.as_str())
-            .map_err(|error| search_clear_sqlite_app_error(&error))?;
-        let compaction = store.compact_after_clear();
+            .map_err(|error| search_maintenance_app_error(&error))?;
         Ok(ClearSearchDataResponse {
             results: vec![
-                catalog_clear_provider_result(catalog.deleted_document_count),
-                observed_clear_provider_result(observed),
+                catalog_clear_provider_result(cleared.catalog.deleted_document_count),
+                observed_clear_provider_result(cleared.observed),
             ],
-            storage_cleanup: search_storage_cleanup_result(&compaction),
+            storage_cleanup: store.compact_after_clear(),
         })
     }
 
@@ -433,27 +461,28 @@ impl SearchManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<ClearSearchDataResponse, SearchManagerError> {
-        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)
-            .map_err(|error| search_clear_sqlite_app_error(&error))?;
-        let (catalog, observed) = store
+        let store = self
+            .storage
+            .open_workspace(workspace_name)
+            .map_err(|error| search_maintenance_app_error(&error))?;
+        let cleared = store
             .clear_workspace_all()
-            .map_err(|error| search_clear_sqlite_app_error(&error))?;
-        let compaction = store.compact_after_clear();
+            .map_err(|error| search_maintenance_app_error(&error))?;
         Ok(ClearSearchDataResponse {
             results: vec![
-                catalog_clear_provider_result(catalog.deleted_document_count),
-                observed_clear_provider_result(observed),
+                catalog_clear_provider_result(cleared.catalog.deleted_document_count),
+                observed_clear_provider_result(cleared.observed),
             ],
-            storage_cleanup: search_storage_cleanup_result(&compaction),
+            storage_cleanup: store.compact_after_clear(),
         })
     }
 
     pub(crate) async fn drain_before_shutdown(&self) -> Result<(), SearchManagerError> {
-        if !self.observed_values_search_enabled {
+        let (true, Some(observed)) = (self.observed_values_search_enabled, self.observed.clone())
+        else {
             return Ok(());
-        }
+        };
         let workspaces = self.workspaces.list_workspaces().await?;
-        let observed = self.observed.clone();
         run_blocking_search_operation(move || {
             let deadline = Instant::now() + SHUTDOWN_DRAIN_SOFT_BUDGET;
             for workspace in workspaces {
@@ -523,7 +552,11 @@ impl SearchManager {
         if !self.observed_values_search_enabled {
             return observed_values_search_disabled_maintenance_result();
         }
-        match self.try_rebuild_observed_index(request) {
+        let observed = match self.observed_provider() {
+            Ok(observed) => observed,
+            Err(unavailable) => return unavailable,
+        };
+        match self.try_rebuild_observed_index(observed, request) {
             Ok(result) => result,
             Err(error) => observed_rebuild_error_provider_result(&error),
         }
@@ -531,10 +564,11 @@ impl SearchManager {
 
     fn try_rebuild_observed_index(
         &self,
+        observed: &ObservedValuesProvider,
         request: &RebuildSearchIndexRequest,
     ) -> Result<SearchMaintenanceResult, SearchManagerError> {
         let policy = self.observed_retrieval_policy(&request.workspace_name)?;
-        self.observed.rebuild_index(
+        observed.rebuild_index(
             SearchProviderRebuildRequest {
                 workspace_name: &request.workspace_name,
             },
@@ -551,7 +585,11 @@ impl SearchManager {
         if !self.observed_values_search_enabled {
             return Ok(observed_values_search_disabled_maintenance_result());
         }
-        self.observed.drain_queue(
+        let observed = match self.observed_provider() {
+            Ok(observed) => observed,
+            Err(unavailable) => return Ok(unavailable),
+        };
+        observed.drain_queue(
             workspace_name,
             ObservedValuesDrainBudget::new(
                 MANUAL_DRAIN_MAX_JOBS,
@@ -762,59 +800,22 @@ fn observed_values_search_disabled_maintenance_result() -> SearchMaintenanceResu
     }
 }
 
+fn observed_values_search_unavailable_maintenance_result(
+    backend_name: &str,
+) -> SearchMaintenanceResult {
+    SearchMaintenanceResult {
+        provider: SearchProviderKind::ObservedValues,
+        state: SearchMaintenanceState::Skipped,
+        note: format!(
+            "observed value search is not available on the {backend_name} search backend"
+        ),
+        detail: None,
+    }
+}
+
 fn search_manager_error_message(error: &SearchManagerError) -> String {
     match error {
         SearchManagerError::App(error) => error.to_string(),
-    }
-}
-
-fn search_clear_sqlite_app_error(error: &SqliteSearchError) -> AppError {
-    if error.is_lock_contention() {
-        AppError::Unavailable(format!("search maintenance storage is busy: {error}"))
-    } else if error.is_storage_exhaustion() {
-        AppError::ResourceExhausted(format!("search maintenance storage is exhausted: {error}"))
-    } else if matches!(
-        error,
-        SqliteSearchError::UnsupportedCapability { .. }
-            | SqliteSearchError::UnsupportedSchemaVersion { .. }
-    ) {
-        AppError::FailedPrecondition(format!("search maintenance is not supported: {error}"))
-    } else {
-        AppError::Internal(format!("search maintenance storage failed: {error}"))
-    }
-}
-
-fn search_storage_cleanup_result(
-    result: &SqliteSearchCompactionResult,
-) -> SearchStorageCleanupResult {
-    let (state, note) = match (
-        result.wal_checkpoint_truncate_completed,
-        result.vacuum_completed,
-    ) {
-        (true, true) => (
-            SearchMaintenanceState::Completed,
-            "local search storage cleanup completed",
-        ),
-        (true, false) | (false, true) => (
-            SearchMaintenanceState::Partial,
-            "local search storage cleanup partially completed",
-        ),
-        (false, false) => (
-            SearchMaintenanceState::Failed,
-            "local search storage cleanup did not complete",
-        ),
-    };
-    if state != SearchMaintenanceState::Completed {
-        tracing::warn!(
-            wal_checkpoint_truncate_completed = result.wal_checkpoint_truncate_completed,
-            vacuum_completed = result.vacuum_completed,
-            detail = %result.note,
-            "local search storage cleanup did not fully complete"
-        );
-    }
-    SearchStorageCleanupResult {
-        state,
-        note: note.to_string(),
     }
 }
 

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod provider;
 pub(crate) mod result;
 pub(crate) mod service;
 pub(crate) mod sqlite_store;
+pub(crate) mod store;

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -19,13 +19,14 @@ pub(crate) use policy::{
     ObservedValuesLiveScope, ObservedValuesLiveScopeLoadFailure, ObservedValuesRetrievalPolicy,
 };
 pub(crate) use publisher::{SearchObservationHandle, SearchObservationSource};
-pub(crate) use sqlite_projection::ObservedValuesDrainBudget;
+pub(crate) use sqlite_projection::{
+    ObservedValuesDrainBudget, ObservedValuesDrainResult, ObservedValuesRebuildResult,
+    ObservedValuesSearchHits,
+};
 pub(crate) use sqlite_store::{
-    ObservedValuesClearResult, clear_observed_source_in_transaction,
+    ObservedValuesClearResult, SqliteObservedValuesStore, clear_observed_source_in_transaction,
     clear_observed_workspace_in_transaction,
 };
 
 #[cfg(test)]
 pub(crate) use sqlite_queue::{ObservedValuesQueueJob, ObservedValuesSurfaceKind};
-#[cfg(test)]
-pub(crate) use sqlite_store::SqliteObservedValuesStore;

--- a/crates/coral-app/src/search/observed/provider.rs
+++ b/crates/coral-app/src/search/observed/provider.rs
@@ -1,5 +1,6 @@
 //! Observed-values Universal Search provider.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::bootstrap::AppError;
@@ -8,7 +9,7 @@ use crate::search::maintenance::{
     ObservedClearMaintenanceResult, ObservedDrainMaintenanceResult,
     ObservedRebuildMaintenanceResult, SearchClearTarget, SearchDataScope, SearchMaintenanceDetail,
     SearchMaintenanceResult, SearchMaintenanceState, SearchProviderClearOutcome,
-    SearchProviderClearRequest, SearchProviderRebuildRequest, SearchStorageCleanupResult,
+    SearchProviderClearRequest, SearchProviderRebuildRequest,
 };
 use crate::search::observed::ObservedValuesRetrievalPolicy;
 use crate::search::observed::ranking;
@@ -17,7 +18,7 @@ use crate::search::observed::sqlite_projection::{
     ObservedValuesSearchHits,
 };
 use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
-use crate::search::observed::sqlite_store::{ObservedValuesClearResult, SqliteObservedValuesStore};
+use crate::search::observed::sqlite_store::ObservedValuesClearResult;
 use crate::search::provider::{
     LocalSearchWriteCoordinator, PreparedRetrievers, ProviderFailure, ProviderSearchOutcome,
     Retriever, RetrieverError, RetrieverOutcome, SearchExecutionContext, SearchProvider,
@@ -27,9 +28,7 @@ use crate::search::result::{
     SearchProviderKind, SearchProviderState, SearchRequest, SearchSurfaceId, SearchSurfaceKind,
     SurfaceMatch,
 };
-use crate::search::sqlite_store::SqliteSearchCompactionResult;
-use crate::search::sqlite_store::SqliteSearchError;
-use crate::state::AppStateLayout;
+use crate::search::store::{ObservedValuesStore, SearchStoreError, search_maintenance_app_error};
 use crate::workspaces::WorkspaceName;
 
 const OBSERVED_PROVIDER_RETRIEVAL_MULTIPLIER: usize = 5;
@@ -41,17 +40,17 @@ const OBSERVED_REBUILD_DRAIN_MS: u64 = 1_000;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValuesProvider {
-    store: SqliteObservedValuesStore,
+    store: Arc<dyn ObservedValuesStore>,
     write_coordinator: LocalSearchWriteCoordinator,
 }
 
 impl ObservedValuesProvider {
-    pub(crate) fn with_write_coordinator(
-        layout: AppStateLayout,
+    pub(crate) fn from_store(
+        store: Arc<dyn ObservedValuesStore>,
         write_coordinator: LocalSearchWriteCoordinator,
     ) -> Self {
         Self {
-            store: SqliteObservedValuesStore::new(layout),
+            store,
             write_coordinator,
         }
     }
@@ -108,7 +107,7 @@ impl ObservedValuesProvider {
         let result = self
             .store
             .drain_queue(workspace_name, budget)
-            .map_err(|error| observed_sqlite_app_error(&error))?;
+            .map_err(|error| search_maintenance_app_error(&error))?;
         log_storage_drops(workspace_name, &result);
         log_drain_maintenance(workspace_name, &result);
         Ok(observed_drain_provider_result(&result))
@@ -176,13 +175,13 @@ impl ObservedValuesProvider {
                     Duration::from_millis(OBSERVED_REBUILD_DRAIN_MS),
                 ),
             )
-            .map_err(|error| observed_sqlite_app_error(&error))?;
+            .map_err(|error| search_maintenance_app_error(&error))?;
         log_storage_drops(request.workspace_name, &drain);
         log_drain_maintenance(request.workspace_name, &drain);
         let result = self
             .store
             .rebuild_fts(request.workspace_name, policy)
-            .map_err(|error| observed_sqlite_app_error(&error))?;
+            .map_err(|error| search_maintenance_app_error(&error))?;
         Ok(observed_rebuild_provider_result(
             &drain,
             policy,
@@ -209,20 +208,20 @@ impl ObservedValuesProvider {
             SearchClearTarget::Workspace => self
                 .store
                 .clear_workspace_and_advance_epoch(request.workspace_name)
-                .map_err(|error| observed_sqlite_app_error(&error))?,
+                .map_err(|error| search_maintenance_app_error(&error))?,
             SearchClearTarget::Source(source_name) => self
                 .store
                 .clear_source_and_advance_epoch(request.workspace_name, source_name.as_str())
-                .map_err(|error| observed_sqlite_app_error(&error))?,
+                .map_err(|error| search_maintenance_app_error(&error))?,
         };
         Ok(SearchProviderClearOutcome {
             result: observed_clear_provider_result(result),
             storage_cleanup: if request.compact_after_clear {
-                let compaction = self
-                    .store
-                    .compact_after_clear(request.workspace_name)
-                    .map_err(|error| observed_sqlite_app_error(&error))?;
-                Some(observed_storage_cleanup_result(&compaction))
+                Some(
+                    self.store
+                        .compact_after_clear(request.workspace_name)
+                        .map_err(|error| search_maintenance_app_error(&error))?,
+                )
             } else {
                 None
             },
@@ -514,7 +513,7 @@ fn observed_policy_load_failure_note(policy: &ObservedValuesRetrievalPolicy) -> 
     ))
 }
 
-fn observed_error_outcome(error: &SqliteSearchError) -> ProviderSearchOutcome {
+fn observed_error_outcome(error: &SearchStoreError) -> ProviderSearchOutcome {
     ProviderSearchOutcome {
         rankings: Vec::new(),
         status: ProviderStatus {
@@ -765,56 +764,6 @@ fn log_drain_maintenance(workspace_name: &WorkspaceName, result: &ObservedValues
             budget_exhausted = result.budget_exhausted,
             "observed-value queue drain ran storage maintenance"
         );
-    }
-}
-
-fn observed_storage_cleanup_result(
-    result: &SqliteSearchCompactionResult,
-) -> SearchStorageCleanupResult {
-    let (state, note) = match (
-        result.wal_checkpoint_truncate_completed,
-        result.vacuum_completed,
-    ) {
-        (true, true) => (
-            SearchMaintenanceState::Completed,
-            "local search storage cleanup completed",
-        ),
-        (true, false) | (false, true) => (
-            SearchMaintenanceState::Partial,
-            "local search storage cleanup partially completed",
-        ),
-        (false, false) => (
-            SearchMaintenanceState::Failed,
-            "local search storage cleanup did not complete",
-        ),
-    };
-    if state != SearchMaintenanceState::Completed {
-        tracing::warn!(
-            wal_checkpoint_truncate_completed = result.wal_checkpoint_truncate_completed,
-            vacuum_completed = result.vacuum_completed,
-            detail = %result.note,
-            "local search storage cleanup did not fully complete"
-        );
-    }
-    SearchStorageCleanupResult {
-        state,
-        note: note.to_string(),
-    }
-}
-
-fn observed_sqlite_app_error(error: &SqliteSearchError) -> AppError {
-    if error.is_lock_contention() {
-        AppError::Unavailable(format!("search maintenance storage is busy: {error}"))
-    } else if error.is_storage_exhaustion() {
-        AppError::ResourceExhausted(format!("search maintenance storage is exhausted: {error}"))
-    } else if matches!(
-        error,
-        SqliteSearchError::UnsupportedCapability { .. }
-            | SqliteSearchError::UnsupportedSchemaVersion { .. }
-    ) {
-        AppError::FailedPrecondition(format!("search maintenance is not supported: {error}"))
-    } else {
-        AppError::Internal(format!("search maintenance storage failed: {error}"))
     }
 }
 

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -6,10 +6,12 @@ use std::time::{Duration, Instant};
 
 use rusqlite::{Connection, ErrorCode, TransactionBehavior};
 
-use crate::search::catalog::sqlite_index::{
+use crate::search::catalog::index::{
     CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
-    CatalogRefreshResult, CatalogSearchHits, SqliteCatalogIndex,
-    clear_catalog_source_documents_in_transaction,
+    CatalogRefreshResult, CatalogSearchHits,
+};
+use crate::search::catalog::sqlite_index::{
+    SqliteCatalogIndex, clear_catalog_source_documents_in_transaction,
     clear_catalog_workspace_documents_in_transaction,
 };
 use crate::search::observed::{

--- a/crates/coral-app/src/search/sqlite_store/tests.rs
+++ b/crates/coral-app/src/search/sqlite_store/tests.rs
@@ -8,7 +8,7 @@ use super::{
     WalCheckpointOutcome, classify_capability_probe, configure_connection,
     sqlite_file_creation_result, wal_checkpoint_truncate,
 };
-use crate::search::catalog::sqlite_index::{
+use crate::search::catalog::index::{
     CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
 };
 use crate::state::AppStateLayout;

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -1,0 +1,306 @@
+//! Dual-backend storage seam for Universal Search.
+//!
+//! [`SearchStorage`] is configured once per process and opens one
+//! [`SearchStore`] per Workspace, where `SqliteSearchStore::open_workspace`
+//! used to be called directly. A store serves the catalog projection through
+//! [`CatalogStore`] and the clear/compaction operations that span every data
+//! class. Observed values are reached through [`ObservedValuesStore`] when the
+//! backend keeps them; only `SQLite` does, and that stays so until observed
+//! memory is redesigned identity-scoped (lagoon #37).
+//!
+//! The seam is synchronous on purpose. The provider registry owns the blocking
+//! boundary (`provider::run_provider`), so retrievers can borrow request-scoped
+//! state; a backend that talks to an async driver blocks inside these calls.
+//! Retrieval order is the ranking and must be a deterministic total order,
+//! whichever backend serves it.
+
+mod sqlite;
+
+use std::sync::Arc;
+
+use crate::bootstrap::AppError;
+use crate::search::catalog::index::{
+    CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
+    CatalogRefreshResult, CatalogSearchHits,
+};
+use crate::search::maintenance::SearchStorageCleanupResult;
+use crate::search::observed::{
+    ObservedValuesClearResult, ObservedValuesDrainBudget, ObservedValuesDrainResult,
+    ObservedValuesRebuildResult, ObservedValuesRetrievalPolicy, ObservedValuesSearchHits,
+};
+use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+use sqlite::SqliteSearchStorage;
+
+/// Catalog projection storage for one Workspace.
+///
+/// Snapshots arrive already fingerprinted; the store decides whether the
+/// projection is current and replaces it atomically when it is not.
+pub(crate) trait CatalogStore: Send + Sync {
+    fn projection_is_current(&self, fingerprint: &str) -> Result<bool, SearchStoreError>;
+
+    fn refresh_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+    ) -> Result<CatalogRefreshResult, SearchStoreError>;
+
+    fn rebuild_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+        force: bool,
+    ) -> Result<CatalogRebuildResult, SearchStoreError>;
+
+    fn document_count(&self) -> Result<u32, SearchStoreError>;
+
+    /// Retrieves one class of document in ranked order.
+    ///
+    /// Terms are normalized upstream (`result::query_terms`); the backend owns
+    /// turning them into its query form and must return a deterministic total
+    /// order, because the returned position *is* the ranking.
+    fn search(
+        &self,
+        terms: &[String],
+        limit: usize,
+        class: CatalogDocumentClass,
+    ) -> Result<CatalogSearchHits, SearchStoreError>;
+
+    fn clear_source(&self, source_name: &str) -> Result<CatalogClearResult, SearchStoreError>;
+
+    fn clear_workspace(&self) -> Result<CatalogClearResult, SearchStoreError>;
+}
+
+/// Observed-values queue, projection, and retrieval for every Workspace of a
+/// backend.
+///
+/// Queue and projection share one trait because they interleave in one
+/// transaction (drain-then-search, savepoint per job). The retrieval policy
+/// travels as an argument on every call, never as connection state, so a
+/// pooled backend cannot leak scope across requests.
+pub(crate) trait ObservedValuesStore: std::fmt::Debug + Send + Sync {
+    fn search(
+        &self,
+        workspace_name: &WorkspaceName,
+        terms: &[String],
+        limit: usize,
+        policy: &ObservedValuesRetrievalPolicy,
+    ) -> Result<ObservedValuesSearchHits, SearchStoreError>;
+
+    fn drain_queue(
+        &self,
+        workspace_name: &WorkspaceName,
+        budget: ObservedValuesDrainBudget,
+    ) -> Result<ObservedValuesDrainResult, SearchStoreError>;
+
+    fn rebuild_fts(
+        &self,
+        workspace_name: &WorkspaceName,
+        policy: &ObservedValuesRetrievalPolicy,
+    ) -> Result<ObservedValuesRebuildResult, SearchStoreError>;
+
+    fn pending_queue_job_count(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<usize, SearchStoreError>;
+
+    fn clear_workspace_and_advance_epoch(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<ObservedValuesClearResult, SearchStoreError>;
+
+    fn clear_source_and_advance_epoch(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+    ) -> Result<ObservedValuesClearResult, SearchStoreError>;
+
+    fn compact_after_clear(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<SearchStorageCleanupResult, SearchStoreError>;
+}
+
+/// The configured search storage backend; opens per-Workspace stores.
+#[derive(Debug, Clone)]
+pub(crate) struct SearchStorage {
+    backend: SearchStorageBackend,
+}
+
+#[derive(Debug, Clone)]
+enum SearchStorageBackend {
+    Sqlite(SqliteSearchStorage),
+}
+
+impl SearchStorage {
+    /// One `SQLite` sidecar per Workspace under the app-state layout.
+    pub(crate) fn sqlite(layout: AppStateLayout) -> Self {
+        Self {
+            backend: SearchStorageBackend::Sqlite(SqliteSearchStorage::new(layout)),
+        }
+    }
+
+    pub(crate) fn backend_name(&self) -> &'static str {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => "sqlite",
+        }
+    }
+
+    /// Opens the Workspace's store, creating and migrating it when needed.
+    ///
+    /// Capability probing and migrations run here, fail-loud: a backend that
+    /// cannot serve search reports which feature is missing instead of
+    /// serving degraded results.
+    pub(crate) fn open_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<SearchStore, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(storage) => Ok(SearchStore {
+                backend: SearchStoreBackend::Sqlite(storage.open_workspace(workspace_name)?),
+            }),
+        }
+    }
+
+    /// Opens the Workspace's store only when search state already exists for
+    /// it, so best-effort cleanup never creates state as a side effect.
+    pub(crate) fn open_existing_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<SearchStore>, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(storage) => Ok(storage
+                .open_existing_workspace(workspace_name)?
+                .map(|store| SearchStore {
+                    backend: SearchStoreBackend::Sqlite(store),
+                })),
+        }
+    }
+
+    /// The observed-values store, when this backend keeps observed values.
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "backends without observed values answer None; SQLite is the only backend until the Postgres store lands"
+    )]
+    pub(crate) fn observed_values(&self) -> Option<Arc<dyn ObservedValuesStore>> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(storage) => Some(Arc::new(storage.observed_values())),
+        }
+    }
+}
+
+/// One Workspace's search store, opened through [`SearchStorage`].
+#[derive(Debug, Clone)]
+pub(crate) struct SearchStore {
+    backend: SearchStoreBackend,
+}
+
+#[derive(Debug, Clone)]
+enum SearchStoreBackend {
+    Sqlite(SqliteSearchStore),
+}
+
+/// Outcome of clearing every data class of a source or a Workspace at once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SearchClearAllResult {
+    pub(crate) catalog: CatalogClearResult,
+    pub(crate) observed: ObservedValuesClearResult,
+}
+
+impl SearchStore {
+    pub(crate) fn backend_name(&self) -> &'static str {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(_) => "sqlite",
+        }
+    }
+
+    pub(crate) fn catalog(&self) -> &dyn CatalogStore {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(store) => store,
+        }
+    }
+
+    /// Clears one source's catalog and observed state in one transaction, so a
+    /// failure in either data class leaves both untouched.
+    pub(crate) fn clear_source_all(
+        &self,
+        source_name: &str,
+    ) -> Result<SearchClearAllResult, SearchStoreError> {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(store) => {
+                let (catalog, observed) = store.clear_source_all(source_name)?;
+                Ok(SearchClearAllResult { catalog, observed })
+            }
+        }
+    }
+
+    /// Clears the Workspace's catalog and observed state in one transaction.
+    pub(crate) fn clear_workspace_all(&self) -> Result<SearchClearAllResult, SearchStoreError> {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(store) => {
+                let (catalog, observed) = store.clear_workspace_all()?;
+                Ok(SearchClearAllResult { catalog, observed })
+            }
+        }
+    }
+
+    /// Reclaims storage after a clear. Best effort: the result reports what
+    /// completed instead of failing the clear that already committed.
+    pub(crate) fn compact_after_clear(&self) -> SearchStorageCleanupResult {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(store) => {
+                sqlite::storage_cleanup_result(&store.compact_after_clear())
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SearchStoreError {
+    #[error(transparent)]
+    Sqlite(#[from] SqliteSearchError),
+}
+
+impl SearchStoreError {
+    /// Another writer holds the store; the caller may serve cached state.
+    pub(crate) fn is_lock_contention(&self) -> bool {
+        match self {
+            Self::Sqlite(error) => error.is_lock_contention(),
+        }
+    }
+
+    pub(crate) fn is_storage_exhaustion(&self) -> bool {
+        match self {
+            Self::Sqlite(error) => error.is_storage_exhaustion(),
+        }
+    }
+
+    /// The backend cannot serve search at all: a required capability is
+    /// missing, or the stored schema is newer than this binary supports.
+    pub(crate) fn is_unsupported(&self) -> bool {
+        match self {
+            Self::Sqlite(error) => matches!(
+                error,
+                SqliteSearchError::UnsupportedCapability { .. }
+                    | SqliteSearchError::UnsupportedSchemaVersion { .. }
+            ),
+        }
+    }
+}
+
+/// Maps a storage failure during search maintenance onto the app error
+/// taxonomy the maintenance RPCs expose.
+pub(crate) fn search_maintenance_app_error(error: &SearchStoreError) -> AppError {
+    if error.is_lock_contention() {
+        AppError::Unavailable(format!("search maintenance storage is busy: {error}"))
+    } else if error.is_storage_exhaustion() {
+        AppError::ResourceExhausted(format!("search maintenance storage is exhausted: {error}"))
+    } else if error.is_unsupported() {
+        AppError::FailedPrecondition(format!("search maintenance is not supported: {error}"))
+    } else {
+        AppError::Internal(format!("search maintenance storage failed: {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/search/store/sqlite.rs
+++ b/crates/coral-app/src/search/store/sqlite.rs
@@ -1,0 +1,207 @@
+//! `SQLite` side of the storage seam: one sidecar file per Workspace.
+
+use crate::search::catalog::index::{
+    CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
+    CatalogRefreshResult, CatalogSearchHits,
+};
+use crate::search::maintenance::{SearchMaintenanceState, SearchStorageCleanupResult};
+use crate::search::observed::{
+    ObservedValuesClearResult, ObservedValuesDrainBudget, ObservedValuesDrainResult,
+    ObservedValuesRebuildResult, ObservedValuesRetrievalPolicy, ObservedValuesSearchHits,
+    SqliteObservedValuesStore,
+};
+use crate::search::sqlite_store::{
+    SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
+};
+use crate::search::store::{CatalogStore, ObservedValuesStore, SearchStoreError};
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone)]
+pub(super) struct SqliteSearchStorage {
+    layout: AppStateLayout,
+}
+
+impl SqliteSearchStorage {
+    pub(super) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    pub(super) fn open_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<SqliteSearchStore, SearchStoreError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let capabilities = store.capabilities();
+        tracing::debug!(
+            workspace = %workspace_name,
+            sqlite_version = %capabilities.sqlite_version,
+            fts5 = capabilities.fts5,
+            trigram = capabilities.trigram,
+            "opened SQLite search store"
+        );
+        Ok(store)
+    }
+
+    pub(super) fn open_existing_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<SqliteSearchStore>, SearchStoreError> {
+        let exists = self
+            .layout
+            .search_sqlite_file(workspace_name)
+            .try_exists()
+            .map_err(SqliteSearchError::from)?;
+        if !exists {
+            return Ok(None);
+        }
+        self.open_workspace(workspace_name).map(Some)
+    }
+
+    pub(super) fn observed_values(&self) -> SqliteObservedValuesStore {
+        SqliteObservedValuesStore::new(self.layout.clone())
+    }
+}
+
+impl CatalogStore for SqliteSearchStore {
+    fn projection_is_current(&self, fingerprint: &str) -> Result<bool, SearchStoreError> {
+        Ok(self.catalog_projection_is_current(fingerprint)?)
+    }
+
+    fn refresh_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+    ) -> Result<CatalogRefreshResult, SearchStoreError> {
+        Ok(self.refresh_catalog_projection(snapshot)?)
+    }
+
+    fn rebuild_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+        force: bool,
+    ) -> Result<CatalogRebuildResult, SearchStoreError> {
+        Ok(self.rebuild_catalog_projection(snapshot, force)?)
+    }
+
+    fn document_count(&self) -> Result<u32, SearchStoreError> {
+        Ok(self.catalog_document_count()?)
+    }
+
+    fn search(
+        &self,
+        terms: &[String],
+        limit: usize,
+        class: CatalogDocumentClass,
+    ) -> Result<CatalogSearchHits, SearchStoreError> {
+        Ok(self.search_catalog(terms, limit, class)?)
+    }
+
+    fn clear_source(&self, source_name: &str) -> Result<CatalogClearResult, SearchStoreError> {
+        Ok(self.clear_catalog_source(source_name)?)
+    }
+
+    fn clear_workspace(&self) -> Result<CatalogClearResult, SearchStoreError> {
+        Ok(self.clear_catalog_workspace()?)
+    }
+}
+
+impl ObservedValuesStore for SqliteObservedValuesStore {
+    fn search(
+        &self,
+        workspace_name: &WorkspaceName,
+        terms: &[String],
+        limit: usize,
+        policy: &ObservedValuesRetrievalPolicy,
+    ) -> Result<ObservedValuesSearchHits, SearchStoreError> {
+        Ok(Self::search(self, workspace_name, terms, limit, policy)?)
+    }
+
+    fn drain_queue(
+        &self,
+        workspace_name: &WorkspaceName,
+        budget: ObservedValuesDrainBudget,
+    ) -> Result<ObservedValuesDrainResult, SearchStoreError> {
+        Ok(Self::drain_queue(self, workspace_name, budget)?)
+    }
+
+    fn rebuild_fts(
+        &self,
+        workspace_name: &WorkspaceName,
+        policy: &ObservedValuesRetrievalPolicy,
+    ) -> Result<ObservedValuesRebuildResult, SearchStoreError> {
+        Ok(Self::rebuild_fts(self, workspace_name, policy)?)
+    }
+
+    fn pending_queue_job_count(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<usize, SearchStoreError> {
+        Ok(Self::pending_queue_job_count(self, workspace_name)?)
+    }
+
+    fn clear_workspace_and_advance_epoch(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<ObservedValuesClearResult, SearchStoreError> {
+        Ok(Self::clear_workspace_and_advance_epoch(
+            self,
+            workspace_name,
+        )?)
+    }
+
+    fn clear_source_and_advance_epoch(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+    ) -> Result<ObservedValuesClearResult, SearchStoreError> {
+        Ok(Self::clear_source_and_advance_epoch(
+            self,
+            workspace_name,
+            source_name,
+        )?)
+    }
+
+    fn compact_after_clear(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<SearchStorageCleanupResult, SearchStoreError> {
+        let compaction = Self::compact_after_clear(self, workspace_name)?;
+        Ok(storage_cleanup_result(&compaction))
+    }
+}
+
+/// Projects the sidecar's checkpoint + `VACUUM` outcome onto the maintenance
+/// result the RPC reports.
+pub(super) fn storage_cleanup_result(
+    result: &SqliteSearchCompactionResult,
+) -> SearchStorageCleanupResult {
+    let (state, note) = match (
+        result.wal_checkpoint_truncate_completed,
+        result.vacuum_completed,
+    ) {
+        (true, true) => (
+            SearchMaintenanceState::Completed,
+            "local search storage cleanup completed",
+        ),
+        (true, false) | (false, true) => (
+            SearchMaintenanceState::Partial,
+            "local search storage cleanup partially completed",
+        ),
+        (false, false) => (
+            SearchMaintenanceState::Failed,
+            "local search storage cleanup did not complete",
+        ),
+    };
+    if state != SearchMaintenanceState::Completed {
+        tracing::warn!(
+            wal_checkpoint_truncate_completed = result.wal_checkpoint_truncate_completed,
+            vacuum_completed = result.vacuum_completed,
+            detail = %result.note,
+            "local search storage cleanup did not fully complete"
+        );
+    }
+    SearchStorageCleanupResult {
+        state,
+        note: note.to_string(),
+    }
+}

--- a/crates/coral-app/src/search/store/tests.rs
+++ b/crates/coral-app/src/search/store/tests.rs
@@ -1,0 +1,303 @@
+//! Behavioral tests at the storage seam.
+//!
+//! `contract` holds the backend-neutral assertions: given these documents and
+//! this query, a store returns these hits in this order. Every backend runs
+//! the same contract; the `SQLite` side runs here, paired backends add their
+//! own entry point next to their implementation.
+
+use tempfile::tempdir;
+
+use super::{SearchStorage, SearchStoreError, search_maintenance_app_error};
+use crate::bootstrap::AppError;
+use crate::search::sqlite_store::SqliteSearchError;
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+pub(super) mod contract {
+    use super::super::SearchStore;
+    use crate::search::catalog::index::{
+        CatalogDocumentClass, CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
+    };
+
+    /// Runs the catalog contract against one freshly opened, empty store.
+    pub(crate) fn assert_catalog_store_contract(store: &SearchStore) {
+        let catalog = store.catalog();
+        let snapshot = catalog_snapshot("catalog-contract-v1");
+
+        assert!(
+            !catalog
+                .projection_is_current(&snapshot.fingerprint)
+                .expect("projection check on empty store"),
+            "an empty store has no current projection"
+        );
+        let refresh = catalog
+            .refresh_projection(&snapshot)
+            .expect("refresh projection");
+        assert!(refresh.refreshed);
+        assert_eq!(refresh.document_count, 4);
+        assert_eq!(catalog.document_count().expect("document count"), 4);
+        assert!(
+            catalog
+                .projection_is_current(&snapshot.fingerprint)
+                .expect("projection check after refresh")
+        );
+        assert!(
+            !catalog
+                .refresh_projection(&snapshot)
+                .expect("second refresh")
+                .refreshed,
+            "an unchanged fingerprint must not refresh again"
+        );
+
+        // Substring match inside an identifier, entries only.
+        let entries = catalog
+            .search(&["enchmark".to_string()], 10, CatalogDocumentClass::Entries)
+            .expect("entry search");
+        assert_eq!(
+            hit_ids(&entries.hits),
+            vec!["catalog:table:github.benchmark_runs"],
+            "entries lane must find a mid-word substring and return no field documents"
+        );
+        assert!(!entries.retrieval_limited);
+
+        // Field lane returns only field documents, ranked deterministically.
+        let fields = catalog
+            .search(&["sha".to_string()], 10, CatalogDocumentClass::Fields)
+            .expect("field search");
+        assert_eq!(
+            hit_ids(&fields.hits),
+            vec!["column:github.benchmark_runs.sha"]
+        );
+        assert!(
+            fields.hits.iter().all(|hit| !hit.field_name.is_empty()),
+            "fields lane must not return entry documents"
+        );
+
+        // A limit smaller than the candidate set reports that it was cut short.
+        let limited = catalog
+            .search(&["github".to_string()], 1, CatalogDocumentClass::Fields)
+            .expect("limited search");
+        assert_eq!(limited.hits.len(), 1);
+        assert!(limited.retrieval_limited);
+
+        // Negative: nothing shares a trigram with this.
+        let none = catalog
+            .search(&["zzqxv".to_string()], 10, CatalogDocumentClass::Entries)
+            .expect("negative search");
+        assert!(none.hits.is_empty());
+
+        // Repeated calls are stable.
+        let again = catalog
+            .search(&["github".to_string()], 10, CatalogDocumentClass::Fields)
+            .expect("repeat search");
+        let once_more = catalog
+            .search(&["github".to_string()], 10, CatalogDocumentClass::Fields)
+            .expect("repeat search again");
+        assert_eq!(hit_ids(&again.hits), hit_ids(&once_more.hits));
+
+        // Clearing one source keeps the other and invalidates the fingerprint.
+        let cleared = catalog.clear_source("github").expect("clear source");
+        assert_eq!(cleared.deleted_document_count, 3);
+        assert_eq!(catalog.document_count().expect("count after clear"), 1);
+        assert!(
+            !catalog
+                .projection_is_current(&snapshot.fingerprint)
+                .expect("projection check after source clear")
+        );
+
+        // A rebuild with the same fingerprint is a no-op unless forced.
+        let rebuilt = catalog
+            .rebuild_projection(&snapshot, false)
+            .expect("rebuild after clear");
+        assert!(rebuilt.projection_changed);
+        assert_eq!(rebuilt.new_document_count, 4);
+        let noop = catalog
+            .rebuild_projection(&snapshot, false)
+            .expect("noop rebuild");
+        assert!(!noop.rebuild_performed);
+        let forced = catalog
+            .rebuild_projection(&snapshot, true)
+            .expect("forced rebuild");
+        assert!(forced.rebuild_performed);
+        assert!(!forced.projection_changed);
+
+        let cleared = catalog.clear_workspace().expect("clear workspace");
+        assert_eq!(cleared.deleted_document_count, 4);
+        assert_eq!(catalog.document_count().expect("count after clear"), 0);
+    }
+
+    pub(crate) fn hit_ids(hits: &[crate::search::catalog::index::CatalogSearchHit]) -> Vec<&str> {
+        hits.iter().map(|hit| hit.doc_id.as_str()).collect()
+    }
+
+    pub(crate) fn catalog_snapshot(fingerprint: &str) -> CatalogIndexSnapshot {
+        CatalogIndexSnapshot {
+            fingerprint: fingerprint.to_string(),
+            documents: vec![
+                document(
+                    "catalog:table:github.benchmark_runs",
+                    CatalogIndexDocumentKind::CatalogTable,
+                    "github",
+                    "benchmark_runs",
+                    "",
+                    "",
+                    "github.benchmark_runs",
+                    "benchmark_runs",
+                    "Benchmark runs recorded per commit",
+                ),
+                document(
+                    "column:github.benchmark_runs.sha",
+                    CatalogIndexDocumentKind::ColumnHint,
+                    "github",
+                    "benchmark_runs",
+                    "sha",
+                    "table_column",
+                    "github.benchmark_runs.sha",
+                    "sha",
+                    "Commit SHA",
+                ),
+                document(
+                    "column:github.benchmark_runs.duration_ms",
+                    CatalogIndexDocumentKind::ColumnHint,
+                    "github",
+                    "benchmark_runs",
+                    "duration_ms",
+                    "table_column",
+                    "github.benchmark_runs.duration_ms",
+                    "duration_ms",
+                    "Wall-clock duration",
+                ),
+                document(
+                    "catalog:table:linear.issue_labels",
+                    CatalogIndexDocumentKind::CatalogTable,
+                    "linear",
+                    "issue_labels",
+                    "",
+                    "",
+                    "linear.issue_labels",
+                    "issue labels",
+                    "Labels attached to issues",
+                ),
+            ],
+        }
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "fixture builder mirrors the document's column list"
+    )]
+    fn document(
+        doc_id: &str,
+        doc_kind: CatalogIndexDocumentKind,
+        source_name: &str,
+        surface_name: &str,
+        field_name: &str,
+        field_role: &str,
+        qualified_name: &str,
+        title: &str,
+        description: &str,
+    ) -> CatalogIndexDocument {
+        CatalogIndexDocument {
+            doc_id: doc_id.to_string(),
+            doc_kind,
+            source_name: source_name.to_string(),
+            catalog_name: None,
+            surface_kind: "table".to_string(),
+            surface_name: surface_name.to_string(),
+            field_name: field_name.to_string(),
+            field_role: field_role.to_string(),
+            qualified_name: qualified_name.to_string(),
+            title: title.to_string(),
+            description: description.to_string(),
+            searchable_text: format!("{source_name} {surface_name} {field_name}"),
+        }
+    }
+}
+
+fn sqlite_storage() -> (tempfile::TempDir, SearchStorage) {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+    (temp, SearchStorage::sqlite(layout))
+}
+
+#[test]
+fn sqlite_store_serves_the_catalog_contract() {
+    let (_temp, storage) = sqlite_storage();
+    let store = storage
+        .open_workspace(&WorkspaceName::default())
+        .expect("open workspace store");
+
+    assert_eq!(store.backend_name(), "sqlite");
+    contract::assert_catalog_store_contract(&store);
+}
+
+#[test]
+fn open_existing_workspace_never_creates_search_state() {
+    let (_temp, storage) = sqlite_storage();
+    let workspace = WorkspaceName::default();
+
+    assert!(
+        storage
+            .open_existing_workspace(&workspace)
+            .expect("probe missing store")
+            .is_none()
+    );
+    storage.open_workspace(&workspace).expect("create store");
+    assert!(
+        storage
+            .open_existing_workspace(&workspace)
+            .expect("probe existing store")
+            .is_some()
+    );
+}
+
+#[test]
+fn sqlite_storage_keeps_observed_values() {
+    let (_temp, storage) = sqlite_storage();
+    assert!(storage.observed_values().is_some());
+}
+
+#[test]
+fn clear_all_spans_both_data_classes_and_reports_cleanup() {
+    let (_temp, storage) = sqlite_storage();
+    let store = storage
+        .open_workspace(&WorkspaceName::default())
+        .expect("open workspace store");
+    store
+        .catalog()
+        .refresh_projection(&contract::catalog_snapshot("clear-all-v1"))
+        .expect("refresh");
+
+    let cleared = store.clear_source_all("github").expect("clear source all");
+    assert_eq!(cleared.catalog.deleted_document_count, 3);
+    assert_eq!(cleared.observed.values, 0);
+    let cleared = store.clear_workspace_all().expect("clear workspace all");
+    assert_eq!(cleared.catalog.deleted_document_count, 1);
+    assert_eq!(
+        store.compact_after_clear().state,
+        crate::search::maintenance::SearchMaintenanceState::Completed
+    );
+}
+
+#[test]
+fn maintenance_errors_keep_their_app_error_class() {
+    let unsupported = SearchStoreError::from(SqliteSearchError::UnsupportedCapability {
+        feature: "FTS5",
+        sqlite_version: "3.0.0".to_string(),
+    });
+    assert!(unsupported.is_unsupported());
+    assert!(matches!(
+        search_maintenance_app_error(&unsupported),
+        AppError::FailedPrecondition(note) if note.contains("FTS5")
+    ));
+
+    let io = SearchStoreError::from(SqliteSearchError::Io(std::io::Error::new(
+        std::io::ErrorKind::StorageFull,
+        "disk full",
+    )));
+    assert!(io.is_storage_exhaustion());
+    assert!(matches!(
+        search_maintenance_app_error(&io),
+        AppError::ResourceExhausted(_)
+    ));
+}

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -17,7 +17,7 @@ use crate::credentials::{
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
 use crate::search::observed::SearchObservationHandle;
-use crate::search::sqlite_store::SqliteSearchStore;
+use crate::search::store::SearchStorage;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
@@ -49,6 +49,7 @@ pub(crate) struct SourceManager {
     lifecycle_lock: WorkspaceLifecycleLock,
     diagnostic_reporter: SourceDiagnosticReporter,
     search_observations: Option<SearchObservationHandle>,
+    search_storage: SearchStorage,
     pool_registry: Arc<WorkspacePoolRegistry>,
     database_sources_enabled: bool,
 }
@@ -235,6 +236,7 @@ impl SourceManager {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
+            search_storage: SearchStorage::sqlite(layout.clone()),
             layout,
             lifecycle_lock,
             diagnostic_reporter,
@@ -242,6 +244,11 @@ impl SourceManager {
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
             database_sources_enabled: false,
         }
+    }
+
+    pub(crate) fn with_search_storage(mut self, search_storage: SearchStorage) -> Self {
+        self.search_storage = search_storage;
+        self
     }
 
     pub(crate) fn with_database_sources_enabled(mut self, enabled: bool) -> Self {
@@ -951,27 +958,29 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) {
-        let search_sqlite_file = self.layout.search_sqlite_file(workspace_name);
-        if !search_sqlite_file.exists() {
-            return;
-        }
-        match SqliteSearchStore::open_workspace(&self.layout, workspace_name)
-            .and_then(|store| store.clear_catalog_workspace())
-        {
-            Ok(result) => {
+        match self
+            .search_storage
+            .open_existing_workspace(workspace_name)
+            .and_then(|store| {
+                store
+                    .map(|store| store.catalog().clear_workspace())
+                    .transpose()
+            }) {
+            Ok(None) => {}
+            Ok(Some(result)) => {
                 tracing::debug!(
                     workspace = %workspace_name,
                     source = %source_name,
                     deleted_document_count = result.deleted_document_count,
-                    "cleared SQLite catalog projection for source lifecycle change"
+                    "cleared catalog search projection for source lifecycle change"
                 );
             }
             Err(error) => {
                 warn!(
                     workspace = %workspace_name,
                     source = %source_name,
-                    search_sqlite_file = %search_sqlite_file.display(),
-                    "source lifecycle changed, but failed to clear SQLite catalog projection: {error}"
+                    search_backend = self.search_storage.backend_name(),
+                    "source lifecycle changed, but failed to clear catalog search projection: {error}"
                 );
             }
         }


### PR DESCRIPTION
Introduce `SearchStorage` and `SearchStore` with the `CatalogStore` and
`ObservedValuesStore` component traits, following the `CoralDbBackend`
precedent. The SQLite store moves behind the seam unchanged; the catalog
provider, search manager, and source manager open per-workspace stores
through it instead of constructing `SqliteSearchStore` directly.
Backend-neutral catalog index types and match semantics move to
`search::catalog::index` so a second backend can share them.

The observed provider becomes optional on the manager: a backend that
keeps no observed values reports maintenance as skipped instead of
opening SQLite. Only the SQLite backend exists in this change.

No behavior change: the existing SQLite search tests run unchanged and
the seam gets contract tests that a paired backend reuses.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1
