### PR TITLE
feat(ui): route workspace users management

### DIFF
--- a/apps/coral-ui/app/components/sidebar/sidebar.tsx
+++ b/apps/coral-ui/app/components/sidebar/sidebar.tsx
@@ -70,11 +70,15 @@ export function Sidebar({
   const tracesPath = workspaceNavTarget
     ? routePath('workspaceTraces', { workspaceId: workspaceNavTarget.name })
     : routePath('home')
+  const usersPath = workspaceNavTarget
+    ? routePath('workspaceUsers', { workspaceId: workspaceNavTarget.name })
+    : routePath('home')
   const workspaceNavItems = [
     { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
     { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
     { icon: 'Braces', label: 'Functions', paths: [functionsPath], to: functionsPath },
     { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
+    { icon: 'Users', label: 'Users', paths: [usersPath], to: usersPath },
   ] satisfies NavItem[]
   const settingsPath = routePath('settings')
   const mcpClientsPath = routePath('settingsMcpClients')

--- a/apps/coral-ui/app/components/workspace-users/workspace-users.tsx
+++ b/apps/coral-ui/app/components/workspace-users/workspace-users.tsx
@@ -43,8 +43,9 @@ export interface WorkspaceUsersActionData {
    * user per call, so a batch add can land in part and the route reports the rest.
    */
   readonly failures?: ReadonlyArray<WorkspaceUserFailure>
-  readonly intent: 'add' | 'remove' | 'role'
+  readonly intent: 'add' | 'remove' | 'role' | 'unsupported'
   readonly message: string
+  readonly removedCurrentUser?: boolean
   readonly status: 'error' | 'success'
   /** The users the action was about. One add can carry several. */
   readonly userIds: ReadonlyArray<string>
@@ -506,7 +507,7 @@ function WorkspaceUserRow({
             </Dialog.Title>
             <Dialog.Description>
               {member.userId === currentUserId
-                ? `You will lose access to ${workspaceName}.`
+                ? `You will lose access to ${workspaceName} and be redirected.`
                 : `${member.displayName || member.userId} will lose access to ${workspaceName}.`}
             </Dialog.Description>
             {removalError ? <Banner variant="error">{removalError}</Banner> : null}

--- a/apps/coral-ui/app/lib/coral-request.server.ts
+++ b/apps/coral-ui/app/lib/coral-request.server.ts
@@ -15,6 +15,7 @@ import { GuiOnboardingService } from '@/generated/coral/v1/gui_onboarding_pb'
 import { QueryService } from '@/generated/coral/v1/query_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
 import { TraceService } from '@/generated/coral/v1/traces_pb'
+import { UserService } from '@/generated/coral/v1/users_pb'
 import { WorkspaceService } from '@/generated/coral/v1/workspaces_pb'
 import { Health } from '@/generated/grpc/health/v1/health_pb'
 import { expiredSessionRedirect } from '@/auth/response.server'
@@ -27,6 +28,10 @@ export function sourceClientForRequest(request: Request, accessToken: string | n
 
 export function workspaceClientForRequest(request: Request, accessToken: string | null) {
   return createClient(WorkspaceService, coralTransportForRequest(request, accessToken))
+}
+
+export function userClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(UserService, coralTransportForRequest(request, accessToken))
 }
 
 export function catalogClientForRequest(request: Request, accessToken: string | null) {

--- a/apps/coral-ui/app/lib/workspace-routing.test.ts
+++ b/apps/coral-ui/app/lib/workspace-routing.test.ts
@@ -23,6 +23,7 @@ describe('workspace routing', () => {
     ['/workspaces/default/schema/github/issues', '/workspaces/team%20alpha/schema'],
     ['/workspaces/default/functions', '/workspaces/team%20alpha/functions'],
     ['/workspaces/default/traces/trace-1', '/workspaces/team%20alpha/traces'],
+    ['/workspaces/default/users', '/workspaces/team%20alpha/users'],
     ['/settings', '/workspaces/team%20alpha/sources'],
   ])('targets the corresponding section for %s', (pathname, expectedPath) => {
     expect(workspacePathForCurrentSection('team alpha', pathname)).toBe(expectedPath)

--- a/apps/coral-ui/app/lib/workspace-routing.ts
+++ b/apps/coral-ui/app/lib/workspace-routing.ts
@@ -26,7 +26,10 @@ export function workspacePathForCurrentSection(workspaceId: string, pathname: st
   if (isSchemaSection) return routePath('workspaceSchema', { workspaceId })
 
   const isTracesSection = matchPath({ end: false, path: routePattern('workspaceTraces') }, pathname)
-  return isTracesSection
-    ? routePath('workspaceTraces', { workspaceId })
+  if (isTracesSection) return routePath('workspaceTraces', { workspaceId })
+
+  const isUsersSection = matchPath({ end: false, path: routePattern('workspaceUsers') }, pathname)
+  return isUsersSection
+    ? routePath('workspaceUsers', { workspaceId })
     : routePath('workspaceSources', { workspaceId })
 }

--- a/apps/coral-ui/app/routes.ts
+++ b/apps/coral-ui/app/routes.ts
@@ -37,6 +37,7 @@ export default [
       route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
         route(':traceId', 'routes/trace-detail.tsx'),
       ]),
+      route(routePattern('workspaceUsers'), 'routes/workspace-users.tsx'),
       route(routePattern('settings'), 'routes/settings.tsx', [
         index('routes/settings/index.ts'),
         route('mcp-clients', 'routes/settings/mcp-clients.tsx'),

--- a/apps/coral-ui/app/routes/workspace-users.tsx
+++ b/apps/coral-ui/app/routes/workspace-users.tsx
@@ -1,0 +1,254 @@
+import { create } from '@bufbuild/protobuf'
+import { data, redirect } from 'react-router'
+
+import type { Route } from './+types/workspace-users'
+
+import { requestAuthContext } from '@/auth/server-context'
+import {
+  WorkspaceUsers,
+  type WorkspaceUser,
+  type WorkspaceUserCandidate,
+  type WorkspaceUserRole,
+  type WorkspaceUsersActionData,
+  type WorkspaceUsersData,
+} from '@/components/workspace-users'
+import {
+  AddWorkspaceMemberRequestSchema,
+  ListWorkspaceMembersRequestSchema,
+  RemoveWorkspaceMemberRequestSchema,
+  WorkspaceRole,
+  type WorkspaceMember,
+  type WorkspaceMembership,
+} from '@/generated/coral/v1/workspaces_pb'
+import { GetCurrentUserRequestSchema, ListUsersRequestSchema } from '@/generated/coral/v1/users_pb'
+import { userClientForRequest, workspaceClientForRequest } from '@/lib/coral-request.server'
+import { errorMessage } from '@/lib/utils'
+import { routePath } from '@/routing/routemap'
+import { addToast } from '@/wax/components/toast'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<WorkspaceUsersData> {
+  const accessToken = context.get(requestAuthContext).accessToken
+  const workspace = workspaceFromParams(params)
+  const workspaceClient = workspaceClientForRequest(request, accessToken)
+  const userClient = userClientForRequest(request, accessToken)
+
+  const [currentUserResponse, workspacesResponse] = await Promise.all([
+    userClient.getCurrentUser(create(GetCurrentUserRequestSchema, {}), { signal: request.signal }),
+    workspaceClient.listWorkspaces({}, { signal: request.signal }),
+  ])
+  const currentUser = currentUserResponse.user
+  if (!currentUser) throw new Error('Coral did not return the current user')
+
+  const currentMembership = membershipForWorkspace(workspacesResponse.memberships, workspace.name)
+  if (!currentMembership) {
+    throw new Response('Workspace not found.', {
+      status: 404,
+      statusText: 'Workspace Not Found',
+    })
+  }
+
+  const currentUserRole = toWorkspaceUserRole(currentMembership.role)
+  const baseData = {
+    availableUsers: [],
+    currentUserId: currentUser.userId,
+    currentUserRole,
+    members: [],
+    workspaceName: workspace.name,
+  } satisfies WorkspaceUsersData
+
+  if (currentUserRole !== 'owner') return baseData
+
+  try {
+    const [directory, roster] = await Promise.all([
+      userClient.listUsers(create(ListUsersRequestSchema, {}), { signal: request.signal }),
+      workspaceClient.listWorkspaceMembers(
+        create(ListWorkspaceMembersRequestSchema, { workspace }),
+        { signal: request.signal },
+      ),
+    ])
+
+    return {
+      ...baseData,
+      availableUsers: directory.users.map(toWorkspaceUserCandidate),
+      members: roster.members.map(toWorkspaceUser),
+    }
+  } catch (error) {
+    return { ...baseData, error: errorMessage(error) }
+  }
+}
+
+export async function action({ context, params, request }: Route.ActionArgs) {
+  const formData = await request.formData()
+  const intent = formIntent(formData)
+  if (!intent) {
+    return data(actionError('unsupported', [], 'Unsupported workspace user action.'), {
+      status: 400,
+    })
+  }
+
+  const userIds = formStrings(formData, 'userId')
+  if (userIds.length === 0) return actionError(intent, [], 'Choose a user.')
+
+  const workspace = workspaceFromParams(params)
+  const accessToken = context.get(requestAuthContext).accessToken
+  const workspaceClient = workspaceClientForRequest(request, accessToken)
+
+  try {
+    if (intent === 'remove') {
+      const userId = userIds[0]
+      const currentUserResponse = await userClientForRequest(request, accessToken).getCurrentUser(
+        create(GetCurrentUserRequestSchema, {}),
+        { signal: request.signal },
+      )
+      const currentUser = currentUserResponse.user
+      if (!currentUser) throw new Error('Coral did not return the current user')
+
+      await workspaceClient.removeWorkspaceMember(
+        create(RemoveWorkspaceMemberRequestSchema, { userId, workspace }),
+        { signal: request.signal },
+      )
+      return actionSuccess(intent, userId, 'Workspace user removed.', {
+        removedCurrentUser: currentUser.userId === userId,
+      })
+    }
+
+    const role = formRole(formData)
+    if (!role) return actionError(intent, userIds, 'Choose a role.')
+
+    if (intent === 'add') {
+      const results = await Promise.allSettled(
+        userIds.map((userId) =>
+          workspaceClient.addWorkspaceMember(
+            create(AddWorkspaceMemberRequestSchema, { role, userId, workspace }),
+            { signal: request.signal },
+          ),
+        ),
+      )
+      const added = userIds.filter((_, index) => results[index].status === 'fulfilled')
+      const failures = results.flatMap((result, index) =>
+        result.status === 'rejected'
+          ? [{ message: errorMessage(result.reason), userId: userIds[index] }]
+          : [],
+      )
+
+      if (failures.length > 0) {
+        return {
+          failures,
+          intent,
+          message:
+            added.length > 0
+              ? `Added ${added.length} of ${userIds.length} users.`
+              : 'Coral could not add these users.',
+          status: added.length > 0 ? 'success' : 'error',
+          userIds: added,
+        } satisfies WorkspaceUsersActionData
+      }
+
+      return actionSuccess(intent, userIds, 'Workspace users added.')
+    }
+
+    await workspaceClient.addWorkspaceMember(
+      create(AddWorkspaceMemberRequestSchema, { role, userId: userIds[0], workspace }),
+      { signal: request.signal },
+    )
+    return actionSuccess(intent, userIds, 'Workspace user updated.')
+  } catch (error) {
+    return actionError(intent, userIds, errorMessage(error))
+  }
+}
+
+export async function clientAction({ params, serverAction }: Route.ClientActionArgs) {
+  const result = await serverAction()
+  if (result.status !== 'success' || result.intent !== 'remove' || !result.removedCurrentUser) {
+    return result
+  }
+
+  addToast('success', {
+    description: 'You no longer have access to this workspace.',
+    title: `Left ${params.workspaceId}`,
+  })
+  return redirect(routePath('home'))
+}
+
+export default function WorkspaceUsersRoute({ loaderData }: Route.ComponentProps) {
+  return <WorkspaceUsers data={loaderData} />
+}
+
+function membershipForWorkspace(
+  memberships: readonly WorkspaceMembership[],
+  workspaceName: string,
+): WorkspaceMembership | undefined {
+  return memberships.find((membership) => membership.workspace?.name === workspaceName)
+}
+
+function toWorkspaceUser(member: WorkspaceMember): WorkspaceUser {
+  return {
+    displayName: member.displayName || undefined,
+    role: toWorkspaceUserRole(member.role),
+    userId: member.userId,
+  }
+}
+
+function toWorkspaceUserCandidate(user: {
+  displayName: string
+  userId: string
+}): WorkspaceUserCandidate {
+  return {
+    displayName: user.displayName || undefined,
+    userId: user.userId,
+  }
+}
+
+function toWorkspaceUserRole(role: WorkspaceRole): WorkspaceUserRole {
+  if (role === WorkspaceRole.OWNER) return 'owner'
+  if (role === WorkspaceRole.MEMBER) return 'member'
+  throw new Error(`Coral returned an unsupported workspace role: ${role}`)
+}
+
+function formIntent(
+  formData: FormData,
+): Exclude<WorkspaceUsersActionData['intent'], 'unsupported'> | undefined {
+  const intent = formData.get('intent')
+  return intent === 'add' || intent === 'remove' || intent === 'role' ? intent : undefined
+}
+
+function formRole(formData: FormData): WorkspaceRole | undefined {
+  const role = formData.get('role')
+  if (role === 'owner') return WorkspaceRole.OWNER
+  if (role === 'member') return WorkspaceRole.MEMBER
+  return undefined
+}
+
+function formStrings(formData: FormData, key: string): string[] {
+  return formData
+    .getAll(key)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+}
+
+function actionSuccess(
+  intent: WorkspaceUsersActionData['intent'],
+  userIds: string | ReadonlyArray<string>,
+  message: string,
+  extra?: Pick<WorkspaceUsersActionData, 'removedCurrentUser'>,
+): WorkspaceUsersActionData {
+  return {
+    intent,
+    message,
+    status: 'success',
+    userIds: typeof userIds === 'string' ? [userIds] : userIds,
+    ...extra,
+  }
+}
+
+function actionError(
+  intent: WorkspaceUsersActionData['intent'],
+  userIds: ReadonlyArray<string>,
+  message: string,
+): WorkspaceUsersActionData {
+  return { intent, message, status: 'error', userIds }
+}

--- a/apps/coral-ui/app/routing/routemap.ts
+++ b/apps/coral-ui/app/routing/routemap.ts
@@ -18,6 +18,7 @@ const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
 const WORKSPACE_SOURCE_PATH = '/workspaces/:workspaceId/sources/:sourceName'
 const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
 const WORKSPACE_TRACE_PATH = '/workspaces/:workspaceId/traces/:traceId'
+const WORKSPACE_USERS_PATH = '/workspaces/:workspaceId/users'
 const SETTINGS_PATH = '/settings'
 const SETTINGS_MCP_CLIENTS_PATH = '/settings/mcp-clients'
 const SETTINGS_RUNTIME_FEATURES_PATH = '/settings/runtime-features'
@@ -141,6 +142,13 @@ export const routeDefinitions = {
     path: WORKSPACE_TRACES_PATH,
     toPath: (params: { workspaceId: string }) =>
       generatePath(WORKSPACE_TRACES_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceUsers: {
+    path: WORKSPACE_USERS_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_USERS_PATH, {
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/coral-ui/buf.gen.yaml
+++ b/apps/coral-ui/buf.gen.yaml
@@ -17,5 +17,6 @@ inputs:
       - ../../crates/coral-api/proto/coral/v1/sources.proto
       - ../../crates/coral-api/proto/coral/v1/task.proto
       - ../../crates/coral-api/proto/coral/v1/traces.proto
+      - ../../crates/coral-api/proto/coral/v1/users.proto
       - ../../crates/coral-api/proto/coral/v1/workspaces.proto
       - ../../crates/coral-api/proto/grpc/health/v1/health.proto


### PR DESCRIPTION
### TL;DR

Adds a Users page to the workspace sidebar, allowing workspace owners to manage workspace members.

### What changed?

- Added a **Users** nav item to the workspace sidebar linking to `/workspaces/:workspaceId/users`
- Introduced a new `workspace-users` route with a loader, server action, and client action that handles adding, removing, and updating roles for workspace members
- When a user removes themselves from a workspace, they are redirected to the home page with a toast notification
- The removal confirmation dialog now informs the current user they will be redirected after losing access
- Added `removedCurrentUser` to `WorkspaceUsersActionData` and an `'unsupported'` intent variant to handle invalid form submissions
- Registered `workspaceUsers` in the route map and workspace section routing logic so switching workspaces preserves the Users section context
- Wired up the `UserService` proto client via a new `userClientForRequest` helper and included `users.proto` in the buf code generation config

### How to test?

1. Navigate to a workspace and confirm a **Users** item appears in the sidebar.
2. As a workspace owner, open the Users page and verify the member list and available users are displayed.
3. Add a user to the workspace and confirm the success toast appears.
4. Change a member's role and confirm the update is reflected.
5. Remove another user and confirm they are removed without redirecting the current user.
6. Remove yourself from the workspace and confirm you are redirected to the home page with a toast indicating you left the workspace.
7. As a non-owner member, open the Users page and confirm the member management controls are not shown.

### Why make this change?

Workspace user management was previously inaccessible from the UI. This change surfaces it as a first-class section in the workspace navigation, giving workspace owners a dedicated place to add, remove, and update the roles of workspace members.