### PR TITLE
fix(coral-ui): anchor wax Combobox InputGroup to Base UI

### DIFF
--- a/apps/coral-ui/app/wax/components/combobox/combobox.css.ts
+++ b/apps/coral-ui/app/wax/components/combobox/combobox.css.ts
@@ -168,6 +168,7 @@ export const inputBare = style({
 export const inputGroup = style({
   alignItems: 'center',
   backgroundColor: 'transparent',
+  cursor: 'text',
   border: `1px solid ${theme.input.stroke.default}`,
   borderRadius: '8px',
   boxShadow: 'none',

--- a/apps/coral-ui/app/wax/components/combobox/input-group.tsx
+++ b/apps/coral-ui/app/wax/components/combobox/input-group.tsx
@@ -1,3 +1,4 @@
+import { Combobox as BaseCombobox } from '@base-ui/react/combobox'
 import classNames from 'classnames'
 import { useCallback } from 'react'
 
@@ -19,8 +20,11 @@ export function InputGroup({ children, className }: InputGroupProps) {
   )
 
   return (
-    <div className={classNames(styles.inputGroup, className)} ref={setInputGroupAnchor}>
+    <BaseCombobox.InputGroup
+      className={classNames(styles.inputGroup, className)}
+      ref={setInputGroupAnchor}
+    >
       {children}
-    </div>
+    </BaseCombobox.InputGroup>
   )
 }


### PR DESCRIPTION
## Summary

Render InputGroup as BaseCombobox.InputGroup instead of a plain div so clicking anywhere in the group focuses the input, and pair it with a text cursor.