### PR TITLE
feat(search): sweep the Postgres search ledger at boot and drop deleted workspaces

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1,5 +1,6 @@
 //! Builds and runs the Coral gRPC server.
 
+use std::collections::BTreeSet;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -346,8 +347,7 @@ impl ServerBuilder {
         let principal_provider = self.config.principal_provider.clone();
         let grpc_listener = self.config.grpc_listener.clone();
         layout.ensure()?;
-        let feature_store = FeatureStore::from_layout(layout.clone());
-        let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
+        let (feature_store, features) = self.load_features(&layout)?;
         let (database_config, coral_db) = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store, &layout).await?;
@@ -367,10 +367,10 @@ impl ServerBuilder {
             layout.clone(),
             workspace_lifecycle_lock.clone(),
             diagnostic_reporter.clone(),
+            search_storage.clone(),
         )
         .with_pool_registry(Arc::clone(&workspace_pool_registry))
-        .with_database_sources_enabled(database_sources_enabled)
-        .with_search_storage(search_storage.clone());
+        .with_database_sources_enabled(database_sources_enabled);
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
@@ -380,7 +380,9 @@ impl ServerBuilder {
             Arc::clone(&coral_db),
             diagnostic_reporter.clone(),
         )
-        .with_pool_registry(Arc::clone(&workspace_pool_registry));
+        .with_pool_registry(Arc::clone(&workspace_pool_registry))
+        .with_search_storage(search_storage.clone());
+        sweep_search_storage(&search_storage, &workspace_manager).await?;
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
@@ -406,9 +408,8 @@ impl ServerBuilder {
         .with_database_sources_enabled(database_sources_enabled)
         .with_task_activity_recorder(task_activity);
         let observed_values_search_enabled = features.enabled(Feature::ObservedValuesSearch);
-        let search_observations = (observed_values_search_enabled
-            && search_storage.keeps_observed_values())
-        .then(|| SearchObservationHandle::new(layout.clone()));
+        let search_observations =
+            init_search_observations(observed_values_search_enabled, &search_storage, &layout);
         let search_manager = SearchManager::with_diagnostic_reporter(
             search_storage,
             layout,
@@ -481,6 +482,17 @@ fn trace_components_for_store(
     })
 }
 
+impl ServerBuilder {
+    fn load_features(
+        &self,
+        layout: &AppStateLayout,
+    ) -> Result<(FeatureStore, crate::features::Features), AppError> {
+        let feature_store = FeatureStore::from_layout(layout.clone());
+        let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
+        Ok((feature_store, features))
+    }
+}
+
 fn init_credential_manager(layout: &AppStateLayout) -> Result<CredentialManager, AppError> {
     let credential_config = CredentialStorageConfig::load(layout)?;
     let credential_store =
@@ -513,6 +525,56 @@ async fn init_search_storage(
                 .map_err(|error| search_storage_open_error(&error))
         }
     }
+}
+
+/// The boot sweep over shared search storage, before serving, like
+/// `coral_db.migrate()`: stale Workspace schemas are migrated, and Workspaces
+/// that no longer exist lose their search state.
+async fn sweep_search_storage(
+    search_storage: &SearchStorage,
+    workspace_manager: &WorkspaceManager,
+) -> Result<(), AppError> {
+    let migrated = search_storage
+        .migrate_all()
+        .await
+        .map_err(|error| search_storage_open_error(&error))?;
+    if !migrated.is_empty() {
+        tracing::info!(
+            migrated_workspace_schemas = migrated.len(),
+            "migrated stale search schemas at startup"
+        );
+    }
+    if !search_storage.has_workspace_registry() {
+        return Ok(());
+    }
+    let live = workspace_manager
+        .list_workspaces()
+        .await?
+        .into_iter()
+        .map(|workspace| workspace.name.as_str().to_string())
+        .collect::<BTreeSet<_>>();
+    let pruned = search_storage
+        .prune_workspaces_except(&live)
+        .await
+        .map_err(|error| search_storage_open_error(&error))?;
+    if !pruned.is_empty() {
+        tracing::warn!(
+            pruned_workspaces = pruned.len(),
+            "removed search state of workspaces that no longer exist"
+        );
+    }
+    Ok(())
+}
+
+/// The observed-values capture pipeline runs only when the feature is on and
+/// the search backend keeps observed values to write into.
+fn init_search_observations(
+    observed_values_search_enabled: bool,
+    search_storage: &SearchStorage,
+    layout: &AppStateLayout,
+) -> Option<SearchObservationHandle> {
+    (observed_values_search_enabled && search_storage.keeps_observed_values())
+        .then(|| SearchObservationHandle::new(layout.clone()))
 }
 
 fn search_storage_open_error(error: &SearchStoreError) -> AppError {

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -24,8 +24,8 @@ use crate::search::maintenance::{
 };
 use crate::search::observed::provider::{ObservedValuesProvider, observed_clear_provider_result};
 use crate::search::observed::{
-    ObservedValuesDrainBudget, ObservedValuesLiveScopeLoad, ObservedValuesLiveScopeLoader,
-    ObservedValuesRetrievalPolicy,
+    ObservedValuesClearResult, ObservedValuesDrainBudget, ObservedValuesLiveScopeLoad,
+    ObservedValuesLiveScopeLoader, ObservedValuesRetrievalPolicy,
 };
 use crate::search::provider::{
     LocalSearchWriteCoordinator, SearchExecutionContext, SearchProviderRegistry,
@@ -458,10 +458,22 @@ impl SearchManager {
         Ok(ClearSearchDataResponse {
             results: vec![
                 catalog_clear_provider_result(cleared.catalog.deleted_document_count),
-                observed_clear_provider_result(cleared.observed),
+                self.observed_clear_all_result(cleared.observed),
             ],
             storage_cleanup: store.compact_after_clear(),
         })
+    }
+
+    /// The observed half of an all-data clear: the clear's own result, or the
+    /// explicit absence when the backend keeps no observed values.
+    fn observed_clear_all_result(
+        &self,
+        observed: Option<ObservedValuesClearResult>,
+    ) -> SearchMaintenanceResult {
+        observed.map_or_else(
+            || observed_values_search_unavailable_maintenance_result(self.storage.backend_name()),
+            observed_clear_provider_result,
+        )
     }
 
     fn clear_workspace_all(
@@ -478,7 +490,7 @@ impl SearchManager {
         Ok(ClearSearchDataResponse {
             results: vec![
                 catalog_clear_provider_result(cleared.catalog.deleted_document_count),
-                observed_clear_provider_result(cleared.observed),
+                self.observed_clear_all_result(cleared.observed),
             ],
             storage_cleanup: store.compact_after_clear(),
         })

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -18,6 +18,7 @@ mod config;
 mod postgres;
 mod sqlite;
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use tokio::runtime::Handle;
@@ -205,13 +206,21 @@ impl SearchStorage {
         }
     }
 
+    /// Clears the Workspace's catalog projection when it has search state, and
+    /// creates none when it has not. Source lifecycle changes call this best
+    /// effort; `None` means there was nothing to clear.
+    pub(crate) fn clear_existing_workspace_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<CatalogClearResult>, SearchStoreError> {
+        self.open_existing_workspace(workspace_name)?
+            .map(|store| store.catalog().clear_workspace())
+            .transpose()
+    }
+
     /// Removes every trace of the Workspace's search state. Returns whether
     /// there was any. The `SQLite` sidecar lives inside the Workspace
     /// directory, which Workspace deletion removes as a whole.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
-    )]
     pub(crate) async fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
@@ -224,12 +233,32 @@ impl SearchStorage {
         }
     }
 
+    /// Whether this backend registers Workspaces in shared storage that
+    /// outlives the Workspace directory, and so needs boot-time pruning.
+    pub(crate) fn has_workspace_registry(&self) -> bool {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => false,
+            SearchStorageBackend::Postgres(_) => true,
+        }
+    }
+
+    /// Removes the search state of every registered Workspace that is not in
+    /// `live`, and returns their names. The safety net for a deletion whose
+    /// best-effort cleanup failed: the next boot finishes it.
+    pub(crate) async fn prune_workspaces_except(
+        &self,
+        live: &BTreeSet<String>,
+    ) -> Result<Vec<String>, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => Ok(Vec::new()),
+            SearchStorageBackend::Postgres(storage) => {
+                Ok(storage.prune_workspaces_except(live).await?)
+            }
+        }
+    }
+
     /// Boot-time ledger sweep: migrates every Workspace schema the backend
     /// knows to be behind this binary. `SQLite` sidecars migrate on open.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into server startup next in this stack")
-    )]
     pub(crate) async fn migrate_all(
         &self,
     ) -> Result<Vec<MigratedWorkspaceSchema>, SearchStoreError> {
@@ -271,7 +300,9 @@ enum SearchStoreBackend {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SearchClearAllResult {
     pub(crate) catalog: CatalogClearResult,
-    pub(crate) observed: ObservedValuesClearResult,
+    /// `None` when the backend keeps no observed values, so callers report
+    /// the absence instead of an empty clear.
+    pub(crate) observed: Option<ObservedValuesClearResult>,
 }
 
 impl SearchStore {
@@ -306,11 +337,14 @@ impl SearchStore {
         match &self.backend {
             SearchStoreBackend::Sqlite(store) => {
                 let (catalog, observed) = store.clear_source_all(source_name)?;
-                Ok(SearchClearAllResult { catalog, observed })
+                Ok(SearchClearAllResult {
+                    catalog,
+                    observed: Some(observed),
+                })
             }
             SearchStoreBackend::Postgres(store) => Ok(SearchClearAllResult {
                 catalog: store.clear_source(source_name)?,
-                observed: ObservedValuesClearResult::default(),
+                observed: None,
             }),
         }
     }
@@ -320,11 +354,14 @@ impl SearchStore {
         match &self.backend {
             SearchStoreBackend::Sqlite(store) => {
                 let (catalog, observed) = store.clear_workspace_all()?;
-                Ok(SearchClearAllResult { catalog, observed })
+                Ok(SearchClearAllResult {
+                    catalog,
+                    observed: Some(observed),
+                })
             }
             SearchStoreBackend::Postgres(store) => Ok(SearchClearAllResult {
                 catalog: store.clear_workspace()?,
-                observed: ObservedValuesClearResult::default(),
+                observed: None,
             }),
         }
     }

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -14,6 +14,7 @@
 mod catalog;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 use std::future::Future;
 
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -72,13 +73,6 @@ struct WorkspaceRegistration {
 }
 
 /// What a registry sweep did for one Workspace schema.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the boot ledger sweep is wired into server startup next in this stack"
-    )
-)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MigratedWorkspaceSchema {
     pub(crate) workspace_name: String,
@@ -133,19 +127,47 @@ impl PostgresSearchStorage {
 
     /// Removes the Workspace's registry row and drops its schema. Complete
     /// and instant: no tenant rows survive offboarding.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
-    )]
     pub(crate) async fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
+    ) -> Result<bool, PostgresSearchError> {
+        self.delete_registered_workspace(workspace_name.as_str())
+            .await
+    }
+
+    /// Removes every registered Workspace that is not in `live` and returns
+    /// their names. Runs at boot, before serving, so nothing registers
+    /// concurrently.
+    pub(crate) async fn prune_workspaces_except(
+        &self,
+        live: &BTreeSet<String>,
+    ) -> Result<Vec<String>, PostgresSearchError> {
+        let registered: Vec<String> = sqlx::query_scalar(
+            "SELECT workspace_name FROM search_registry.workspaces ORDER BY surrogate_id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        let mut pruned = Vec::new();
+        for workspace_name in registered {
+            if live.contains(&workspace_name) {
+                continue;
+            }
+            if self.delete_registered_workspace(&workspace_name).await? {
+                pruned.push(workspace_name);
+            }
+        }
+        Ok(pruned)
+    }
+
+    async fn delete_registered_workspace(
+        &self,
+        workspace_name: &str,
     ) -> Result<bool, PostgresSearchError> {
         let mut tx = self.pool.begin().await?;
         let deleted: Option<i64> = sqlx::query_scalar(
             "DELETE FROM search_registry.workspaces WHERE workspace_name = $1 RETURNING surrogate_id",
         )
-        .bind(workspace_name.as_str())
+        .bind(workspace_name)
         .fetch_optional(&mut *tx)
         .await?;
         let Some(surrogate_id) = deleted else {
@@ -165,10 +187,6 @@ impl PostgresSearchStorage {
 
     /// Boot-time ledger sweep: migrates every registered schema that is behind
     /// this binary. A steady-state boot costs one query and does no work.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into server startup next in this stack")
-    )]
     pub(crate) async fn migrate_all(
         &self,
     ) -> Result<Vec<MigratedWorkspaceSchema>, PostgresSearchError> {

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -357,6 +357,64 @@ async fn ledger_sweep_migrates_stale_schemas_and_is_idempotent_against_postgres(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the boot prune against Postgres"]
+async fn boot_prune_removes_workspaces_missing_from_the_live_set_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let orphaned = unique_workspace("orphaned");
+    let live = unique_workspace("live");
+    {
+        let storage = storage.clone();
+        let (orphaned, live) = (orphaned.clone(), live.clone());
+        blocking(move || {
+            storage.open_workspace(&orphaned).expect("open orphaned");
+            storage.open_workspace(&live).expect("open live");
+        })
+        .await;
+    }
+
+    // Every other registered Workspace stays live: the registry is shared with
+    // concurrent tests, so only this test's orphan may be missing.
+    let mut live_names: std::collections::BTreeSet<String> =
+        sqlx::query_scalar("SELECT workspace_name FROM search_registry.workspaces")
+            .fetch_all(&test_pool().await)
+            .await
+            .expect("registered workspaces")
+            .into_iter()
+            .collect();
+    assert!(live_names.remove(orphaned.as_str()));
+
+    let pruned = storage
+        .prune_workspaces_except(&live_names)
+        .await
+        .expect("prune");
+
+    assert_eq!(pruned, vec![orphaned.as_str().to_string()]);
+    let (orphan_exists, live_exists) = {
+        let storage = storage.clone();
+        let (orphaned, live) = (orphaned.clone(), live.clone());
+        blocking(move || {
+            (
+                storage
+                    .open_existing_workspace(&orphaned)
+                    .expect("probe orphan")
+                    .is_some(),
+                storage
+                    .open_existing_workspace(&live)
+                    .expect("probe live")
+                    .is_some(),
+            )
+        })
+        .await
+    };
+    assert!(!orphan_exists, "the orphaned workspace must be gone");
+    assert!(live_exists, "a live workspace must survive the prune");
+
+    delete_workspaces(&storage, &[live]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
 async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     let Some(storage) = open_storage().await else {

--- a/crates/coral-app/src/search/store/tests.rs
+++ b/crates/coral-app/src/search/store/tests.rs
@@ -387,7 +387,13 @@ fn clear_all_spans_both_data_classes_and_reports_cleanup() {
 
     let cleared = store.clear_source_all("github").expect("clear source all");
     assert_eq!(cleared.catalog.deleted_document_count, 3);
-    assert_eq!(cleared.observed.values, 0);
+    assert_eq!(
+        cleared
+            .observed
+            .expect("sqlite keeps observed values")
+            .values,
+        0
+    );
     let cleared = store.clear_workspace_all().expect("clear workspace all");
     assert_eq!(cleared.catalog.deleted_document_count, 1);
     assert_eq!(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -215,28 +215,34 @@ impl SourceManager {
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
+        let search_storage = SearchStorage::sqlite(layout.clone());
         Self::with_diagnostic_reporter(
             config_store,
             credential_manager,
             layout,
             lifecycle_lock,
             SourceDiagnosticReporter::default(),
+            search_storage,
         )
         .with_database_sources_enabled(true)
     }
 
+    /// `search_storage` is required, not defaulted: a source lifecycle change
+    /// must clear the catalog projection on the backend that serves it, and a
+    /// default would clear the wrong one in silence.
     pub(crate) fn with_diagnostic_reporter(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
         diagnostic_reporter: SourceDiagnosticReporter,
+        search_storage: SearchStorage,
     ) -> Self {
         Self {
             config_store,
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
-            search_storage: SearchStorage::sqlite(layout.clone()),
+            search_storage,
             layout,
             lifecycle_lock,
             diagnostic_reporter,
@@ -244,11 +250,6 @@ impl SourceManager {
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
             database_sources_enabled: false,
         }
-    }
-
-    pub(crate) fn with_search_storage(mut self, search_storage: SearchStorage) -> Self {
-        self.search_storage = search_storage;
-        self
     }
 
     pub(crate) fn with_database_sources_enabled(mut self, enabled: bool) -> Self {
@@ -960,12 +961,8 @@ impl SourceManager {
     ) {
         match self
             .search_storage
-            .open_existing_workspace(workspace_name)
-            .and_then(|store| {
-                store
-                    .map(|store| store.catalog().clear_workspace())
-                    .transpose()
-            }) {
+            .clear_existing_workspace_catalog(workspace_name)
+        {
             Ok(None) => {}
             Ok(Some(result)) => {
                 tracing::debug!(
@@ -980,7 +977,8 @@ impl SourceManager {
                     workspace = %workspace_name,
                     source = %source_name,
                     search_backend = self.search_storage.backend_name(),
-                    "source lifecycle changed, but failed to clear catalog search projection: {error}"
+                    error = %error,
+                    "source lifecycle changed, but failed to clear catalog search projection"
                 );
             }
         }

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -5,6 +5,7 @@ use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
+use crate::search::store::SearchStorage;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::ConfigStore;
 use crate::state::db::{CoralDb, DbRepos, now_unix_nanos_i64};
@@ -25,6 +26,7 @@ pub(crate) struct WorkspaceManager {
     db: Arc<CoralDb>,
     diagnostic_reporter: SourceDiagnosticReporter,
     pool_registry: Arc<WorkspacePoolRegistry>,
+    search_storage: Option<SearchStorage>,
 }
 
 impl WorkspaceManager {
@@ -65,11 +67,23 @@ impl WorkspaceManager {
             db,
             diagnostic_reporter,
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
+            search_storage: None,
         }
     }
 
     pub(crate) fn with_pool_registry(mut self, pool_registry: Arc<WorkspacePoolRegistry>) -> Self {
         self.pool_registry = pool_registry;
+        self
+    }
+
+    /// Search storage whose per-Workspace state is removed on deletion.
+    ///
+    /// Optional because only shared backends keep state outside the Workspace
+    /// directory: the `SQLite` sidecar goes with the directory. The server
+    /// bootstrap always sets it; a constructor parameter would need an
+    /// `AppStateLayout` that the generic `WorkspacePaths` tests use cannot give.
+    pub(crate) fn with_search_storage(mut self, search_storage: SearchStorage) -> Self {
+        self.search_storage = Some(search_storage);
         self
     }
 
@@ -217,7 +231,37 @@ impl WorkspaceManager {
         Self::commit_deleted_workspace_dir(&deleted_workspace_name, workspace_dir_backup);
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
+        self.delete_workspace_search_state(&deleted_workspace_name)
+            .await;
         Ok(deleted.workspace)
+    }
+
+    /// Best effort, after the deletion committed: a Workspace that no longer
+    /// exists must not keep catalog rows in shared search storage. A failure
+    /// here is finished by the next boot's sweep, which prunes registered
+    /// Workspaces that the database no longer lists.
+    async fn delete_workspace_search_state(&self, workspace_name: &WorkspaceName) {
+        let Some(search_storage) = &self.search_storage else {
+            return;
+        };
+        match search_storage.delete_workspace(workspace_name).await {
+            Ok(deleted) => {
+                tracing::debug!(
+                    workspace = %workspace_name,
+                    search_backend = search_storage.backend_name(),
+                    deleted,
+                    "removed deleted workspace's search state"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    search_backend = search_storage.backend_name(),
+                    error = %error,
+                    "workspace deleted, but failed to remove its search state; the next boot sweep removes it"
+                );
+            }
+        }
     }
 
     fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
@@ -315,7 +359,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::WorkspaceManager;
+    use crate::bootstrap;
     use crate::credentials::{CredentialManager, CredentialSetId, CredentialStore};
+    use crate::search::store::SearchStorage;
     use crate::sources::SourceName;
     use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
     use crate::sources::model::{InstalledSource, SourceOrigin};
@@ -349,6 +395,71 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         Arc::new(db)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run Workspace deletion against Postgres search storage"]
+    async fn delete_workspace_removes_search_state_contract_on_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url: url.clone() })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let search_storage = SearchStorage::postgres(&url, tokio::runtime::Handle::current())
+            .await
+            .expect("open postgres search storage");
+        let manager = WorkspaceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            None,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+            Arc::new(db),
+            SourceDiagnosticReporter::default(),
+        )
+        .with_search_storage(search_storage.clone());
+        let workspace_name =
+            WorkspaceName::parse(&format!("usp-delete-{}", uuid::Uuid::new_v4().simple()))
+                .expect("workspace");
+        manager
+            .create_workspace(&workspace_name)
+            .await
+            .expect("create workspace");
+        let open_storage = search_storage.clone();
+        let open_workspace = workspace_name.clone();
+        tokio::task::spawn_blocking(move || {
+            open_storage
+                .open_workspace(&open_workspace)
+                .expect("first search registers the workspace's search schema");
+        })
+        .await
+        .expect("open search state");
+
+        manager
+            .delete_workspace(&workspace_name)
+            .await
+            .expect("delete workspace");
+
+        let probe_workspace = workspace_name.clone();
+        let remaining = tokio::task::spawn_blocking(move || {
+            search_storage
+                .open_existing_workspace(&probe_workspace)
+                .expect("probe search state")
+                .is_some()
+        })
+        .await
+        .expect("probe search state");
+        assert!(
+            !remaining,
+            "deleting the workspace must remove its search state"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -8,6 +8,11 @@
 use std::collections::BTreeMap;
 use std::fs;
 
+use coral_api::v1::{
+    CreateWorkspaceRequest, DeleteWorkspaceRequest, SearchProvider, SearchProviderState,
+    SearchRequest, Workspace,
+};
+use coral_client::AppClient;
 use coral_client::local::ServerBuilder;
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
@@ -18,6 +23,157 @@ use coral_spec::{
 };
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
+use tonic::Request;
+
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Postgres catalog search end to end"]
+async fn server_serves_catalog_search_from_postgres_and_removes_deleted_workspace_state() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n\n[search]\nbackend = \"postgres\"\n",
+    )
+    .expect("write config");
+    let pool = PgPoolOptions::new()
+        .connect(&database_url)
+        .await
+        .expect("open Postgres database");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server with Postgres search config");
+    let registry_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('search_registry.workspaces') IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("probe search registry");
+    assert!(registry_exists, "boot must bootstrap the search registry");
+    assert!(
+        !config_dir.join("workspaces").exists()
+            || !any_sqlite_search_file(&config_dir.join("workspaces")),
+        "no SQLite search sidecar may exist with the Postgres backend"
+    );
+
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    let workspace_name = format!("usp-e2e-{}", uuid::Uuid::new_v4().simple());
+    let workspace = Workspace {
+        name: workspace_name.clone(),
+    };
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace.clone()),
+        }))
+        .await
+        .expect("create workspace");
+
+    assert_search_reports_postgres_provider_statuses(&app, &workspace).await;
+
+    let surrogate_id = registry_surrogate_id(&pool, &workspace_name)
+        .await
+        .expect("the first search registers the workspace");
+    let schema = format!("search_ws_{surrogate_id}");
+    assert!(
+        postgres_schema_exists(&pool, &schema).await,
+        "schema {schema} must exist after the first search"
+    );
+
+    app.workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace),
+        }))
+        .await
+        .expect("delete workspace");
+    assert_eq!(
+        registry_surrogate_id(&pool, &workspace_name).await,
+        None,
+        "deletion must remove the registry row"
+    );
+    assert!(
+        !postgres_schema_exists(&pool, &schema).await,
+        "deletion must drop schema {schema}"
+    );
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+/// Catalog search on an empty Workspace answers `Empty`, and observed values
+/// report `not_enabled` naming the backend rather than erroring.
+async fn assert_search_reports_postgres_provider_statuses(app: &AppClient, workspace: &Workspace) {
+    let response = app
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(workspace.clone()),
+            query: "benchmark".to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect("search")
+        .into_inner();
+    assert_eq!(response.provider_statuses.len(), 3);
+    let status = |provider: SearchProvider| {
+        response
+            .provider_statuses
+            .iter()
+            .find(|status| status.provider == provider as i32)
+            .unwrap_or_else(|| panic!("missing status for {provider:?}"))
+    };
+    assert_eq!(
+        status(SearchProvider::CatalogMetadata).state,
+        SearchProviderState::Empty as i32,
+        "an empty catalog is served, not errored: {:?}",
+        status(SearchProvider::CatalogMetadata)
+    );
+    let observed = status(SearchProvider::ObservedValues);
+    assert_eq!(observed.state, SearchProviderState::NotEnabled as i32);
+    assert!(
+        observed
+            .note
+            .contains("not available on the postgres search backend"),
+        "unexpected observed note: {}",
+        observed.note
+    );
+}
+
+async fn registry_surrogate_id(pool: &sqlx::PgPool, workspace_name: &str) -> Option<i64> {
+    sqlx::query_scalar(
+        "SELECT surrogate_id FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace_name)
+    .fetch_optional(pool)
+    .await
+    .expect("read registry row")
+}
+
+fn any_sqlite_search_file(root: &std::path::Path) -> bool {
+    fs::read_dir(root).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                any_sqlite_search_file(&path)
+            } else {
+                path.extension()
+                    .is_some_and(|extension| extension == "sqlite3")
+            }
+        })
+    })
+}
+
+async fn postgres_schema_exists(pool: &sqlx::PgPool, schema: &str) -> bool {
+    sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = $1)")
+        .bind(schema)
+        .fetch_one(pool)
+        .await
+        .expect("probe schema")
+}
 
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]


### PR DESCRIPTION
Server startup now runs the search registry's ledger sweep right after
opening the Postgres backend, before serving: every Workspace schema the
ledger records as behind this binary is migrated inside the boot window,
and a steady-state boot costs one query. Workspace deletion removes the
Workspace's registry row and drops its schema, so no tenant catalog rows
outlive offboarding; the SQLite sidecar needs nothing because it lives
inside the Workspace directory that deletion already removes.

Covered end to end behind `CORAL_TEST_POSTGRES_URL`: a server on
`[search] backend = "postgres"` bootstraps the registry, answers a search
with the catalog provider `empty` and observed values `not_enabled`
naming the backend, registers the Workspace on first search, and leaves
neither registry row nor schema after the Workspace is deleted.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1
