### PR TITLE
feat(search): remove deleted workspaces' search state and sweep the ledger at boot

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1,5 +1,6 @@
 //! Builds and runs the Coral gRPC server.
 
+use std::collections::BTreeSet;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -53,7 +54,7 @@ use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
-use crate::search::store::SearchStorage;
+use crate::search::store::{SearchStorage, SearchStoreError};
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
@@ -339,6 +340,10 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "server bootstrap wires every collaborator once, in dependency order"
+    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
@@ -380,7 +385,9 @@ impl ServerBuilder {
             Arc::clone(&coral_db),
             diagnostic_reporter.clone(),
         )
-        .with_pool_registry(Arc::clone(&workspace_pool_registry));
+        .with_pool_registry(Arc::clone(&workspace_pool_registry))
+        .with_search_storage(search_storage.clone());
+        sweep_search_storage(&search_storage, &workspace_manager).await?;
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
@@ -478,6 +485,53 @@ fn trace_components_for_store(
             ))),
         }
     })
+}
+
+/// The boot sweep over shared search storage, before serving, like
+/// `coral_db.migrate()`. Workspaces that no longer exist lose their search
+/// state first, so a dead schema at an unknown version cannot block the
+/// migration of the live ones that follows.
+async fn sweep_search_storage(
+    search_storage: &SearchStorage,
+    workspace_manager: &WorkspaceManager,
+) -> Result<(), AppError> {
+    if search_storage.has_workspace_registry() {
+        let live = workspace_manager
+            .list_workspaces()
+            .await?
+            .into_iter()
+            .map(|workspace| workspace.name.as_str().to_string())
+            .collect::<BTreeSet<_>>();
+        let pruned = search_storage
+            .prune_workspaces_except(&live)
+            .await
+            .map_err(|error| search_storage_open_error(&error))?;
+        if !pruned.is_empty() {
+            tracing::warn!(
+                pruned_workspaces = pruned.len(),
+                "removed search state of workspaces that no longer exist"
+            );
+        }
+    }
+    let migrated = search_storage
+        .migrate_all()
+        .await
+        .map_err(|error| search_storage_open_error(&error))?;
+    if !migrated.is_empty() {
+        tracing::info!(
+            migrated_workspace_schemas = migrated.len(),
+            "migrated stale search schemas at startup"
+        );
+    }
+    Ok(())
+}
+
+fn search_storage_open_error(error: &SearchStoreError) -> AppError {
+    if error.is_unsupported() {
+        AppError::FailedPrecondition(format!("search storage is not supported: {error}"))
+    } else {
+        AppError::Internal(format!("search storage failed to open: {error}"))
+    }
 }
 
 fn init_credential_manager(layout: &AppStateLayout) -> Result<CredentialManager, AppError> {

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -226,10 +226,6 @@ impl SearchStorage {
     /// Removes every trace of the Workspace's search state. Returns whether
     /// there was any. The `SQLite` sidecar lives inside the Workspace
     /// directory, which Workspace deletion removes as a whole.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
-    )]
     pub(crate) async fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
@@ -242,13 +238,18 @@ impl SearchStorage {
         }
     }
 
+    /// Whether this backend registers Workspaces in shared storage that
+    /// outlives the Workspace directory, and so needs boot-time pruning.
+    pub(crate) fn has_workspace_registry(&self) -> bool {
+        match &self.backend {
+            SearchStorageBackend::Sqlite(_) => false,
+            SearchStorageBackend::Postgres(_) => true,
+        }
+    }
+
     /// Removes the search state of every registered Workspace that is not in
     /// `live`, and returns their names. The safety net for a deletion whose
     /// best-effort cleanup failed: the next boot finishes it.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into the boot sweep next in this stack")
-    )]
     pub(crate) async fn prune_workspaces_except(
         &self,
         live: &BTreeSet<String>,
@@ -263,10 +264,6 @@ impl SearchStorage {
 
     /// Boot-time ledger sweep: migrates every Workspace schema the backend
     /// knows to be behind this binary. `SQLite` sidecars migrate on open.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into the boot sweep next in this stack")
-    )]
     pub(crate) async fn migrate_all(
         &self,
     ) -> Result<Vec<MigratedWorkspaceSchema>, SearchStoreError> {

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -126,10 +126,6 @@ impl PostgresSearchStorage {
 
     /// Removes the Workspace's registry row and drops its schema. Complete
     /// and instant: no tenant rows survive offboarding.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into Workspace deletion next in this stack")
-    )]
     pub(crate) async fn delete_workspace(
         &self,
         workspace_name: &WorkspaceName,
@@ -141,10 +137,6 @@ impl PostgresSearchStorage {
     /// Removes every registered Workspace that is not in `live` and returns
     /// their names. Runs at boot, before serving, so nothing registers
     /// concurrently.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into the boot sweep next in this stack")
-    )]
     pub(crate) async fn prune_workspaces_except(
         &self,
         live: &BTreeSet<String>,
@@ -201,10 +193,6 @@ impl PostgresSearchStorage {
 
     /// Boot-time ledger sweep: migrates every registered schema that is behind
     /// this binary. A steady-state boot costs one query and does no work.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired into the boot sweep next in this stack")
-    )]
     pub(crate) async fn migrate_all(
         &self,
     ) -> Result<Vec<MigratedWorkspaceSchema>, PostgresSearchError> {

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -362,6 +362,45 @@ async fn ledger_sweep_migrates_stale_schemas_and_is_idempotent_against_postgres(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the boot order against Postgres"]
+async fn boot_prunes_a_dead_future_version_schema_before_migrating_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let _sweep = LEDGER_SWEEP_LOCK.lock().await;
+    let dead = unique_workspace("dead-future");
+    {
+        let storage = storage.clone();
+        let dead = dead.clone();
+        blocking(move || {
+            storage.open_workspace(&dead).expect("open");
+        })
+        .await;
+    }
+    set_registry_schema_version(&dead, super::SEARCH_POSTGRES_SCHEMA_VERSION + 1).await;
+    let mut live_names: std::collections::BTreeSet<String> =
+        sqlx::query_scalar("SELECT workspace_name FROM search_registry.workspaces")
+            .fetch_all(&test_pool().await)
+            .await
+            .expect("registered workspaces")
+            .into_iter()
+            .collect();
+    assert!(live_names.remove(dead.as_str()));
+
+    // Boot order: prune first, then migrate. The dead schema's unknown version
+    // must not block the sweep of the live ones.
+    let pruned = storage
+        .prune_workspaces_except(&live_names)
+        .await
+        .expect("prune");
+    assert_eq!(pruned, vec![dead.as_str().to_string()]);
+    storage
+        .migrate_all()
+        .await
+        .expect("sweep succeeds once the dead schema is gone");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run writer contention against Postgres"]
 async fn a_concurrent_writer_is_reported_as_contention_against_postgres() {
     let Some(storage) = open_storage().await else {

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -5,6 +5,7 @@ use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
+use crate::search::store::SearchStorage;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::ConfigStore;
 use crate::state::db::{CoralDb, DbRepos, now_unix_nanos_i64};
@@ -25,6 +26,7 @@ pub(crate) struct WorkspaceManager {
     db: Arc<CoralDb>,
     diagnostic_reporter: SourceDiagnosticReporter,
     pool_registry: Arc<WorkspacePoolRegistry>,
+    search_storage: Option<SearchStorage>,
 }
 
 impl WorkspaceManager {
@@ -65,11 +67,23 @@ impl WorkspaceManager {
             db,
             diagnostic_reporter,
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
+            search_storage: None,
         }
     }
 
     pub(crate) fn with_pool_registry(mut self, pool_registry: Arc<WorkspacePoolRegistry>) -> Self {
         self.pool_registry = pool_registry;
+        self
+    }
+
+    /// Search storage whose per-Workspace state is removed on deletion.
+    ///
+    /// Optional because only shared backends keep state outside the Workspace
+    /// directory: the `SQLite` sidecar goes with the directory. The server
+    /// bootstrap always sets it; a constructor parameter would need an
+    /// `AppStateLayout` that the generic `WorkspacePaths` tests use cannot give.
+    pub(crate) fn with_search_storage(mut self, search_storage: SearchStorage) -> Self {
+        self.search_storage = Some(search_storage);
         self
     }
 
@@ -209,6 +223,9 @@ impl WorkspaceManager {
             let workspace_dir_backup = self.stage_deleted_workspace_dir(&deleted.workspace.name);
             (deleted, workspace_dir_backup)
         };
+        // While the marker still holds off a same-name create: a new Workspace
+        // must never adopt the old one's search schema.
+        self.delete_workspace_search_state(workspace_name).await;
         drop(deletion_marker);
 
         let deleted_workspace_name = deleted.workspace.name.clone();
@@ -218,6 +235,35 @@ impl WorkspaceManager {
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
         Ok(deleted.workspace)
+    }
+
+    /// Best effort, after the deletion committed and before the deletion
+    /// marker is released: a Workspace that no longer exists must not keep
+    /// catalog rows in shared search storage. A failure here is finished by
+    /// the next boot's sweep, which prunes registered Workspaces that the
+    /// database no longer lists.
+    async fn delete_workspace_search_state(&self, workspace_name: &WorkspaceName) {
+        let Some(search_storage) = &self.search_storage else {
+            return;
+        };
+        match search_storage.delete_workspace(workspace_name).await {
+            Ok(deleted) => {
+                tracing::debug!(
+                    workspace = %workspace_name,
+                    search_backend = search_storage.backend_name(),
+                    deleted,
+                    "removed deleted workspace's search state"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    search_backend = search_storage.backend_name(),
+                    error = %error,
+                    "workspace deleted, but failed to remove its search state; the next boot sweep removes it"
+                );
+            }
+        }
     }
 
     fn remove_deleted_workspace_credentials(&self, deleted: &DeletedWorkspace) {
@@ -315,7 +361,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::WorkspaceManager;
+    use crate::bootstrap;
     use crate::credentials::{CredentialManager, CredentialSetId, CredentialStore};
+    use crate::search::store::SearchStorage;
     use crate::sources::SourceName;
     use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
     use crate::sources::model::{InstalledSource, SourceOrigin};
@@ -349,6 +397,71 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         Arc::new(db)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run Workspace deletion against Postgres search storage"]
+    async fn delete_workspace_removes_search_state_contract_on_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url: url.clone() })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let search_storage = SearchStorage::postgres(&url, tokio::runtime::Handle::current())
+            .await
+            .expect("open postgres search storage");
+        let manager = WorkspaceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            None,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+            Arc::new(db),
+            SourceDiagnosticReporter::default(),
+        )
+        .with_search_storage(search_storage.clone());
+        let workspace_name =
+            WorkspaceName::parse(&format!("usp-delete-{}", uuid::Uuid::new_v4().simple()))
+                .expect("workspace");
+        manager
+            .create_workspace(&workspace_name)
+            .await
+            .expect("create workspace");
+        let open_storage = search_storage.clone();
+        let open_workspace = workspace_name.clone();
+        tokio::task::spawn_blocking(move || {
+            open_storage
+                .open_workspace(&open_workspace)
+                .expect("first search registers the workspace's search schema");
+        })
+        .await
+        .expect("open search state");
+
+        manager
+            .delete_workspace(&workspace_name)
+            .await
+            .expect("delete workspace");
+
+        let probe_workspace = workspace_name.clone();
+        let remaining = tokio::task::spawn_blocking(move || {
+            search_storage
+                .open_existing_workspace(&probe_workspace)
+                .expect("probe search state")
+                .is_some()
+        })
+        .await
+        .expect("probe search state");
+        assert!(
+            !remaining,
+            "deleting the workspace must remove its search state"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Workspace deletion now removes the Workspace's shared search state —
registry row and schema on Postgres, nothing on SQLite, whose sidecar
goes with the Workspace directory — before the deletion marker is
released, so a same-name create can never adopt the old schema.

Server startup sweeps shared search storage before serving, like
`coral_db.migrate()`: registered Workspaces that the database no longer
lists are pruned first (the safety net for a deletion whose cleanup
failed), then every schema the ledger records as behind this binary is
migrated. Pruning before migrating keeps a dead schema at an unknown
version from blocking startup. A steady-state boot costs one query.

Covered behind `CORAL_TEST_POSTGRES_URL`: deletion through
`WorkspaceManager` on a Postgres CoralDb, and the boot order with a
dead future-version schema that is pruned before the sweep.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1
