### PR TITLE
fix(coral-ui): drop the desktop-only notice from onboarding

### DIFF
--- a/apps/coral-ui/app/components/onboarding/onboarding-next-steps-page.tsx
+++ b/apps/coral-ui/app/components/onboarding/onboarding-next-steps-page.tsx
@@ -217,11 +217,6 @@ function ManualConnectInstructions() {
         <Typography.CodeInline as="code">coral</Typography.CodeInline>.
       </Typography.Body>
 
-      <Typography.BodySmall variant="tertiary">
-        Open this step in Coral Desktop to connect a client for you. This browser cannot configure a
-        local MCP server, and web agents cannot launch a local stdio one.
-      </Typography.BodySmall>
-
       <Typography.Body variant="tertiary">
         See the{' '}
         <OnboardingLink href="https://withcoral.com/docs/guides/use-coral-over-mcp">


### PR DESCRIPTION
## Summary

Don't think it bring any values, and makes it harder to understand what to do. (Since you can't just open that page on the desktop app like it says..)

<img width="703" height="502" alt="image" src="https://github.com/user-attachments/assets/d1bc3428-ce7b-4b17-a5db-350904fb6a15" />
