### PR TITLE
refactor(search): move catalog index types out of the SQLite module

### DIFF
--- a/crates/coral-app/src/search/catalog/index.rs
+++ b/crates/coral-app/src/search/catalog/index.rs
@@ -1,0 +1,198 @@
+//! Backend-neutral catalog projection types and index semantics.
+//!
+//! Every search backend stores the same projection documents and answers the
+//! same retrieval questions. The types here are the contract both sides of the
+//! storage seam share; the term normalization and searchable-text composition
+//! define what "matches" means independently of the engine that indexes it.
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogIndexSnapshot {
+    pub(crate) documents: Vec<CatalogIndexDocument>,
+    pub(crate) fingerprint: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogIndexDocument {
+    pub(crate) doc_id: String,
+    pub(crate) doc_kind: CatalogIndexDocumentKind,
+    pub(crate) source_name: String,
+    pub(crate) catalog_name: Option<String>,
+    pub(crate) surface_kind: String,
+    pub(crate) surface_name: String,
+    pub(crate) field_name: String,
+    pub(crate) field_role: String,
+    pub(crate) qualified_name: String,
+    pub(crate) title: String,
+    pub(crate) description: String,
+    pub(crate) searchable_text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogIndexDocumentKind {
+    CatalogTable,
+    CatalogTableFunction,
+    ColumnHint,
+}
+
+impl CatalogIndexDocumentKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::CatalogTable => "catalog_table",
+            Self::CatalogTableFunction => "catalog_table_function",
+            Self::ColumnHint => "column_hint",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogRefreshResult {
+    pub(crate) refreshed: bool,
+    pub(crate) document_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogRebuildResult {
+    pub(crate) old_document_count: u32,
+    pub(crate) new_document_count: u32,
+    pub(crate) projection_changed: bool,
+    pub(crate) rebuild_performed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogClearResult {
+    pub(crate) deleted_document_count: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogSearchHits {
+    pub(crate) hits: Vec<CatalogSearchHit>,
+    /// Whether the candidate window cut the result short. Surfaced so callers
+    /// can report `has_more` rather than implying the index held nothing else.
+    pub(crate) retrieval_limited: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogSearchHit {
+    /// Storage identity of the matched document. Retrieval keys on the entry
+    /// it resolves to, so this is carried for diagnostics rather than ranking.
+    #[cfg_attr(not(test), expect(dead_code, reason = "read by index tests only"))]
+    pub(crate) doc_id: String,
+    pub(crate) source_name: String,
+    pub(crate) catalog_name: Option<String>,
+    pub(crate) surface_kind: String,
+    pub(crate) surface_name: String,
+    pub(crate) field_name: String,
+    pub(crate) field_role: String,
+}
+
+/// Vocabulary a stored `surface_kind` may take; both backends enforce it as a
+/// CHECK constraint and re-validate rows on read.
+pub(crate) fn is_known_surface_kind(value: &str) -> bool {
+    matches!(value, "" | "table" | "table_function")
+}
+
+/// Vocabulary a stored `field_role` may take.
+pub(crate) fn is_known_field_role(value: &str) -> bool {
+    matches!(
+        value,
+        "" | "table_column"
+            | "table_filter"
+            | "table_function_argument"
+            | "table_function_result_column"
+    )
+}
+
+/// Which population of documents a retriever is asking for.
+///
+/// Entry documents and field documents share an index, but not a candidate
+/// window. Measured: in a 50-document window over one shared list, 45 slots go
+/// to field documents and only 7 distinct entries survive — wide tables crowd
+/// everything else out. Separate windows are what keep entry recall.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogDocumentClass {
+    Entries,
+    Fields,
+}
+
+impl CatalogDocumentClass {
+    /// The document kinds this class retrieves. Each backend renders its own
+    /// predicate from them.
+    pub(crate) fn document_kinds(self) -> &'static [CatalogIndexDocumentKind] {
+        match self {
+            Self::Entries => &[
+                CatalogIndexDocumentKind::CatalogTable,
+                CatalogIndexDocumentKind::CatalogTableFunction,
+            ],
+            Self::Fields => &[CatalogIndexDocumentKind::ColumnHint],
+        }
+    }
+}
+
+/// Lowercases, trims, and de-duplicates query terms, adding the compact
+/// identifier variant of each term so `deploy_url` and `deployurl` meet.
+pub(crate) fn normalized_search_terms(terms: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for term in terms {
+        let term = term.trim().to_lowercase();
+        if term.is_empty() {
+            continue;
+        }
+        push_search_term(&mut normalized, term.clone());
+        if let Some(compact) = compact_identifier_variant(&term) {
+            push_search_term(&mut normalized, compact);
+        }
+    }
+    normalized
+}
+
+fn push_search_term(terms: &mut Vec<String>, term: String) {
+    if !terms.iter().any(|existing| existing == &term) {
+        terms.push(term);
+    }
+}
+
+/// The text a backend indexes as the document's searchable body: the
+/// snapshot's searchable text plus compact identifier variants of every name.
+pub(crate) fn indexed_searchable_text(document: &CatalogIndexDocument) -> String {
+    let mut parts = vec![document.searchable_text.clone()];
+    for value in [
+        document.source_name.as_str(),
+        document.surface_name.as_str(),
+        document.field_name.as_str(),
+        document.qualified_name.as_str(),
+        document.title.as_str(),
+    ] {
+        if let Some(compact) = compact_identifier_variant(value) {
+            parts.push(compact);
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn compact_identifier_variant(value: &str) -> Option<String> {
+    let normalized = value.trim().to_lowercase();
+    let compact = normalized
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .collect::<String>();
+    (!compact.is_empty() && compact != normalized).then_some(compact)
+}
+
+/// Fetches one row past the limit so the caller can tell "exactly full" from
+/// "cut short" without a second count query.
+pub(crate) fn probe_limit(limit: usize) -> usize {
+    limit.saturating_add(1).max(1)
+}
+
+pub(crate) fn truncate_probe_hits(hits: &mut Vec<CatalogSearchHit>, limit: usize) -> bool {
+    if hits.len() > limit {
+        hits.truncate(limit);
+        true
+    } else {
+        false
+    }
+}

--- a/crates/coral-app/src/search/catalog/mod.rs
+++ b/crates/coral-app/src/search/catalog/mod.rs
@@ -1,5 +1,6 @@
 //! Catalog metadata search provider.
 
+pub(crate) mod index;
 pub(crate) mod provider;
 pub(crate) mod snapshot;
 pub(crate) mod sqlite_index;

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -7,11 +7,9 @@ use coral_engine::{CatalogInfo, TableFunctionInfo, TableInfo};
 use crate::bootstrap::AppError;
 use crate::catalog::model::CatalogResolution;
 use crate::query::manager::QueryManagerError;
+use crate::search::catalog::index::{CatalogDocumentClass, CatalogRefreshResult, CatalogSearchHit};
 use crate::search::catalog::snapshot::{
     CatalogSearchSnapshot, field_role_from_str, surface_kind_from_str,
-};
-use crate::search::catalog::sqlite_index::{
-    CatalogDocumentClass, CatalogRefreshResult, CatalogSearchHit,
 };
 use crate::search::maintenance::{
     CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult, SearchClearTarget,

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -7,7 +7,7 @@ use coral_engine::{
 use coral_spec::SourceTableFunctionKind;
 use sha2::{Digest as _, Sha256};
 
-use crate::search::catalog::sqlite_index::{
+use crate::search::catalog::index::{
     CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
 };
 use crate::search::result::{FieldRole, SearchSurfaceKind};

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -4,6 +4,12 @@ use rusqlite::{
     Connection, OptionalExtension as _, Transaction, TransactionBehavior, params, types::Type,
 };
 
+use crate::search::catalog::index::{
+    CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
+    CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits, indexed_searchable_text,
+    is_known_field_role, is_known_surface_kind, normalized_search_terms, probe_limit,
+    truncate_probe_hits,
+};
 use crate::search::sqlite_store::SqliteSearchError;
 use crate::workspaces::WorkspaceName;
 
@@ -194,86 +200,6 @@ fn rebuild_catalog_documents(
     })
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogIndexSnapshot {
-    pub(crate) documents: Vec<CatalogIndexDocument>,
-    pub(crate) fingerprint: String,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogIndexDocument {
-    pub(crate) doc_id: String,
-    pub(crate) doc_kind: CatalogIndexDocumentKind,
-    pub(crate) source_name: String,
-    pub(crate) catalog_name: Option<String>,
-    pub(crate) surface_kind: String,
-    pub(crate) surface_name: String,
-    pub(crate) field_name: String,
-    pub(crate) field_role: String,
-    pub(crate) qualified_name: String,
-    pub(crate) title: String,
-    pub(crate) description: String,
-    pub(crate) searchable_text: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CatalogIndexDocumentKind {
-    CatalogTable,
-    CatalogTableFunction,
-    ColumnHint,
-}
-
-impl CatalogIndexDocumentKind {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::CatalogTable => "catalog_table",
-            Self::CatalogTableFunction => "catalog_table_function",
-            Self::ColumnHint => "column_hint",
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogRefreshResult {
-    pub(crate) refreshed: bool,
-    pub(crate) document_count: u32,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CatalogRebuildResult {
-    pub(crate) old_document_count: u32,
-    pub(crate) new_document_count: u32,
-    pub(crate) projection_changed: bool,
-    pub(crate) rebuild_performed: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CatalogClearResult {
-    pub(crate) deleted_document_count: u32,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogSearchHits {
-    pub(crate) hits: Vec<CatalogSearchHit>,
-    /// Whether the candidate window cut the result short. Surfaced so callers
-    /// can report `has_more` rather than implying the index held nothing else.
-    pub(crate) retrieval_limited: bool,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CatalogSearchHit {
-    /// Storage identity of the matched document. Retrieval keys on the entry
-    /// it resolves to, so this is carried for diagnostics rather than ranking.
-    #[cfg_attr(not(test), expect(dead_code, reason = "read by index tests only"))]
-    pub(crate) doc_id: String,
-    pub(crate) source_name: String,
-    pub(crate) catalog_name: Option<String>,
-    pub(crate) surface_kind: String,
-    pub(crate) surface_name: String,
-    pub(crate) field_name: String,
-    pub(crate) field_role: String,
-}
-
 fn replace_catalog_documents(
     transaction: &Transaction<'_>,
     workspace_name: &WorkspaceName,
@@ -326,7 +252,7 @@ fn insert_catalog_snapshot_documents(
     )?;
 
     for document in &snapshot.documents {
-        let searchable_text = fts_searchable_text(document);
+        let searchable_text = indexed_searchable_text(document);
         document_insert.execute(params![
             workspace_name.as_str(),
             &document.doc_id,
@@ -506,28 +432,6 @@ fn catalog_document_count(
     Ok(u32::try_from(count).unwrap_or(u32::MAX))
 }
 
-/// Which population of documents a retriever is asking for.
-///
-/// Entry documents and field documents share an index, but not a candidate
-/// window. Measured: in a 50-document window over one shared list, 45 slots go
-/// to field documents and only 7 distinct entries survive — wide tables crowd
-/// everything else out. Separate windows are what keep entry recall.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CatalogDocumentClass {
-    Entries,
-    Fields,
-}
-
-impl CatalogDocumentClass {
-    /// Fixed SQL fragment — never built from caller input.
-    fn doc_kind_predicate(self) -> &'static str {
-        match self {
-            Self::Entries => "d.doc_kind IN ('catalog_table', 'catalog_table_function')",
-            Self::Fields => "d.doc_kind = 'column_hint'",
-        }
-    }
-}
-
 fn fts_search(
     connection: &Connection,
     workspace_name: &WorkspaceName,
@@ -553,7 +457,7 @@ fn fts_search(
             d.doc_id ASC
         LIMIT ?3
         ",
-        predicate = class.doc_kind_predicate(),
+        predicate = doc_kind_predicate(class),
     ))?;
     let rows = statement.query_map(
         params![
@@ -567,17 +471,16 @@ fn fts_search(
     collect_hits(rows)
 }
 
-fn probe_limit(limit: usize) -> usize {
-    limit.saturating_add(1).max(1)
-}
-
-fn truncate_probe_hits(hits: &mut Vec<CatalogSearchHit>, limit: usize) -> bool {
-    if hits.len() > limit {
-        hits.truncate(limit);
-        true
-    } else {
-        false
-    }
+/// Fixed SQL over the `d` alias; the kind names are the vocabulary's own
+/// literals, never caller input.
+fn doc_kind_predicate(class: CatalogDocumentClass) -> String {
+    let kinds = class
+        .document_kinds()
+        .iter()
+        .map(|kind| format!("'{}'", kind.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("d.doc_kind IN ({kinds})")
 }
 
 fn hit_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CatalogSearchHit> {
@@ -597,20 +500,18 @@ fn hit_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CatalogSearchHit> {
 }
 
 fn surface_kind_from_storage(value: &str) -> rusqlite::Result<String> {
-    match value {
-        "" | "table" | "table_function" => Ok(value.to_string()),
-        _ => invalid_catalog_storage_value(2, "surface_kind", value),
+    if is_known_surface_kind(value) {
+        Ok(value.to_string())
+    } else {
+        invalid_catalog_storage_value(2, "surface_kind", value)
     }
 }
 
 fn field_role_from_storage(value: &str) -> rusqlite::Result<String> {
-    match value {
-        ""
-        | "table_column"
-        | "table_filter"
-        | "table_function_argument"
-        | "table_function_result_column" => Ok(value.to_string()),
-        _ => invalid_catalog_storage_value(5, "field_role", value),
+    if is_known_field_role(value) {
+        Ok(value.to_string())
+    } else {
+        invalid_catalog_storage_value(5, "field_role", value)
     }
 }
 
@@ -661,56 +562,6 @@ fn fts_match_query(terms: &[String]) -> Option<String> {
     } else {
         Some(phrases.join(" OR "))
     }
-}
-
-fn normalized_search_terms(terms: &[String]) -> Vec<String> {
-    let mut normalized = Vec::new();
-    for term in terms {
-        let term = term.trim().to_lowercase();
-        if term.is_empty() {
-            continue;
-        }
-        push_search_term(&mut normalized, term.clone());
-        if let Some(compact) = compact_identifier_variant(&term) {
-            push_search_term(&mut normalized, compact);
-        }
-    }
-    normalized
-}
-
-fn push_search_term(terms: &mut Vec<String>, term: String) {
-    if !terms.iter().any(|existing| existing == &term) {
-        terms.push(term);
-    }
-}
-
-fn fts_searchable_text(document: &CatalogIndexDocument) -> String {
-    let mut parts = vec![document.searchable_text.clone()];
-    for value in [
-        document.source_name.as_str(),
-        document.surface_name.as_str(),
-        document.field_name.as_str(),
-        document.qualified_name.as_str(),
-        document.title.as_str(),
-    ] {
-        if let Some(compact) = compact_identifier_variant(value) {
-            parts.push(compact);
-        }
-    }
-    parts
-        .into_iter()
-        .filter(|part| !part.trim().is_empty())
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn compact_identifier_variant(value: &str) -> Option<String> {
-    let normalized = value.trim().to_lowercase();
-    let compact = normalized
-        .chars()
-        .filter(|ch| ch.is_alphanumeric())
-        .collect::<String>();
-    (!compact.is_empty() && compact != normalized).then_some(compact)
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -1,8 +1,8 @@
 use tempfile::{TempDir, tempdir};
 
-use super::{
+use super::{SqliteCatalogIndex, refresh_catalog_documents_after_stale_check};
+use crate::search::catalog::index::{
     CatalogDocumentClass, CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
-    SqliteCatalogIndex, refresh_catalog_documents_after_stale_check,
 };
 use crate::search::sqlite_store::SqliteSearchStore;
 use crate::workspaces::WorkspaceName;

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -6,10 +6,12 @@ use std::time::{Duration, Instant};
 
 use rusqlite::{Connection, ErrorCode, TransactionBehavior};
 
-use crate::search::catalog::sqlite_index::{
+use crate::search::catalog::index::{
     CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
-    CatalogRefreshResult, CatalogSearchHits, SqliteCatalogIndex,
-    clear_catalog_source_documents_in_transaction,
+    CatalogRefreshResult, CatalogSearchHits,
+};
+use crate::search::catalog::sqlite_index::{
+    SqliteCatalogIndex, clear_catalog_source_documents_in_transaction,
     clear_catalog_workspace_documents_in_transaction,
 };
 use crate::search::observed::{

--- a/crates/coral-app/src/search/sqlite_store/tests.rs
+++ b/crates/coral-app/src/search/sqlite_store/tests.rs
@@ -8,7 +8,7 @@ use super::{
     WalCheckpointOutcome, classify_capability_probe, configure_connection,
     sqlite_file_creation_result, wal_checkpoint_truncate,
 };
-use crate::search::catalog::sqlite_index::{
+use crate::search::catalog::index::{
     CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
 };
 use crate::state::AppStateLayout;


### PR DESCRIPTION
# WAITING ON LAGOON 



  
The catalog projection's document, snapshot, result, and hit types, the
query-term normalization, the searchable-text composition, and the
closed vocabularies for surface kinds and field roles move from
`catalog::sqlite_index` to a backend-neutral `catalog::index`. The
retrieval class now names document kinds instead of carrying SQL, so a
second storage backend can share the vocabulary and render its own
predicate.

No behavior change; the SQLite index keeps its statements and tests.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1