### PR TITLE
feat(search): add the Postgres catalog search store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,9 @@ postgres-tests: $(POSTGRES_TESTS_PREREQS)
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
 	  contract_on_postgres \
 	  -- --ignored; \
+	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
+	  search::store::postgres:: \
+	  -- --ignored; \
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app \
 	  --test postgres_database_tests \
 	  -- --ignored

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,7 +53,7 @@ use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
-use crate::search::store::{ResolvedSearchConfig, SearchConfig, SearchStorage};
+use crate::search::store::{ResolvedSearchConfig, SearchConfig, SearchStorage, SearchStoreError};
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
@@ -360,7 +360,7 @@ impl ServerBuilder {
         let workspace_pool_registry = Arc::new(WorkspacePoolRegistry::default());
         let diagnostic_reporter = SourceDiagnosticReporter::default();
         let database_sources_enabled = features.enabled(Feature::DatabaseSources);
-        let search_storage = init_search_storage(&layout, &database_config)?;
+        let search_storage = init_search_storage(&layout, &database_config).await?;
         let source_manager = SourceManager::with_diagnostic_reporter(
             config_store.clone(),
             credential_manager.clone(),
@@ -498,15 +498,28 @@ async fn init_database(
 }
 
 /// Resolves `[search]` against the database config and opens the backend.
-fn init_search_storage(
+///
+/// A backend that cannot serve search fails startup here, naming the missing
+/// capability, rather than serving degraded results later.
+async fn init_search_storage(
     layout: &AppStateLayout,
     database_config: &ResolvedDatabaseConfig,
 ) -> Result<SearchStorage, AppError> {
     match SearchConfig::load(layout)?.resolve(database_config)? {
         ResolvedSearchConfig::Sqlite => Ok(SearchStorage::sqlite(layout.clone())),
-        ResolvedSearchConfig::Postgres { .. } => Err(AppError::FailedPrecondition(
-            "search backend 'postgres' is not available in this build yet".to_string(),
-        )),
+        ResolvedSearchConfig::Postgres { url } => {
+            SearchStorage::postgres(&url, tokio::runtime::Handle::current())
+                .await
+                .map_err(|error| search_storage_open_error(&error))
+        }
+    }
+}
+
+fn search_storage_open_error(error: &SearchStoreError) -> AppError {
+    if error.is_unsupported() {
+        AppError::FailedPrecondition(format!("search storage is not supported: {error}"))
+    } else {
+        AppError::Internal(format!("search storage failed to open: {error}"))
     }
 }
 

--- a/crates/coral-app/src/search/catalog/index.rs
+++ b/crates/coral-app/src/search/catalog/index.rs
@@ -85,6 +85,23 @@ pub(crate) struct CatalogSearchHit {
     pub(crate) field_role: String,
 }
 
+/// Vocabulary a stored `surface_kind` may take; both backends enforce it as a
+/// CHECK constraint and re-validate rows on read.
+pub(crate) fn is_known_surface_kind(value: &str) -> bool {
+    matches!(value, "" | "table" | "table_function")
+}
+
+/// Vocabulary a stored `field_role` may take.
+pub(crate) fn is_known_field_role(value: &str) -> bool {
+    matches!(
+        value,
+        "" | "table_column"
+            | "table_filter"
+            | "table_function_argument"
+            | "table_function_result_column"
+    )
+}
+
 /// Which population of documents a retriever is asking for.
 ///
 /// Entry documents and field documents share an index, but not a candidate

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -7,7 +7,8 @@ use rusqlite::{
 use crate::search::catalog::index::{
     CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
     CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits, indexed_searchable_text,
-    normalized_search_terms, probe_limit, truncate_probe_hits,
+    is_known_field_role, is_known_surface_kind, normalized_search_terms, probe_limit,
+    truncate_probe_hits,
 };
 use crate::search::sqlite_store::SqliteSearchError;
 use crate::workspaces::WorkspaceName;
@@ -487,20 +488,18 @@ fn hit_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CatalogSearchHit> {
 }
 
 fn surface_kind_from_storage(value: &str) -> rusqlite::Result<String> {
-    match value {
-        "" | "table" | "table_function" => Ok(value.to_string()),
-        _ => invalid_catalog_storage_value(2, "surface_kind", value),
+    if is_known_surface_kind(value) {
+        Ok(value.to_string())
+    } else {
+        invalid_catalog_storage_value(2, "surface_kind", value)
     }
 }
 
 fn field_role_from_storage(value: &str) -> rusqlite::Result<String> {
-    match value {
-        ""
-        | "table_column"
-        | "table_filter"
-        | "table_function_argument"
-        | "table_function_result_column" => Ok(value.to_string()),
-        _ => invalid_catalog_storage_value(5, "field_role", value),
+    if is_known_field_role(value) {
+        Ok(value.to_string())
+    } else {
+        invalid_catalog_storage_value(5, "field_role", value)
     }
 }
 

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -123,16 +123,23 @@ impl SearchManager {
             .map(|store| ObservedValuesProvider::from_store(store, write_coordinator));
         let observed_scope_loader =
             ObservedValuesLiveScopeLoader::new(layout, config_store.clone(), diagnostic_reporter);
+        let registry = match &observed {
+            Some(observed) => SearchProviderRegistry::local(
+                catalog.clone(),
+                observed_values_search_enabled.then(|| observed.clone()),
+            ),
+            None => SearchProviderRegistry::local_without_observed_values(
+                catalog.clone(),
+                storage.backend_name(),
+            ),
+        };
         Self {
             catalog_discovery,
-            catalog: catalog.clone(),
-            observed: observed.clone(),
+            catalog,
+            observed,
             observed_scope_loader,
             observed_values_search_enabled,
-            engine: UniversalSearchEngine::new(SearchProviderRegistry::local(
-                catalog,
-                observed_values_search_enabled.then_some(observed).flatten(),
-            )),
+            engine: UniversalSearchEngine::new(registry),
             workspaces: workspace_manager,
             lifecycle_lock,
             storage,

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -304,6 +304,23 @@ impl SearchProviderRegistry {
         }
     }
 
+    /// Registers the catalog provider beside a static status explaining that
+    /// the search backend keeps no observed values, whatever the feature flag
+    /// says.
+    pub(crate) fn local_without_observed_values(
+        catalog: CatalogMetadataProvider,
+        backend_name: &str,
+    ) -> Self {
+        let ordered = vec![
+            SearchProviderRegistration::Provider(Arc::new(catalog)),
+            SearchProviderRegistration::StaticStatus(observed_unavailable_status(backend_name)),
+            SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
+        ];
+        Self {
+            ordered: ordered.into(),
+        }
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = &SearchProviderRegistration> {
         self.ordered.iter()
     }
@@ -381,6 +398,17 @@ pub(crate) fn provider_error_outcome(provider: SearchProviderKind) -> ProviderSe
             note: "search provider failed without affecting other providers".to_string(),
             coverage: None,
         },
+    }
+}
+
+fn observed_unavailable_status(backend_name: &str) -> ProviderStatus {
+    ProviderStatus {
+        provider: SearchProviderKind::ObservedValues,
+        state: SearchProviderState::NotEnabled,
+        note: format!(
+            "observed value search is not available on the {backend_name} search backend"
+        ),
+        coverage: None,
     }
 }
 

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -15,16 +15,19 @@
 //! whichever backend serves it.
 
 mod config;
+mod postgres;
 mod sqlite;
 
 use std::sync::Arc;
+
+use tokio::runtime::Handle;
 
 use crate::bootstrap::AppError;
 use crate::search::catalog::index::{
     CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
     CatalogRefreshResult, CatalogSearchHits,
 };
-use crate::search::maintenance::SearchStorageCleanupResult;
+use crate::search::maintenance::{SearchMaintenanceState, SearchStorageCleanupResult};
 use crate::search::observed::{
     ObservedValuesClearResult, ObservedValuesDrainBudget, ObservedValuesDrainResult,
     ObservedValuesRebuildResult, ObservedValuesRetrievalPolicy, ObservedValuesSearchHits,
@@ -34,6 +37,8 @@ use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
 pub(crate) use config::{ResolvedSearchConfig, SearchConfig, SearchConfigError};
+pub(crate) use postgres::MigratedWorkspaceSchema;
+use postgres::{PostgresSearchError, PostgresSearchStorage, PostgresSearchStore};
 use sqlite::SqliteSearchStorage;
 
 /// Catalog projection storage for one Workspace.
@@ -132,6 +137,7 @@ pub(crate) struct SearchStorage {
 #[derive(Debug, Clone)]
 enum SearchStorageBackend {
     Sqlite(SqliteSearchStorage),
+    Postgres(PostgresSearchStorage),
 }
 
 impl SearchStorage {
@@ -142,9 +148,21 @@ impl SearchStorage {
         }
     }
 
+    /// One Postgres schema per Workspace in the `[database]` Postgres database, reached
+    /// through a small dedicated pool on the same URL. Bootstraps the
+    /// registry and verifies `pg_trgm`, failing loud when it is missing.
+    pub(crate) async fn postgres(url: &str, handle: Handle) -> Result<Self, SearchStoreError> {
+        Ok(Self {
+            backend: SearchStorageBackend::Postgres(
+                PostgresSearchStorage::open(url, handle).await?,
+            ),
+        })
+    }
+
     pub(crate) fn backend_name(&self) -> &'static str {
         match &self.backend {
             SearchStorageBackend::Sqlite(_) => "sqlite",
+            SearchStorageBackend::Postgres(_) => "postgres",
         }
     }
 
@@ -161,6 +179,9 @@ impl SearchStorage {
             SearchStorageBackend::Sqlite(storage) => Ok(SearchStore {
                 backend: SearchStoreBackend::Sqlite(storage.open_workspace(workspace_name)?),
             }),
+            SearchStorageBackend::Postgres(storage) => Ok(SearchStore {
+                backend: SearchStoreBackend::Postgres(storage.open_workspace(workspace_name)?),
+            }),
         }
     }
 
@@ -176,6 +197,45 @@ impl SearchStorage {
                 .map(|store| SearchStore {
                     backend: SearchStoreBackend::Sqlite(store),
                 })),
+            SearchStorageBackend::Postgres(storage) => Ok(storage
+                .open_existing_workspace(workspace_name)?
+                .map(|store| SearchStore {
+                    backend: SearchStoreBackend::Postgres(store),
+                })),
+        }
+    }
+
+    /// Removes every trace of the Workspace's search state. Returns whether
+    /// there was any. The `SQLite` sidecar lives inside the Workspace
+    /// directory, which Workspace deletion removes as a whole.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
+    )]
+    pub(crate) async fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<bool, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => Ok(false),
+            SearchStorageBackend::Postgres(storage) => {
+                Ok(storage.delete_workspace(workspace_name).await?)
+            }
+        }
+    }
+
+    /// Boot-time ledger sweep: migrates every Workspace schema the backend
+    /// knows to be behind this binary. `SQLite` sidecars migrate on open.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into server startup next in this stack")
+    )]
+    pub(crate) async fn migrate_all(
+        &self,
+    ) -> Result<Vec<MigratedWorkspaceSchema>, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => Ok(Vec::new()),
+            SearchStorageBackend::Postgres(storage) => Ok(storage.migrate_all().await?),
         }
     }
 
@@ -186,13 +246,11 @@ impl SearchStorage {
     }
 
     /// The observed-values store, when this backend keeps observed values.
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "backends without observed values answer None; SQLite is the only backend until the Postgres store lands"
-    )]
+    /// Postgres keeps none: cloud observed memory waits for lagoon #37.
     pub(crate) fn observed_values(&self) -> Option<Arc<dyn ObservedValuesStore>> {
         match &self.backend {
             SearchStorageBackend::Sqlite(storage) => Some(Arc::new(storage.observed_values())),
+            SearchStorageBackend::Postgres(_) => None,
         }
     }
 }
@@ -206,6 +264,7 @@ pub(crate) struct SearchStore {
 #[derive(Debug, Clone)]
 enum SearchStoreBackend {
     Sqlite(SqliteSearchStore),
+    Postgres(PostgresSearchStore),
 }
 
 /// Outcome of clearing every data class of a source or a Workspace at once.
@@ -219,12 +278,22 @@ impl SearchStore {
     pub(crate) fn backend_name(&self) -> &'static str {
         match &self.backend {
             SearchStoreBackend::Sqlite(_) => "sqlite",
+            SearchStoreBackend::Postgres(_) => "postgres",
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn postgres_schema_name(&self) -> String {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(_) => panic!("not a Postgres store"),
+            SearchStoreBackend::Postgres(store) => store.schema_name(),
         }
     }
 
     pub(crate) fn catalog(&self) -> &dyn CatalogStore {
         match &self.backend {
             SearchStoreBackend::Sqlite(store) => store,
+            SearchStoreBackend::Postgres(store) => store,
         }
     }
 
@@ -239,6 +308,10 @@ impl SearchStore {
                 let (catalog, observed) = store.clear_source_all(source_name)?;
                 Ok(SearchClearAllResult { catalog, observed })
             }
+            SearchStoreBackend::Postgres(store) => Ok(SearchClearAllResult {
+                catalog: store.clear_source(source_name)?,
+                observed: ObservedValuesClearResult::default(),
+            }),
         }
     }
 
@@ -249,6 +322,10 @@ impl SearchStore {
                 let (catalog, observed) = store.clear_workspace_all()?;
                 Ok(SearchClearAllResult { catalog, observed })
             }
+            SearchStoreBackend::Postgres(store) => Ok(SearchClearAllResult {
+                catalog: store.clear_workspace()?,
+                observed: ObservedValuesClearResult::default(),
+            }),
         }
     }
 
@@ -259,6 +336,10 @@ impl SearchStore {
             SearchStoreBackend::Sqlite(store) => {
                 sqlite::storage_cleanup_result(&store.compact_after_clear())
             }
+            SearchStoreBackend::Postgres(_) => SearchStorageCleanupResult {
+                state: SearchMaintenanceState::Noop,
+                note: "no storage cleanup is needed on the postgres search backend".to_string(),
+            },
         }
     }
 }
@@ -267,6 +348,8 @@ impl SearchStore {
 pub(crate) enum SearchStoreError {
     #[error(transparent)]
     Sqlite(#[from] SqliteSearchError),
+    #[error(transparent)]
+    Postgres(#[from] PostgresSearchError),
 }
 
 impl SearchStoreError {
@@ -274,12 +357,14 @@ impl SearchStoreError {
     pub(crate) fn is_lock_contention(&self) -> bool {
         match self {
             Self::Sqlite(error) => error.is_lock_contention(),
+            Self::Postgres(error) => error.is_lock_contention(),
         }
     }
 
     pub(crate) fn is_storage_exhaustion(&self) -> bool {
         match self {
             Self::Sqlite(error) => error.is_storage_exhaustion(),
+            Self::Postgres(error) => error.is_storage_exhaustion(),
         }
     }
 
@@ -292,6 +377,7 @@ impl SearchStoreError {
                 SqliteSearchError::UnsupportedCapability { .. }
                     | SqliteSearchError::UnsupportedSchemaVersion { .. }
             ),
+            Self::Postgres(error) => error.is_unsupported(),
         }
     }
 }

--- a/crates/coral-app/src/search/store/postgres/catalog.rs
+++ b/crates/coral-app/src/search/store/postgres/catalog.rs
@@ -1,0 +1,513 @@
+//! Catalog projection and retrieval on the Postgres store.
+//!
+//! Retrieval is the engine the benchmark locked: trigram-accelerated `ILIKE`
+//! per term for candidates (exact substring semantics; the executor's recheck
+//! makes false positives impossible), then a deterministic total order —
+//! field-weighted whole-phrase boost, weighted `ts_rank_cd`, trigram
+//! similarity, primary key.
+
+use std::collections::BTreeSet;
+
+use sqlx::{Postgres, Row as _, Transaction};
+
+use super::{PostgresSearchError, PostgresSearchStore};
+use crate::search::catalog::index::{
+    CatalogClearResult, CatalogDocumentClass, CatalogIndexDocument, CatalogIndexSnapshot,
+    CatalogRebuildResult, CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
+    indexed_searchable_text, is_known_field_role, is_known_surface_kind, normalized_search_terms,
+    probe_limit, truncate_probe_hits,
+};
+use crate::search::store::{CatalogStore, SearchStoreError};
+
+const CATALOG_SNAPSHOT_FINGERPRINT_META_KEY: &str = "catalog_snapshot_fingerprint";
+/// Rows per `UNNEST` insert. Bounds the parameter arrays a 21k-document
+/// snapshot sends without turning the rebuild into thousands of round trips.
+const INSERT_CHUNK_ROWS: usize = 2_000;
+/// Terms shorter than this cannot match a trigram index; the `SQLite` side
+/// applies the same floor.
+const MIN_TERM_CHARS: usize = 3;
+const PHRASE_WEIGHT_QUALIFIED_NAME: u8 = 8;
+const PHRASE_WEIGHT_TITLE: u8 = 6;
+const PHRASE_WEIGHT_DESCRIPTION: u8 = 2;
+const PHRASE_WEIGHT_SEARCHABLE_TEXT: u8 = 1;
+
+impl CatalogStore for PostgresSearchStore {
+    fn projection_is_current(&self, fingerprint: &str) -> Result<bool, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin().await?;
+            let current = current_fingerprint(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(current.as_deref() == Some(fingerprint))
+        })?)
+    }
+
+    fn refresh_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+    ) -> Result<CatalogRefreshResult, SearchStoreError> {
+        let document_count = u32::try_from(snapshot.documents.len()).unwrap_or(u32::MAX);
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            if current_fingerprint(&mut tx).await?.as_deref() == Some(snapshot.fingerprint.as_str())
+            {
+                tx.commit().await?;
+                return Ok::<_, PostgresSearchError>(CatalogRefreshResult {
+                    refreshed: false,
+                    document_count,
+                });
+            }
+            replace_documents(&mut tx, snapshot).await?;
+            tx.commit().await?;
+            Ok(CatalogRefreshResult {
+                refreshed: true,
+                document_count,
+            })
+        })?)
+    }
+
+    fn rebuild_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+        force: bool,
+    ) -> Result<CatalogRebuildResult, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            let current = current_fingerprint(&mut tx).await?;
+            let old_document_count = document_count(&mut tx).await?;
+            let projection_changed = current.as_deref() != Some(snapshot.fingerprint.as_str());
+            let rebuild_performed = force || projection_changed;
+            if rebuild_performed {
+                replace_documents(&mut tx, snapshot).await?;
+            }
+            let new_document_count = if rebuild_performed {
+                document_count(&mut tx).await?
+            } else {
+                old_document_count
+            };
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(CatalogRebuildResult {
+                old_document_count,
+                new_document_count,
+                projection_changed,
+                rebuild_performed,
+            })
+        })?)
+    }
+
+    fn document_count(&self) -> Result<u32, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin().await?;
+            let count = document_count(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(count)
+        })?)
+    }
+
+    fn search(
+        &self,
+        terms: &[String],
+        limit: usize,
+        class: CatalogDocumentClass,
+    ) -> Result<CatalogSearchHits, SearchStoreError> {
+        let terms = normalized_search_terms(terms);
+        let Some(plan) = (if limit == 0 {
+            None
+        } else {
+            CatalogQueryPlan::build(&terms)
+        }) else {
+            return Ok(CatalogSearchHits {
+                hits: Vec::new(),
+                retrieval_limited: false,
+            });
+        };
+        let mut hits = self.block_on(async {
+            let mut tx = self.begin().await?;
+            let hits = plan.fetch(&mut tx, class, probe_limit(limit)).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(hits)
+        })?;
+        let retrieval_limited = truncate_probe_hits(&mut hits, limit);
+        Ok(CatalogSearchHits {
+            hits,
+            retrieval_limited,
+        })
+    }
+
+    fn clear_source(&self, source_name: &str) -> Result<CatalogClearResult, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            let deleted = sqlx::query("DELETE FROM catalog_documents WHERE source_name = $1")
+                .bind(source_name)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+            clear_fingerprint(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(CatalogClearResult {
+                deleted_document_count: u32::try_from(deleted).unwrap_or(u32::MAX),
+            })
+        })?)
+    }
+
+    fn clear_workspace(&self) -> Result<CatalogClearResult, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            let deleted = sqlx::query("DELETE FROM catalog_documents")
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+            clear_fingerprint(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(CatalogClearResult {
+                deleted_document_count: u32::try_from(deleted).unwrap_or(u32::MAX),
+            })
+        })?)
+    }
+}
+
+/// The stored fingerprint, or `None` when any row disagrees with it — a
+/// half-written projection is treated as absent, as on the `SQLite` side.
+async fn current_fingerprint(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<Option<String>, PostgresSearchError> {
+    let fingerprint: Option<String> =
+        sqlx::query_scalar("SELECT value FROM search_meta WHERE key = $1")
+            .bind(CATALOG_SNAPSHOT_FINGERPRINT_META_KEY)
+            .fetch_optional(&mut **tx)
+            .await?;
+    let Some(fingerprint) = fingerprint else {
+        return Ok(None);
+    };
+    let projection_is_stale: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM catalog_documents WHERE snapshot_fingerprint <> $1)",
+    )
+    .bind(&fingerprint)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok((!projection_is_stale).then_some(fingerprint))
+}
+
+async fn document_count(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<u32, PostgresSearchError> {
+    let count: i64 = sqlx::query_scalar("SELECT count(*) FROM catalog_documents")
+        .fetch_one(&mut **tx)
+        .await?;
+    Ok(u32::try_from(count).unwrap_or(u32::MAX))
+}
+
+async fn replace_documents(
+    tx: &mut Transaction<'static, Postgres>,
+    snapshot: &CatalogIndexSnapshot,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query("DELETE FROM catalog_documents")
+        .execute(&mut **tx)
+        .await?;
+    for chunk in snapshot.documents.chunks(INSERT_CHUNK_ROWS) {
+        insert_documents(tx, chunk, &snapshot.fingerprint).await?;
+    }
+    sqlx::query(
+        "INSERT INTO search_meta (key, value, updated_at) VALUES ($1, $2, now())
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(CATALOG_SNAPSHOT_FINGERPRINT_META_KEY)
+    .bind(&snapshot.fingerprint)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn insert_documents(
+    tx: &mut Transaction<'static, Postgres>,
+    documents: &[CatalogIndexDocument],
+    fingerprint: &str,
+) -> Result<(), PostgresSearchError> {
+    let column = |select: fn(&CatalogIndexDocument) -> &str| {
+        documents.iter().map(select).collect::<Vec<_>>()
+    };
+    sqlx::query(
+        "INSERT INTO catalog_documents (
+            doc_id, doc_kind, source_name, catalog_name, surface_kind, surface_name,
+            field_name, field_role, qualified_name, title, description, searchable_text,
+            snapshot_fingerprint
+        )
+        SELECT
+            u.doc_id, u.doc_kind, u.source_name, u.catalog_name, u.surface_kind, u.surface_name,
+            u.field_name, u.field_role, u.qualified_name, u.title, u.description,
+            u.searchable_text, $13
+        FROM UNNEST(
+            $1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[],
+            $7::text[], $8::text[], $9::text[], $10::text[], $11::text[], $12::text[]
+        ) AS u(
+            doc_id, doc_kind, source_name, catalog_name, surface_kind, surface_name,
+            field_name, field_role, qualified_name, title, description, searchable_text
+        )",
+    )
+    .bind(column(|document| document.doc_id.as_str()))
+    .bind(
+        documents
+            .iter()
+            .map(|document| document.doc_kind.as_str())
+            .collect::<Vec<_>>(),
+    )
+    .bind(column(|document| document.source_name.as_str()))
+    .bind(
+        documents
+            .iter()
+            .map(|document| document.catalog_name.as_deref())
+            .collect::<Vec<_>>(),
+    )
+    .bind(column(|document| document.surface_kind.as_str()))
+    .bind(column(|document| document.surface_name.as_str()))
+    .bind(column(|document| document.field_name.as_str()))
+    .bind(column(|document| document.field_role.as_str()))
+    .bind(column(|document| document.qualified_name.as_str()))
+    .bind(column(|document| document.title.as_str()))
+    .bind(column(|document| document.description.as_str()))
+    .bind(
+        documents
+            .iter()
+            .map(indexed_searchable_text)
+            .collect::<Vec<_>>(),
+    )
+    .bind(fingerprint)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn clear_fingerprint(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query("DELETE FROM search_meta WHERE key = $1")
+        .bind(CATALOG_SNAPSHOT_FINGERPRINT_META_KEY)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// One retrieval, fully parameterized: every value travels as a bind, and the
+/// only interpolated fragments are fixed SQL (`doc_kind_predicate`) and
+/// placeholder numbers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CatalogQueryPlan {
+    /// `%term%` per term, `LIKE` metacharacters escaped, for candidates.
+    patterns: Vec<String>,
+    /// The whole normalized query as a `%phrase%` pattern for the boost. It is
+    /// the longest term: query construction appends the whole query as a term,
+    /// and it contains every other token.
+    phrase_pattern: String,
+    /// `word | word` for `to_tsquery('simple', …)`; `None` when no term yields
+    /// a lexeme, which drops the rank tier instead of erroring.
+    words_query: Option<String>,
+    /// All terms joined for `similarity()`.
+    joined_terms: String,
+}
+
+impl CatalogQueryPlan {
+    fn build(terms: &[String]) -> Option<Self> {
+        let terms = terms
+            .iter()
+            .filter(|term| term.chars().count() >= MIN_TERM_CHARS)
+            .cloned()
+            .collect::<Vec<_>>();
+        let phrase = terms
+            .iter()
+            .max_by_key(|term| term.chars().count())?
+            .clone();
+        let words = terms
+            .iter()
+            .flat_map(|term| lexeme_words(term))
+            .collect::<BTreeSet<_>>();
+        Some(Self {
+            patterns: terms.iter().map(|term| contains_pattern(term)).collect(),
+            phrase_pattern: contains_pattern(&phrase),
+            words_query: (!words.is_empty())
+                .then(|| words.into_iter().collect::<Vec<_>>().join(" | ")),
+            joined_terms: terms.join(" "),
+        })
+    }
+
+    fn sql(&self, class: CatalogDocumentClass) -> String {
+        let candidates = (1..=self.patterns.len())
+            .map(|index| format!("d.all_text ILIKE ${index}"))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        let phrase = self.patterns.len() + 1;
+        let mut next = phrase + 1;
+        let rank = if self.words_query.is_some() {
+            let words = next;
+            next += 1;
+            format!("ts_rank_cd(d.tsv, to_tsquery('simple', ${words}))")
+        } else {
+            "0".to_string()
+        };
+        let joined = next;
+        let limit = next + 1;
+        format!(
+            "SELECT d.doc_id, d.source_name, d.surface_kind, d.surface_name, d.field_name,
+                    d.field_role, d.catalog_name
+             FROM catalog_documents AS d
+             WHERE {predicate} AND ({candidates})
+             ORDER BY
+                 (d.qualified_name ILIKE ${phrase})::int * {PHRASE_WEIGHT_QUALIFIED_NAME}
+                 + (d.title ILIKE ${phrase})::int * {PHRASE_WEIGHT_TITLE}
+                 + (d.description ILIKE ${phrase})::int * {PHRASE_WEIGHT_DESCRIPTION}
+                 + (d.searchable_text ILIKE ${phrase})::int * {PHRASE_WEIGHT_SEARCHABLE_TEXT} DESC,
+                 {rank} DESC,
+                 similarity(d.all_text, ${joined}) DESC,
+                 d.doc_id ASC
+             LIMIT ${limit}",
+            predicate = class.doc_kind_predicate(),
+        )
+    }
+
+    async fn fetch(
+        &self,
+        tx: &mut Transaction<'static, Postgres>,
+        class: CatalogDocumentClass,
+        limit: usize,
+    ) -> Result<Vec<CatalogSearchHit>, PostgresSearchError> {
+        // Audited: the only dynamic fragments are `doc_kind_predicate`, a
+        // fixed literal, and placeholder numbers; every value is a bind.
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(self.sql(class)));
+        for pattern in &self.patterns {
+            query = query.bind(pattern);
+        }
+        query = query.bind(&self.phrase_pattern);
+        if let Some(words_query) = &self.words_query {
+            query = query.bind(words_query);
+        }
+        let rows = query
+            .bind(&self.joined_terms)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(&mut **tx)
+            .await?;
+        rows.iter().map(hit_from_row).collect()
+    }
+}
+
+fn hit_from_row(row: &sqlx::postgres::PgRow) -> Result<CatalogSearchHit, PostgresSearchError> {
+    let surface_kind: String = row.try_get("surface_kind")?;
+    if !is_known_surface_kind(&surface_kind) {
+        return Err(PostgresSearchError::InvalidStorageValue {
+            field: "surface_kind",
+            value: surface_kind,
+        });
+    }
+    let field_role: String = row.try_get("field_role")?;
+    if !is_known_field_role(&field_role) {
+        return Err(PostgresSearchError::InvalidStorageValue {
+            field: "field_role",
+            value: field_role,
+        });
+    }
+    Ok(CatalogSearchHit {
+        doc_id: row.try_get("doc_id")?,
+        source_name: row.try_get("source_name")?,
+        catalog_name: row.try_get("catalog_name")?,
+        surface_kind,
+        surface_name: row.try_get("surface_name")?,
+        field_name: row.try_get("field_name")?,
+        field_role,
+    })
+}
+
+/// `%term%` with `\`, `%`, and `_` escaped, so identifiers such as
+/// `deploy_url` match literally.
+fn contains_pattern(term: &str) -> String {
+    let mut escaped = String::with_capacity(term.len() + 2);
+    escaped.push('%');
+    for ch in term.chars() {
+        if matches!(ch, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped.push('%');
+    escaped
+}
+
+/// Lexeme candidates for the rank tier: runs of alphanumerics (any script,
+/// terms are already lowercased) and `_`, which the `simple` parser accepts
+/// without operators or quoting.
+fn lexeme_words(term: &str) -> Vec<String> {
+    term.split(|ch: char| !(ch.is_alphanumeric() || ch == '_'))
+        .filter(|word| !word.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+pub(super) mod plan_tests {
+    use super::{CatalogQueryPlan, contains_pattern};
+    use crate::search::catalog::index::CatalogDocumentClass;
+
+    #[test]
+    fn patterns_escape_like_metacharacters_and_drop_short_terms() {
+        let plan = CatalogQueryPlan::build(&[
+            "ab".to_string(),
+            "deploy_url".to_string(),
+            "100%".to_string(),
+        ])
+        .expect("plan");
+
+        assert_eq!(plan.patterns, vec!["%deploy\\_url%", "%100\\%%"]);
+        assert_eq!(contains_pattern("a\\b"), "%a\\\\b%");
+    }
+
+    #[test]
+    fn the_phrase_is_the_longest_term_and_words_feed_the_rank_tier() {
+        let plan = CatalogQueryPlan::build(&[
+            "issue".to_string(),
+            "issue labels".to_string(),
+            "labels".to_string(),
+        ])
+        .expect("plan");
+
+        assert_eq!(plan.phrase_pattern, "%issue labels%");
+        assert_eq!(plan.words_query.as_deref(), Some("issue | labels"));
+        assert_eq!(plan.joined_terms, "issue issue labels labels");
+    }
+
+    #[test]
+    fn lexemes_keep_non_ascii_letters() {
+        let plan = CatalogQueryPlan::build(&["über-café".to_string()]).expect("plan");
+
+        assert_eq!(plan.words_query.as_deref(), Some("café | über"));
+    }
+
+    #[test]
+    fn terms_without_lexemes_drop_the_rank_tier_instead_of_erroring() {
+        let plan = CatalogQueryPlan::build(&["---".to_string()]).expect("plan");
+
+        assert_eq!(plan.words_query, None);
+        assert!(plan.sql(CatalogDocumentClass::Entries).contains("0 DESC"));
+        assert!(
+            !plan
+                .sql(CatalogDocumentClass::Entries)
+                .contains("to_tsquery")
+        );
+    }
+
+    #[test]
+    fn only_short_terms_yield_no_plan() {
+        assert_eq!(CatalogQueryPlan::build(&["ab".to_string()]), None);
+        assert_eq!(CatalogQueryPlan::build(&[]), None);
+    }
+
+    #[test]
+    fn placeholders_are_numbered_in_bind_order() {
+        let plan =
+            CatalogQueryPlan::build(&["alpha".to_string(), "beta".to_string()]).expect("plan");
+
+        let sql = plan.sql(CatalogDocumentClass::Fields);
+
+        assert!(sql.contains("d.all_text ILIKE $1 OR d.all_text ILIKE $2"));
+        assert!(sql.contains("d.qualified_name ILIKE $3"));
+        assert!(sql.contains("to_tsquery('simple', $4)"));
+        assert!(sql.contains("similarity(d.all_text, $5)"));
+        assert!(sql.contains("LIMIT $6"));
+        assert!(sql.contains("d.doc_kind = 'column_hint'"));
+    }
+}

--- a/crates/coral-app/src/search/store/postgres/migrations/0001_catalog_documents.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0001_catalog_documents.sql
@@ -1,0 +1,59 @@
+-- Per-Workspace catalog projection. Runs with `search_path` set to the
+-- Workspace's surrogate schema plus the schema that holds `pg_trgm`, so every
+-- name below is unqualified on purpose.
+--
+-- No workspace column: the schema *is* the Workspace. The extension point for
+-- a future scope/identity dimension (lagoon #37) is an additive column on
+-- this table, precedented by observed memory's `source_scope_id`.
+--
+-- `STORED` is spelled out on every generated column: Postgres 18 changed the
+-- default to VIRTUAL, which cannot be indexed.
+CREATE TABLE IF NOT EXISTS catalog_documents (
+    doc_id text PRIMARY KEY,
+    doc_kind text NOT NULL CHECK (
+        doc_kind IN ('catalog_table', 'catalog_table_function', 'column_hint')
+    ),
+    source_name text NOT NULL DEFAULT '',
+    catalog_name text,
+    surface_kind text NOT NULL DEFAULT '' CHECK (
+        surface_kind IN ('', 'table', 'table_function')
+    ),
+    surface_name text NOT NULL DEFAULT '',
+    field_name text NOT NULL DEFAULT '',
+    field_role text NOT NULL DEFAULT '' CHECK (
+        field_role IN (
+            '',
+            'table_column',
+            'table_filter',
+            'table_function_argument',
+            'table_function_result_column'
+        )
+    ),
+    qualified_name text NOT NULL DEFAULT '',
+    title text NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    searchable_text text NOT NULL DEFAULT '',
+    snapshot_fingerprint text NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    all_text text GENERATED ALWAYS AS (
+        qualified_name || ' ' || title || ' ' || description || ' ' || searchable_text
+    ) STORED,
+    tsv tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('simple', qualified_name), 'A')
+        || setweight(to_tsvector('simple', title), 'B')
+        || setweight(to_tsvector('simple', description), 'C')
+        || setweight(to_tsvector('simple', searchable_text), 'D')
+    ) STORED
+);
+
+CREATE INDEX IF NOT EXISTS catalog_documents_all_text_trgm
+    ON catalog_documents USING gin (all_text gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS catalog_documents_tsv
+    ON catalog_documents USING gin (tsv);
+
+CREATE TABLE IF NOT EXISTS search_meta (
+    key text PRIMARY KEY,
+    value text NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/crates/coral-app/src/search/store/postgres/migrations/0001_search_registry.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0001_search_registry.sql
@@ -1,0 +1,19 @@
+-- Shared registry for the per-Workspace search schemas. Idempotent: it runs on
+-- every storage open, under an advisory lock, and doubles as the boot-time
+-- migration ledger.
+--
+-- The raw workspace name lives ONLY here. Every SQL identifier derives from
+-- `surrogate_id` (`search_ws_<id>`), never from the name: Postgres truncates
+-- identifiers at 63 bytes silently, and a workspace name is nearly
+-- unconstrained, so interpolating it would be a cross-tenant collision risk.
+--
+-- No foreign key to CoralDb's `workspaces`: the app-state and search
+-- migration streams stay uncoupled.
+CREATE SCHEMA IF NOT EXISTS search_registry;
+
+CREATE TABLE IF NOT EXISTS search_registry.workspaces (
+    workspace_name text PRIMARY KEY,
+    surrogate_id bigint GENERATED ALWAYS AS IDENTITY UNIQUE,
+    schema_version integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -1,0 +1,543 @@
+//! Postgres side of the storage seam: one schema per Workspace inside the
+//! `[database]` Postgres database, named by a surrogate registry.
+//!
+//! `search_registry.workspaces` maps the raw Workspace name to a generated
+//! surrogate id and records each schema's migration version, so it doubles as
+//! the boot-time ledger. Every SQL identifier derives from the surrogate
+//! (`search_ws_<id>`); a Workspace name never reaches SQL as an identifier.
+//! Deleting a Workspace is one registry row plus `DROP SCHEMA … CASCADE`.
+//!
+//! The pool is small and dedicated: catalog rebuilds run long transactions
+//! that must not starve app-state connections. `search_path` is set per
+//! transaction, never per pooled connection.
+
+mod catalog;
+
+use std::borrow::Cow;
+use std::future::Future;
+
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::{Postgres, Row as _, Transaction};
+use tokio::runtime::Handle;
+
+use crate::state::db::{DbError, postgres_connect_options};
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 1;
+
+struct SearchPostgresMigration {
+    version: i32,
+    sql: &'static str,
+}
+
+const REGISTRY_BOOTSTRAP_SQL: &str = include_str!("migrations/0001_search_registry.sql");
+
+/// Per-Workspace schema stream, versioned in the registry ledger. Every
+/// statement is idempotent so a replay after a partial failure converges.
+const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[SearchPostgresMigration {
+    version: 1,
+    sql: include_str!("migrations/0001_catalog_documents.sql"),
+}];
+
+const SEARCH_POOL_MAX_CONNECTIONS: u32 = 4;
+/// Serializes registry bootstrap across processes; per-Workspace work locks
+/// on the surrogate id instead.
+const REGISTRY_BOOTSTRAP_LOCK_KEY: i64 = 0x636f_7261_6c5f_7373;
+const PG_TRGM_EXTENSION: &str = "pg_trgm";
+const PG_TRGM_FEATURE: &str = "pg_trgm extension";
+const WORKSPACE_SCHEMA_PREFIX: &str = "search_ws_";
+
+#[derive(Debug, Clone)]
+pub(crate) struct PostgresSearchStorage {
+    pool: PgPool,
+    handle: Handle,
+    /// Schema that holds `pg_trgm`. It joins every operation's `search_path`
+    /// so `similarity()` and `gin_trgm_ops` resolve without qualification.
+    trgm_schema: String,
+}
+
+/// One Workspace's catalog schema, opened and migrated.
+#[derive(Debug, Clone)]
+pub(crate) struct PostgresSearchStore {
+    pool: PgPool,
+    handle: Handle,
+    surrogate_id: i64,
+    search_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkspaceRegistration {
+    surrogate_id: i64,
+    schema_version: i32,
+}
+
+/// What a registry sweep did for one Workspace schema.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the boot ledger sweep is wired into server startup next in this stack"
+    )
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MigratedWorkspaceSchema {
+    pub(crate) workspace_name: String,
+    pub(crate) from_version: i32,
+}
+
+impl PostgresSearchStorage {
+    /// Connects a dedicated pool, bootstraps the registry, and verifies
+    /// `pg_trgm`. Fails loud, naming the missing capability, so a
+    /// misprovisioned database never serves degraded search.
+    pub(crate) async fn open(url: &str, handle: Handle) -> Result<Self, PostgresSearchError> {
+        let options = postgres_connect_options(url).map_err(PostgresSearchError::Connect)?;
+        let pool = PgPoolOptions::new()
+            .max_connections(SEARCH_POOL_MAX_CONNECTIONS)
+            .connect_with(options)
+            .await?;
+        bootstrap_registry(&pool).await?;
+        let trgm_schema = ensure_pg_trgm(&pool).await?;
+        Ok(Self {
+            pool,
+            handle,
+            trgm_schema,
+        })
+    }
+
+    /// Opens the Workspace's schema, registering and creating it on first use
+    /// and migrating it when the ledger says it is behind.
+    pub(crate) fn open_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<PostgresSearchStore, PostgresSearchError> {
+        block_on(&self.handle, async {
+            let registration = register_workspace(&self.pool, workspace_name).await?;
+            self.ensure_schema_current(registration).await?;
+            Ok(self.store_for(registration.surrogate_id))
+        })
+    }
+
+    /// Opens the Workspace's schema only when the registry already knows it.
+    pub(crate) fn open_existing_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<PostgresSearchStore>, PostgresSearchError> {
+        block_on(&self.handle, async {
+            let Some(registration) = registered_workspace(&self.pool, workspace_name).await? else {
+                return Ok(None);
+            };
+            self.ensure_schema_current(registration).await?;
+            Ok(Some(self.store_for(registration.surrogate_id)))
+        })
+    }
+
+    /// Removes the Workspace's registry row and drops its schema. Complete
+    /// and instant: no tenant rows survive offboarding.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
+    )]
+    pub(crate) async fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<bool, PostgresSearchError> {
+        let mut tx = self.pool.begin().await?;
+        let deleted: Option<i64> = sqlx::query_scalar(
+            "DELETE FROM search_registry.workspaces WHERE workspace_name = $1 RETURNING surrogate_id",
+        )
+        .bind(workspace_name.as_str())
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(surrogate_id) = deleted else {
+            tx.commit().await?;
+            return Ok(false);
+        };
+        sqlx::query(schema_ddl(
+            "DROP SCHEMA IF EXISTS",
+            surrogate_id,
+            " CASCADE",
+        ))
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Boot-time ledger sweep: migrates every registered schema that is behind
+    /// this binary. A steady-state boot costs one query and does no work.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into server startup next in this stack")
+    )]
+    pub(crate) async fn migrate_all(
+        &self,
+    ) -> Result<Vec<MigratedWorkspaceSchema>, PostgresSearchError> {
+        let stale = sqlx::query(
+            "SELECT workspace_name, surrogate_id, schema_version
+             FROM search_registry.workspaces
+             WHERE schema_version <> $1
+             ORDER BY surrogate_id",
+        )
+        .bind(SEARCH_POSTGRES_SCHEMA_VERSION)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut migrated = Vec::with_capacity(stale.len());
+        for row in stale {
+            let workspace_name: String = row.try_get("workspace_name")?;
+            let registration = registration_from_row(&row)?;
+            self.ensure_schema_current(registration).await?;
+            migrated.push(MigratedWorkspaceSchema {
+                workspace_name,
+                from_version: registration.schema_version,
+            });
+        }
+        Ok(migrated)
+    }
+
+    fn store_for(&self, surrogate_id: i64) -> PostgresSearchStore {
+        let search_path = format!(
+            "{}, {}",
+            quote_identifier(&schema_name(surrogate_id)),
+            quote_identifier(&self.trgm_schema)
+        );
+        PostgresSearchStore {
+            pool: self.pool.clone(),
+            handle: self.handle.clone(),
+            surrogate_id,
+            search_path,
+        }
+    }
+
+    /// Brings one Workspace schema to the current version under an advisory
+    /// lock on its surrogate id, re-reading the ledger once the lock is held.
+    async fn ensure_schema_current(
+        &self,
+        registration: WorkspaceRegistration,
+    ) -> Result<(), PostgresSearchError> {
+        ensure_supported_schema_version(registration.schema_version)?;
+        if registration.schema_version == SEARCH_POSTGRES_SCHEMA_VERSION {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+        lock_workspace(&mut tx, registration.surrogate_id).await?;
+        let current_version: i32 = sqlx::query_scalar(
+            "SELECT schema_version FROM search_registry.workspaces WHERE surrogate_id = $1",
+        )
+        .bind(registration.surrogate_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        ensure_supported_schema_version(current_version)?;
+        if current_version == SEARCH_POSTGRES_SCHEMA_VERSION {
+            tx.commit().await?;
+            return Ok(());
+        }
+
+        let store = self.store_for(registration.surrogate_id);
+        sqlx::query(schema_ddl(
+            "CREATE SCHEMA IF NOT EXISTS",
+            registration.surrogate_id,
+            "",
+        ))
+        .execute(&mut *tx)
+        .await?;
+        set_search_path(&mut tx, &store.search_path).await?;
+        for migration in WORKSPACE_MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version > current_version)
+        {
+            sqlx::raw_sql(migration.sql).execute(&mut *tx).await?;
+        }
+        sqlx::query(
+            "UPDATE search_registry.workspaces SET schema_version = $1 WHERE surrogate_id = $2",
+        )
+        .bind(SEARCH_POSTGRES_SCHEMA_VERSION)
+        .bind(registration.surrogate_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        tracing::info!(
+            surrogate_id = registration.surrogate_id,
+            from_version = current_version,
+            to_version = SEARCH_POSTGRES_SCHEMA_VERSION,
+            "migrated Postgres search schema"
+        );
+        Ok(())
+    }
+}
+
+impl PostgresSearchStore {
+    #[cfg(test)]
+    pub(crate) fn schema_name(&self) -> String {
+        schema_name(self.surrogate_id)
+    }
+
+    /// A read transaction with `search_path` pointing at this schema.
+    async fn begin(&self) -> Result<Transaction<'static, Postgres>, PostgresSearchError> {
+        let mut tx = self.pool.begin().await?;
+        set_search_path(&mut tx, &self.search_path).await?;
+        Ok(tx)
+    }
+
+    /// A write transaction that also holds the Workspace's advisory lock, so
+    /// concurrent writers from other processes serialize on the projection.
+    async fn begin_write(&self) -> Result<Transaction<'static, Postgres>, PostgresSearchError> {
+        let mut tx = self.begin().await?;
+        lock_workspace(&mut tx, self.surrogate_id).await?;
+        Ok(tx)
+    }
+
+    fn block_on<F: Future>(&self, future: F) -> F::Output {
+        block_on(&self.handle, future)
+    }
+}
+
+/// Runs the future to completion from the seam's synchronous surface.
+///
+/// The seam is called from blocking-pool threads (the provider registry's
+/// `spawn_blocking` boundary and the manager's blocking operations), where
+/// `Handle::block_on` is legal. `block_in_place` covers the multi-thread
+/// runtime's worker threads too, so a caller on the wrong thread degrades to
+/// parking that worker instead of panicking.
+fn block_on<F: Future>(handle: &Handle, future: F) -> F::Output {
+    tokio::task::block_in_place(|| handle.block_on(future))
+}
+
+async fn bootstrap_registry(pool: &PgPool) -> Result<(), PostgresSearchError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(REGISTRY_BOOTSTRAP_LOCK_KEY)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::raw_sql(REGISTRY_BOOTSTRAP_SQL)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Creates `pg_trgm` when the role may, then verifies it exists. Returns the
+/// schema the extension lives in.
+///
+/// A role without `CREATE` on the database can still find the extension
+/// installed by an administrator, so a privilege refusal (and the duplicate
+/// error two concurrent creators can race into) defers to the probe. Any
+/// other failure is a real error and stops startup.
+async fn ensure_pg_trgm(pool: &PgPool) -> Result<String, PostgresSearchError> {
+    let create_error = match sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        .execute(pool)
+        .await
+    {
+        Ok(_) => None,
+        Err(error) if extension_create_may_be_deferred(&error) => Some(error),
+        Err(error) => return Err(error.into()),
+    };
+    let extension_schema: Option<String> = sqlx::query_scalar(
+        "SELECT n.nspname
+         FROM pg_extension AS e
+         INNER JOIN pg_namespace AS n ON n.oid = e.extnamespace
+         WHERE e.extname = $1",
+    )
+    .bind(PG_TRGM_EXTENSION)
+    .fetch_optional(pool)
+    .await?;
+    let server_version: String = sqlx::query_scalar("SELECT current_setting('server_version')")
+        .fetch_one(pool)
+        .await?;
+    classify_extension_probe(extension_schema, server_version, create_error)
+}
+
+/// `insufficient_privilege`, `duplicate_object`, or the `unique_violation` a
+/// concurrent `CREATE EXTENSION` produces.
+fn extension_create_may_be_deferred(error: &sqlx::Error) -> bool {
+    matches!(
+        error,
+        sqlx::Error::Database(error)
+            if matches!(error.code().as_deref(), Some("42501" | "42710" | "23505"))
+    )
+}
+
+fn classify_extension_probe(
+    extension_schema: Option<String>,
+    server_version: String,
+    create_error: Option<sqlx::Error>,
+) -> Result<String, PostgresSearchError> {
+    extension_schema.ok_or(PostgresSearchError::UnsupportedCapability {
+        feature: PG_TRGM_FEATURE,
+        server_version,
+        cause: create_error,
+    })
+}
+
+async fn registered_workspace(
+    pool: &PgPool,
+    workspace_name: &WorkspaceName,
+) -> Result<Option<WorkspaceRegistration>, PostgresSearchError> {
+    let row = sqlx::query(
+        "SELECT surrogate_id, schema_version FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace_name.as_str())
+    .fetch_optional(pool)
+    .await?;
+    row.as_ref().map(registration_from_row).transpose()
+}
+
+fn registration_from_row(
+    row: &sqlx::postgres::PgRow,
+) -> Result<WorkspaceRegistration, PostgresSearchError> {
+    Ok(WorkspaceRegistration {
+        surrogate_id: row.try_get("surrogate_id")?,
+        schema_version: row.try_get("schema_version")?,
+    })
+}
+
+/// Returns the Workspace's registration, allocating a surrogate on first use.
+/// Safe under concurrent first opens: the loser of the insert re-reads.
+async fn register_workspace(
+    pool: &PgPool,
+    workspace_name: &WorkspaceName,
+) -> Result<WorkspaceRegistration, PostgresSearchError> {
+    if let Some(registration) = registered_workspace(pool, workspace_name).await? {
+        return Ok(registration);
+    }
+    let inserted = sqlx::query(
+        "INSERT INTO search_registry.workspaces (workspace_name) VALUES ($1)
+         ON CONFLICT (workspace_name) DO NOTHING
+         RETURNING surrogate_id, schema_version",
+    )
+    .bind(workspace_name.as_str())
+    .fetch_optional(pool)
+    .await?;
+    if let Some(row) = inserted {
+        return registration_from_row(&row);
+    }
+    registered_workspace(pool, workspace_name)
+        .await?
+        .ok_or_else(|| PostgresSearchError::RegistryRace(workspace_name.to_string()))
+}
+
+async fn lock_workspace(
+    tx: &mut Transaction<'static, Postgres>,
+    surrogate_id: i64,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(surrogate_id)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// `SET LOCAL` scopes the path to the transaction, so a pooled connection
+/// never carries one Workspace's schema into another request.
+async fn set_search_path(
+    tx: &mut Transaction<'static, Postgres>,
+    search_path: &str,
+) -> Result<(), PostgresSearchError> {
+    // Audited: `search_path` is built by `store_for` from `quote_identifier`
+    // over a surrogate-derived schema name and the `pg_trgm` schema read from
+    // `pg_namespace`; no caller input reaches it.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SET LOCAL search_path TO {search_path}"
+    )))
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Schema DDL for one surrogate. Audited: the identifier is
+/// `search_ws_<i64>` through `quote_identifier`; the name never sees SQL.
+fn schema_ddl(statement: &str, surrogate_id: i64, suffix: &str) -> sqlx::AssertSqlSafe<String> {
+    sqlx::AssertSqlSafe(format!(
+        "{statement} {}{suffix}",
+        quote_identifier(&schema_name(surrogate_id))
+    ))
+}
+
+fn ensure_supported_schema_version(version: i32) -> Result<(), PostgresSearchError> {
+    if version > SEARCH_POSTGRES_SCHEMA_VERSION {
+        return Err(PostgresSearchError::UnsupportedSchemaVersion {
+            database_version: version,
+            supported_version: SEARCH_POSTGRES_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+fn schema_name(surrogate_id: i64) -> String {
+    format!("{WORKSPACE_SCHEMA_PREFIX}{surrogate_id}")
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PostgresSearchError {
+    #[error("search backend 'postgres' cannot use the database URL: {0}")]
+    Connect(#[source] DbError),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(
+        "Postgres {server_version} does not provide required search feature: {feature}{}",
+        cause_suffix(.cause.as_ref())
+    )]
+    UnsupportedCapability {
+        feature: &'static str,
+        server_version: String,
+        #[source]
+        cause: Option<sqlx::Error>,
+    },
+    #[error(
+        "Postgres search schema version {database_version} is newer than this binary supports ({supported_version})"
+    )]
+    UnsupportedSchemaVersion {
+        database_version: i32,
+        supported_version: i32,
+    },
+    #[error("search registry lost workspace '{0}' between insert and lookup")]
+    RegistryRace(String),
+    #[error("Postgres search store holds an unknown catalog search {field} '{value}'")]
+    InvalidStorageValue { field: &'static str, value: String },
+}
+
+fn cause_suffix(cause: Option<&sqlx::Error>) -> String {
+    cause.map_or_else(String::new, |cause| format!(" ({cause})"))
+}
+
+impl PostgresSearchError {
+    fn sqlstate(&self) -> Option<Cow<'_, str>> {
+        match self {
+            Self::Sqlx(sqlx::Error::Database(error)) => error.code(),
+            Self::Sqlx(_)
+            | Self::Connect(_)
+            | Self::UnsupportedCapability { .. }
+            | Self::UnsupportedSchemaVersion { .. }
+            | Self::RegistryRace(_)
+            | Self::InvalidStorageValue { .. } => None,
+        }
+    }
+
+    /// `lock_not_available` or a deadlock: another writer holds the
+    /// projection and the caller may serve cached state.
+    pub(crate) fn is_lock_contention(&self) -> bool {
+        matches!(self.sqlstate().as_deref(), Some("55P03" | "40P01"))
+    }
+
+    /// `disk_full`, `out_of_memory`, or `insufficient_resources`.
+    pub(crate) fn is_storage_exhaustion(&self) -> bool {
+        matches!(
+            self.sqlstate().as_deref(),
+            Some("53100" | "53200" | "53000")
+        )
+    }
+
+    pub(crate) fn is_unsupported(&self) -> bool {
+        matches!(
+            self,
+            Self::UnsupportedCapability { .. } | Self::UnsupportedSchemaVersion { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -1,0 +1,415 @@
+//! Postgres side of the paired-backend tests.
+//!
+//! Database-backed tests are ignored unless `CORAL_TEST_POSTGRES_URL` is set
+//! (`make postgres-tests` provisions one). They share one registry, so every
+//! test works in Workspaces of its own and removes them when done.
+
+use tokio::runtime::Handle;
+
+use super::{
+    PG_TRGM_FEATURE, PostgresSearchError, classify_extension_probe, quote_identifier, schema_name,
+};
+use crate::bootstrap;
+use crate::search::catalog::index::CatalogDocumentClass;
+use crate::search::store::tests::contract;
+use crate::search::store::{SearchStorage, SearchStoreError};
+use crate::workspaces::WorkspaceName;
+
+#[test]
+fn schema_names_derive_from_the_surrogate_only() {
+    assert_eq!(schema_name(42), "search_ws_42");
+    assert_eq!(quote_identifier("search_ws_42"), "\"search_ws_42\"");
+    assert_eq!(quote_identifier("odd\"schema"), "\"odd\"\"schema\"");
+}
+
+#[test]
+fn capability_probe_names_the_missing_extension() {
+    let error = classify_extension_probe(
+        None,
+        "17.2".to_string(),
+        Some(sqlx::Error::Protocol(
+            "permission denied to create extension \"pg_trgm\"".to_string(),
+        )),
+    )
+    .expect_err("missing extension must fail");
+
+    assert!(error.is_unsupported());
+    let message = error.to_string();
+    assert!(message.contains("Postgres 17.2"), "{message}");
+    assert!(message.contains(PG_TRGM_FEATURE), "{message}");
+    assert!(message.contains("permission denied"), "{message}");
+    assert!(
+        SearchStoreError::from(error).is_unsupported(),
+        "the seam must keep the unsupported class"
+    );
+}
+
+#[test]
+fn newer_schema_versions_are_refused() {
+    let error = super::ensure_supported_schema_version(super::SEARCH_POSTGRES_SCHEMA_VERSION + 1)
+        .expect_err("future version must fail");
+
+    assert!(matches!(
+        error,
+        PostgresSearchError::UnsupportedSchemaVersion { database_version, .. }
+            if database_version == super::SEARCH_POSTGRES_SCHEMA_VERSION + 1
+    ));
+    assert!(error.is_unsupported());
+}
+
+fn postgres_test_url() -> Option<String> {
+    bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+        .expect("read CORAL_TEST_POSTGRES_URL")
+        .filter(|value| !value.is_empty())
+}
+
+async fn open_storage() -> Option<SearchStorage> {
+    let url = postgres_test_url()?;
+    Some(
+        SearchStorage::postgres(&url, Handle::current())
+            .await
+            .expect("open Postgres search storage"),
+    )
+}
+
+fn unique_workspace(label: &str) -> WorkspaceName {
+    WorkspaceName::parse(&format!("{label}-{}", uuid::Uuid::new_v4().simple()))
+        .expect("workspace name")
+}
+
+/// Runs seam calls where production runs them: on a blocking-pool thread.
+async fn blocking<T: Send + 'static>(work: impl FnOnce() -> T + Send + 'static) -> T {
+    tokio::task::spawn_blocking(work)
+        .await
+        .expect("blocking work")
+}
+
+async fn delete_workspaces(storage: &SearchStorage, workspaces: &[WorkspaceName]) {
+    for workspace in workspaces {
+        storage
+            .delete_workspace(workspace)
+            .await
+            .expect("delete workspace");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the search store contract against Postgres"]
+async fn postgres_store_serves_the_catalog_contract_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("contract");
+
+    let contract_storage = storage.clone();
+    let contract_workspace = workspace.clone();
+    blocking(move || {
+        let store = contract_storage
+            .open_workspace(&contract_workspace)
+            .expect("open workspace store");
+        assert_eq!(store.backend_name(), "postgres");
+        contract::assert_catalog_store_contract(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Workspace isolation against Postgres"]
+async fn workspaces_are_isolated_by_schema_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let populated = unique_workspace("populated");
+    let empty = unique_workspace("empty");
+
+    let (populated_schema, empty_schema) = {
+        let storage = storage.clone();
+        let (populated, empty) = (populated.clone(), empty.clone());
+        blocking(move || {
+            let populated_store = storage.open_workspace(&populated).expect("open populated");
+            let empty_store = storage.open_workspace(&empty).expect("open empty");
+            populated_store
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("isolation-v1"))
+                .expect("refresh populated");
+
+            assert_eq!(empty_store.catalog().document_count().expect("count"), 0);
+            let leaked = empty_store
+                .catalog()
+                .search(&["github".to_string()], 10, CatalogDocumentClass::Entries)
+                .expect("search empty workspace");
+            assert!(leaked.hits.is_empty(), "rows leaked across Workspaces");
+            assert!(
+                !empty_store
+                    .catalog()
+                    .projection_is_current("isolation-v1")
+                    .expect("fingerprint check")
+            );
+            (
+                populated_store.postgres_schema_name(),
+                empty_store.postgres_schema_name(),
+            )
+        })
+        .await
+    };
+    assert_ne!(populated_schema, empty_schema);
+
+    delete_workspaces(&storage, &[populated, empty]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run registry naming against Postgres"]
+async fn registry_keeps_hostile_workspace_names_out_of_identifiers_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    // Two names that agree on their first 63 bytes would collide if names
+    // became identifiers; quoting hazards ride along.
+    let long_prefix = format!("{}-{suffix}", "w".repeat(80));
+    let hostile = [
+        WorkspaceName::parse(&format!("{long_prefix}-a")).expect("name"),
+        WorkspaceName::parse(&format!("{long_prefix}-b")).expect("name"),
+        WorkspaceName::parse(&format!("quote\"drop;--{suffix}")).expect("name"),
+        WorkspaceName::parse(&format!("ünïcödé {suffix}")).expect("name"),
+    ];
+
+    let schemas = {
+        let storage = storage.clone();
+        let hostile = hostile.clone();
+        blocking(move || {
+            hostile
+                .iter()
+                .map(|workspace| {
+                    let store = storage
+                        .open_workspace(workspace)
+                        .expect("open hostile name");
+                    store
+                        .catalog()
+                        .refresh_projection(&contract::catalog_snapshot("hostile-v1"))
+                        .expect("refresh");
+                    assert_eq!(store.catalog().document_count().expect("count"), 4);
+                    store.postgres_schema_name()
+                })
+                .collect::<Vec<_>>()
+        })
+        .await
+    };
+    for (workspace, schema) in hostile.iter().zip(&schemas) {
+        assert!(schema.starts_with("search_ws_"), "{schema}");
+        assert!(
+            !schema.contains(workspace.as_str()),
+            "workspace name leaked into identifier {schema}"
+        );
+    }
+    let distinct = schemas.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(distinct.len(), hostile.len(), "surrogates must be distinct");
+
+    delete_workspaces(&storage, &hostile).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Workspace deletion against Postgres"]
+async fn deleting_a_workspace_removes_its_schema_and_registry_row_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("deleted");
+
+    let first_schema = {
+        let storage = storage.clone();
+        let workspace = workspace.clone();
+        blocking(move || {
+            let store = storage.open_workspace(&workspace).expect("open");
+            store
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("deleted-v1"))
+                .expect("refresh");
+            store.postgres_schema_name()
+        })
+        .await
+    };
+
+    assert!(storage.delete_workspace(&workspace).await.expect("delete"));
+    assert!(
+        !storage
+            .delete_workspace(&workspace)
+            .await
+            .expect("second delete"),
+        "a second delete finds nothing"
+    );
+    assert!(
+        !postgres_schema_exists(&first_schema).await,
+        "schema {first_schema} must be dropped"
+    );
+
+    let (existing, reopened_schema, reopened_count) = {
+        let storage = storage.clone();
+        let workspace = workspace.clone();
+        blocking(move || {
+            let existing = storage
+                .open_existing_workspace(&workspace)
+                .expect("probe deleted workspace")
+                .is_some();
+            let store = storage.open_workspace(&workspace).expect("reopen");
+            (
+                existing,
+                store.postgres_schema_name(),
+                store.catalog().document_count().expect("count"),
+            )
+        })
+        .await
+    };
+    assert!(!existing, "registry row must be gone");
+    assert_ne!(reopened_schema, first_schema, "surrogates are never reused");
+    assert_eq!(reopened_count, 0, "a reopened Workspace starts empty");
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the migration ledger against Postgres"]
+async fn ledger_sweep_migrates_stale_schemas_and_is_idempotent_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let stale = unique_workspace("stale");
+    let current = unique_workspace("current");
+
+    {
+        let storage = storage.clone();
+        let (stale, current) = (stale.clone(), current.clone());
+        blocking(move || {
+            for workspace in [&stale, &current] {
+                storage
+                    .open_workspace(workspace)
+                    .expect("open")
+                    .catalog()
+                    .refresh_projection(&contract::catalog_snapshot("ledger-v1"))
+                    .expect("refresh");
+            }
+        })
+        .await;
+    }
+    set_registry_schema_version(&stale, 0).await;
+
+    let migrated = storage.migrate_all().await.expect("sweep");
+    assert_eq!(
+        migrated
+            .iter()
+            .filter(|entry| entry.workspace_name == stale.as_str())
+            .map(|entry| entry.from_version)
+            .collect::<Vec<_>>(),
+        vec![0]
+    );
+    assert!(
+        migrated
+            .iter()
+            .all(|entry| entry.workspace_name != current.as_str()),
+        "a current schema is never touched"
+    );
+    assert_eq!(
+        registry_schema_version(&stale).await,
+        super::SEARCH_POSTGRES_SCHEMA_VERSION
+    );
+
+    let second_sweep = storage.migrate_all().await.expect("second sweep");
+    assert!(
+        second_sweep
+            .iter()
+            .all(|entry| entry.workspace_name != stale.as_str()),
+        "a migrated schema is not migrated again"
+    );
+
+    // Replaying the stream over an existing schema kept the data.
+    let stale_count = {
+        let storage = storage.clone();
+        let stale = stale.clone();
+        blocking(move || {
+            storage
+                .open_workspace(&stale)
+                .expect("reopen")
+                .catalog()
+                .document_count()
+                .expect("count")
+        })
+        .await
+    };
+    assert_eq!(stale_count, 4);
+
+    set_registry_schema_version(&stale, super::SEARCH_POSTGRES_SCHEMA_VERSION + 1).await;
+    let error = storage
+        .migrate_all()
+        .await
+        .expect_err("a newer schema must refuse to serve");
+    assert!(error.is_unsupported(), "{error}");
+    let open_error = {
+        let storage = storage.clone();
+        let stale = stale.clone();
+        blocking(move || storage.open_workspace(&stale).err()).await
+    }
+    .expect("open must fail on a newer schema");
+    assert!(open_error.is_unsupported(), "{open_error}");
+
+    delete_workspaces(&storage, &[stale, current]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
+async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("semantics");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        contract::assert_match_semantics(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+async fn test_pool() -> sqlx::PgPool {
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&postgres_test_url().expect("CORAL_TEST_POSTGRES_URL"))
+        .await
+        .expect("connect test pool")
+}
+
+async fn postgres_schema_exists(schema: &str) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = $1)")
+        .bind(schema)
+        .fetch_one(&test_pool().await)
+        .await
+        .expect("schema probe")
+}
+
+async fn set_registry_schema_version(workspace: &WorkspaceName, version: i32) {
+    sqlx::query(
+        "UPDATE search_registry.workspaces SET schema_version = $1 WHERE workspace_name = $2",
+    )
+    .bind(version)
+    .bind(workspace.as_str())
+    .execute(&test_pool().await)
+    .await
+    .expect("set schema version");
+}
+
+async fn registry_schema_version(workspace: &WorkspaceName) -> i32 {
+    sqlx::query_scalar(
+        "SELECT schema_version FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace.as_str())
+    .fetch_one(&test_pool().await)
+    .await
+    .expect("read schema version")
+}

--- a/crates/coral-app/src/search/store/tests.rs
+++ b/crates/coral-app/src/search/store/tests.rs
@@ -126,6 +126,113 @@ pub(super) mod contract {
         assert_eq!(catalog.document_count().expect("count after clear"), 0);
     }
 
+    /// The benchmark strata (substring, word, phrase, 3-char floor,
+    /// negatives) on a synthetic fixture: presence is the contract; order is
+    /// asserted only where the ranking contract demands it.
+    pub(crate) fn assert_match_semantics(store: &SearchStore) {
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&semantics_snapshot())
+            .expect("refresh");
+        let entries = |terms: &[&str]| {
+            let terms = terms
+                .iter()
+                .map(|term| (*term).to_string())
+                .collect::<Vec<_>>();
+            hit_ids(
+                &catalog
+                    .search(&terms, 10, CatalogDocumentClass::Entries)
+                    .expect("search")
+                    .hits,
+            )
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+        };
+        let sorted = |mut ids: Vec<String>| {
+            ids.sort();
+            ids
+        };
+
+        // Substring, mid-identifier.
+        assert_eq!(entries(&["enchmark"]), vec!["table:benchmark_runs"]);
+        // Whole word, wherever it appears.
+        assert_eq!(
+            sorted(entries(&["labels"])),
+            vec!["table:issue_labels", "table:label_issue_counts"]
+        );
+        // Phrase: the whole-phrase match outranks a co-occurrence match. The
+        // query construction upstream appends the whole query as a term.
+        assert_eq!(
+            entries(&["issue", "issue labels", "labels"]),
+            vec!["table:issue_labels", "table:label_issue_counts"]
+        );
+        // Three-character floor: shorter terms are dropped, not matched.
+        assert!(entries(&["ru"]).is_empty());
+        assert_eq!(entries(&["run"]), vec!["table:benchmark_runs"]);
+        // Pattern metacharacters are literal: `_` never acts as a wildcard.
+        assert_eq!(entries(&["deploy_url"]), vec!["table:deploy_url"]);
+        // Negatives: no junk from near misses.
+        assert!(entries(&["benchmarq"]).is_empty());
+        assert!(entries(&["zzqxv"]).is_empty());
+        // Deterministic order across repeated calls.
+        assert_eq!(entries(&["issue"]), entries(&["issue"]));
+    }
+
+    fn semantics_snapshot() -> CatalogIndexSnapshot {
+        let table = |doc_id: &str, surface_name: &str, title: &str, description: &str| {
+            CatalogIndexDocument {
+                doc_id: doc_id.to_string(),
+                doc_kind: CatalogIndexDocumentKind::CatalogTable,
+                source_name: "fixture".to_string(),
+                catalog_name: None,
+                surface_kind: "table".to_string(),
+                surface_name: surface_name.to_string(),
+                field_name: String::new(),
+                field_role: String::new(),
+                qualified_name: format!("fixture.{surface_name}"),
+                title: title.to_string(),
+                description: description.to_string(),
+                searchable_text: format!("fixture {surface_name}"),
+            }
+        };
+        CatalogIndexSnapshot {
+            fingerprint: "semantics-v1".to_string(),
+            documents: vec![
+                table(
+                    "table:benchmark_runs",
+                    "benchmark_runs",
+                    "benchmark_runs",
+                    "One row per benchmark run",
+                ),
+                table(
+                    "table:issue_labels",
+                    "issue_labels",
+                    "issue labels",
+                    "Labels attached to issues",
+                ),
+                table(
+                    "table:label_issue_counts",
+                    "label_issue_counts",
+                    "label counts",
+                    "How many issues carry each label; labels and issue counts",
+                ),
+                table(
+                    "table:deploy_url",
+                    "deploy_url",
+                    "deploy_url",
+                    "Deployment URLs",
+                ),
+                table(
+                    "table:deployxurl",
+                    "deployxurl",
+                    "deployxurl",
+                    "Not the same identifier",
+                ),
+            ],
+        }
+    }
+
     pub(crate) fn hit_ids(hits: &[crate::search::catalog::index::CatalogSearchHit]) -> Vec<&str> {
         hits.iter().map(|hit| hit.doc_id.as_str()).collect()
     }
@@ -229,6 +336,16 @@ fn sqlite_store_serves_the_catalog_contract() {
 
     assert_eq!(store.backend_name(), "sqlite");
     contract::assert_catalog_store_contract(&store);
+}
+
+#[test]
+fn sqlite_store_follows_the_benchmark_match_strata() {
+    let (_temp, storage) = sqlite_storage();
+    let store = storage
+        .open_workspace(&WorkspaceName::default())
+        .expect("open workspace store");
+
+    contract::assert_match_semantics(&store);
 }
 
 #[test]

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -72,7 +72,9 @@ async fn open_postgres(url: &str) -> Result<CoralDb, DbError> {
     })
 }
 
-fn postgres_connect_options(url: &str) -> Result<PgConnectOptions, DbError> {
+/// Connect options for the app-state URL, enforcing the TLS posture every
+/// consumer of that URL must share (the search backend reuses it).
+pub(crate) fn postgres_connect_options(url: &str) -> Result<PgConnectOptions, DbError> {
     let parsed_url = url::Url::parse(url)
         .map_err(|error| DbError::Config(format!("invalid Postgres database URL: {error}")))?;
     let explicit_ssl_mode = postgres_url_ssl_mode(&parsed_url)?;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -18,7 +18,7 @@ mod workspace_state;
 
 pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
-pub(crate) use coral_db::CoralDb;
+pub(crate) use coral_db::{CoralDb, postgres_connect_options};
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::identity_specs::{


### PR DESCRIPTION
Catalog Universal Search can now run on the CoralDb Postgres instance:
one schema per Workspace in the same database, named through a
`search_registry.workspaces` surrogate registry that also serves as the
per-schema migration ledger. Workspace names never reach SQL as
identifiers. The backend owns a small dedicated pool on the `[database]`
URL, sets `search_path` per transaction, runs its own embedded migration
stream, and fails startup loudly when `pg_trgm` is missing.

Retrieval is the benchmark-locked engine: trigram-accelerated `ILIKE`
candidates per term (substring semantics, `LIKE` metacharacters escaped),
ordered by the field-weighted whole-phrase boost (8/6/2/1), weighted
`ts_rank_cd`, trigram similarity, and primary key — a deterministic total
order. Observed values are not kept on this backend; the provider
registry reports them `not_enabled` with the backend named.

Paired-backend tests run the seam contract against Postgres behind
`CORAL_TEST_POSTGRES_URL` (`make postgres-tests`), plus registry naming
with hostile Workspace names, schema isolation, deletion, the ledger
sweep, and the benchmark match strata. Boot sweep and Workspace deletion
are wired next in this stack.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1
