### PR TITLE
fix(coral-ui): resolve the implied workspace as default

### DIFF
--- a/apps/coral-ui/app/lib/workspace-redirect.server.ts
+++ b/apps/coral-ui/app/lib/workspace-redirect.server.ts
@@ -1,13 +1,13 @@
 import { redirect } from 'react-router'
 
-import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
+import { impliedWorkspaceForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 
-export async function redirectToFirstWorkspaceTraces(
+export async function redirectToImpliedWorkspaceTraces(
   request: Request,
   accessToken: string | null,
 ): Promise<Response> {
-  const workspace = await firstWorkspaceForRequest(request, accessToken)
+  const workspace = await impliedWorkspaceForRequest(request, accessToken)
   const search = new URL(request.url).search
   return redirect(`${routePath('workspaceTraces', { workspaceId: workspace.name })}${search}`)
 }

--- a/apps/coral-ui/app/lib/workspaces.server.ts
+++ b/apps/coral-ui/app/lib/workspaces.server.ts
@@ -13,11 +13,21 @@ export async function listWorkspacesForRequest(
   return response.workspaces
 }
 
-export async function firstWorkspaceForRequest(
+export const DEFAULT_WORKSPACE_ID = 'default'
+
+/**
+ * `ListWorkspaces` makes no promise about order: the server sorts by name, so a
+ * workspace named before `default` would otherwise take its place.
+ */
+export function pickImpliedWorkspace(workspaces: readonly Workspace[]): Workspace | undefined {
+  return workspaces.find(({ name }) => name === DEFAULT_WORKSPACE_ID) ?? workspaces[0]
+}
+
+export async function impliedWorkspaceForRequest(
   request: Request,
   accessToken: string | null,
 ): Promise<Workspace> {
-  const [workspace] = await listWorkspacesForRequest(request, accessToken)
+  const workspace = pickImpliedWorkspace(await listWorkspacesForRequest(request, accessToken))
   if (workspace) return workspace
 
   throw new Response('No Coral workspace is configured.', {

--- a/apps/coral-ui/app/routes/index.tsx
+++ b/apps/coral-ui/app/routes/index.tsx
@@ -4,13 +4,13 @@ import { replace } from 'react-router'
 
 import { requestAuthContext } from '@/auth/server-context'
 import { getGuiOnboardingCompleted } from '@/lib/gui-onboarding.server'
-import { redirectToFirstWorkspaceTraces } from '@/lib/workspace-redirect.server'
+import { redirectToImpliedWorkspaceTraces } from '@/lib/workspace-redirect.server'
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
   if (!(await getGuiOnboardingCompleted(request, accessToken))) return replace('/onboarding')
 
-  return redirectToFirstWorkspaceTraces(request, accessToken)
+  return redirectToImpliedWorkspaceTraces(request, accessToken)
 }
 
 export default function AppIndex() {

--- a/apps/coral-ui/app/routes/onboarding-action.ts
+++ b/apps/coral-ui/app/routes/onboarding-action.ts
@@ -3,7 +3,7 @@ import { data, redirect } from 'react-router'
 import { completeGuiOnboarding } from '@/lib/gui-onboarding.server'
 import { COMPLETE_ONBOARDING_INTENT, type CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
 import { errorMessage } from '@/lib/utils'
-import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
+import { impliedWorkspaceForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 
 /**
@@ -13,7 +13,7 @@ import { routePath } from '@/routing/routemap'
  */
 export async function runCompleteOnboardingAction(request: Request, accessToken: string | null) {
   try {
-    const workspace = await firstWorkspaceForRequest(request, accessToken)
+    const workspace = await impliedWorkspaceForRequest(request, accessToken)
     await completeGuiOnboarding(request, accessToken)
     return redirect(routePath('workspaceTraces', { workspaceId: workspace.name }))
   } catch (error) {

--- a/apps/coral-ui/app/routes/onboarding.server.test.ts
+++ b/apps/coral-ui/app/routes/onboarding.server.test.ts
@@ -4,26 +4,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   completeGuiOnboarding,
-  firstWorkspaceForRequest,
   getGuiOnboardingCompleted,
+  impliedWorkspaceForRequest,
   listWorkspacesForRequest,
   loadOnboardingSampleQuery,
   loadSourcesRouteData,
   runSourcesAction,
 } = vi.hoisted(() => ({
   completeGuiOnboarding: vi.fn(),
-  firstWorkspaceForRequest: vi.fn(),
   getGuiOnboardingCompleted: vi.fn(),
+  impliedWorkspaceForRequest: vi.fn(),
   listWorkspacesForRequest: vi.fn(),
   loadOnboardingSampleQuery: vi.fn(),
   loadSourcesRouteData: vi.fn(),
   runSourcesAction: vi.fn(),
 }))
 
-// The loader lists workspaces (it renders a switcher and 404s when there are
-// none); the action still resolves just the first one.
-vi.mock('@/lib/workspaces.server', () => ({
-  firstWorkspaceForRequest,
+// `pickImpliedWorkspace` stays real, so these cases exercise the actual choice.
+vi.mock('@/lib/workspaces.server', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/workspaces.server')>()),
+  impliedWorkspaceForRequest,
   listWorkspacesForRequest,
 }))
 vi.mock('@/lib/gui-onboarding.server', () => ({
@@ -40,17 +40,18 @@ import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 import { action, loader } from './onboarding'
 
 const workspace = create(WorkspaceSchema, { name: 'analytics' })
+const defaultWorkspace = create(WorkspaceSchema, { name: 'default' })
 
 beforeEach(() => {
   completeGuiOnboarding.mockReset()
-  firstWorkspaceForRequest.mockReset()
+  impliedWorkspaceForRequest.mockReset()
   listWorkspacesForRequest.mockReset()
   getGuiOnboardingCompleted.mockReset()
   loadOnboardingSampleQuery.mockReset()
   loadSourcesRouteData.mockReset()
   runSourcesAction.mockReset()
   getGuiOnboardingCompleted.mockResolvedValue(false)
-  firstWorkspaceForRequest.mockResolvedValue(workspace)
+  impliedWorkspaceForRequest.mockResolvedValue(workspace)
   listWorkspacesForRequest.mockResolvedValue([workspace])
   loadSourcesRouteData.mockResolvedValue({
     entries: [{ installed: true, name: 'github' }],
@@ -101,7 +102,7 @@ describe('onboarding route authentication', () => {
 
     await action(authRouteTestArgs(request, {}, 'coral-access-token'))
 
-    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
+    expect(impliedWorkspaceForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
     expect(runSourcesAction).toHaveBeenCalledWith(request, workspace, 'coral-access-token')
   })
 
@@ -123,6 +124,21 @@ describe('onboarding route authentication', () => {
 })
 
 describe('onboarding server route', () => {
+  it('loads the default workspace even when another workspace is listed first', async () => {
+    listWorkspacesForRequest.mockResolvedValue([workspace, defaultWorkspace])
+    const request = new Request('http://coral-ui.test/onboarding?step=query')
+
+    const result = await loader(authRouteTestArgs(request, {}, null))
+
+    expect(loadSourcesRouteData).toHaveBeenCalledWith(request, defaultWorkspace, null)
+    expect(loadOnboardingSampleQuery).toHaveBeenCalledWith(request, null, 'default')
+    expect(result).toMatchObject({
+      workspaceId: 'default',
+      // The switcher still needs the rest, so the choice must not filter them out.
+      workspaces: [{ name: 'analytics' }, { name: 'default' }],
+    })
+  })
+
   it('replaces completed users directly into the normal app before loading onboarding data', async () => {
     getGuiOnboardingCompleted.mockResolvedValue(true)
     const request = new Request('http://coral-ui.test/onboarding')
@@ -133,7 +149,7 @@ describe('onboarding server route', () => {
     expect((response as Response).status).toBe(302)
     expect((response as Response).headers.get('Location')).toBe('/workspaces/analytics/traces')
     expect((response as Response).headers.get('X-Remix-Replace')).toBe('true')
-    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, null)
+    expect(impliedWorkspaceForRequest).toHaveBeenCalledWith(request, null)
     expect(listWorkspacesForRequest).not.toHaveBeenCalled()
     expect(loadSourcesRouteData).not.toHaveBeenCalled()
   })
@@ -190,7 +206,7 @@ describe('onboarding server route', () => {
       status: 404,
       statusText: 'Workspace Not Found',
     })
-    firstWorkspaceForRequest.mockRejectedValueOnce(missingWorkspace)
+    impliedWorkspaceForRequest.mockRejectedValueOnce(missingWorkspace)
 
     await expect(action(authRouteTestArgs(completionRequest(), {}, null))).rejects.toBe(
       missingWorkspace,

--- a/apps/coral-ui/app/routes/onboarding.tsx
+++ b/apps/coral-ui/app/routes/onboarding.tsx
@@ -8,7 +8,11 @@ import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { COMPLETE_ONBOARDING_INTENT } from '@/lib/gui-onboarding'
 import { getGuiOnboardingCompleted } from '@/lib/gui-onboarding.server'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
-import { firstWorkspaceForRequest, listWorkspacesForRequest } from '@/lib/workspaces.server'
+import {
+  impliedWorkspaceForRequest,
+  listWorkspacesForRequest,
+  pickImpliedWorkspace,
+} from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 import { OnboardingView } from '@/views/onboarding/onboarding'
 import { addToast } from '@/wax/components/toast'
@@ -25,12 +29,12 @@ import {
 export async function loader({ context, request }: Route.LoaderArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
   if (await getGuiOnboardingCompleted(request, accessToken)) {
-    const workspace = await firstWorkspaceForRequest(request, accessToken)
+    const workspace = await impliedWorkspaceForRequest(request, accessToken)
     return replace(routePath('workspaceTraces', { workspaceId: workspace.name }))
   }
 
   const workspaces = await listWorkspacesForRequest(request, accessToken)
-  const [workspace] = workspaces
+  const workspace = pickImpliedWorkspace(workspaces)
   if (!workspace) {
     throw new Response('No Coral workspace is configured.', {
       status: 404,
@@ -67,7 +71,7 @@ export async function action({ context, request }: Route.ActionArgs) {
 
   return runSourcesAction(
     request,
-    await firstWorkspaceForRequest(request, accessToken),
+    await impliedWorkspaceForRequest(request, accessToken),
     accessToken,
   )
 }


### PR DESCRIPTION
## Summary

Coral orgs always have a default workspace, and that's what should be shown in the onboarding.
This is a bit hazy with the upcoming workspace ownership changes, but better than defaulting to the first workspace (which atm could be someone else's)