### PR TITLE
feat(search): select the search backend with [search] and serve catalog search from Postgres

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -43,6 +43,19 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
   Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.
 </Note>
 
+### Search storage
+
+Universal Search keeps its catalog index in a store of its own. By default the store follows `[database].backend`: SQLite app state uses one SQLite search file per workspace under the local state directory, and Postgres app state keeps catalog search in the same Postgres database, as one schema per workspace.
+
+Use `[search]` to choose the search backend on its own. The section has no `path` or `url_env` key: the `postgres` backend reuses the `[database]` connection URL with a small connection pool of its own, so it requires `[database].backend = "postgres"`.
+
+```toml
+[search]
+backend = "sqlite"
+```
+
+The Postgres search backend needs the `pg_trgm` extension. Coral creates it when the database role may, and refuses to start when it is missing. Observed-values search is not available on the Postgres search backend.
+
 ## Workspaces
 
 Workspace metadata is stored under `[workspaces]`. The `default` workspace

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -11,6 +11,7 @@ use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
+use crate::search::store::SearchConfigError;
 use crate::state::db::DbError;
 
 /// Errors surfaced by the local application layer.
@@ -170,6 +171,18 @@ impl From<DbError> for AppError {
             DbError::TomlDecode(error) => Self::TomlDecode(error),
             DbError::Sqlx(error) => Self::Database(error.to_string()),
             DbError::Migration(error) => Self::Database(error.to_string()),
+        }
+    }
+}
+
+impl From<SearchConfigError> for AppError {
+    fn from(error: SearchConfigError) -> Self {
+        match error {
+            SearchConfigError::Config(detail) => {
+                Self::FailedPrecondition(format!("search configuration is invalid: {detail}"))
+            }
+            SearchConfigError::Io(error) => Self::Io(error),
+            SearchConfigError::TomlDecode(error) => Self::TomlDecode(error),
         }
     }
 }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -54,7 +54,7 @@ use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
-use crate::search::store::{SearchStorage, SearchStoreError};
+use crate::search::store::{ResolvedSearchConfig, SearchConfig, SearchStorage, SearchStoreError};
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
@@ -353,7 +353,7 @@ impl ServerBuilder {
         layout.ensure()?;
         let feature_store = FeatureStore::from_layout(layout.clone());
         let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
-        let coral_db = init_database(&layout).await?;
+        let (database_config, coral_db) = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store, &layout).await?;
         let coral_db = Arc::new(coral_db);
@@ -365,7 +365,7 @@ impl ServerBuilder {
         let workspace_pool_registry = Arc::new(WorkspacePoolRegistry::default());
         let diagnostic_reporter = SourceDiagnosticReporter::default();
         let database_sources_enabled = features.enabled(Feature::DatabaseSources);
-        let search_storage = SearchStorage::sqlite(layout.clone());
+        let search_storage = init_search_storage(&layout, &database_config).await?;
         let source_manager = SourceManager::with_diagnostic_reporter(
             config_store.clone(),
             credential_manager.clone(),
@@ -414,7 +414,7 @@ impl ServerBuilder {
         .with_task_activity_recorder(task_activity);
         let observed_values_search_enabled = features.enabled(Feature::ObservedValuesSearch);
         let search_observations =
-            observed_values_search_enabled.then(|| SearchObservationHandle::new(layout.clone()));
+            init_search_observations(observed_values_search_enabled, &search_storage, &layout);
         let search_manager = SearchManager::with_diagnostic_reporter(
             search_storage,
             layout,
@@ -541,11 +541,42 @@ fn init_credential_manager(layout: &AppStateLayout) -> Result<CredentialManager,
     Ok(CredentialManager::new(credential_store))
 }
 
-async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
+async fn init_database(
+    layout: &AppStateLayout,
+) -> Result<(ResolvedDatabaseConfig, CoralDb), AppError> {
     let database_config = resolve_database_config(layout)?;
-    let coral_db = CoralDb::open(database_config).await?;
+    let coral_db = CoralDb::open(database_config.clone()).await?;
     coral_db.migrate().await?;
-    Ok(coral_db)
+    Ok((database_config, coral_db))
+}
+
+/// Resolves `[search]` against the database config and opens the backend.
+///
+/// A backend that cannot serve search fails startup here, naming the missing
+/// capability, rather than serving degraded results later.
+async fn init_search_storage(
+    layout: &AppStateLayout,
+    database_config: &ResolvedDatabaseConfig,
+) -> Result<SearchStorage, AppError> {
+    match SearchConfig::load(layout)?.resolve(database_config)? {
+        ResolvedSearchConfig::Sqlite => Ok(SearchStorage::sqlite(layout.clone())),
+        ResolvedSearchConfig::Postgres { url } => {
+            SearchStorage::postgres(&url, tokio::runtime::Handle::current())
+                .await
+                .map_err(|error| search_storage_open_error(&error))
+        }
+    }
+}
+
+/// The observed-values capture pipeline runs only when the feature is on and
+/// the search backend keeps observed values to write into.
+fn init_search_observations(
+    observed_values_search_enabled: bool,
+    search_storage: &SearchStorage,
+    layout: &AppStateLayout,
+) -> Option<SearchObservationHandle> {
+    (observed_values_search_enabled && search_storage.keeps_observed_values())
+        .then(|| SearchObservationHandle::new(layout.clone()))
 }
 
 fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseConfig, AppError> {

--- a/crates/coral-app/src/search/store/config.rs
+++ b/crates/coral-app/src/search/store/config.rs
@@ -1,0 +1,272 @@
+//! `[search]` configuration: which storage backend serves Universal Search.
+//!
+//! ```toml
+//! [search]
+//! backend = "postgres"   # "sqlite" | "postgres"; default: follow [database].backend
+//! ```
+//!
+//! The section mirrors `[database]` (`state::db::config`) and carries no path
+//! or URL of its own: `sqlite` derives per-Workspace files from the app-state
+//! layout, and `postgres` reuses the resolved `[database]` URL with a small
+//! pool of its own. The knob stays independently settable so a deployment can
+//! keep app state on Postgres while search stays on `SQLite` during rollout.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::state::AppStateLayout;
+use crate::state::db::ResolvedDatabaseConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum SearchBackendKind {
+    Sqlite,
+    Postgres,
+}
+
+impl SearchBackendKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Postgres => "postgres",
+        }
+    }
+}
+
+/// The persisted `[search]` section. `backend: None` follows `[database]`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SearchConfig {
+    backend: Option<SearchBackendKind>,
+}
+
+/// The effective search backend after resolving against the database config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResolvedSearchConfig {
+    Sqlite,
+    Postgres { url: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SearchConfigError {
+    #[error("search configuration is invalid: {0}")]
+    Config(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    TomlDecode(#[from] toml::de::Error),
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedConfig {
+    #[serde(default)]
+    search: Option<RawPersistedSearchConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPersistedSearchConfig {
+    #[serde(default)]
+    backend: Option<SearchBackendKind>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, toml::Value>,
+}
+
+impl RawPersistedSearchConfig {
+    fn into_backend(self) -> Result<SearchBackendKind, SearchConfigError> {
+        if let Some(field) = self.extra.keys().next() {
+            return Err(SearchConfigError::Config(format!(
+                "unsupported [search].{field} configuration key"
+            )));
+        }
+        self.backend.ok_or_else(|| {
+            SearchConfigError::Config(
+                "[search].backend is required when [search] is present".to_string(),
+            )
+        })
+    }
+}
+
+impl SearchConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, SearchConfigError> {
+        if !layout.config_file().try_exists()? {
+            return Ok(Self { backend: None });
+        }
+
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let persisted: PersistedConfig = toml::from_str(&raw)?;
+        let Some(search) = persisted.search else {
+            return Ok(Self { backend: None });
+        };
+        Ok(Self {
+            backend: Some(search.into_backend()?),
+        })
+    }
+
+    /// Resolves the effective backend. Postgres search reuses the database
+    /// connection, so it needs the database to be Postgres too.
+    pub(crate) fn resolve(
+        &self,
+        database: &ResolvedDatabaseConfig,
+    ) -> Result<ResolvedSearchConfig, SearchConfigError> {
+        let backend = self.backend.unwrap_or(match database {
+            ResolvedDatabaseConfig::Sqlite { .. } => SearchBackendKind::Sqlite,
+            ResolvedDatabaseConfig::Postgres { .. } => SearchBackendKind::Postgres,
+        });
+        match (backend, database) {
+            (SearchBackendKind::Sqlite, _) => Ok(ResolvedSearchConfig::Sqlite),
+            (SearchBackendKind::Postgres, ResolvedDatabaseConfig::Postgres { url }) => {
+                Ok(ResolvedSearchConfig::Postgres { url: url.clone() })
+            }
+            (SearchBackendKind::Postgres, ResolvedDatabaseConfig::Sqlite { .. }) => {
+                Err(SearchConfigError::Config(format!(
+                    "search backend '{}' reuses the [database] connection and requires [database].backend = \"postgres\"",
+                    backend.as_str()
+                )))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use tempfile::tempdir;
+
+    use super::{ResolvedSearchConfig, SearchConfig, SearchConfigError};
+    use crate::state::AppStateLayout;
+    use crate::state::db::ResolvedDatabaseConfig;
+
+    fn layout_with_config(raw_config: Option<&str>) -> (tempfile::TempDir, AppStateLayout) {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        if let Some(raw_config) = raw_config {
+            fs::create_dir_all(layout.config_dir()).expect("config dir");
+            fs::write(layout.config_file(), raw_config).expect("config");
+        }
+        (temp, layout)
+    }
+
+    fn sqlite_database() -> ResolvedDatabaseConfig {
+        ResolvedDatabaseConfig::Sqlite {
+            path: PathBuf::from("coral.db"),
+        }
+    }
+
+    fn postgres_database() -> ResolvedDatabaseConfig {
+        ResolvedDatabaseConfig::Postgres {
+            url: "postgres://coral@127.0.0.1/coral".to_string(),
+        }
+    }
+
+    #[test]
+    fn follows_the_database_backend_when_unset() {
+        for raw_config in [None, Some("[database]\nbackend = \"sqlite\"\n")] {
+            let (_temp, layout) = layout_with_config(raw_config);
+            let config = SearchConfig::load(&layout).expect("search config");
+
+            assert_eq!(config, SearchConfig { backend: None });
+            assert_eq!(
+                config.resolve(&sqlite_database()).expect("resolve sqlite"),
+                ResolvedSearchConfig::Sqlite
+            );
+            assert_eq!(
+                config
+                    .resolve(&postgres_database())
+                    .expect("resolve postgres"),
+                ResolvedSearchConfig::Postgres {
+                    url: "postgres://coral@127.0.0.1/coral".to_string()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_sqlite_keeps_search_local_beside_a_postgres_database() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"sqlite\"\n"));
+
+        let config = SearchConfig::load(&layout).expect("search config");
+
+        assert_eq!(
+            config.resolve(&postgres_database()).expect("resolve"),
+            ResolvedSearchConfig::Sqlite
+        );
+    }
+
+    #[test]
+    fn explicit_postgres_reuses_the_database_url() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"postgres\"\n"));
+
+        let config = SearchConfig::load(&layout).expect("search config");
+
+        assert_eq!(
+            config.resolve(&postgres_database()).expect("resolve"),
+            ResolvedSearchConfig::Postgres {
+                url: "postgres://coral@127.0.0.1/coral".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_postgres_requires_a_postgres_database() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"postgres\"\n"));
+
+        let error = SearchConfig::load(&layout)
+            .expect("search config")
+            .resolve(&sqlite_database())
+            .expect_err("postgres search over a sqlite database must be rejected");
+
+        assert!(
+            matches!(error, SearchConfigError::Config(ref detail) if detail.contains("requires [database].backend = \"postgres\"")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn search_section_requires_explicit_backend() {
+        let (_temp, layout) = layout_with_config(Some("[search]\n"));
+
+        let error = SearchConfig::load(&layout).expect_err("search config should reject backend");
+
+        assert!(
+            matches!(error, SearchConfigError::Config(ref detail) if detail.contains("[search].backend is required")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn search_section_rejects_unsupported_fields() {
+        for (raw_config, expected_error) in [
+            (
+                "[search]\nbackend = \"sqlite\"\npath = \"search.sqlite3\"\n",
+                "unsupported [search].path configuration key",
+            ),
+            (
+                "[search]\nbackend = \"postgres\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+                "unsupported [search].url_env configuration key",
+            ),
+        ] {
+            let (_temp, layout) = layout_with_config(Some(raw_config));
+
+            let error = SearchConfig::load(&layout).expect_err("search config should reject field");
+
+            assert!(
+                matches!(error, SearchConfigError::Config(ref detail) if detail.contains(expected_error)),
+                "unexpected error for config {raw_config:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_backend_values_are_rejected() {
+        let (_temp, layout) = layout_with_config(Some("[search]\nbackend = \"paradedb\"\n"));
+
+        let error = SearchConfig::load(&layout).expect_err("unknown backend must be rejected");
+
+        assert!(
+            matches!(error, SearchConfigError::TomlDecode(_)),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/coral-app/src/search/store/mod.rs
+++ b/crates/coral-app/src/search/store/mod.rs
@@ -14,6 +14,7 @@
 //! Retrieval order is the ranking and must be a deterministic total order,
 //! whichever backend serves it.
 
+mod config;
 mod postgres;
 mod sqlite;
 
@@ -36,6 +37,7 @@ use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
+pub(crate) use config::{ResolvedSearchConfig, SearchConfig, SearchConfigError};
 pub(crate) use postgres::MigratedWorkspaceSchema;
 use postgres::{PostgresSearchError, PostgresSearchStorage, PostgresSearchStore};
 use sqlite::SqliteSearchStorage;
@@ -150,13 +152,6 @@ impl SearchStorage {
     /// One Postgres schema per Workspace in the `[database]` Postgres database, reached
     /// through a small dedicated pool on the same URL. Bootstraps the
     /// registry and verifies `pg_trgm`, failing loud when it is missing.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "selected by the [search] config next in this stack"
-        )
-    )]
     pub(crate) async fn postgres(url: &str, handle: Handle) -> Result<Self, SearchStoreError> {
         Ok(Self {
             backend: SearchStorageBackend::Postgres(
@@ -271,6 +266,12 @@ impl SearchStorage {
             SearchStorageBackend::Sqlite(_) => Ok(Vec::new()),
             SearchStorageBackend::Postgres(storage) => Ok(storage.migrate_all().await?),
         }
+    }
+
+    /// Whether this backend keeps observed values at all; when it does not,
+    /// the capture pipeline has nowhere to write and must not start.
+    pub(crate) fn keeps_observed_values(&self) -> bool {
+        self.observed_values().is_some()
     }
 
     /// The observed-values store, when this backend keeps observed values.

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -87,6 +87,38 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     }
 }
 
+#[tokio::test]
+async fn server_lifecycle_rejects_postgres_search_over_a_sqlite_database() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[search]\nbackend = \"postgres\"\n",
+    )
+    .expect("write config");
+
+    let result = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(server) => {
+            server.shutdown().await.expect("shutdown unexpected server");
+            panic!("server start should fail when search is on Postgres but the database is not");
+        }
+    };
+
+    match error {
+        LocalServerError::FailedPrecondition(detail) => assert!(
+            detail.contains("requires [database].backend = \"postgres\""),
+            "unexpected detail: {detail}"
+        ),
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
 async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
     let database_file = config_dir.join("coral.db");
     assert!(

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -8,6 +8,11 @@
 use std::collections::BTreeMap;
 use std::fs;
 
+use coral_api::v1::{
+    CreateWorkspaceRequest, DeleteWorkspaceRequest, SearchProvider, SearchProviderState,
+    SearchRequest, Workspace,
+};
+use coral_client::AppClient;
 use coral_client::local::ServerBuilder;
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
@@ -18,6 +23,157 @@ use coral_spec::{
 };
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
+use tonic::Request;
+
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Postgres catalog search end to end"]
+async fn server_serves_catalog_search_from_postgres_and_removes_deleted_workspace_state() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n\n[search]\nbackend = \"postgres\"\n",
+    )
+    .expect("write config");
+    let pool = PgPoolOptions::new()
+        .connect(&database_url)
+        .await
+        .expect("open Postgres database");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server with Postgres search config");
+    let registry_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('search_registry.workspaces') IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("probe search registry");
+    assert!(registry_exists, "boot must bootstrap the search registry");
+    assert!(
+        !config_dir.join("workspaces").exists()
+            || !any_sqlite_search_file(&config_dir.join("workspaces")),
+        "no SQLite search sidecar may exist with the Postgres backend"
+    );
+
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    let workspace_name = format!("usp-e2e-{}", uuid::Uuid::new_v4().simple());
+    let workspace = Workspace {
+        name: workspace_name.clone(),
+    };
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace.clone()),
+        }))
+        .await
+        .expect("create workspace");
+
+    assert_search_reports_postgres_provider_statuses(&app, &workspace).await;
+
+    let surrogate_id = registry_surrogate_id(&pool, &workspace_name)
+        .await
+        .expect("the first search registers the workspace");
+    let schema = format!("search_ws_{surrogate_id}");
+    assert!(
+        postgres_schema_exists(&pool, &schema).await,
+        "schema {schema} must exist after the first search"
+    );
+
+    app.workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace),
+        }))
+        .await
+        .expect("delete workspace");
+    assert_eq!(
+        registry_surrogate_id(&pool, &workspace_name).await,
+        None,
+        "deletion must remove the registry row"
+    );
+    assert!(
+        !postgres_schema_exists(&pool, &schema).await,
+        "deletion must drop schema {schema}"
+    );
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+/// Catalog search on an empty Workspace answers `Empty`, and observed values
+/// report `not_enabled` naming the backend rather than erroring.
+async fn assert_search_reports_postgres_provider_statuses(app: &AppClient, workspace: &Workspace) {
+    let response = app
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(workspace.clone()),
+            query: "benchmark".to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect("search")
+        .into_inner();
+    assert_eq!(response.provider_statuses.len(), 3);
+    let status = |provider: SearchProvider| {
+        response
+            .provider_statuses
+            .iter()
+            .find(|status| status.provider == provider as i32)
+            .unwrap_or_else(|| panic!("missing status for {provider:?}"))
+    };
+    assert_eq!(
+        status(SearchProvider::CatalogMetadata).state,
+        SearchProviderState::Empty as i32,
+        "an empty catalog is served, not errored: {:?}",
+        status(SearchProvider::CatalogMetadata)
+    );
+    let observed = status(SearchProvider::ObservedValues);
+    assert_eq!(observed.state, SearchProviderState::NotEnabled as i32);
+    assert!(
+        observed
+            .note
+            .contains("not available on the postgres search backend"),
+        "unexpected observed note: {}",
+        observed.note
+    );
+}
+
+async fn registry_surrogate_id(pool: &sqlx::PgPool, workspace_name: &str) -> Option<i64> {
+    sqlx::query_scalar(
+        "SELECT surrogate_id FROM search_registry.workspaces WHERE workspace_name = $1",
+    )
+    .bind(workspace_name)
+    .fetch_optional(pool)
+    .await
+    .expect("read registry row")
+}
+
+fn any_sqlite_search_file(root: &std::path::Path) -> bool {
+    fs::read_dir(root).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                any_sqlite_search_file(&path)
+            } else {
+                path.extension()
+                    .is_some_and(|extension| extension == "sqlite3")
+            }
+        })
+    })
+}
+
+async fn postgres_schema_exists(pool: &sqlx::PgPool, schema: &str) -> bool {
+    sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = $1)")
+        .bind(schema)
+        .fetch_one(pool)
+        .await
+        .expect("probe schema")
+}
 
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]


### PR DESCRIPTION
Add `[search] backend = "sqlite" | "postgres"`, defaulting to follow
`[database].backend`. Validation mirrors the `[database]` section:
unknown keys are rejected and the section carries no path or URL of its
own, because the Postgres backend reuses the resolved database URL.
Selecting `postgres` beside a SQLite database is rejected at boot with
the reason.

Startup resolves the section next to the database config, opens the
selected backend (failing loudly, naming the capability, when Postgres
lacks `pg_trgm`), and starts the observed-values capture pipeline only
when the backend keeps observed values. This is the change that puts a
`[database] backend = "postgres"` deployment onto Postgres catalog
search; every earlier change in the stack was inert without it.

Covered end to end behind `CORAL_TEST_POSTGRES_URL`: a server on the
Postgres search backend bootstraps the registry, answers a search with
the catalog provider `empty` and observed values `not_enabled` naming
the backend, registers the Workspace on first search, and leaves
neither registry row nor schema after the Workspace is deleted.

https://claude.ai/code/session_01WGJRTvciKJkDniTJVSwSY1
