### PR TITLE
feat(search): add the Postgres catalog search store, not yet selectable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,9 @@ postgres-tests: $(POSTGRES_TESTS_PREREQS)
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
 	  contract_on_postgres \
 	  -- --ignored; \
+	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
+	  search::store::postgres:: \
+	  -- --ignored; \
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app \
 	  --test postgres_database_tests \
 	  -- --ignored

--- a/crates/coral-app/src/search/catalog/index.rs
+++ b/crates/coral-app/src/search/catalog/index.rs
@@ -128,26 +128,53 @@ impl CatalogDocumentClass {
     }
 }
 
+/// One normalized query term and where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NormalizedSearchTerm {
+    pub(crate) text: String,
+    /// Synthesized by removing every non-alphanumeric character from a term
+    /// the caller gave (`deploy_url` → `deployurl`); never typed by the
+    /// caller. Documents index the same variant of each of their names, so
+    /// the only designed match for one is a whole lexeme. A backend that can
+    /// tell whether its corpus holds that lexeme may drop a variant it does
+    /// not; the whole query's variant of a sentence is the common case.
+    pub(crate) compact_variant: bool,
+}
+
 /// Lowercases, trims, and de-duplicates query terms, adding the compact
 /// identifier variant of each term so `deploy_url` and `deployurl` meet.
 pub(crate) fn normalized_search_terms(terms: &[String]) -> Vec<String> {
+    normalized_search_term_variants(terms)
+        .into_iter()
+        .map(|term| term.text)
+        .collect()
+}
+
+/// [`normalized_search_terms`] with each term's provenance kept.
+pub(crate) fn normalized_search_term_variants(terms: &[String]) -> Vec<NormalizedSearchTerm> {
     let mut normalized = Vec::new();
     for term in terms {
         let term = term.trim().to_lowercase();
         if term.is_empty() {
             continue;
         }
-        push_search_term(&mut normalized, term.clone());
+        push_search_term(&mut normalized, term.clone(), false);
         if let Some(compact) = compact_identifier_variant(&term) {
-            push_search_term(&mut normalized, compact);
+            push_search_term(&mut normalized, compact, true);
         }
     }
     normalized
 }
 
-fn push_search_term(terms: &mut Vec<String>, term: String) {
-    if !terms.iter().any(|existing| existing == &term) {
-        terms.push(term);
+fn push_search_term(terms: &mut Vec<NormalizedSearchTerm>, text: String, compact_variant: bool) {
+    match terms.iter_mut().find(|existing| existing.text == text) {
+        // A term the caller typed is never demoted to a variant, whichever
+        // of the two spellings arrived first.
+        Some(existing) => existing.compact_variant &= compact_variant,
+        None => terms.push(NormalizedSearchTerm {
+            text,
+            compact_variant,
+        }),
     }
 }
 
@@ -194,5 +221,67 @@ pub(crate) fn truncate_probe_hits(hits: &mut Vec<CatalogSearchHit>, limit: usize
         true
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NormalizedSearchTerm, normalized_search_term_variants, normalized_search_terms};
+
+    fn terms(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn compact_variants_are_flagged_and_typed_terms_are_not() {
+        let normalized = normalized_search_term_variants(&terms(&["Deploy_URL", "issue labels"]));
+
+        assert_eq!(
+            normalized,
+            vec![
+                NormalizedSearchTerm {
+                    text: "deploy_url".to_string(),
+                    compact_variant: false,
+                },
+                NormalizedSearchTerm {
+                    text: "deployurl".to_string(),
+                    compact_variant: true,
+                },
+                NormalizedSearchTerm {
+                    text: "issue labels".to_string(),
+                    compact_variant: false,
+                },
+                NormalizedSearchTerm {
+                    text: "issuelabels".to_string(),
+                    compact_variant: true,
+                },
+            ]
+        );
+        assert_eq!(
+            normalized_search_terms(&terms(&["Deploy_URL", "issue labels"])),
+            terms(&["deploy_url", "deployurl", "issue labels", "issuelabels"])
+        );
+    }
+
+    #[test]
+    fn a_typed_term_is_never_demoted_to_a_variant() {
+        // The variant arrives first, then the same spelling typed by the caller.
+        let first = normalized_search_term_variants(&terms(&["deploy_url", "deployurl"]));
+        assert_eq!(
+            first
+                .iter()
+                .map(|term| term.compact_variant)
+                .collect::<Vec<_>>(),
+            vec![false, false]
+        );
+        // And the other way round.
+        let second = normalized_search_term_variants(&terms(&["deployurl", "deploy_url"]));
+        assert_eq!(
+            second
+                .iter()
+                .map(|term| term.compact_variant)
+                .collect::<Vec<_>>(),
+            vec![false, false]
+        );
     }
 }

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -20,11 +20,12 @@ use crate::search::maintenance::{
     DrainSearchQueueResponse, RebuildSearchIndexRequest, RebuildSearchIndexResponse,
     SearchClearTarget, SearchDataScope, SearchIndexProvider, SearchMaintenanceResult,
     SearchMaintenanceState, SearchProviderClearRequest, SearchProviderRebuildRequest,
+    SearchStorageCleanupResult,
 };
 use crate::search::observed::provider::{ObservedValuesProvider, observed_clear_provider_result};
 use crate::search::observed::{
-    ObservedValuesDrainBudget, ObservedValuesLiveScopeLoad, ObservedValuesLiveScopeLoader,
-    ObservedValuesRetrievalPolicy,
+    ObservedValuesClearResult, ObservedValuesDrainBudget, ObservedValuesLiveScopeLoad,
+    ObservedValuesLiveScopeLoader, ObservedValuesRetrievalPolicy,
 };
 use crate::search::provider::{
     LocalSearchWriteCoordinator, SearchExecutionContext, SearchProviderRegistry,
@@ -45,7 +46,9 @@ use crate::workspaces::{
 pub(crate) struct SearchManager {
     catalog_discovery: CatalogDiscovery,
     catalog: CatalogMetadataProvider,
-    observed: ObservedValuesProvider,
+    /// `None` when the search backend keeps no observed values; the feature
+    /// flag then has nothing to enable.
+    observed: Option<ObservedValuesProvider>,
     observed_scope_loader: ObservedValuesLiveScopeLoader,
     observed_values_search_enabled: bool,
     engine: UniversalSearchEngine,
@@ -115,23 +118,42 @@ impl SearchManager {
             storage.clone(),
             write_coordinator.clone(),
         );
-        let observed =
-            ObservedValuesProvider::from_store(storage.observed_values(), write_coordinator);
+        let observed = storage
+            .observed_values()
+            .map(|store| ObservedValuesProvider::from_store(store, write_coordinator));
         let observed_scope_loader =
             ObservedValuesLiveScopeLoader::new(layout, config_store.clone(), diagnostic_reporter);
+        let registry = match &observed {
+            Some(observed) => SearchProviderRegistry::local(
+                catalog.clone(),
+                observed_values_search_enabled.then(|| observed.clone()),
+            ),
+            None => SearchProviderRegistry::local_without_observed_values(
+                catalog.clone(),
+                storage.backend_name(),
+            ),
+        };
         Self {
             catalog_discovery,
-            catalog: catalog.clone(),
-            observed: observed.clone(),
+            catalog,
+            observed,
             observed_scope_loader,
             observed_values_search_enabled,
-            engine: UniversalSearchEngine::new(SearchProviderRegistry::local(
-                catalog,
-                observed_values_search_enabled.then(|| observed.clone()),
-            )),
+            engine: UniversalSearchEngine::new(registry),
             workspaces: workspace_manager,
             lifecycle_lock,
             storage,
+        }
+    }
+
+    /// The observed provider, or the maintenance result explaining why the
+    /// requested observed-values work cannot run.
+    fn observed_provider(&self) -> Result<&ObservedValuesProvider, SearchMaintenanceResult> {
+        match &self.observed {
+            Some(observed) => Ok(observed),
+            None => Err(observed_values_search_unavailable_maintenance_result(
+                self.storage.backend_name(),
+            )),
         }
     }
 
@@ -165,7 +187,7 @@ impl SearchManager {
                         continue;
                     };
                     let (observed_values_policy, lifecycle_lease) =
-                        if self.observed_values_search_enabled {
+                        if self.observed_values_search_enabled && self.observed.is_some() {
                             let search = self.clone();
                             let workspace_name = request.workspace_name.clone();
                             run_blocking_search_operation(move || {
@@ -361,9 +383,21 @@ impl SearchManager {
                 }
             };
         }
+        let observed = match self.observed_provider() {
+            Ok(observed) => observed,
+            Err(unavailable) => {
+                return Ok(ClearSearchDataResponse {
+                    results: vec![unavailable],
+                    storage_cleanup: SearchStorageCleanupResult {
+                        state: SearchMaintenanceState::Noop,
+                        note: "no search storage cleanup was needed".to_string(),
+                    },
+                });
+            }
+        };
         let provider_outcomes = match request.scope {
             SearchDataScope::ObservedValues => {
-                vec![self.observed.clear_data(SearchProviderClearRequest {
+                vec![observed.clear_data(SearchProviderClearRequest {
                     workspace_name: &request.workspace_name,
                     scope: request.scope,
                     target: &request.target,
@@ -378,7 +412,7 @@ impl SearchManager {
                         target: &request.target,
                         compact_after_clear: false,
                     })?,
-                    self.observed.clear_data(SearchProviderClearRequest {
+                    observed.clear_data(SearchProviderClearRequest {
                         workspace_name: &request.workspace_name,
                         scope: request.scope,
                         target: &request.target,
@@ -424,10 +458,22 @@ impl SearchManager {
         Ok(ClearSearchDataResponse {
             results: vec![
                 catalog_clear_provider_result(cleared.catalog.deleted_document_count),
-                observed_clear_provider_result(cleared.observed),
+                self.observed_clear_all_result(cleared.observed),
             ],
             storage_cleanup: store.compact_after_clear(),
         })
+    }
+
+    /// The observed half of an all-data clear: the clear's own result, or the
+    /// explicit absence when the backend keeps no observed values.
+    fn observed_clear_all_result(
+        &self,
+        observed: Option<ObservedValuesClearResult>,
+    ) -> SearchMaintenanceResult {
+        observed.map_or_else(
+            || observed_values_search_unavailable_maintenance_result(self.storage.backend_name()),
+            observed_clear_provider_result,
+        )
     }
 
     fn clear_workspace_all(
@@ -444,18 +490,18 @@ impl SearchManager {
         Ok(ClearSearchDataResponse {
             results: vec![
                 catalog_clear_provider_result(cleared.catalog.deleted_document_count),
-                observed_clear_provider_result(cleared.observed),
+                self.observed_clear_all_result(cleared.observed),
             ],
             storage_cleanup: store.compact_after_clear(),
         })
     }
 
     pub(crate) async fn drain_before_shutdown(&self) -> Result<(), SearchManagerError> {
-        if !self.observed_values_search_enabled {
+        let (true, Some(observed)) = (self.observed_values_search_enabled, self.observed.clone())
+        else {
             return Ok(());
-        }
+        };
         let workspaces = self.workspaces.list_workspaces().await?;
-        let observed = self.observed.clone();
         run_blocking_search_operation(move || {
             let deadline = Instant::now() + SHUTDOWN_DRAIN_SOFT_BUDGET;
             for workspace in workspaces {
@@ -525,7 +571,11 @@ impl SearchManager {
         if !self.observed_values_search_enabled {
             return observed_values_search_disabled_maintenance_result();
         }
-        match self.try_rebuild_observed_index(request) {
+        let observed = match self.observed_provider() {
+            Ok(observed) => observed,
+            Err(unavailable) => return unavailable,
+        };
+        match self.try_rebuild_observed_index(observed, request) {
             Ok(result) => result,
             Err(error) => observed_rebuild_error_provider_result(&error),
         }
@@ -533,10 +583,11 @@ impl SearchManager {
 
     fn try_rebuild_observed_index(
         &self,
+        observed: &ObservedValuesProvider,
         request: &RebuildSearchIndexRequest,
     ) -> Result<SearchMaintenanceResult, SearchManagerError> {
         let policy = self.observed_retrieval_policy(&request.workspace_name)?;
-        self.observed.rebuild_index(
+        observed.rebuild_index(
             SearchProviderRebuildRequest {
                 workspace_name: &request.workspace_name,
             },
@@ -553,7 +604,11 @@ impl SearchManager {
         if !self.observed_values_search_enabled {
             return Ok(observed_values_search_disabled_maintenance_result());
         }
-        self.observed.drain_queue(
+        let observed = match self.observed_provider() {
+            Ok(observed) => observed,
+            Err(unavailable) => return Ok(unavailable),
+        };
+        observed.drain_queue(
             workspace_name,
             ObservedValuesDrainBudget::new(
                 MANUAL_DRAIN_MAX_JOBS,
@@ -760,6 +815,19 @@ fn observed_values_search_disabled_maintenance_result() -> SearchMaintenanceResu
         provider: SearchProviderKind::ObservedValues,
         state: SearchMaintenanceState::Skipped,
         note: OBSERVED_VALUES_SEARCH_DISABLED_MAINTENANCE_NOTE.to_string(),
+        detail: None,
+    }
+}
+
+fn observed_values_search_unavailable_maintenance_result(
+    backend_name: &str,
+) -> SearchMaintenanceResult {
+    SearchMaintenanceResult {
+        provider: SearchProviderKind::ObservedValues,
+        state: SearchMaintenanceState::Skipped,
+        note: format!(
+            "observed value search is not available on the {backend_name} search backend"
+        ),
         detail: None,
     }
 }

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -304,6 +304,23 @@ impl SearchProviderRegistry {
         }
     }
 
+    /// Registers the catalog provider beside a static status explaining that
+    /// the search backend keeps no observed values, whatever the feature flag
+    /// says.
+    pub(crate) fn local_without_observed_values(
+        catalog: CatalogMetadataProvider,
+        backend_name: &str,
+    ) -> Self {
+        let ordered = vec![
+            SearchProviderRegistration::Provider(Arc::new(catalog)),
+            SearchProviderRegistration::StaticStatus(observed_unavailable_status(backend_name)),
+            SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
+        ];
+        Self {
+            ordered: ordered.into(),
+        }
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = &SearchProviderRegistration> {
         self.ordered.iter()
     }
@@ -381,6 +398,17 @@ pub(crate) fn provider_error_outcome(provider: SearchProviderKind) -> ProviderSe
             note: "search provider failed without affecting other providers".to_string(),
             coverage: None,
         },
+    }
+}
+
+fn observed_unavailable_status(backend_name: &str) -> ProviderStatus {
+    ProviderStatus {
+        provider: SearchProviderKind::ObservedValues,
+        state: SearchProviderState::NotEnabled,
+        note: format!(
+            "observed value search is not available on the {backend_name} search backend"
+        ),
+        coverage: None,
     }
 }
 

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -14,16 +14,20 @@
 //! Retrieval order is the ranking and must be a deterministic total order,
 //! whichever backend serves it.
 
+mod postgres;
 mod sqlite;
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
+
+use tokio::runtime::Handle;
 
 use crate::bootstrap::AppError;
 use crate::search::catalog::index::{
     CatalogClearResult, CatalogDocumentClass, CatalogIndexSnapshot, CatalogRebuildResult,
     CatalogRefreshResult, CatalogSearchHits,
 };
-use crate::search::maintenance::SearchStorageCleanupResult;
+use crate::search::maintenance::{SearchMaintenanceState, SearchStorageCleanupResult};
 use crate::search::observed::{
     ObservedValuesClearResult, ObservedValuesDrainBudget, ObservedValuesDrainResult,
     ObservedValuesRebuildResult, ObservedValuesRetrievalPolicy, ObservedValuesSearchHits,
@@ -32,6 +36,8 @@ use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
+pub(crate) use postgres::MigratedWorkspaceSchema;
+use postgres::{PostgresSearchError, PostgresSearchStorage, PostgresSearchStore};
 use sqlite::SqliteSearchStorage;
 
 /// Catalog projection storage for one Workspace.
@@ -130,6 +136,7 @@ pub(crate) struct SearchStorage {
 #[derive(Debug, Clone)]
 enum SearchStorageBackend {
     Sqlite(SqliteSearchStorage),
+    Postgres(PostgresSearchStorage),
 }
 
 impl SearchStorage {
@@ -140,9 +147,28 @@ impl SearchStorage {
         }
     }
 
+    /// One Postgres schema per Workspace in the `[database]` Postgres database, reached
+    /// through a small dedicated pool on the same URL. Bootstraps the
+    /// registry and verifies `pg_trgm`, failing loud when it is missing.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "selected by the [search] config next in this stack"
+        )
+    )]
+    pub(crate) async fn postgres(url: &str, handle: Handle) -> Result<Self, SearchStoreError> {
+        Ok(Self {
+            backend: SearchStorageBackend::Postgres(
+                PostgresSearchStorage::open(url, handle).await?,
+            ),
+        })
+    }
+
     pub(crate) fn backend_name(&self) -> &'static str {
         match &self.backend {
             SearchStorageBackend::Sqlite(_) => "sqlite",
+            SearchStorageBackend::Postgres(_) => "postgres",
         }
     }
 
@@ -159,6 +185,9 @@ impl SearchStorage {
             SearchStorageBackend::Sqlite(storage) => Ok(SearchStore {
                 backend: SearchStoreBackend::Sqlite(storage.open_workspace(workspace_name)?),
             }),
+            SearchStorageBackend::Postgres(storage) => Ok(SearchStore {
+                backend: SearchStoreBackend::Postgres(storage.open_workspace(workspace_name)?),
+            }),
         }
     }
 
@@ -173,6 +202,11 @@ impl SearchStorage {
                 .open_existing_workspace(workspace_name)?
                 .map(|store| SearchStore {
                     backend: SearchStoreBackend::Sqlite(store),
+                })),
+            SearchStorageBackend::Postgres(storage) => Ok(storage
+                .open_existing_workspace(workspace_name)?
+                .map(|store| SearchStore {
+                    backend: SearchStoreBackend::Postgres(store),
                 })),
         }
     }
@@ -189,10 +223,65 @@ impl SearchStorage {
             .transpose()
     }
 
-    /// The observed-values store of this backend.
-    pub(crate) fn observed_values(&self) -> Arc<dyn ObservedValuesStore> {
+    /// Removes every trace of the Workspace's search state. Returns whether
+    /// there was any. The `SQLite` sidecar lives inside the Workspace
+    /// directory, which Workspace deletion removes as a whole.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
+    )]
+    pub(crate) async fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<bool, SearchStoreError> {
         match &self.backend {
-            SearchStorageBackend::Sqlite(storage) => Arc::new(storage.observed_values()),
+            SearchStorageBackend::Sqlite(_) => Ok(false),
+            SearchStorageBackend::Postgres(storage) => {
+                Ok(storage.delete_workspace(workspace_name).await?)
+            }
+        }
+    }
+
+    /// Removes the search state of every registered Workspace that is not in
+    /// `live`, and returns their names. The safety net for a deletion whose
+    /// best-effort cleanup failed: the next boot finishes it.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into the boot sweep next in this stack")
+    )]
+    pub(crate) async fn prune_workspaces_except(
+        &self,
+        live: &BTreeSet<String>,
+    ) -> Result<Vec<String>, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => Ok(Vec::new()),
+            SearchStorageBackend::Postgres(storage) => {
+                Ok(storage.prune_workspaces_except(live).await?)
+            }
+        }
+    }
+
+    /// Boot-time ledger sweep: migrates every Workspace schema the backend
+    /// knows to be behind this binary. `SQLite` sidecars migrate on open.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into the boot sweep next in this stack")
+    )]
+    pub(crate) async fn migrate_all(
+        &self,
+    ) -> Result<Vec<MigratedWorkspaceSchema>, SearchStoreError> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => Ok(Vec::new()),
+            SearchStorageBackend::Postgres(storage) => Ok(storage.migrate_all().await?),
+        }
+    }
+
+    /// The observed-values store, when this backend keeps observed values.
+    /// Postgres keeps none: cloud observed memory waits for lagoon #37.
+    pub(crate) fn observed_values(&self) -> Option<Arc<dyn ObservedValuesStore>> {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(storage) => Some(Arc::new(storage.observed_values())),
+            SearchStorageBackend::Postgres(_) => None,
         }
     }
 }
@@ -206,25 +295,38 @@ pub(crate) struct SearchStore {
 #[derive(Debug, Clone)]
 enum SearchStoreBackend {
     Sqlite(SqliteSearchStore),
+    Postgres(PostgresSearchStore),
 }
 
 /// Outcome of clearing every data class of a source or a Workspace at once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SearchClearAllResult {
     pub(crate) catalog: CatalogClearResult,
-    pub(crate) observed: ObservedValuesClearResult,
+    /// `None` when the backend keeps no observed values, so callers report
+    /// the absence instead of an empty clear.
+    pub(crate) observed: Option<ObservedValuesClearResult>,
 }
 
 impl SearchStore {
     pub(crate) fn backend_name(&self) -> &'static str {
         match &self.backend {
             SearchStoreBackend::Sqlite(_) => "sqlite",
+            SearchStoreBackend::Postgres(_) => "postgres",
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn postgres_schema_name(&self) -> String {
+        match &self.backend {
+            SearchStoreBackend::Sqlite(_) => panic!("not a Postgres store"),
+            SearchStoreBackend::Postgres(store) => store.schema_name(),
         }
     }
 
     pub(crate) fn catalog(&self) -> &dyn CatalogStore {
         match &self.backend {
             SearchStoreBackend::Sqlite(store) => store,
+            SearchStoreBackend::Postgres(store) => store,
         }
     }
 
@@ -237,8 +339,15 @@ impl SearchStore {
         match &self.backend {
             SearchStoreBackend::Sqlite(store) => {
                 let (catalog, observed) = store.clear_source_all(source_name)?;
-                Ok(SearchClearAllResult { catalog, observed })
+                Ok(SearchClearAllResult {
+                    catalog,
+                    observed: Some(observed),
+                })
             }
+            SearchStoreBackend::Postgres(store) => Ok(SearchClearAllResult {
+                catalog: store.clear_source(source_name)?,
+                observed: None,
+            }),
         }
     }
 
@@ -247,8 +356,15 @@ impl SearchStore {
         match &self.backend {
             SearchStoreBackend::Sqlite(store) => {
                 let (catalog, observed) = store.clear_workspace_all()?;
-                Ok(SearchClearAllResult { catalog, observed })
+                Ok(SearchClearAllResult {
+                    catalog,
+                    observed: Some(observed),
+                })
             }
+            SearchStoreBackend::Postgres(store) => Ok(SearchClearAllResult {
+                catalog: store.clear_workspace()?,
+                observed: None,
+            }),
         }
     }
 
@@ -259,6 +375,10 @@ impl SearchStore {
             SearchStoreBackend::Sqlite(store) => {
                 sqlite::storage_cleanup_result(&store.compact_after_clear())
             }
+            SearchStoreBackend::Postgres(_) => SearchStorageCleanupResult {
+                state: SearchMaintenanceState::Noop,
+                note: "no storage cleanup is needed on the postgres search backend".to_string(),
+            },
         }
     }
 }
@@ -267,6 +387,8 @@ impl SearchStore {
 pub(crate) enum SearchStoreError {
     #[error(transparent)]
     Sqlite(#[from] SqliteSearchError),
+    #[error(transparent)]
+    Postgres(#[from] PostgresSearchError),
 }
 
 impl SearchStoreError {
@@ -274,12 +396,14 @@ impl SearchStoreError {
     pub(crate) fn is_lock_contention(&self) -> bool {
         match self {
             Self::Sqlite(error) => error.is_lock_contention(),
+            Self::Postgres(error) => error.is_lock_contention(),
         }
     }
 
     pub(crate) fn is_storage_exhaustion(&self) -> bool {
         match self {
             Self::Sqlite(error) => error.is_storage_exhaustion(),
+            Self::Postgres(error) => error.is_storage_exhaustion(),
         }
     }
 
@@ -292,6 +416,7 @@ impl SearchStoreError {
                 SqliteSearchError::UnsupportedCapability { .. }
                     | SqliteSearchError::UnsupportedSchemaVersion { .. }
             ),
+            Self::Postgres(error) => error.is_unsupported(),
         }
     }
 }

--- a/crates/coral-app/src/search/store/postgres/catalog.rs
+++ b/crates/coral-app/src/search/store/postgres/catalog.rs
@@ -1,0 +1,1039 @@
+//! Catalog projection and retrieval on the Postgres store.
+//!
+//! Retrieval is BM25 in plain SQL, the `SQLite` side's `bm25()` rebuilt on
+//! vanilla Postgres (`ts_rank_cd` has no corpus statistics and degenerates
+//! to a term-frequency count under coral's disjunctive queries):
+//! corpus IDF from the per-Workspace `catalog_terms` statistics, FTS5's `k1`
+//! and negative-IDF clamp, a `b` tuned for short structured documents, and
+//! the same 8/6/2/1 field weights the `SQLite` side passes to `bm25()`.
+//! Every query word scores with its true IDF; only *candidate selection* —
+//! a prefix `tsquery` OR-ed with trigram `ILIKE` patterns (exact substring
+//! semantics; the executor's recheck makes false positives impossible) — is
+//! restricted to words below the document-frequency cap, which is a latency
+//! lever. The whole-query phrase boost leads the order so a whole-phrase
+//! match outranks a co-occurrence match; `doc_id` closes the deterministic
+//! total order.
+
+use std::collections::BTreeSet;
+
+use sqlx::{Postgres, Row as _, Transaction};
+
+use super::{PostgresSearchError, PostgresSearchStore};
+use crate::search::catalog::index::{
+    CatalogClearResult, CatalogDocumentClass, CatalogIndexDocument, CatalogIndexSnapshot,
+    CatalogRebuildResult, CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
+    NormalizedSearchTerm, indexed_searchable_text, is_known_field_role, is_known_surface_kind,
+    normalized_search_term_variants, probe_limit, truncate_probe_hits,
+};
+use crate::search::store::{CatalogStore, SearchStoreError};
+
+const CATALOG_SNAPSHOT_FINGERPRINT_META_KEY: &str = "catalog_snapshot_fingerprint";
+/// Rows per `UNNEST` insert. Bounds the parameter arrays a 21k-document
+/// snapshot sends without turning the rebuild into thousands of round trips.
+const INSERT_CHUNK_ROWS: usize = 2_000;
+/// Terms shorter than this cannot match a trigram index; the `SQLite` side
+/// applies the same floor.
+const MIN_TERM_CHARS: usize = 3;
+/// Field weights, identical to what the `SQLite` side passes to `bm25()`:
+/// qualified name, title, description, searchable text. They weight both the
+/// whole-query phrase boost and each lexeme occurrence in the BM25 score.
+const FIELD_WEIGHT_QUALIFIED_NAME: u8 = 8;
+const FIELD_WEIGHT_TITLE: u8 = 6;
+const FIELD_WEIGHT_DESCRIPTION: u8 = 2;
+const FIELD_WEIGHT_SEARCHABLE_TEXT: u8 = 1;
+/// FTS5's term-frequency saturation constant (`fts5_aux.c`).
+const BM25_K1: f64 = 1.2;
+/// Length normalization. FTS5 hard-codes 0.75 for prose; catalog documents
+/// are short and structured, and 0.75 makes a column-rich canonical table pay
+/// in its name field for its column count. 0.4 measured best on the replay
+/// of recorded agent queries against the used-table labels.
+const BM25_B: f64 = 0.4;
+/// FTS5 clamps a non-positive IDF to this instead of letting a term that
+/// appears in more than half the corpus push results around.
+const IDF_FLOOR: f64 = 1e-6;
+/// Words in more of the corpus than this share are dropped from *candidate
+/// selection* only — a latency lever, not a relevance rule (measured:
+/// uncapped candidates cost 5× for the same relevance). Every word still
+/// scores with its true IDF: at 10% frequency a word carries real signal
+/// (IDF ≈ 2.2) that FTS5's clamp — which only bites above half the corpus —
+/// would keep.
+const DOCUMENT_FREQUENCY_CAP: f64 = 0.05;
+/// When every word is above the cap, keep this many rarest words as
+/// candidate keys instead of searching for nothing.
+const RARE_WORD_KEEP: usize = 3;
+
+// Recorded alternatives to the document-frequency cap (2026-09-10; neither
+// is implemented, both were sized against the replay harness):
+//
+// A. A materialized postings table, `catalog_postings(term, doc_kind, doc_id,
+//    tf)`, written by `refresh_ranking_stats` from `unnest(tsv)` with the
+//    8/6/2/1 weights folded into `tf` (~500k rows at 21k documents). Scoring
+//    becomes a join of the query words against it (`term LIKE word || '%'`
+//    ranges over a `text_pattern_ops` btree) grouped by `doc_id`: cost is the
+//    sum of the words' posting lengths, as in an inverted index, instead of
+//    candidates × lexemes × words as here. That removes the per-candidate
+//    lateral and, with it, the query-length latency scaling, and the cap is
+//    no longer needed on the tsquery path. GIN itself cannot do this: it
+//    holds lexeme → TID only; positions and weights live in the heap row.
+//    The substring path (`ILIKE`) has no posting and stays as a fallback for
+//    typed words that prefix-match no lexeme at all.
+//
+// B. Keep this shape and choose candidate keys by score bound instead of by
+//    frequency (MaxScore): store `max_tf` per term, bound a word by
+//    `idf × sat(max_tf)` at the shortest document, key the highest bounds,
+//    read the k-th score θ from the first pass, and run a second pass with
+//    more keys only if the excluded words' bounds sum to θ or more. Exact for
+//    the top k with no threshold constant. Costs more than the cap unless k
+//    is the request limit rather than the lane window (the 51st score is
+//    usually weak, so `issues`-class words would become keys), and the
+//    prefix join needs the bound summed over the prefix range (`github` alone
+//    prefixes ~20k lexemes through compact variants). Does not change the
+//    per-candidate cost, so it is not a latency fix on its own.
+//
+// Independent of both: the `ILIKE` disjunct is the expensive half of
+// candidate selection (measured 264 ms vs 31 ms for tsquery alone) and only
+// earns its place for words that prefix-match no lexeme; restricting it to
+// those is one `EXISTS` per word in the statistics lookup.
+
+impl CatalogStore for PostgresSearchStore {
+    fn projection_is_current(&self, fingerprint: &str) -> Result<bool, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin().await?;
+            let current = current_fingerprint(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(current.as_deref() == Some(fingerprint))
+        })?)
+    }
+
+    fn refresh_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+    ) -> Result<CatalogRefreshResult, SearchStoreError> {
+        let document_count = u32::try_from(snapshot.documents.len()).unwrap_or(u32::MAX);
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            if current_fingerprint(&mut tx).await?.as_deref() == Some(snapshot.fingerprint.as_str())
+            {
+                tx.commit().await?;
+                return Ok::<_, PostgresSearchError>(CatalogRefreshResult {
+                    refreshed: false,
+                    document_count,
+                });
+            }
+            replace_documents(&mut tx, snapshot).await?;
+            tx.commit().await?;
+            Ok(CatalogRefreshResult {
+                refreshed: true,
+                document_count,
+            })
+        })?)
+    }
+
+    fn rebuild_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+        force: bool,
+    ) -> Result<CatalogRebuildResult, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            let current = current_fingerprint(&mut tx).await?;
+            let old_document_count = document_count(&mut tx).await?;
+            let projection_changed = current.as_deref() != Some(snapshot.fingerprint.as_str());
+            let rebuild_performed = force || projection_changed;
+            if rebuild_performed {
+                replace_documents(&mut tx, snapshot).await?;
+            }
+            let new_document_count = if rebuild_performed {
+                document_count(&mut tx).await?
+            } else {
+                old_document_count
+            };
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(CatalogRebuildResult {
+                old_document_count,
+                new_document_count,
+                projection_changed,
+                rebuild_performed,
+            })
+        })?)
+    }
+
+    fn document_count(&self) -> Result<u32, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin().await?;
+            let count = document_count(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(count)
+        })?)
+    }
+
+    fn search(
+        &self,
+        terms: &[String],
+        limit: usize,
+        class: CatalogDocumentClass,
+    ) -> Result<CatalogSearchHits, SearchStoreError> {
+        let terms = normalized_search_term_variants(terms);
+        let Some(plan) = (if limit == 0 {
+            None
+        } else {
+            CatalogQueryPlan::build(&terms)
+        }) else {
+            return Ok(CatalogSearchHits {
+                hits: Vec::new(),
+                retrieval_limited: false,
+            });
+        };
+        let mut hits = self.block_on(async {
+            let mut tx = self.begin().await?;
+            let hits = plan.fetch(&mut tx, class, probe_limit(limit)).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(hits)
+        })?;
+        let retrieval_limited = truncate_probe_hits(&mut hits, limit);
+        Ok(CatalogSearchHits {
+            hits,
+            retrieval_limited,
+        })
+    }
+
+    fn clear_source(&self, source_name: &str) -> Result<CatalogClearResult, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            let deleted = sqlx::query("DELETE FROM catalog_documents WHERE source_name = $1")
+                .bind(source_name)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+            // The ranking statistics stay: rows remain, and the cleared
+            // fingerprint makes the next search rebuild the projection, which
+            // rewrites them. Stale-but-present beats absent for a search that
+            // races the rebuild.
+            clear_fingerprint(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(CatalogClearResult {
+                deleted_document_count: u32::try_from(deleted).unwrap_or(u32::MAX),
+            })
+        })?)
+    }
+
+    fn clear_workspace(&self) -> Result<CatalogClearResult, SearchStoreError> {
+        Ok(self.block_on(async {
+            let mut tx = self.begin_write().await?;
+            let deleted = sqlx::query("DELETE FROM catalog_documents")
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+            sqlx::query("DELETE FROM catalog_terms")
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM catalog_stats")
+                .execute(&mut *tx)
+                .await?;
+            clear_fingerprint(&mut tx).await?;
+            tx.commit().await?;
+            Ok::<_, PostgresSearchError>(CatalogClearResult {
+                deleted_document_count: u32::try_from(deleted).unwrap_or(u32::MAX),
+            })
+        })?)
+    }
+}
+
+/// The stored fingerprint. Replacement is one transaction, so the rows always
+/// match it; there is no per-row copy to reconcile.
+async fn current_fingerprint(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<Option<String>, PostgresSearchError> {
+    Ok(
+        sqlx::query_scalar("SELECT value FROM search_meta WHERE key = $1")
+            .bind(CATALOG_SNAPSHOT_FINGERPRINT_META_KEY)
+            .fetch_optional(&mut **tx)
+            .await?,
+    )
+}
+
+async fn document_count(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<u32, PostgresSearchError> {
+    let count: i64 = sqlx::query_scalar("SELECT count(*) FROM catalog_documents")
+        .fetch_one(&mut **tx)
+        .await?;
+    Ok(u32::try_from(count).unwrap_or(u32::MAX))
+}
+
+async fn replace_documents(
+    tx: &mut Transaction<'static, Postgres>,
+    snapshot: &CatalogIndexSnapshot,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query("DELETE FROM catalog_documents")
+        .execute(&mut **tx)
+        .await?;
+    for chunk in snapshot.documents.chunks(INSERT_CHUNK_ROWS) {
+        insert_documents(tx, chunk).await?;
+    }
+    refresh_ranking_stats(tx).await?;
+    sqlx::query(
+        "INSERT INTO search_meta (key, value) VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(CATALOG_SNAPSHOT_FINGERPRINT_META_KEY)
+    .bind(&snapshot.fingerprint)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn insert_documents(
+    tx: &mut Transaction<'static, Postgres>,
+    documents: &[CatalogIndexDocument],
+) -> Result<(), PostgresSearchError> {
+    let column = |select: fn(&CatalogIndexDocument) -> &str| {
+        documents.iter().map(select).collect::<Vec<_>>()
+    };
+    sqlx::query(
+        "INSERT INTO catalog_documents (
+            doc_id, doc_kind, source_name, catalog_name, surface_kind, surface_name,
+            field_name, field_role, qualified_name, title, description, searchable_text
+        )
+        SELECT * FROM UNNEST(
+            $1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[],
+            $7::text[], $8::text[], $9::text[], $10::text[], $11::text[], $12::text[]
+        )",
+    )
+    .bind(column(|document| document.doc_id.as_str()))
+    .bind(
+        documents
+            .iter()
+            .map(|document| document.doc_kind.as_str())
+            .collect::<Vec<_>>(),
+    )
+    .bind(column(|document| document.source_name.as_str()))
+    .bind(
+        documents
+            .iter()
+            .map(|document| document.catalog_name.as_deref())
+            .collect::<Vec<_>>(),
+    )
+    .bind(column(|document| document.surface_kind.as_str()))
+    .bind(column(|document| document.surface_name.as_str()))
+    .bind(column(|document| document.field_name.as_str()))
+    .bind(column(|document| document.field_role.as_str()))
+    .bind(column(|document| document.qualified_name.as_str()))
+    .bind(column(|document| document.title.as_str()))
+    .bind(column(|document| document.description.as_str()))
+    .bind(
+        documents
+            .iter()
+            .map(indexed_searchable_text)
+            .collect::<Vec<_>>(),
+    )
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Rewrites the BM25 corpus statistics from the rows just inserted, inside the
+/// same transaction, so statistics and projection can never disagree.
+async fn refresh_ranking_stats(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query(
+        "UPDATE catalog_documents AS d SET doc_len = coalesce((
+             SELECT sum(coalesce(array_length(u.positions, 1), 1))
+             FROM unnest(d.tsv) AS u(lexeme, positions, weights)
+         ), 0)",
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query("DELETE FROM catalog_terms")
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO catalog_terms (term, ndoc)
+         SELECT word, ndoc FROM ts_stat('SELECT tsv FROM catalog_documents')",
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query("DELETE FROM catalog_stats")
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO catalog_stats (total_docs, avgdl)
+         SELECT count(*), coalesce(avg(doc_len), 1.0) FROM catalog_documents",
+    )
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn clear_fingerprint(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query("DELETE FROM search_meta WHERE key = $1")
+        .bind(CATALOG_SNAPSHOT_FINGERPRINT_META_KEY)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// One retrieval, fully parameterized: every value travels as a bind, and the
+/// only interpolated fragments are fixed SQL (`doc_kind_predicate`, the BM25
+/// constants) and placeholder numbers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CatalogQueryPlan {
+    /// The whole normalized query as a `%phrase%` pattern for the boost. It is
+    /// the longest term: query construction appends the whole query as a term,
+    /// and it contains every other token.
+    phrase_pattern: String,
+    /// Lexeme words of every term (runs of alphanumerics and `_`), the floor
+    /// applied, sorted and deduplicated. They key the statistics lookup and,
+    /// after the document-frequency cap, drive candidates and scoring.
+    words: Vec<String>,
+    /// The subset of `words` that only a compact identifier variant produced
+    /// (`issuelabels` from `issue labels`), never a term the caller typed.
+    /// Documents hold such a variant only as a whole lexeme, so one the
+    /// statistics show absent is dropped before it can key candidates,
+    /// score, or count as a survivor of the document-frequency cap.
+    variant_words: Vec<String>,
+    /// `%term%` per term that yields no word above the floor
+    /// (punctuation-heavy identifiers), so its substring semantics survive
+    /// the word derivation.
+    wordless_patterns: Vec<String>,
+}
+
+/// One query word's document frequency, read from `catalog_terms`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WordStat {
+    word: String,
+    ndoc: i64,
+}
+
+/// What the statistics lookup resolved the plan's words into.
+#[derive(Debug, Clone, PartialEq)]
+struct ScoringPlan {
+    /// Every query word with its IDF — all of them score.
+    scored: Vec<ScoredWord>,
+    /// Words under the document-frequency cap (or the rarest few when nothing
+    /// is): the candidate-selection keys.
+    candidate_words: Vec<String>,
+    avgdl: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ScoredWord {
+    word: String,
+    idf: f64,
+}
+
+impl CatalogQueryPlan {
+    fn build(terms: &[NormalizedSearchTerm]) -> Option<Self> {
+        let terms = terms
+            .iter()
+            .filter(|term| term.text.chars().count() >= MIN_TERM_CHARS)
+            .collect::<Vec<_>>();
+        let phrase = terms
+            .iter()
+            .max_by_key(|term| term.text.chars().count())?
+            .text
+            .clone();
+        let mut given_words = BTreeSet::new();
+        let mut variant_words = BTreeSet::new();
+        let mut wordless = BTreeSet::new();
+        for term in &terms {
+            let term_words = lexeme_words(&term.text)
+                .into_iter()
+                .filter(|word| word.chars().count() >= MIN_TERM_CHARS)
+                .collect::<Vec<_>>();
+            if term_words.is_empty() {
+                wordless.insert(contains_pattern(&term.text));
+            } else if term.compact_variant {
+                variant_words.extend(term_words);
+            } else {
+                given_words.extend(term_words);
+            }
+        }
+        let words = given_words.union(&variant_words).cloned().collect();
+        let variant_words = variant_words.difference(&given_words).cloned().collect();
+        Some(Self {
+            phrase_pattern: contains_pattern(&phrase),
+            words,
+            variant_words,
+            wordless_patterns: wordless.into_iter().collect(),
+        })
+    }
+
+    async fn fetch(
+        &self,
+        tx: &mut Transaction<'static, Postgres>,
+        class: CatalogDocumentClass,
+        limit: usize,
+    ) -> Result<Vec<CatalogSearchHit>, PostgresSearchError> {
+        let scoring = if self.words.is_empty() {
+            ScoringPlan {
+                scored: Vec::new(),
+                candidate_words: Vec::new(),
+                avgdl: 1.0,
+            }
+        } else {
+            let (stats, total_docs, avgdl) = fetch_word_stats(tx, &self.words).await?;
+            scoring_plan(&stats, total_docs, avgdl, &self.variant_words)
+        };
+        if scoring.scored.is_empty() && self.wordless_patterns.is_empty() {
+            // Every word was a compact variant the corpus lacks: nothing is
+            // left to select candidates with.
+            return Ok(Vec::new());
+        }
+        // Audited: the only dynamic fragments are `doc_kind_predicate`, fixed
+        // literals, and placeholder numbers; every value is a bind.
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(self.sql(&scoring, class)));
+        if !scoring.scored.is_empty() {
+            query = query.bind(tsquery(&scoring.candidate_words));
+            for word in &scoring.scored {
+                query = query.bind(prefix_pattern(&word.word));
+                query = query.bind(word.idf);
+            }
+            for word in &scoring.candidate_words {
+                query = query.bind(contains_pattern(word));
+            }
+        }
+        for pattern in &self.wordless_patterns {
+            query = query.bind(pattern);
+        }
+        if !scoring.scored.is_empty() {
+            query = query.bind(scoring.avgdl);
+        }
+        let rows = query
+            .bind(&self.phrase_pattern)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(&mut **tx)
+            .await?;
+        rows.iter().map(hit_from_row).collect()
+    }
+
+    fn sql(&self, scoring: &ScoringPlan, class: CatalogDocumentClass) -> String {
+        let scored_count = scoring.scored.len();
+        let candidate_word_count = scoring.candidate_words.len();
+        let mut next = 1_usize;
+        let mut take = |count: usize| {
+            let start = next;
+            next += count;
+            start
+        };
+        let tsquery = (scored_count > 0).then(|| take(1));
+        let values_start = take(scored_count * 2);
+        let word_pattern_start = take(candidate_word_count);
+        let wordless_start = take(self.wordless_patterns.len());
+        let avgdl = (scored_count > 0).then(|| take(1));
+        let phrase = take(1);
+        let limit = take(1);
+
+        let mut candidates = Vec::new();
+        if let Some(tsquery) = tsquery {
+            candidates.push(format!("d.tsv @@ to_tsquery('simple', ${tsquery})"));
+        }
+        for index in 0..candidate_word_count {
+            candidates.push(format!("d.all_text ILIKE ${}", word_pattern_start + index));
+        }
+        for index in 0..self.wordless_patterns.len() {
+            candidates.push(format!("d.all_text ILIKE ${}", wordless_start + index));
+        }
+        let candidates = candidates.join(" OR ");
+
+        let score = match avgdl {
+            Some(avgdl) => {
+                let values = (0..scored_count)
+                    .map(|index| {
+                        let pattern = values_start + 2 * index;
+                        let idf = pattern + 1;
+                        format!("(${pattern}::text, ${idf}::float8)")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "CROSS JOIN LATERAL (
+                         SELECT coalesce(sum(
+                             q.idf * (tf.f * ({BM25_K1} + 1))
+                             / (tf.f + {BM25_K1} * (1 - {BM25_B} + {BM25_B} * coalesce(c.doc_len::float8, ${avgdl}) / ${avgdl}))
+                         ), 0)::float8 AS score
+                         FROM (VALUES {values}) AS q(pattern, idf)
+                         JOIN unnest(c.tsv) AS u(lexeme, positions, weights)
+                           ON u.lexeme LIKE q.pattern
+                         CROSS JOIN LATERAL (
+                             SELECT sum(CASE w
+                                 WHEN 'A' THEN {FIELD_WEIGHT_QUALIFIED_NAME}::float8
+                                 WHEN 'B' THEN {FIELD_WEIGHT_TITLE}
+                                 WHEN 'C' THEN {FIELD_WEIGHT_DESCRIPTION}
+                                 ELSE {FIELD_WEIGHT_SEARCHABLE_TEXT} END) AS f
+                             FROM unnest(u.weights) AS w
+                         ) AS tf
+                     ) AS s"
+                )
+            }
+            None => "CROSS JOIN LATERAL (SELECT 0::float8 AS score) AS s".to_string(),
+        };
+        // `MATERIALIZED` walls candidate selection off from the scoring join
+        // and the sort: planned together, the planner abandons the trigram/tsv
+        // bitmap scans for a sequential scan (measured 2x the median). The
+        // score joins through a LATERAL with `coalesce` so a candidate no
+        // scored word reaches — a mid-word substring match — keeps rank
+        // instead of vanishing, which an inner-join GROUP BY shape gets wrong.
+        format!(
+            "WITH candidates AS MATERIALIZED (
+                 SELECT d.doc_id, d.source_name, d.surface_kind, d.surface_name, d.field_name,
+                        d.field_role, d.catalog_name, d.qualified_name, d.title, d.description,
+                        d.searchable_text, d.tsv, d.doc_len
+                 FROM catalog_documents AS d
+                 WHERE {predicate} AND ({candidates})
+             )
+             SELECT c.doc_id, c.source_name, c.surface_kind, c.surface_name, c.field_name,
+                    c.field_role, c.catalog_name
+             FROM candidates AS c
+             {score}
+             ORDER BY
+                 (c.qualified_name ILIKE ${phrase})::int * {FIELD_WEIGHT_QUALIFIED_NAME}
+                 + (c.title ILIKE ${phrase})::int * {FIELD_WEIGHT_TITLE}
+                 + (c.description ILIKE ${phrase})::int * {FIELD_WEIGHT_DESCRIPTION}
+                 + (c.searchable_text ILIKE ${phrase})::int * {FIELD_WEIGHT_SEARCHABLE_TEXT} DESC,
+                 s.score DESC,
+                 c.doc_id ASC
+             LIMIT ${limit}",
+            predicate = doc_kind_predicate(class),
+        )
+    }
+}
+
+/// Document frequency per word plus the corpus totals, in one statement. A
+/// schema whose statistics were never built reads as an empty corpus and
+/// degrades to unweighted scoring instead of failing.
+async fn fetch_word_stats(
+    tx: &mut Transaction<'static, Postgres>,
+    words: &[String],
+) -> Result<(Vec<WordStat>, i64, f64), PostgresSearchError> {
+    let rows = sqlx::query(
+        "SELECT w.term, coalesce(t.ndoc, 0) AS ndoc,
+                coalesce(s.total_docs, 0) AS total_docs,
+                coalesce(s.avgdl, 0) AS avgdl
+         FROM unnest($1::text[]) AS w(term)
+         LEFT JOIN catalog_terms AS t ON t.term = w.term
+         LEFT JOIN catalog_stats AS s ON true",
+    )
+    .bind(words)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut stats = Vec::with_capacity(rows.len());
+    let mut total_docs = 0_i64;
+    let mut avgdl = 0.0_f64;
+    for row in &rows {
+        let ndoc: i32 = row.try_get("ndoc")?;
+        stats.push(WordStat {
+            word: row.try_get("term")?,
+            ndoc: i64::from(ndoc),
+        });
+        total_docs = row.try_get("total_docs")?;
+        avgdl = row.try_get("avgdl")?;
+    }
+    Ok((stats, total_docs, avgdl))
+}
+
+/// Splits words into candidate keys (document-frequency cap applied) and the
+/// scoring set (every word, with FTS5's IDF formula and clamp).
+///
+/// A compact variant the corpus does not hold as a lexeme has nothing to
+/// meet, so it leaves first: it must not key candidates, score, or count as
+/// a survivor of the cap — an absent variant of the whole query would
+/// otherwise keep every real word from reaching the rarest-few fallback and
+/// select no candidates at all. A word the caller typed keeps its substring
+/// and prefix reach whatever its statistics say.
+fn scoring_plan(
+    stats: &[WordStat],
+    total_docs: i64,
+    avgdl: f64,
+    variant_words: &[String],
+) -> ScoringPlan {
+    let stats = stats
+        .iter()
+        .filter(|stat| stat.ndoc > 0 || !variant_words.contains(&stat.word))
+        .collect::<Vec<_>>();
+    let total = total_docs.max(0);
+    let cap = DOCUMENT_FREQUENCY_CAP * precise_f64(total.max(1));
+    let mut kept = stats
+        .iter()
+        .copied()
+        .filter(|stat| precise_f64(stat.ndoc.max(0)) <= cap)
+        .collect::<Vec<_>>();
+    if kept.is_empty() {
+        let mut by_rarity = stats.clone();
+        by_rarity.sort_by_key(|stat| (stat.ndoc, stat.word.clone()));
+        by_rarity.truncate(RARE_WORD_KEEP);
+        kept = by_rarity;
+    }
+    ScoringPlan {
+        scored: stats
+            .iter()
+            .map(|stat| ScoredWord {
+                word: stat.word.clone(),
+                idf: inverse_document_frequency(total, stat.ndoc),
+            })
+            .collect(),
+        candidate_words: kept.into_iter().map(|stat| stat.word.clone()).collect(),
+        avgdl: if avgdl > 0.0 { avgdl } else { 1.0 },
+    }
+}
+
+/// FTS5's IDF (`fts5_aux.c`): `log((N - n + 0.5) / (n + 0.5))`, clamped to a
+/// small positive floor so a word in more than half the corpus scores nothing
+/// instead of scoring negative.
+fn inverse_document_frequency(total_docs: i64, ndoc: i64) -> f64 {
+    let total = precise_f64(total_docs.max(0));
+    let matched = precise_f64(ndoc.clamp(0, total_docs.max(0)));
+    ((total - matched + 0.5) / (matched + 0.5))
+        .ln()
+        .max(IDF_FLOOR)
+}
+
+/// Catalog corpora stay far below `f64`'s exact-integer range; spelled out so
+/// the cast reads as a decision rather than an accident.
+#[expect(clippy::cast_precision_loss, reason = "document counts fit in f64")]
+fn precise_f64(value: i64) -> f64 {
+    value as f64
+}
+
+/// `word:* | word:*` over the scored words for candidate selection. Words are
+/// runs of alphanumerics and `_`, so the tsquery parser accepts them without
+/// quoting; a word with `_` parses as a prefix phrase, which is stricter, not
+/// broken.
+fn tsquery(words: &[String]) -> String {
+    words
+        .iter()
+        .map(|word| format!("{word}:*"))
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// Fixed SQL over the `d` alias; the kind names are the vocabulary's own
+/// literals, never caller input.
+fn doc_kind_predicate(class: CatalogDocumentClass) -> String {
+    let kinds = class
+        .document_kinds()
+        .iter()
+        .map(|kind| format!("'{}'", kind.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("d.doc_kind IN ({kinds})")
+}
+
+fn hit_from_row(row: &sqlx::postgres::PgRow) -> Result<CatalogSearchHit, PostgresSearchError> {
+    let surface_kind: String = row.try_get("surface_kind")?;
+    if !is_known_surface_kind(&surface_kind) {
+        return Err(PostgresSearchError::InvalidStorageValue {
+            field: "surface_kind",
+            value: surface_kind,
+        });
+    }
+    let field_role: String = row.try_get("field_role")?;
+    if !is_known_field_role(&field_role) {
+        return Err(PostgresSearchError::InvalidStorageValue {
+            field: "field_role",
+            value: field_role,
+        });
+    }
+    Ok(CatalogSearchHit {
+        doc_id: row.try_get("doc_id")?,
+        source_name: row.try_get("source_name")?,
+        catalog_name: row.try_get("catalog_name")?,
+        surface_kind,
+        surface_name: row.try_get("surface_name")?,
+        field_name: row.try_get("field_name")?,
+        field_role,
+    })
+}
+
+/// `\`, `%`, and `_` escaped, so identifiers such as `deploy_url` match
+/// literally under `LIKE`.
+fn escape_like(term: &str) -> String {
+    let mut escaped = String::with_capacity(term.len());
+    for ch in term.chars() {
+        if matches!(ch, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+/// `%term%` for substring candidates.
+fn contains_pattern(term: &str) -> String {
+    format!("%{}%", escape_like(term))
+}
+
+/// `term%` for the lexeme-prefix join in the score, mirroring the candidate
+/// tsquery's `:*`.
+fn prefix_pattern(term: &str) -> String {
+    format!("{}%", escape_like(term))
+}
+
+/// Lexeme candidates: runs of alphanumerics (any script, terms are already
+/// lowercased) and `_`, which the `simple` parser accepts without operators
+/// or quoting.
+fn lexeme_words(term: &str) -> Vec<String> {
+    term.split(|ch: char| !(ch.is_alphanumeric() || ch == '_'))
+        .filter(|word| !word.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+pub(super) mod plan_tests {
+    use super::{
+        CatalogQueryPlan, ScoredWord, ScoringPlan, WordStat, contains_pattern,
+        inverse_document_frequency, scoring_plan,
+    };
+    use crate::search::catalog::index::{CatalogDocumentClass, NormalizedSearchTerm};
+
+    fn given(terms: &[&str]) -> Vec<NormalizedSearchTerm> {
+        terms
+            .iter()
+            .map(|term| NormalizedSearchTerm {
+                text: (*term).to_string(),
+                compact_variant: false,
+            })
+            .collect()
+    }
+
+    fn variant(term: &str) -> NormalizedSearchTerm {
+        NormalizedSearchTerm {
+            text: term.to_string(),
+            compact_variant: true,
+        }
+    }
+
+    fn stat(word: &str, ndoc: i64) -> WordStat {
+        WordStat {
+            word: word.to_string(),
+            ndoc,
+        }
+    }
+
+    fn scored(words: &[&str]) -> ScoringPlan {
+        ScoringPlan {
+            scored: words
+                .iter()
+                .map(|word| ScoredWord {
+                    word: (*word).to_string(),
+                    idf: 1.0,
+                })
+                .collect(),
+            candidate_words: words.iter().map(|word| (*word).to_string()).collect(),
+            avgdl: 10.0,
+        }
+    }
+
+    #[test]
+    fn patterns_escape_like_metacharacters_and_drop_short_terms() {
+        let plan = CatalogQueryPlan::build(&given(&["ab", "deploy_url", "100%"])).expect("plan");
+
+        assert_eq!(plan.words, vec!["100", "deploy_url"]);
+        assert_eq!(plan.phrase_pattern, "%deploy\\_url%");
+        assert!(plan.wordless_patterns.is_empty());
+        assert_eq!(contains_pattern("a\\b"), "%a\\\\b%");
+    }
+
+    #[test]
+    fn the_phrase_is_the_longest_term_and_terms_split_into_words() {
+        let plan =
+            CatalogQueryPlan::build(&given(&["issue", "issue labels", "labels"])).expect("plan");
+
+        assert_eq!(plan.phrase_pattern, "%issue labels%");
+        assert_eq!(plan.words, vec!["issue", "labels"]);
+    }
+
+    #[test]
+    fn words_keep_non_ascii_letters() {
+        let plan = CatalogQueryPlan::build(&given(&["über-café"])).expect("plan");
+
+        assert_eq!(plan.words, vec!["café", "über"]);
+    }
+
+    #[test]
+    fn terms_without_words_keep_substring_patterns_and_skip_scoring() {
+        let plan = CatalogQueryPlan::build(&given(&["---", "a-b"])).expect("plan");
+
+        assert!(plan.words.is_empty());
+        assert_eq!(plan.wordless_patterns, vec!["%---%", "%a-b%"]);
+        let sql = plan.sql(&scored(&[]), CatalogDocumentClass::Entries);
+        assert!(sql.contains("0::float8 AS score"));
+        assert!(!sql.contains("to_tsquery"));
+        assert!(sql.contains("d.all_text ILIKE $1 OR d.all_text ILIKE $2"));
+    }
+
+    #[test]
+    fn only_short_terms_yield_no_plan() {
+        assert_eq!(CatalogQueryPlan::build(&given(&["ab"])), None);
+        assert_eq!(CatalogQueryPlan::build(&[]), None);
+    }
+
+    #[test]
+    fn placeholders_are_numbered_in_bind_order() {
+        let plan = CatalogQueryPlan::build(&given(&["alpha", "beta"])).expect("plan");
+
+        let sql = plan.sql(&scored(&["alpha", "beta"]), CatalogDocumentClass::Fields);
+
+        assert!(sql.contains("to_tsquery('simple', $1)"));
+        assert!(sql.contains("($2::text, $3::float8), ($4::text, $5::float8)"));
+        assert!(sql.contains("d.all_text ILIKE $6 OR d.all_text ILIKE $7"));
+        assert!(sql.contains("coalesce(c.doc_len::float8, $8) / $8"));
+        assert!(sql.contains("c.qualified_name ILIKE $9"));
+        assert!(sql.contains("LIMIT $10"));
+        assert!(sql.contains("d.doc_kind IN ('column_hint')"));
+        assert!(sql.contains("WITH candidates AS MATERIALIZED"));
+    }
+
+    #[test]
+    fn the_document_frequency_cap_restricts_candidates_but_not_scoring() {
+        let stats = [
+            WordStat {
+                word: "issues".to_string(),
+                ndoc: 100,
+            },
+            WordStat {
+                word: "slack".to_string(),
+                ndoc: 40,
+            },
+        ];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+
+        assert_eq!(plan.candidate_words, vec!["slack"]);
+        // The common word still scores, with its true IDF, not a clamp.
+        let issues = plan
+            .scored
+            .iter()
+            .find(|word| word.word == "issues")
+            .expect("capped word scores");
+        let expected = ((1_000.0_f64 - 100.0 + 0.5) / 100.5).ln();
+        assert!((issues.idf - expected).abs() < 1e-12);
+        assert!((plan.avgdl - 23.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn all_common_words_fall_back_to_the_rarest_few() {
+        let stats = ["delta", "alpha", "bravo", "charlie"]
+            .iter()
+            .zip([400_i64, 100, 200, 300])
+            .map(|(word, ndoc)| WordStat {
+                word: (*word).to_string(),
+                ndoc,
+            })
+            .collect::<Vec<_>>();
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+
+        assert_eq!(
+            plan.candidate_words,
+            vec!["alpha", "bravo", "charlie"],
+            "the rarest words survive as candidate keys, rarest first"
+        );
+        assert_eq!(plan.scored.len(), 4, "every word still scores");
+    }
+
+    #[test]
+    fn idf_follows_fts5_including_the_negative_clamp() {
+        // A word in most of the corpus is clamped off, not negative.
+        assert!((inverse_document_frequency(1_000, 977) - 1e-6).abs() < f64::EPSILON);
+        // A rare word scores by the FTS5 formula.
+        let expected = ((1_000.0_f64 - 40.0 + 0.5) / 40.5).ln();
+        assert!((inverse_document_frequency(1_000, 40) - expected).abs() < 1e-12);
+        // Degenerate inputs stay finite.
+        assert!((inverse_document_frequency(0, 0) - 1e-6).abs() < f64::EPSILON);
+        assert!(inverse_document_frequency(10, 20).is_finite());
+    }
+
+    #[test]
+    fn a_statistics_free_schema_degrades_to_unweighted_scoring() {
+        let stats = [WordStat {
+            word: "github".to_string(),
+            ndoc: 0,
+        }];
+
+        let plan = scoring_plan(&stats, 0, 0.0, &[]);
+
+        let word = plan.scored.first().expect("the only word survives");
+        assert!((word.idf - 1e-6).abs() < f64::EPSILON);
+        assert_eq!(plan.candidate_words, vec!["github"]);
+        assert!((plan.avgdl - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compact_variants_are_tracked_apart_from_typed_words() {
+        let mut terms = given(&["issue", "issue labels", "labels"]);
+        terms.push(variant("issuelabels"));
+
+        let plan = CatalogQueryPlan::build(&terms).expect("plan");
+
+        assert_eq!(plan.words, vec!["issue", "issuelabels", "labels"]);
+        assert_eq!(plan.variant_words, vec!["issuelabels"]);
+    }
+
+    #[test]
+    fn a_word_both_typed_and_derived_counts_as_typed() {
+        let mut terms = given(&["deploy_url", "deployurl"]);
+        terms.push(variant("deployurl"));
+
+        let plan = CatalogQueryPlan::build(&terms).expect("plan");
+
+        assert_eq!(plan.words, vec!["deploy_url", "deployurl"]);
+        assert!(plan.variant_words.is_empty());
+    }
+
+    #[test]
+    fn an_absent_compact_variant_neither_keys_candidates_nor_scores() {
+        // `github events` on a corpus where both words are common and no
+        // document is named `githubevents`.
+        let stats = [
+            stat("events", 920),
+            stat("github", 970),
+            stat("githubevents", 0),
+        ];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &["githubevents".to_string()]);
+
+        assert_eq!(
+            plan.candidate_words,
+            vec!["events", "github"],
+            "with the variant gone, the rarest-few fallback runs on the real words"
+        );
+        assert_eq!(
+            plan.scored
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["events", "github"]
+        );
+    }
+
+    #[test]
+    fn a_present_compact_variant_keys_candidates_and_scores() {
+        // `pull requests` where `github.pull_requests` indexes `pullrequests`.
+        let stats = [
+            stat("pull", 300),
+            stat("pullrequests", 6),
+            stat("requests", 200),
+        ];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &["pullrequests".to_string()]);
+
+        assert_eq!(plan.candidate_words, vec!["pullrequests"]);
+        assert_eq!(plan.scored.len(), 3);
+    }
+
+    #[test]
+    fn a_typed_word_the_corpus_lacks_keeps_its_substring_reach() {
+        // `enchmark` is no lexeme, but `%enchmark%` must still select
+        // `benchmark_runs`; only variants are subject to the absence rule.
+        let stats = [stat("enchmark", 0), stat("github", 970)];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+
+        assert_eq!(plan.candidate_words, vec!["enchmark"]);
+    }
+}

--- a/crates/coral-app/src/search/store/postgres/migrations/0001_catalog_documents.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0001_catalog_documents.sql
@@ -1,0 +1,87 @@
+-- Per-Workspace catalog projection. Runs with `search_path` set to the
+-- Workspace's surrogate schema plus the schema that holds `pg_trgm`, so every
+-- name below is unqualified on purpose.
+--
+-- No workspace column: the schema *is* the Workspace. The extension point for
+-- a future scope/identity dimension (lagoon #37) is an additive column on
+-- this table, precedented by observed memory's `source_scope_id`.
+--
+-- Not idempotent on purpose: DDL and the ledger bump share one transaction,
+-- so a replay never happens, and an object that already exists is drift the
+-- ledger must not certify.
+--
+-- `STORED` is spelled out on every generated column: Postgres 18 changed the
+-- default to VIRTUAL, which cannot be indexed.
+--
+-- `tsv` splits `.` in the identifier-carrying fields before tokenization. The
+-- default text-search parser fuses `source.name` into one host lexeme, so a
+-- two-part canonical name (`linear.issues`) would have no A-weighted lexeme a
+-- query word could reach, while an underscore compound
+-- (`linear.initiative_projects`) collects real A lexemes from its tail —
+-- inverting the field-weight intent. `description` is prose, not an
+-- identifier field; it keeps the plain expression.
+CREATE TABLE catalog_documents (
+    doc_id text PRIMARY KEY,
+    doc_kind text NOT NULL CHECK (
+        doc_kind IN ('catalog_table', 'catalog_table_function', 'column_hint')
+    ),
+    source_name text NOT NULL DEFAULT '',
+    catalog_name text,
+    surface_kind text NOT NULL DEFAULT '' CHECK (
+        surface_kind IN ('', 'table', 'table_function')
+    ),
+    surface_name text NOT NULL DEFAULT '',
+    field_name text NOT NULL DEFAULT '',
+    field_role text NOT NULL DEFAULT '' CHECK (
+        field_role IN (
+            '',
+            'table_column',
+            'table_filter',
+            'table_function_argument',
+            'table_function_result_column'
+        )
+    ),
+    qualified_name text NOT NULL DEFAULT '',
+    title text NOT NULL DEFAULT '',
+    description text NOT NULL DEFAULT '',
+    searchable_text text NOT NULL DEFAULT '',
+    -- Lexeme count of `tsv`, the length BM25 normalizes by. Written by
+    -- `replace_documents` in the projection's transaction, with the two
+    -- statistics tables below, so it can never disagree with the rows.
+    doc_len integer,
+    all_text text GENERATED ALWAYS AS (
+        qualified_name || ' ' || title || ' ' || description || ' ' || searchable_text
+    ) STORED,
+    tsv tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('simple', replace(qualified_name, '.', ' ')), 'A')
+        || setweight(to_tsvector('simple', replace(title, '.', ' ')), 'B')
+        || setweight(to_tsvector('simple', description), 'C')
+        || setweight(to_tsvector('simple', replace(searchable_text, '.', ' ')), 'D')
+    ) STORED
+);
+
+CREATE INDEX catalog_documents_all_text_trgm
+    ON catalog_documents USING gin (all_text gin_trgm_ops);
+
+CREATE INDEX catalog_documents_tsv
+    ON catalog_documents USING gin (tsv);
+
+-- Corpus statistics for BM25 ranking: per-lexeme document frequency and the
+-- corpus totals. Rewritten with the rows on every projection replacement.
+CREATE TABLE catalog_terms (
+    term text PRIMARY KEY,
+    ndoc integer NOT NULL
+);
+
+CREATE TABLE catalog_stats (
+    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    total_docs bigint NOT NULL,
+    avgdl double precision NOT NULL
+);
+
+-- The projection's fingerprint lives here, once. Replacement is one
+-- transaction, so the rows never disagree with it.
+CREATE TABLE search_meta (
+    key text PRIMARY KEY,
+    value text NOT NULL
+);

--- a/crates/coral-app/src/search/store/postgres/migrations/0001_search_registry.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0001_search_registry.sql
@@ -1,0 +1,19 @@
+-- Shared registry for the per-Workspace search schemas. Idempotent: it runs on
+-- every storage open, under an advisory lock, and doubles as the boot-time
+-- migration ledger.
+--
+-- The raw workspace name lives ONLY here. Every SQL identifier derives from
+-- `surrogate_id` (`search_ws_<id>`), never from the name: Postgres truncates
+-- identifiers at 63 bytes silently, and a workspace name is nearly
+-- unconstrained, so interpolating it would be a cross-tenant collision risk.
+--
+-- No foreign key to CoralDb's `workspaces`: the app-state and search
+-- migration streams stay uncoupled.
+CREATE SCHEMA IF NOT EXISTS search_registry;
+
+CREATE TABLE IF NOT EXISTS search_registry.workspaces (
+    workspace_name text PRIMARY KEY,
+    surrogate_id bigint GENERATED ALWAYS AS IDENTITY UNIQUE,
+    schema_version integer NOT NULL DEFAULT 0,
+    created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -1,0 +1,594 @@
+//! Postgres side of the storage seam: one schema per Workspace inside the
+//! `[database]` Postgres database, named by a surrogate registry.
+//!
+//! `search_registry.workspaces` maps the raw Workspace name to a generated
+//! surrogate id and records each schema's migration version, so it doubles as
+//! the boot-time ledger. Every SQL identifier derives from the surrogate
+//! (`search_ws_<id>`); a Workspace name never reaches SQL as an identifier.
+//! Deleting a Workspace is one registry row plus `DROP SCHEMA … CASCADE`.
+//!
+//! The pool is small and dedicated: catalog rebuilds run long transactions
+//! that must not starve app-state connections. `search_path` is set per
+//! transaction, never per pooled connection.
+
+mod catalog;
+
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+use std::future::Future;
+
+use sqlx::postgres::PgPool;
+use sqlx::{Postgres, Row as _, Transaction};
+use tokio::runtime::Handle;
+
+use crate::state::db::{DbError, connect_postgres_pool};
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 1;
+
+struct SearchPostgresMigration {
+    version: i32,
+    sql: &'static str,
+}
+
+const REGISTRY_BOOTSTRAP_SQL: &str = include_str!("migrations/0001_search_registry.sql");
+
+/// Per-Workspace schema stream, versioned in the registry ledger. Each step
+/// runs in one transaction with its ledger bump, so a partial failure leaves
+/// the schema at its recorded version and the step is never replayed.
+const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[SearchPostgresMigration {
+    version: 1,
+    sql: include_str!("migrations/0001_catalog_documents.sql"),
+}];
+
+const SEARCH_POOL_MAX_CONNECTIONS: u32 = 4;
+/// Serializes registry bootstrap across processes; per-Workspace work locks
+/// on the surrogate id instead.
+const REGISTRY_BOOTSTRAP_LOCK_KEY: i64 = 0x636f_7261_6c5f_7373;
+const PG_TRGM_EXTENSION: &str = "pg_trgm";
+const PG_TRGM_FEATURE: &str = "pg_trgm extension";
+const WORKSPACE_SCHEMA_PREFIX: &str = "search_ws_";
+
+#[derive(Debug, Clone)]
+pub(crate) struct PostgresSearchStorage {
+    pool: PgPool,
+    handle: Handle,
+    /// Schema that holds `pg_trgm`. It joins every operation's `search_path`
+    /// so `gin_trgm_ops` resolves without qualification.
+    trgm_schema: String,
+}
+
+/// One Workspace's catalog schema, opened and migrated.
+#[derive(Debug, Clone)]
+pub(crate) struct PostgresSearchStore {
+    pool: PgPool,
+    handle: Handle,
+    surrogate_id: i64,
+    search_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WorkspaceRegistration {
+    surrogate_id: i64,
+    schema_version: i32,
+}
+
+/// What a registry sweep did for one Workspace schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MigratedWorkspaceSchema {
+    pub(crate) workspace_name: String,
+    pub(crate) from_version: i32,
+}
+
+impl PostgresSearchStorage {
+    /// Connects a dedicated pool, bootstraps the registry, and verifies
+    /// `pg_trgm`. Fails loud, naming the missing capability, so a
+    /// misprovisioned database never serves degraded search.
+    pub(crate) async fn open(url: &str, handle: Handle) -> Result<Self, PostgresSearchError> {
+        let pool = connect_postgres_pool(url, Some(SEARCH_POOL_MAX_CONNECTIONS))
+            .await
+            .map_err(PostgresSearchError::Connect)?;
+        bootstrap_registry(&pool).await?;
+        let trgm_schema = ensure_pg_trgm(&pool).await?;
+        Ok(Self {
+            pool,
+            handle,
+            trgm_schema,
+        })
+    }
+
+    /// Opens the Workspace's schema, registering and creating it on first use
+    /// and migrating it when the ledger says it is behind.
+    pub(crate) fn open_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<PostgresSearchStore, PostgresSearchError> {
+        block_on(&self.handle, async {
+            let registration = register_workspace(&self.pool, workspace_name).await?;
+            self.ensure_schema_current(registration).await?;
+            Ok(self.store_for(registration.surrogate_id))
+        })
+    }
+
+    /// Opens the Workspace's schema only when the registry already knows it.
+    pub(crate) fn open_existing_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<PostgresSearchStore>, PostgresSearchError> {
+        block_on(&self.handle, async {
+            let Some(registration) = registered_workspace(&self.pool, workspace_name).await? else {
+                return Ok(None);
+            };
+            self.ensure_schema_current(registration).await?;
+            Ok(Some(self.store_for(registration.surrogate_id)))
+        })
+    }
+
+    /// Removes the Workspace's registry row and drops its schema. Complete
+    /// and instant: no tenant rows survive offboarding.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
+    )]
+    pub(crate) async fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<bool, PostgresSearchError> {
+        self.delete_registered_workspace(workspace_name.as_str())
+            .await
+    }
+
+    /// Removes every registered Workspace that is not in `live` and returns
+    /// their names. Runs at boot, before serving, so nothing registers
+    /// concurrently.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into the boot sweep next in this stack")
+    )]
+    pub(crate) async fn prune_workspaces_except(
+        &self,
+        live: &BTreeSet<String>,
+    ) -> Result<Vec<String>, PostgresSearchError> {
+        let registered: Vec<String> = sqlx::query_scalar(
+            "SELECT workspace_name FROM search_registry.workspaces ORDER BY surrogate_id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        let mut pruned = Vec::new();
+        for workspace_name in registered {
+            if live.contains(&workspace_name) {
+                continue;
+            }
+            if self.delete_registered_workspace(&workspace_name).await? {
+                pruned.push(workspace_name);
+            }
+        }
+        Ok(pruned)
+    }
+
+    async fn delete_registered_workspace(
+        &self,
+        workspace_name: &str,
+    ) -> Result<bool, PostgresSearchError> {
+        let mut tx = self.pool.begin().await?;
+        let registered: Option<i64> = sqlx::query_scalar(
+            "SELECT surrogate_id FROM search_registry.workspaces WHERE workspace_name = $1 FOR UPDATE",
+        )
+        .bind(workspace_name)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(surrogate_id) = registered else {
+            tx.commit().await?;
+            return Ok(false);
+        };
+        // Same lock the writers take, so an in-flight projection write ends
+        // before its schema disappears underneath it.
+        lock_workspace(&mut tx, surrogate_id).await?;
+        sqlx::query("DELETE FROM search_registry.workspaces WHERE surrogate_id = $1")
+            .bind(surrogate_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(schema_ddl(
+            "DROP SCHEMA IF EXISTS",
+            surrogate_id,
+            " CASCADE",
+        ))
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Boot-time ledger sweep: migrates every registered schema that is behind
+    /// this binary. A steady-state boot costs one query and does no work.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired into the boot sweep next in this stack")
+    )]
+    pub(crate) async fn migrate_all(
+        &self,
+    ) -> Result<Vec<MigratedWorkspaceSchema>, PostgresSearchError> {
+        let stale = sqlx::query(
+            "SELECT workspace_name, surrogate_id, schema_version
+             FROM search_registry.workspaces
+             WHERE schema_version <> $1
+             ORDER BY surrogate_id",
+        )
+        .bind(SEARCH_POSTGRES_SCHEMA_VERSION)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut migrated = Vec::with_capacity(stale.len());
+        for row in stale {
+            let workspace_name: String = row.try_get("workspace_name")?;
+            let registration = registration_from_row(&row)?;
+            self.ensure_schema_current(registration).await?;
+            migrated.push(MigratedWorkspaceSchema {
+                workspace_name,
+                from_version: registration.schema_version,
+            });
+        }
+        Ok(migrated)
+    }
+
+    fn store_for(&self, surrogate_id: i64) -> PostgresSearchStore {
+        let search_path = format!(
+            "{}, {}",
+            quote_identifier(&schema_name(surrogate_id)),
+            quote_identifier(&self.trgm_schema)
+        );
+        PostgresSearchStore {
+            pool: self.pool.clone(),
+            handle: self.handle.clone(),
+            surrogate_id,
+            search_path,
+        }
+    }
+
+    /// Brings one Workspace schema to the current version under an advisory
+    /// lock on its surrogate id, re-reading the ledger once the lock is held.
+    async fn ensure_schema_current(
+        &self,
+        registration: WorkspaceRegistration,
+    ) -> Result<(), PostgresSearchError> {
+        ensure_supported_schema_version(registration.schema_version)?;
+        if registration.schema_version == SEARCH_POSTGRES_SCHEMA_VERSION {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+        lock_workspace(&mut tx, registration.surrogate_id).await?;
+        let current_version: i32 = sqlx::query_scalar(
+            "SELECT schema_version FROM search_registry.workspaces WHERE surrogate_id = $1",
+        )
+        .bind(registration.surrogate_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        ensure_supported_schema_version(current_version)?;
+        if current_version == SEARCH_POSTGRES_SCHEMA_VERSION {
+            tx.commit().await?;
+            return Ok(());
+        }
+
+        let store = self.store_for(registration.surrogate_id);
+        sqlx::query(schema_ddl(
+            "CREATE SCHEMA IF NOT EXISTS",
+            registration.surrogate_id,
+            "",
+        ))
+        .execute(&mut *tx)
+        .await?;
+        set_search_path(&mut tx, &store.search_path).await?;
+        for migration in WORKSPACE_MIGRATIONS
+            .iter()
+            .filter(|migration| migration.version > current_version)
+        {
+            sqlx::raw_sql(migration.sql).execute(&mut *tx).await?;
+        }
+        sqlx::query(
+            "UPDATE search_registry.workspaces SET schema_version = $1 WHERE surrogate_id = $2",
+        )
+        .bind(SEARCH_POSTGRES_SCHEMA_VERSION)
+        .bind(registration.surrogate_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        tracing::info!(
+            surrogate_id = registration.surrogate_id,
+            from_version = current_version,
+            to_version = SEARCH_POSTGRES_SCHEMA_VERSION,
+            "migrated Postgres search schema"
+        );
+        Ok(())
+    }
+}
+
+impl PostgresSearchStore {
+    #[cfg(test)]
+    pub(crate) fn schema_name(&self) -> String {
+        schema_name(self.surrogate_id)
+    }
+
+    /// A read transaction with `search_path` pointing at this schema.
+    async fn begin(&self) -> Result<Transaction<'static, Postgres>, PostgresSearchError> {
+        let mut tx = self.pool.begin().await?;
+        set_search_path(&mut tx, &self.search_path).await?;
+        Ok(tx)
+    }
+
+    /// A write transaction that also takes the Workspace's advisory lock
+    /// without waiting: a projection another writer is rewriting is reported
+    /// as contention, so the caller can serve its cached projection, as it
+    /// does on `SQLite`'s busy sidecar.
+    async fn begin_write(&self) -> Result<Transaction<'static, Postgres>, PostgresSearchError> {
+        let mut tx = self.begin().await?;
+        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock($1)")
+            .bind(self.surrogate_id)
+            .fetch_one(&mut *tx)
+            .await?;
+        if !acquired {
+            return Err(PostgresSearchError::WriterBusy {
+                surrogate_id: self.surrogate_id,
+            });
+        }
+        Ok(tx)
+    }
+
+    fn block_on<F: Future>(&self, future: F) -> F::Output {
+        block_on(&self.handle, future)
+    }
+}
+
+/// Runs the future to completion from the seam's synchronous surface.
+///
+/// The seam is called from blocking-pool threads (the provider registry's
+/// `spawn_blocking` boundary and the manager's blocking operations), where
+/// `Handle::block_on` is legal. `block_in_place` covers the multi-thread
+/// runtime's worker threads too, so a caller on the wrong thread degrades to
+/// parking that worker instead of panicking.
+fn block_on<F: Future>(handle: &Handle, future: F) -> F::Output {
+    tokio::task::block_in_place(|| handle.block_on(future))
+}
+
+async fn bootstrap_registry(pool: &PgPool) -> Result<(), PostgresSearchError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(REGISTRY_BOOTSTRAP_LOCK_KEY)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::raw_sql(REGISTRY_BOOTSTRAP_SQL)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Creates `pg_trgm` when the role may, then verifies it exists. Returns the
+/// schema the extension lives in.
+///
+/// A role without `CREATE` on the database can still find the extension
+/// installed by an administrator, so a privilege refusal (and the duplicate
+/// error two concurrent creators can race into) defers to the probe. Any
+/// other failure is a real error and stops startup.
+async fn ensure_pg_trgm(pool: &PgPool) -> Result<String, PostgresSearchError> {
+    let create_error = match sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        .execute(pool)
+        .await
+    {
+        Ok(_) => None,
+        Err(error) if extension_create_may_be_deferred(&error) => Some(error),
+        Err(error) => return Err(error.into()),
+    };
+    let extension_schema: Option<String> = sqlx::query_scalar(
+        "SELECT n.nspname
+         FROM pg_extension AS e
+         INNER JOIN pg_namespace AS n ON n.oid = e.extnamespace
+         WHERE e.extname = $1",
+    )
+    .bind(PG_TRGM_EXTENSION)
+    .fetch_optional(pool)
+    .await?;
+    let server_version: String = sqlx::query_scalar("SELECT current_setting('server_version')")
+        .fetch_one(pool)
+        .await?;
+    classify_extension_probe(extension_schema, server_version, create_error)
+}
+
+/// `insufficient_privilege`, `duplicate_object`, or the `unique_violation` a
+/// concurrent `CREATE EXTENSION` produces.
+fn extension_create_may_be_deferred(error: &sqlx::Error) -> bool {
+    matches!(
+        error,
+        sqlx::Error::Database(error)
+            if matches!(error.code().as_deref(), Some("42501" | "42710" | "23505"))
+    )
+}
+
+fn classify_extension_probe(
+    extension_schema: Option<String>,
+    server_version: String,
+    create_error: Option<sqlx::Error>,
+) -> Result<String, PostgresSearchError> {
+    extension_schema.ok_or(PostgresSearchError::UnsupportedCapability {
+        feature: PG_TRGM_FEATURE,
+        server_version,
+        cause: create_error,
+    })
+}
+
+async fn registered_workspace(
+    pool: &PgPool,
+    workspace_name: &WorkspaceName,
+) -> Result<Option<WorkspaceRegistration>, PostgresSearchError> {
+    let row = sqlx::query(
+        "SELECT surrogate_id, schema_version FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace_name.as_str())
+    .fetch_optional(pool)
+    .await?;
+    row.as_ref().map(registration_from_row).transpose()
+}
+
+fn registration_from_row(
+    row: &sqlx::postgres::PgRow,
+) -> Result<WorkspaceRegistration, PostgresSearchError> {
+    Ok(WorkspaceRegistration {
+        surrogate_id: row.try_get("surrogate_id")?,
+        schema_version: row.try_get("schema_version")?,
+    })
+}
+
+/// Returns the Workspace's registration, allocating a surrogate on first use.
+/// Safe under concurrent first opens: the loser of the insert re-reads.
+async fn register_workspace(
+    pool: &PgPool,
+    workspace_name: &WorkspaceName,
+) -> Result<WorkspaceRegistration, PostgresSearchError> {
+    if let Some(registration) = registered_workspace(pool, workspace_name).await? {
+        return Ok(registration);
+    }
+    let inserted = sqlx::query(
+        "INSERT INTO search_registry.workspaces (workspace_name) VALUES ($1)
+         ON CONFLICT (workspace_name) DO NOTHING
+         RETURNING surrogate_id, schema_version",
+    )
+    .bind(workspace_name.as_str())
+    .fetch_optional(pool)
+    .await?;
+    if let Some(row) = inserted {
+        return registration_from_row(&row);
+    }
+    registered_workspace(pool, workspace_name)
+        .await?
+        .ok_or_else(|| PostgresSearchError::RegistryRace(workspace_name.to_string()))
+}
+
+async fn lock_workspace(
+    tx: &mut Transaction<'static, Postgres>,
+    surrogate_id: i64,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(surrogate_id)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// `SET LOCAL` scopes the path to the transaction, so a pooled connection
+/// never carries one Workspace's schema into another request.
+async fn set_search_path(
+    tx: &mut Transaction<'static, Postgres>,
+    search_path: &str,
+) -> Result<(), PostgresSearchError> {
+    // Audited: `search_path` is built by `store_for` from `quote_identifier`
+    // over a surrogate-derived schema name and the `pg_trgm` schema read from
+    // `pg_namespace`; no caller input reaches it.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SET LOCAL search_path TO {search_path}"
+    )))
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Schema DDL for one surrogate. Audited: the identifier is
+/// `search_ws_<i64>` through `quote_identifier`; the name never sees SQL.
+fn schema_ddl(statement: &str, surrogate_id: i64, suffix: &str) -> sqlx::AssertSqlSafe<String> {
+    sqlx::AssertSqlSafe(format!(
+        "{statement} {}{suffix}",
+        quote_identifier(&schema_name(surrogate_id))
+    ))
+}
+
+fn ensure_supported_schema_version(version: i32) -> Result<(), PostgresSearchError> {
+    if version > SEARCH_POSTGRES_SCHEMA_VERSION {
+        return Err(PostgresSearchError::UnsupportedSchemaVersion {
+            database_version: version,
+            supported_version: SEARCH_POSTGRES_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+fn schema_name(surrogate_id: i64) -> String {
+    format!("{WORKSPACE_SCHEMA_PREFIX}{surrogate_id}")
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PostgresSearchError {
+    #[error("search backend 'postgres' cannot use the database URL: {0}")]
+    Connect(#[source] DbError),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(
+        "Postgres {server_version} does not provide required search feature: {feature}{}",
+        cause_suffix(.cause.as_ref())
+    )]
+    UnsupportedCapability {
+        feature: &'static str,
+        server_version: String,
+        #[source]
+        cause: Option<sqlx::Error>,
+    },
+    #[error(
+        "Postgres search schema version {database_version} is newer than this binary supports ({supported_version})"
+    )]
+    UnsupportedSchemaVersion {
+        database_version: i32,
+        supported_version: i32,
+    },
+    #[error("search registry lost workspace '{0}' between insert and lookup")]
+    RegistryRace(String),
+    #[error("another writer holds the catalog projection of search schema {surrogate_id}")]
+    WriterBusy { surrogate_id: i64 },
+    #[error("Postgres search store holds an unknown catalog search {field} '{value}'")]
+    InvalidStorageValue { field: &'static str, value: String },
+}
+
+fn cause_suffix(cause: Option<&sqlx::Error>) -> String {
+    cause.map_or_else(String::new, |cause| format!(" ({cause})"))
+}
+
+impl PostgresSearchError {
+    fn sqlstate(&self) -> Option<Cow<'_, str>> {
+        match self {
+            Self::Sqlx(sqlx::Error::Database(error)) => error.code(),
+            Self::Sqlx(_)
+            | Self::Connect(_)
+            | Self::UnsupportedCapability { .. }
+            | Self::UnsupportedSchemaVersion { .. }
+            | Self::RegistryRace(_)
+            | Self::WriterBusy { .. }
+            | Self::InvalidStorageValue { .. } => None,
+        }
+    }
+
+    /// Another writer holds the projection (the try-lock lost, or Postgres
+    /// reported `lock_not_available` or a deadlock); the caller may serve
+    /// cached state.
+    pub(crate) fn is_lock_contention(&self) -> bool {
+        matches!(self, Self::WriterBusy { .. })
+            || matches!(self.sqlstate().as_deref(), Some("55P03" | "40P01"))
+    }
+
+    /// `disk_full`, `out_of_memory`, or `insufficient_resources`.
+    pub(crate) fn is_storage_exhaustion(&self) -> bool {
+        matches!(
+            self.sqlstate().as_deref(),
+            Some("53100" | "53200" | "53000")
+        )
+    }
+
+    pub(crate) fn is_unsupported(&self) -> bool {
+        matches!(
+            self,
+            Self::UnsupportedCapability { .. } | Self::UnsupportedSchemaVersion { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -1,0 +1,598 @@
+//! Postgres side of the paired-backend tests.
+//!
+//! Database-backed tests are ignored unless `CORAL_TEST_POSTGRES_URL` is set
+//! (`make postgres-tests` provisions one). They share one registry, so every
+//! test works in Workspaces of its own and removes them when done; a test that
+//! sweeps or prunes the whole registry holds `LEDGER_SWEEP_LOCK` while it does.
+
+use std::sync::LazyLock;
+
+use tokio::runtime::Handle;
+use tokio::sync::Mutex;
+
+use super::{
+    PG_TRGM_FEATURE, PostgresSearchError, classify_extension_probe, quote_identifier, schema_name,
+};
+use crate::bootstrap;
+use crate::search::catalog::index::CatalogDocumentClass;
+use crate::search::store::tests::contract;
+use crate::search::store::{SearchStorage, SearchStoreError};
+use crate::workspaces::WorkspaceName;
+
+#[test]
+fn schema_names_derive_from_the_surrogate_only() {
+    assert_eq!(schema_name(42), "search_ws_42");
+    assert_eq!(quote_identifier("search_ws_42"), "\"search_ws_42\"");
+    assert_eq!(quote_identifier("odd\"schema"), "\"odd\"\"schema\"");
+}
+
+#[test]
+fn capability_probe_names_the_missing_extension() {
+    let error = classify_extension_probe(
+        None,
+        "17.2".to_string(),
+        Some(sqlx::Error::Protocol(
+            "permission denied to create extension \"pg_trgm\"".to_string(),
+        )),
+    )
+    .expect_err("missing extension must fail");
+
+    assert!(error.is_unsupported());
+    let message = error.to_string();
+    assert!(message.contains("Postgres 17.2"), "{message}");
+    assert!(message.contains(PG_TRGM_FEATURE), "{message}");
+    assert!(message.contains("permission denied"), "{message}");
+    assert!(
+        SearchStoreError::from(error).is_unsupported(),
+        "the seam must keep the unsupported class"
+    );
+}
+
+#[test]
+fn newer_schema_versions_are_refused() {
+    let error = super::ensure_supported_schema_version(super::SEARCH_POSTGRES_SCHEMA_VERSION + 1)
+        .expect_err("future version must fail");
+
+    assert!(matches!(
+        error,
+        PostgresSearchError::UnsupportedSchemaVersion { database_version, .. }
+            if database_version == super::SEARCH_POSTGRES_SCHEMA_VERSION + 1
+    ));
+    assert!(error.is_unsupported());
+}
+
+/// `migrate_all` visits every registry row and `prune_workspaces_except`
+/// deletes every row outside a live set read moments earlier, so two such
+/// tests overlapping see — or delete — each other's Workspaces mid-flight.
+/// Held by every test that sweeps, prunes, or plants a future-version row.
+static LEDGER_SWEEP_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn postgres_test_url() -> Option<String> {
+    bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+        .expect("read CORAL_TEST_POSTGRES_URL")
+        .filter(|value| !value.is_empty())
+}
+
+async fn open_storage() -> Option<SearchStorage> {
+    let url = postgres_test_url()?;
+    Some(
+        SearchStorage::postgres(&url, Handle::current())
+            .await
+            .expect("open Postgres search storage"),
+    )
+}
+
+fn unique_workspace(label: &str) -> WorkspaceName {
+    WorkspaceName::parse(&format!("{label}-{}", uuid::Uuid::new_v4().simple()))
+        .expect("workspace name")
+}
+
+/// Runs seam calls where production runs them: on a blocking-pool thread.
+async fn blocking<T: Send + 'static>(work: impl FnOnce() -> T + Send + 'static) -> T {
+    tokio::task::spawn_blocking(work)
+        .await
+        .expect("blocking work")
+}
+
+async fn delete_workspaces(storage: &SearchStorage, workspaces: &[WorkspaceName]) {
+    for workspace in workspaces {
+        storage
+            .delete_workspace(workspace)
+            .await
+            .expect("delete workspace");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the search store contract against Postgres"]
+async fn postgres_store_serves_the_catalog_contract_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("contract");
+
+    let contract_storage = storage.clone();
+    let contract_workspace = workspace.clone();
+    blocking(move || {
+        let store = contract_storage
+            .open_workspace(&contract_workspace)
+            .expect("open workspace store");
+        assert_eq!(store.backend_name(), "postgres");
+        contract::assert_catalog_store_contract(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Workspace isolation against Postgres"]
+async fn workspaces_are_isolated_by_schema_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let populated = unique_workspace("populated");
+    let empty = unique_workspace("empty");
+
+    let (populated_schema, empty_schema) = {
+        let storage = storage.clone();
+        let (populated, empty) = (populated.clone(), empty.clone());
+        blocking(move || {
+            let populated_store = storage.open_workspace(&populated).expect("open populated");
+            let empty_store = storage.open_workspace(&empty).expect("open empty");
+            populated_store
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("isolation-v1"))
+                .expect("refresh populated");
+
+            assert_eq!(empty_store.catalog().document_count().expect("count"), 0);
+            let leaked = empty_store
+                .catalog()
+                .search(&["github".to_string()], 10, CatalogDocumentClass::Entries)
+                .expect("search empty workspace");
+            assert!(leaked.hits.is_empty(), "rows leaked across Workspaces");
+            assert!(
+                !empty_store
+                    .catalog()
+                    .projection_is_current("isolation-v1")
+                    .expect("fingerprint check")
+            );
+            (
+                populated_store.postgres_schema_name(),
+                empty_store.postgres_schema_name(),
+            )
+        })
+        .await
+    };
+    assert_ne!(populated_schema, empty_schema);
+
+    delete_workspaces(&storage, &[populated, empty]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run registry naming against Postgres"]
+async fn registry_keeps_hostile_workspace_names_out_of_identifiers_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    // Two names that agree on their first 63 bytes would collide if names
+    // became identifiers; quoting hazards ride along.
+    let long_prefix = format!("{}-{suffix}", "w".repeat(80));
+    let hostile = [
+        WorkspaceName::parse(&format!("{long_prefix}-a")).expect("name"),
+        WorkspaceName::parse(&format!("{long_prefix}-b")).expect("name"),
+        WorkspaceName::parse(&format!("quote\"drop;--{suffix}")).expect("name"),
+        WorkspaceName::parse(&format!("ünïcödé {suffix}")).expect("name"),
+    ];
+
+    let schemas = {
+        let storage = storage.clone();
+        let hostile = hostile.clone();
+        blocking(move || {
+            hostile
+                .iter()
+                .map(|workspace| {
+                    let store = storage
+                        .open_workspace(workspace)
+                        .expect("open hostile name");
+                    store
+                        .catalog()
+                        .refresh_projection(&contract::catalog_snapshot("hostile-v1"))
+                        .expect("refresh");
+                    assert_eq!(store.catalog().document_count().expect("count"), 4);
+                    store.postgres_schema_name()
+                })
+                .collect::<Vec<_>>()
+        })
+        .await
+    };
+    for (workspace, schema) in hostile.iter().zip(&schemas) {
+        assert!(schema.starts_with("search_ws_"), "{schema}");
+        assert!(
+            !schema.contains(workspace.as_str()),
+            "workspace name leaked into identifier {schema}"
+        );
+    }
+    let distinct = schemas.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(distinct.len(), hostile.len(), "surrogates must be distinct");
+
+    delete_workspaces(&storage, &hostile).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Workspace deletion against Postgres"]
+async fn deleting_a_workspace_removes_its_schema_and_registry_row_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("deleted");
+
+    let first_schema = {
+        let storage = storage.clone();
+        let workspace = workspace.clone();
+        blocking(move || {
+            let store = storage.open_workspace(&workspace).expect("open");
+            store
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("deleted-v1"))
+                .expect("refresh");
+            store.postgres_schema_name()
+        })
+        .await
+    };
+
+    assert!(storage.delete_workspace(&workspace).await.expect("delete"));
+    assert!(
+        !storage
+            .delete_workspace(&workspace)
+            .await
+            .expect("second delete"),
+        "a second delete finds nothing"
+    );
+    assert!(
+        !postgres_schema_exists(&first_schema).await,
+        "schema {first_schema} must be dropped"
+    );
+
+    let (existing, reopened_schema, reopened_count) = {
+        let storage = storage.clone();
+        let workspace = workspace.clone();
+        blocking(move || {
+            let existing = storage
+                .open_existing_workspace(&workspace)
+                .expect("probe deleted workspace")
+                .is_some();
+            let store = storage.open_workspace(&workspace).expect("reopen");
+            (
+                existing,
+                store.postgres_schema_name(),
+                store.catalog().document_count().expect("count"),
+            )
+        })
+        .await
+    };
+    assert!(!existing, "registry row must be gone");
+    assert_ne!(reopened_schema, first_schema, "surrogates are never reused");
+    assert_eq!(reopened_count, 0, "a reopened Workspace starts empty");
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the migration ledger against Postgres"]
+async fn ledger_sweep_migrates_stale_schemas_and_is_idempotent_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let _sweep = LEDGER_SWEEP_LOCK.lock().await;
+    // Registered but never migrated: the shape a crash between registration
+    // and the first schema transaction leaves behind.
+    let stale = unique_workspace("stale");
+    let current = unique_workspace("current");
+    register_without_schema(&stale).await;
+    {
+        let storage = storage.clone();
+        let current = current.clone();
+        blocking(move || {
+            storage.open_workspace(&current).expect("open current");
+        })
+        .await;
+    }
+
+    let migrated = storage.migrate_all().await.expect("sweep");
+    assert_eq!(
+        migrated
+            .iter()
+            .filter(|entry| entry.workspace_name == stale.as_str())
+            .map(|entry| entry.from_version)
+            .collect::<Vec<_>>(),
+        vec![0]
+    );
+    assert!(
+        migrated
+            .iter()
+            .all(|entry| entry.workspace_name != current.as_str()),
+        "a current schema is never touched"
+    );
+    assert_eq!(
+        registry_schema_version(&stale).await,
+        super::SEARCH_POSTGRES_SCHEMA_VERSION
+    );
+
+    let second_sweep = storage.migrate_all().await.expect("second sweep");
+    assert!(
+        second_sweep
+            .iter()
+            .all(|entry| entry.workspace_name != stale.as_str()),
+        "a migrated schema is not migrated again"
+    );
+
+    // The migrated schema serves the contract like any other.
+    let stale_count = {
+        let storage = storage.clone();
+        let stale = stale.clone();
+        blocking(move || {
+            let store = storage.open_workspace(&stale).expect("reopen");
+            store
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("ledger-v1"))
+                .expect("refresh");
+            store.catalog().document_count().expect("count")
+        })
+        .await
+    };
+    assert_eq!(stale_count, 4);
+
+    set_registry_schema_version(&stale, super::SEARCH_POSTGRES_SCHEMA_VERSION + 1).await;
+    let error = storage
+        .migrate_all()
+        .await
+        .expect_err("a newer schema must refuse to serve");
+    assert!(error.is_unsupported(), "{error}");
+    let open_error = {
+        let storage = storage.clone();
+        let stale = stale.clone();
+        blocking(move || storage.open_workspace(&stale).err()).await
+    }
+    .expect("open must fail on a newer schema");
+    assert!(open_error.is_unsupported(), "{open_error}");
+
+    delete_workspaces(&storage, &[stale, current]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run writer contention against Postgres"]
+async fn a_concurrent_writer_is_reported_as_contention_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("contended");
+    let surrogate_id = {
+        let storage = storage.clone();
+        let opened = workspace.clone();
+        blocking(move || storage.open_workspace(&opened).expect("open")).await;
+        registry_surrogate_id(&workspace).await
+    };
+
+    // Another process holds the projection's write lock in an open transaction.
+    let holder = test_pool().await;
+    let mut holding = holder.begin().await.expect("begin holder");
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(surrogate_id)
+        .execute(&mut *holding)
+        .await
+        .expect("hold lock");
+
+    let error = {
+        let storage = storage.clone();
+        let workspace = workspace.clone();
+        blocking(move || {
+            storage
+                .open_workspace(&workspace)
+                .expect("open")
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("contended-v1"))
+                .err()
+        })
+        .await
+    }
+    .expect("a held lock must not block the refresh");
+    assert!(error.is_lock_contention(), "{error}");
+
+    holding.rollback().await.expect("release lock");
+    let refreshed = {
+        let storage = storage.clone();
+        let workspace = workspace.clone();
+        blocking(move || {
+            storage
+                .open_workspace(&workspace)
+                .expect("open")
+                .catalog()
+                .refresh_projection(&contract::catalog_snapshot("contended-v1"))
+                .expect("refresh after release")
+                .refreshed
+        })
+        .await
+    };
+    assert!(refreshed);
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the boot prune against Postgres"]
+async fn boot_prune_removes_workspaces_missing_from_the_live_set_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let _sweep = LEDGER_SWEEP_LOCK.lock().await;
+    let orphaned = unique_workspace("orphaned");
+    let live = unique_workspace("live");
+    {
+        let storage = storage.clone();
+        let (orphaned, live) = (orphaned.clone(), live.clone());
+        blocking(move || {
+            storage.open_workspace(&orphaned).expect("open orphaned");
+            storage.open_workspace(&live).expect("open live");
+        })
+        .await;
+    }
+
+    // Every other registered Workspace stays live: the registry is shared with
+    // concurrent tests, so only this test's orphan may be missing.
+    let mut live_names: std::collections::BTreeSet<String> =
+        sqlx::query_scalar("SELECT workspace_name FROM search_registry.workspaces")
+            .fetch_all(&test_pool().await)
+            .await
+            .expect("registered workspaces")
+            .into_iter()
+            .collect();
+    assert!(live_names.remove(orphaned.as_str()));
+
+    let pruned = storage
+        .prune_workspaces_except(&live_names)
+        .await
+        .expect("prune");
+
+    assert_eq!(pruned, vec![orphaned.as_str().to_string()]);
+    let (orphan_exists, live_exists) = {
+        let storage = storage.clone();
+        let (orphaned, live) = (orphaned.clone(), live.clone());
+        blocking(move || {
+            (
+                storage
+                    .open_existing_workspace(&orphaned)
+                    .expect("probe orphan")
+                    .is_some(),
+                storage
+                    .open_existing_workspace(&live)
+                    .expect("probe live")
+                    .is_some(),
+            )
+        })
+        .await
+    };
+    assert!(!orphan_exists, "the orphaned workspace must be gone");
+    assert!(live_exists, "a live workspace must survive the prune");
+
+    delete_workspaces(&storage, &[live]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run IDF ranking against Postgres"]
+async fn common_word_noise_is_discounted_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("idf");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        contract::assert_rare_terms_outrank_common_noise(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run common-word retrieval against Postgres"]
+async fn common_word_queries_still_retrieve_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("common");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        contract::assert_common_word_queries_still_retrieve(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
+async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("semantics");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        contract::assert_match_semantics(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+async fn test_pool() -> sqlx::PgPool {
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&postgres_test_url().expect("CORAL_TEST_POSTGRES_URL"))
+        .await
+        .expect("connect test pool")
+}
+
+async fn postgres_schema_exists(schema: &str) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = $1)")
+        .bind(schema)
+        .fetch_one(&test_pool().await)
+        .await
+        .expect("schema probe")
+}
+
+async fn register_without_schema(workspace: &WorkspaceName) {
+    sqlx::query("INSERT INTO search_registry.workspaces (workspace_name) VALUES ($1)")
+        .bind(workspace.as_str())
+        .execute(&test_pool().await)
+        .await
+        .expect("register workspace row");
+}
+
+async fn registry_surrogate_id(workspace: &WorkspaceName) -> i64 {
+    sqlx::query_scalar(
+        "SELECT surrogate_id FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace.as_str())
+    .fetch_one(&test_pool().await)
+    .await
+    .expect("read surrogate id")
+}
+
+async fn set_registry_schema_version(workspace: &WorkspaceName, version: i32) {
+    sqlx::query(
+        "UPDATE search_registry.workspaces SET schema_version = $1 WHERE workspace_name = $2",
+    )
+    .bind(version)
+    .bind(workspace.as_str())
+    .execute(&test_pool().await)
+    .await
+    .expect("set schema version");
+}
+
+async fn registry_schema_version(workspace: &WorkspaceName) -> i32 {
+    sqlx::query_scalar(
+        "SELECT schema_version FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace.as_str())
+    .fetch_one(&test_pool().await)
+    .await
+    .expect("read schema version")
+}

--- a/crates/coral-app/src/search/store/tests.rs
+++ b/crates/coral-app/src/search/store/tests.rs
@@ -179,6 +179,109 @@ pub(super) mod contract {
         assert_eq!(entries(&["issue"]), entries(&["issue"]));
     }
 
+    /// A query word present in nearly every document must not outrank the
+    /// query's rare words. Both engines discount it through corpus
+    /// statistics — FTS5's negative-IDF clamp, the Postgres side's IDF floor
+    /// — so the document the rare words name comes first. A ranking without
+    /// corpus statistics (`ts_rank_cd`) fails this. Only the top position
+    /// is asserted: how far a
+    /// common-word-only match ranks (or whether it is retrieved at all)
+    /// legitimately differs by engine.
+    pub(crate) fn assert_rare_terms_outrank_common_noise(store: &SearchStore) {
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&noise_snapshot())
+            .expect("refresh");
+
+        let terms = ["github", "slack", "messages"]
+            .iter()
+            .map(|term| (*term).to_string())
+            .collect::<Vec<_>>();
+        let hits = catalog
+            .search(&terms, 10, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+
+        assert_eq!(
+            hits.first().map(|hit| hit.doc_id.as_str()),
+            Some("table:slack_messages"),
+            "the rare words must beat twelve documents dense in the common word"
+        );
+    }
+
+    /// A query made only of common words must still retrieve. The request
+    /// appends the whole query as a term and the store derives a compact
+    /// variant of it (`firehose events` → `firehoseevents`); nothing in the
+    /// corpus is named that, or starts with it, so the variant must not stand
+    /// in for the real words. Both words are in all twelve event tables and
+    /// in nothing else.
+    pub(crate) fn assert_common_word_queries_still_retrieve(store: &SearchStore) {
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&noise_snapshot())
+            .expect("refresh");
+
+        let terms = ["events", "firehose", "firehose events"]
+            .iter()
+            .map(|term| (*term).to_string())
+            .collect::<Vec<_>>();
+        let hits = catalog
+            .search(&terms, 20, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+
+        assert_eq!(
+            hits.len(),
+            12,
+            "every event table and nothing else must be retrieved"
+        );
+        assert!(
+            hits.first()
+                .is_some_and(|hit| hit.doc_id.starts_with("table:github_noise_")),
+            "an event table must lead, got {:?}",
+            hits.first().map(|hit| hit.doc_id.as_str())
+        );
+    }
+
+    fn noise_snapshot() -> CatalogIndexSnapshot {
+        let table = |doc_id: &str, surface_name: &str, title: &str, description: &str| {
+            CatalogIndexDocument {
+                doc_id: doc_id.to_string(),
+                doc_kind: CatalogIndexDocumentKind::CatalogTable,
+                source_name: "github".to_string(),
+                catalog_name: None,
+                surface_kind: "table".to_string(),
+                surface_name: surface_name.to_string(),
+                field_name: String::new(),
+                field_role: String::new(),
+                qualified_name: format!("github.{surface_name}"),
+                title: title.to_string(),
+                description: description.to_string(),
+                searchable_text: format!("github {surface_name}"),
+            }
+        };
+        let mut documents = (0..12)
+            .map(|index| {
+                table(
+                    &format!("table:github_noise_{index:02}"),
+                    &format!("github_events_{index:02}"),
+                    "github events",
+                    "github events from the github firehose about github activity",
+                )
+            })
+            .collect::<Vec<_>>();
+        documents.push(table(
+            "table:slack_messages",
+            "slack_messages",
+            "slack messages",
+            "Messages posted to Slack channels",
+        ));
+        CatalogIndexSnapshot {
+            fingerprint: "noise-v1".to_string(),
+            documents,
+        }
+    }
+
     fn semantics_snapshot() -> CatalogIndexSnapshot {
         let table = |doc_id: &str, surface_name: &str, title: &str, description: &str| {
             CatalogIndexDocument {
@@ -349,6 +452,26 @@ fn sqlite_store_follows_the_benchmark_match_strata() {
 }
 
 #[test]
+fn sqlite_store_discounts_common_word_noise() {
+    let (_temp, storage) = sqlite_storage();
+    let store = storage
+        .open_workspace(&WorkspaceName::default())
+        .expect("open workspace store");
+
+    contract::assert_rare_terms_outrank_common_noise(&store);
+}
+
+#[test]
+fn sqlite_store_retrieves_common_word_queries() {
+    let (_temp, storage) = sqlite_storage();
+    let store = storage
+        .open_workspace(&WorkspaceName::default())
+        .expect("open workspace store");
+
+    contract::assert_common_word_queries_still_retrieve(&store);
+}
+
+#[test]
 fn open_existing_workspace_never_creates_search_state() {
     let (_temp, storage) = sqlite_storage();
     let workspace = WorkspaceName::default();
@@ -369,6 +492,12 @@ fn open_existing_workspace_never_creates_search_state() {
 }
 
 #[test]
+fn sqlite_storage_keeps_observed_values() {
+    let (_temp, storage) = sqlite_storage();
+    assert!(storage.observed_values().is_some());
+}
+
+#[test]
 fn clear_all_spans_both_data_classes_and_reports_cleanup() {
     let (_temp, storage) = sqlite_storage();
     let store = storage
@@ -381,7 +510,13 @@ fn clear_all_spans_both_data_classes_and_reports_cleanup() {
 
     let cleared = store.clear_source_all("github").expect("clear source all");
     assert_eq!(cleared.catalog.deleted_document_count, 3);
-    assert_eq!(cleared.observed.values, 0);
+    assert_eq!(
+        cleared
+            .observed
+            .expect("sqlite keeps observed values")
+            .values,
+        0
+    );
     let cleared = store.clear_workspace_all().expect("clear workspace all");
     assert_eq!(cleared.catalog.deleted_document_count, 1);
     assert_eq!(

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
@@ -65,11 +65,26 @@ async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
 }
 
 async fn open_postgres(url: &str) -> Result<CoralDb, DbError> {
-    let options = postgres_connect_options(url)?;
-    let pool = PgPoolOptions::new().connect_with(options).await?;
+    let pool = connect_postgres_pool(url, None).await?;
     Ok(CoralDb {
         backend: CoralDbBackend::Postgres(PostgresCoralDb { pool }),
     })
+}
+
+/// Opens a Postgres pool on the app-state URL with the TLS posture every
+/// consumer of that URL must share. Other stores in the same database open
+/// their own pool through this, bounded by `max_connections`, so their long
+/// transactions cannot starve app-state connections.
+pub(crate) async fn connect_postgres_pool(
+    url: &str,
+    max_connections: Option<u32>,
+) -> Result<PgPool, DbError> {
+    let options = postgres_connect_options(url)?;
+    let mut pool_options = PgPoolOptions::new();
+    if let Some(max_connections) = max_connections {
+        pool_options = pool_options.max_connections(max_connections);
+    }
+    Ok(pool_options.connect_with(options).await?)
 }
 
 fn postgres_connect_options(url: &str) -> Result<PgConnectOptions, DbError> {

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -18,7 +18,7 @@ mod workspace_state;
 
 pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
-pub(crate) use coral_db::CoralDb;
+pub(crate) use coral_db::{CoralDb, connect_postgres_pool};
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::identity_specs::{


### PR DESCRIPTION
Catalog Universal Search gains a Postgres backend in the same database
as app state: one schema per Workspace named through the
`search_registry.workspaces` surrogate registry, which also serves as
the per-schema migration ledger. Workspace names never reach SQL as
identifiers. The backend opens its own small pool through the shared
`connect_postgres_pool` helper (same URL and TLS posture as CoralDb),
sets `search_path` per transaction, runs its own migration stream —
non-idempotent by design, since DDL and the ledger bump share one
transaction — and fails open loudly when `pg_trgm` is missing.

Writers take the Workspace's advisory lock without waiting, so a
contended projection is reported as such and the provider serves its
cached projection, as it does on SQLite. Deletion takes the same lock
before dropping a schema.

The backend keeps no observed values; the seam, the provider registry,
and maintenance report that absence explicitly. Nothing selects the
backend yet: configuration lands after lifecycle wiring, so no
deployment changes behavior with this change.

## Retrieval and ranking

The engine is `pg_trgm` + weighted `tsvector` on vanilla Postgres (RDS-installable, per the locked plan). The ranking is BM25 in plain SQL — the SQLite side's `bm25()` rebuilt, with the same constants and field weights — because the obvious alternative measured badly: `ts_rank_cd` has no corpus statistics, and under coral's disjunctive `tsquery` its cover-density machinery never engages, so it degenerates to a weighted term-frequency count. On the benchmark catalog (21k documents) the word `github` appears in 97.7 % of documents; FTS5 clamps it to nothing, `ts_rank_cd` ranks on it. That version placed the table the agent went on to use in the top 3 **14 %** of the time against SQLite's 54 %.

What ships:

- **Corpus statistics in the projection** (`0001_catalog_documents.sql`): `catalog_documents.doc_len`, `catalog_terms(term, ndoc)` filled by `ts_stat`, and a one-row `catalog_stats(total_docs, avgdl)`. `replace_documents` rewrites all three inside the projection's transaction (~150 ms at 21k docs), so statistics and rows can never disagree.
- **Score**: every query word joins the BM25 sum with its true IDF (`ln((N - n + 0.5) / (n + 0.5))`, floored at FTS5's `1e-6`), FTS5's `k1` = 1.2, and `b` = 0.4 — FTS5's 0.75 is a prose constant; on short structured catalog documents it made a column-rich canonical table pay in its name field for its column count. Lexeme occurrences carry the 8/6/2/1 field weights; a lexeme-prefix join lets `pull` score `pulls`.
- **`.`-split identifier fields**: the `tsv` generated column tokenizes `replace(qualified_name, '.', ' ')` (and `title`, `searchable_text`). The default parser fuses `linear.issues` into one host lexeme no query word can match, while `linear.initiative_projects` splits its underscore tail into real A lexemes — the field-weight intent inverted. `description` is prose and keeps the plain expression.
- **Candidates**: prefix `tsquery` (`word:*`) OR trigram `ILIKE '%word%'` per word — substring semantics preserved — inside a `WITH candidates AS MATERIALIZED` wall (planned together with the scoring join, the planner abandons the bitmap index scans for a seq scan and the median doubles). Only candidate selection is restricted to words below a 5 % document-frequency cap; it is a latency lever (uncapped candidates measured 5× the cost for identical relevance), not a relevance rule — every word still scores. If every word is common, the 3 rarest survive as candidate keys.
- **Order**: whole-query phrase boost (8/6/2/1, what keeps `"issue labels"` ahead of co-occurrence matches), BM25 score, `doc_id`. Zero-score candidates (mid-word substring matches like `enchmark` → `benchmark_runs`) keep their rank through a `LATERAL` + `coalesce(sum(…), 0)`; an inner-join `GROUP BY` shape would silently drop them.
- **Compact variants earn their place from the corpus.** Query construction adds a compact identifier variant to every term with a separator (`deploy_url` → `deployurl`), including the whole-query term it appends (`issue labels` → `issuelabels`), so a name typed with spaces meets the identifier. The store now keeps each term's provenance and drops a variant word the statistics show absent (`ndoc = 0`) before candidate selection, scoring, and the rarest-words fallback. Without that, the variant of a sentence — a 60-character word nothing starts with — was always under the cap, so a query made only of common words kept it as its sole candidate key and returned nothing; it also cost an `ILIKE` pattern and a score row on every multi-word query. Typed words are never subject to the rule (`enchmark` still selects `benchmark_runs` by substring). Measured on the 402-query offline replay: identical aggregates, one ranked list changed (used table rank 4 → 3), SQL median 85 → 58 ms, p90 450 → 315 ms.

Measured and rejected along the way: an exact-token qualified-name tier (as a hard sort tier it promotes underscore compounds without the split and wrecks top-k/#1/Slack with it; a soft ×2 multiplier is a wash), `ts_rank_cd` normalization flags (insufficient), and dropping words above the cap from scoring (buried `linear.issues`: `issues` is in 10 % of documents and carries a real IDF ≈ 2.2 that FTS5 keeps).

### Measured

Offline replay of 395 recorded agent queries (387 labeled with the table the agent went on to use), same corpus for both engines:

| | top-3 | #1 | top-k | med rank | GitHub | Linear | Notion | Slack |
|---|---|---|---|---|---|---|---|---|
| SQLite baseline | 52 % | 28 % | 83 % | 2.0 | 38 % | 65 % | 19 % | 71 % |
| `ts_rank_cd` (first cut) | 14 % | 3 % | 51 % | 8.0 | | | | |
| **this PR** | **52 %** | 28 % | 84 % | **2.0** | 40 % | 58 % | 28 % | 70 % |

The paid duel run (`coral-benchmarks/docs/findings/postgres-search-duel.md`, run 3, 2026-09-10) confirms it end to end: used-table top-3 53 % vs SQLite 52 %, at #1 29 % vs 26 %, GitHub 63 vs 50, Linear 54 vs 62, task creation 17/17, cost +5 %, paired outcomes 1 W / 2 L / 98 D.

### Known limit

Search cost scales with query length because every word scores: warm medians of 291 / 480 / 719 ms at 3–8 / 9–12 / 13–25 query words, where SQLite is flat. The 400 ms warm budget passes on one recorded query mix (393 ms) and fails on another (566 ms); in-field agent call time is within noise of the capped variant (0.64 vs 0.62 s). The candidate follow-up is capping the *scored* word count to the k rarest words instead of by document frequency, which should keep this ranking at a flat latency; it validates in minutes on the offline replay before any paid run. Round-trip consolidation (~17 round trips per search) is the other independent latency follow-up.

## Validation

- `make rust-checks` green.
- `make postgres-tests` green against Postgres 17: the full store contract (substring / word / phrase / 3-char floor / negative strata), the common-word-noise ranking contract (twelve documents dense in a common word must lose to the one document the query's rare words name — passes on FTS5 and Postgres, fails on `ts_rank_cd`), the common-word retrieval contract (`firehose events` on a corpus where both words are common and nothing is named `firehoseevents` must return all twelve event tables — 0 of 12 without the variant rule, 12 with it; FTS5 passes either way), registry naming with hostile Workspace names, schema isolation, deletion, the ledger sweep, pruning, contention.
- Offline mirror and real-binary `mcp-stdio` replay agree on every aggregate and per-source figure.

https://claude.ai/code/session_01WeuXrBPjT8Q5nPTruS8xjX
