### PR TITLE
feat(search): add the [search] backend config surface

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -43,6 +43,19 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
   Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.
 </Note>
 
+### Search storage
+
+Universal Search keeps its catalog index in a store of its own. By default the store follows `[database].backend`: SQLite app state uses one SQLite search file per workspace under the local state directory, and Postgres app state keeps catalog search in the same Postgres database, as one schema per workspace.
+
+Use `[search]` to choose the search backend on its own. The section has no `path` or `url_env` key: the `postgres` backend reuses the `[database]` connection URL with a small connection pool of its own, so it requires `[database].backend = "postgres"`.
+
+```toml
+[search]
+backend = "sqlite"
+```
+
+The Postgres search backend needs the `pg_trgm` extension. Coral creates it when the database role may, and refuses to start when it is missing. Observed-values search is not available on the Postgres search backend.
+
 ## Workspaces
 
 Workspace metadata is stored under `[workspaces]`. The `default` workspace

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -11,6 +11,7 @@ use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
+use crate::search::store::SearchConfigError;
 use crate::state::db::DbError;
 
 /// Errors surfaced by the local application layer.
@@ -170,6 +171,18 @@ impl From<DbError> for AppError {
             DbError::TomlDecode(error) => Self::TomlDecode(error),
             DbError::Sqlx(error) => Self::Database(error.to_string()),
             DbError::Migration(error) => Self::Database(error.to_string()),
+        }
+    }
+}
+
+impl From<SearchConfigError> for AppError {
+    fn from(error: SearchConfigError) -> Self {
+        match error {
+            SearchConfigError::Config(detail) => {
+                Self::FailedPrecondition(format!("search configuration is invalid: {detail}"))
+            }
+            SearchConfigError::Io(error) => Self::Io(error),
+            SearchConfigError::TomlDecode(error) => Self::TomlDecode(error),
         }
     }
 }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,7 +53,7 @@ use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
-use crate::search::store::SearchStorage;
+use crate::search::store::{ResolvedSearchConfig, SearchConfig, SearchStorage};
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
@@ -348,7 +348,7 @@ impl ServerBuilder {
         layout.ensure()?;
         let feature_store = FeatureStore::from_layout(layout.clone());
         let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
-        let coral_db = init_database(&layout).await?;
+        let (database_config, coral_db) = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store, &layout).await?;
         let coral_db = Arc::new(coral_db);
@@ -360,7 +360,7 @@ impl ServerBuilder {
         let workspace_pool_registry = Arc::new(WorkspacePoolRegistry::default());
         let diagnostic_reporter = SourceDiagnosticReporter::default();
         let database_sources_enabled = features.enabled(Feature::DatabaseSources);
-        let search_storage = SearchStorage::sqlite(layout.clone());
+        let search_storage = init_search_storage(&layout, &database_config)?;
         let source_manager = SourceManager::with_diagnostic_reporter(
             config_store.clone(),
             credential_manager.clone(),
@@ -406,8 +406,9 @@ impl ServerBuilder {
         .with_database_sources_enabled(database_sources_enabled)
         .with_task_activity_recorder(task_activity);
         let observed_values_search_enabled = features.enabled(Feature::ObservedValuesSearch);
-        let search_observations =
-            observed_values_search_enabled.then(|| SearchObservationHandle::new(layout.clone()));
+        let search_observations = (observed_values_search_enabled
+            && search_storage.keeps_observed_values())
+        .then(|| SearchObservationHandle::new(layout.clone()));
         let search_manager = SearchManager::with_diagnostic_reporter(
             search_storage,
             layout,
@@ -487,11 +488,26 @@ fn init_credential_manager(layout: &AppStateLayout) -> Result<CredentialManager,
     Ok(CredentialManager::new(credential_store))
 }
 
-async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
+async fn init_database(
+    layout: &AppStateLayout,
+) -> Result<(ResolvedDatabaseConfig, CoralDb), AppError> {
     let database_config = resolve_database_config(layout)?;
-    let coral_db = CoralDb::open(database_config).await?;
+    let coral_db = CoralDb::open(database_config.clone()).await?;
     coral_db.migrate().await?;
-    Ok(coral_db)
+    Ok((database_config, coral_db))
+}
+
+/// Resolves `[search]` against the database config and opens the backend.
+fn init_search_storage(
+    layout: &AppStateLayout,
+    database_config: &ResolvedDatabaseConfig,
+) -> Result<SearchStorage, AppError> {
+    match SearchConfig::load(layout)?.resolve(database_config)? {
+        ResolvedSearchConfig::Sqlite => Ok(SearchStorage::sqlite(layout.clone())),
+        ResolvedSearchConfig::Postgres { .. } => Err(AppError::FailedPrecondition(
+            "search backend 'postgres' is not available in this build yet".to_string(),
+        )),
+    }
 }
 
 fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseConfig, AppError> {

--- a/crates/coral-app/src/search/store/config.rs
+++ b/crates/coral-app/src/search/store/config.rs
@@ -1,0 +1,272 @@
+//! `[search]` configuration: which storage backend serves Universal Search.
+//!
+//! ```toml
+//! [search]
+//! backend = "postgres"   # "sqlite" | "postgres"; default: follow [database].backend
+//! ```
+//!
+//! The section mirrors `[database]` (`state::db::config`) and carries no path
+//! or URL of its own: `sqlite` derives per-Workspace files from the app-state
+//! layout, and `postgres` reuses the resolved `[database]` URL with a small
+//! pool of its own. The knob stays independently settable so a deployment can
+//! keep app state on Postgres while search stays on `SQLite` during rollout.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::state::AppStateLayout;
+use crate::state::db::ResolvedDatabaseConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SearchBackendKind {
+    Sqlite,
+    Postgres,
+}
+
+impl SearchBackendKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Postgres => "postgres",
+        }
+    }
+}
+
+/// The persisted `[search]` section. `backend: None` follows `[database]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SearchConfig {
+    backend: Option<SearchBackendKind>,
+}
+
+/// The effective search backend after resolving against the database config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResolvedSearchConfig {
+    Sqlite,
+    Postgres { url: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SearchConfigError {
+    #[error("search configuration is invalid: {0}")]
+    Config(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    TomlDecode(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedConfig {
+    #[serde(default)]
+    search: Option<RawPersistedSearchConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPersistedSearchConfig {
+    #[serde(default)]
+    backend: Option<SearchBackendKind>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, toml::Value>,
+}
+
+impl RawPersistedSearchConfig {
+    fn into_backend(self) -> Result<SearchBackendKind, SearchConfigError> {
+        if let Some(field) = self.extra.keys().next() {
+            return Err(SearchConfigError::Config(format!(
+                "unsupported [search].{field} configuration key"
+            )));
+        }
+        self.backend.ok_or_else(|| {
+            SearchConfigError::Config(
+                "[search].backend is required when [search] is present".to_string(),
+            )
+        })
+    }
+}
+
+impl SearchConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, SearchConfigError> {
+        if !layout.config_file().try_exists()? {
+            return Ok(Self { backend: None });
+        }
+
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let persisted: PersistedConfig = toml::from_str(&raw)?;
+        let Some(search) = persisted.search else {
+            return Ok(Self { backend: None });
+        };
+        Ok(Self {
+            backend: Some(search.into_backend()?),
+        })
+    }
+
+    /// Resolves the effective backend. Postgres search reuses the database
+    /// connection, so it needs the database to be Postgres too.
+    pub(crate) fn resolve(
+        &self,
+        database: &ResolvedDatabaseConfig,
+    ) -> Result<ResolvedSearchConfig, SearchConfigError> {
+        let backend = self.backend.unwrap_or(match database {
+            ResolvedDatabaseConfig::Sqlite { .. } => SearchBackendKind::Sqlite,
+            ResolvedDatabaseConfig::Postgres { .. } => SearchBackendKind::Postgres,
+        });
+        match (backend, database) {
+            (SearchBackendKind::Sqlite, _) => Ok(ResolvedSearchConfig::Sqlite),
+            (SearchBackendKind::Postgres, ResolvedDatabaseConfig::Postgres { url }) => {
+                Ok(ResolvedSearchConfig::Postgres { url: url.clone() })
+            }
+            (SearchBackendKind::Postgres, ResolvedDatabaseConfig::Sqlite { .. }) => {
+                Err(SearchConfigError::Config(format!(
+                    "search backend '{}' reuses the [database] connection and requires [database].backend = \"postgres\"",
+                    backend.as_str()
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
+
+    use super::{ResolvedSearchConfig, SearchConfig, SearchConfigError};
+    use crate::state::AppStateLayout;
+    use crate::state::db::ResolvedDatabaseConfig;
+
+    fn layout_with_config(raw_config: Option<&str>) -> (tempfile::TempDir, AppStateLayout) {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        if let Some(raw_config) = raw_config {
+            fs::create_dir_all(layout.config_dir()).expect("config dir");
+            fs::write(layout.config_file(), raw_config).expect("config");
+        }
+        (temp, layout)
+    }
+
+    fn sqlite_database() -> ResolvedDatabaseConfig {
+        ResolvedDatabaseConfig::Sqlite {
+            path: PathBuf::from("coral.db"),
+        }
+    }
+
+    fn postgres_database() -> ResolvedDatabaseConfig {
+        ResolvedDatabaseConfig::Postgres {
+            url: "postgres://coral@127.0.0.1/coral".to_string(),
+        }
+    }
+
+    #[test]
+    fn follows_the_database_backend_when_unset() {
+        for raw_config in [None, Some("[database]\nbackend = \"sqlite\"\n")] {
+            let (_temp, layout) = layout_with_config(raw_config);
+            let config = SearchConfig::load(&layout).expect("search config");
+
+            assert_eq!(config, SearchConfig { backend: None });
+            assert_eq!(
+                config.resolve(&sqlite_database()).expect("resolve sqlite"),
+                ResolvedSearchConfig::Sqlite
+            );
+            assert_eq!(
+                config
+                    .resolve(&postgres_database())
+                    .expect("resolve postgres"),
+                ResolvedSearchConfig::Postgres {
+                    url: "postgres://coral@127.0.0.1/coral".to_string()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_sqlite_keeps_search_local_beside_a_postgres_database() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"sqlite\"\n"));
+
+        let config = SearchConfig::load(&layout).expect("search config");
+
+        assert_eq!(
+            config.resolve(&postgres_database()).expect("resolve"),
+            ResolvedSearchConfig::Sqlite
+        );
+    }
+
+    #[test]
+    fn explicit_postgres_reuses_the_database_url() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"postgres\"\n"));
+
+        let config = SearchConfig::load(&layout).expect("search config");
+
+        assert_eq!(
+            config.resolve(&postgres_database()).expect("resolve"),
+            ResolvedSearchConfig::Postgres {
+                url: "postgres://coral@127.0.0.1/coral".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_postgres_requires_a_postgres_database() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"postgres\"\n"));
+
+        let error = SearchConfig::load(&layout)
+            .expect("search config")
+            .resolve(&sqlite_database())
+            .expect_err("postgres search over a sqlite database must be rejected");
+
+        assert!(
+            matches!(error, SearchConfigError::Config(ref detail) if detail.contains("requires [database].backend = \"postgres\"")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn search_section_requires_explicit_backend() {
+        let (_temp, layout) = layout_with_config(Some("[search]\n"));
+
+        let error = SearchConfig::load(&layout).expect_err("search config should reject backend");
+
+        assert!(
+            matches!(error, SearchConfigError::Config(ref detail) if detail.contains("[search].backend is required")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn search_section_rejects_unsupported_fields() {
+        for (raw_config, expected_error) in [
+            (
+                "[search]\nbackend = \"sqlite\"\npath = \"search.sqlite3\"\n",
+                "unsupported [search].path configuration key",
+            ),
+            (
+                "[search]\nbackend = \"postgres\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+                "unsupported [search].url_env configuration key",
+            ),
+        ] {
+            let (_temp, layout) = layout_with_config(Some(raw_config));
+
+            let error = SearchConfig::load(&layout).expect_err("search config should reject field");
+
+            assert!(
+                matches!(error, SearchConfigError::Config(ref detail) if detail.contains(expected_error)),
+                "unexpected error for config {raw_config:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_backend_values_are_rejected() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"paradedb\"\n"));
+
+        let error = SearchConfig::load(&layout).expect_err("unknown backend must be rejected");
+
+        assert!(
+            matches!(error, SearchConfigError::TomlDecode(_)),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -14,6 +14,7 @@
 //! Retrieval order is the ranking and must be a deterministic total order,
 //! whichever backend serves it.
 
+mod config;
 mod sqlite;
 
 use std::sync::Arc;
@@ -32,6 +33,7 @@ use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
+pub(crate) use config::{ResolvedSearchConfig, SearchConfig, SearchConfigError};
 use sqlite::SqliteSearchStorage;
 
 /// Catalog projection storage for one Workspace.
@@ -175,6 +177,12 @@ impl SearchStorage {
                     backend: SearchStoreBackend::Sqlite(store),
                 })),
         }
+    }
+
+    /// Whether this backend keeps observed values at all; when it does not,
+    /// the capture pipeline has nowhere to write and must not start.
+    pub(crate) fn keeps_observed_values(&self) -> bool {
+        self.observed_values().is_some()
     }
 
     /// The observed-values store, when this backend keeps observed values.

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -87,6 +87,38 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     }
 }
 
+#[tokio::test]
+async fn server_lifecycle_rejects_postgres_search_over_a_sqlite_database() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[search]\nbackend = \"postgres\"\n",
+    )
+    .expect("write config");
+
+    let result = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(server) => {
+            server.shutdown().await.expect("shutdown unexpected server");
+            panic!("server start should fail when search is on Postgres but the database is not");
+        }
+    };
+
+    match error {
+        LocalServerError::FailedPrecondition(detail) => assert!(
+            detail.contains("requires [database].backend = \"postgres\""),
+            "unexpected detail: {detail}"
+        ),
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
 async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
     let database_file = config_dir.join("coral.db");
     assert!(


### PR DESCRIPTION
Add `[search] backend = "sqlite" | "postgres"`, defaulting to follow
`[database].backend`. Validation mirrors the `[database]` section:
unknown keys are rejected and the section carries no path or URL of its
own, because the Postgres backend reuses the resolved database URL.
Selecting `postgres` beside a SQLite database is rejected at boot with
the reason.

The server resolves the section next to the database config and gates
the observed-values capture pipeline on the backend keeping observed
values. `postgres` resolves but is refused as unavailable until the
Postgres catalog store lands next in this stack.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1
