### PR TITLE
fix(app): stop state-lock waits from starving the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,6 @@ dependencies = [
  "coral-spec",
  "coral-telemetry",
  "etcetera",
- "fs2",
  "jsonwebtoken",
  "keyring-core",
  "opentelemetry",
@@ -3090,16 +3089,6 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -22,7 +22,6 @@ axum = { workspace = true, features = ["http1", "tokio"] }
 base64.workspace = true
 chrono.workspace = true
 etcetera.workspace = true
-fs2.workspace = true
 keyring-core.workspace = true
 jsonwebtoken.workspace = true
 opentelemetry.workspace = true

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -5,7 +5,6 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
 use uuid::Uuid;
 
 pub(crate) fn ensure_dir(path: &Path) -> io::Result<()> {
@@ -204,15 +203,60 @@ pub(crate) struct FileLock {
 
 impl FileLock {
     pub(crate) fn shared(path: &Path) -> io::Result<Self> {
-        let file = open_lock_file(path)?;
-        file.lock_shared()?;
-        Ok(Self { _file: file })
+        Self::acquire(path, File::try_lock_shared, File::lock_shared)
     }
 
     pub(crate) fn exclusive(path: &Path) -> io::Result<Self> {
+        Self::acquire(path, File::try_lock, File::lock)
+    }
+
+    /// Acquires the lock without parking a Tokio runtime worker for the wait.
+    ///
+    /// `flock(2)` blocks the OS thread and cannot be preempted, and these
+    /// acquisitions run on runtime workers: every query takes the state lock
+    /// shared, while source installs and config writes hold it exclusive
+    /// across filesystem I/O — seconds at a time when the state directory is
+    /// on network storage. Once as many shared waiters as the runtime has
+    /// workers pile up behind one slow exclusive holder, every worker is
+    /// parked in the syscall and the process is gone whole: no health
+    /// endpoints, no accept loop, nothing. On a two-CPU host two concurrent
+    /// queries suffice, and a liveness probe then kills a server that was
+    /// never stuck — only locked. `tests/state_lock_liveness.rs` pins this.
+    ///
+    /// The uncontended path stays a plain try-lock. A contended wait enters
+    /// [`tokio::task::block_in_place`] when — and only when — this thread is a
+    /// multi-thread-runtime worker: the runtime hands its queue to a
+    /// replacement thread, so lock waiters no longer consume the worker pool.
+    /// The flavor guard matters because `block_in_place` panics on a
+    /// current-thread runtime; there, and off-runtime (CLI paths, tests), the
+    /// wait blocks the thread exactly as before, which is the correct
+    /// behavior for a thread no runtime depends on. `spawn_blocking` would be
+    /// the conventional shape, but it forces `async` signatures through the
+    /// synchronous `ConfigStore` surface this lock guards, whose callers are
+    /// sync on purpose — see `state/config.rs`.
+    fn acquire(
+        path: &Path,
+        try_lock: fn(&File) -> Result<(), std::fs::TryLockError>,
+        lock: fn(&File) -> io::Result<()>,
+    ) -> io::Result<Self> {
         let file = open_lock_file(path)?;
-        file.lock_exclusive()?;
+        match try_lock(&file) {
+            Ok(()) => return Ok(Self { _file: file }),
+            Err(std::fs::TryLockError::WouldBlock) => {}
+            Err(std::fs::TryLockError::Error(error)) => return Err(error),
+        }
+        in_runtime_blocking_section(|| lock(&file))?;
         Ok(Self { _file: file })
+    }
+}
+
+/// Runs a blocking wait without starving a multi-thread Tokio runtime.
+fn in_runtime_blocking_section<T>(wait: impl FnOnce() -> T) -> T {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(wait)
+        }
+        _ => wait(),
     }
 }
 

--- a/crates/coral-app/tests/state_lock_liveness.rs
+++ b/crates/coral-app/tests/state_lock_liveness.rs
@@ -1,0 +1,151 @@
+//! Pins that a contended state lock cannot starve the runtime's liveness.
+//!
+//! The state lock is a blocking `flock(2)` acquired on runtime workers: every
+//! query takes it shared (`load_query_sources`), and source installs or config
+//! writes hold it exclusive across filesystem I/O — seconds at a time on
+//! network storage. Before `FileLock::acquire` routed contended waits through
+//! `block_in_place`, as many parked shared waiters as the runtime had workers
+//! wedged the process whole: health endpoints, readiness, even `accept(2)`
+//! stopped, and a liveness probe then killed a server that was only waiting.
+//! Observed in production on a two-CPU host, where two concurrent queries
+//! behind one slow exclusive holder were enough.
+//!
+//! The model here: an OS thread holds the lock file exclusively while two
+//! queries run on a two-worker runtime; an external prober (its own thread,
+//! runtime, and connection — the kubelet's view) must keep getting health
+//! answers within the 1s budget a kubelet probe defaults to.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set."
+)]
+
+use std::fs::OpenOptions;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use tonic::Request;
+
+use coral_api::v1::{CreateWorkspaceRequest, ExecuteSqlRequest};
+use coral_app::{ServerBuilder, shutdown_tracing};
+use coral_client::{AppClient, workspace};
+
+const KUBELET_BUDGET: Duration = Duration::from_secs(1);
+const HOLD: Duration = Duration::from_secs(2);
+
+async fn probe_once(client: &AppClient) -> Duration {
+    let start = Instant::now();
+    client.check_engine_ready().await.expect("health rpc");
+    start.elapsed()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn held_state_lock_must_not_starve_liveness() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("config.toml"), "version = 1\n").expect("write config");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server");
+
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    let ws = workspace("lock-repro");
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(ws.clone()),
+        }))
+        .await
+        .expect("create workspace");
+
+    // External prober on its own runtime + connection (the kubelet).
+    let endpoint = server.endpoint_uri().to_string();
+    let stop = Arc::new(AtomicBool::new(false));
+    let latencies: Arc<Mutex<Vec<Duration>>> = Arc::new(Mutex::new(Vec::new()));
+    let poller = {
+        let stop = Arc::clone(&stop);
+        let latencies = Arc::clone(&latencies);
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("prober runtime");
+            rt.block_on(async move {
+                let client = AppClient::connect(&endpoint).await.expect("prober connect");
+                probe_once(&client).await; // warm the readiness cache
+                while !stop.load(Ordering::Relaxed) {
+                    let elapsed = probe_once(&client).await;
+                    latencies.lock().unwrap().push(elapsed);
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            });
+        })
+    };
+    std::thread::sleep(Duration::from_millis(500));
+
+    // The slow exclusive holder: models a source install writing to EFS while
+    // holding state_lock_exclusive. Same flock, held from an OS thread.
+    let lock_path = config_dir.join(".lock");
+    let holder = std::thread::spawn(move || {
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .expect("open lock file");
+        file.lock().expect("exclusive flock");
+        std::thread::sleep(HOLD);
+        drop(file);
+    });
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Two trivial queries. Each takes state_lock_shared on a runtime worker.
+    let q = |sql: &str| {
+        let mut client = app.query_client();
+        let ws = ws.clone();
+        let sql = sql.to_string();
+        async move {
+            client
+                .execute_sql(Request::new(ExecuteSqlRequest {
+                    workspace: Some(ws),
+                    sql,
+                    guide_read_context: None,
+                    task_attribution: None,
+                }))
+                .await
+        }
+    };
+    let started = Instant::now();
+    let (r1, r2) = tokio::join!(q("SELECT 1"), q("SELECT 2"));
+    let query_elapsed = started.elapsed();
+
+    holder.join().expect("join holder");
+    stop.store(true, Ordering::Relaxed);
+    poller.join().expect("join poller");
+
+    let latencies = latencies.lock().unwrap();
+    let max = latencies.iter().max().copied().unwrap_or_default();
+    let over_budget = latencies.iter().filter(|l| **l > KUBELET_BUDGET).count();
+    eprintln!(
+        "queries: {:?}/{:?} in {query_elapsed:?}; probes={} max={max:?} over_1s={over_budget}",
+        r1.as_ref().map(|_| "ok").map_err(|e| e.code()),
+        r2.as_ref().map(|_| "ok").map_err(|e| e.code()),
+        latencies.len(),
+    );
+
+    shutdown_tracing();
+    server.shutdown().await.expect("shutdown");
+
+    assert_eq!(
+        over_budget, 0,
+        "{over_budget} health probes exceeded the kubelet budget (max {max:?}) while the state lock \
+         was contended — lock waiters starved the runtime"
+    );
+}

--- a/crates/coral-app/tests/state_lock_liveness.rs
+++ b/crates/coral-app/tests/state_lock_liveness.rs
@@ -22,7 +22,7 @@
 
 use std::fs::OpenOptions;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
@@ -34,6 +34,14 @@ use coral_client::{AppClient, workspace};
 
 const KUBELET_BUDGET: Duration = Duration::from_secs(1);
 const HOLD: Duration = Duration::from_secs(2);
+
+/// Waits for an OS-thread signal without parking a runtime worker.
+async fn recv_signal(rx: mpsc::Receiver<()>, what: &str) {
+    tokio::task::spawn_blocking(move || rx.recv_timeout(Duration::from_secs(30)))
+        .await
+        .expect("join recv task")
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"));
+}
 
 async fn probe_once(client: &AppClient) -> Duration {
     let start = Instant::now();
@@ -47,6 +55,7 @@ fn spawn_kubelet_prober(
     endpoint: String,
     stop: Arc<AtomicBool>,
     latencies: Arc<Mutex<Vec<Duration>>>,
+    warmed: mpsc::Sender<()>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -56,6 +65,7 @@ fn spawn_kubelet_prober(
         rt.block_on(async move {
             let client = AppClient::connect(&endpoint).await.expect("prober connect");
             probe_once(&client).await; // warm the readiness cache
+            warmed.send(()).expect("signal prober warmed");
             while !stop.load(Ordering::Relaxed) {
                 let elapsed = probe_once(&client).await;
                 latencies.lock().expect("latencies mutex").push(elapsed);
@@ -66,8 +76,13 @@ fn spawn_kubelet_prober(
 }
 
 /// The slow exclusive holder: models a source install writing through the
-/// state lock on slow storage. Same flock, held from an OS thread.
-fn hold_lock_exclusively(lock_path: std::path::PathBuf) -> std::thread::JoinHandle<()> {
+/// state lock on slow storage. Same flock, held from an OS thread. Sends on
+/// `held` once the lock is actually acquired, so the test can sequence on the
+/// lock itself rather than on wall-clock sleeps a loaded CI runner can miss.
+fn hold_lock_exclusively(
+    lock_path: std::path::PathBuf,
+    held: mpsc::Sender<()>,
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let file = OpenOptions::new()
             .create(true)
@@ -76,6 +91,7 @@ fn hold_lock_exclusively(lock_path: std::path::PathBuf) -> std::thread::JoinHand
             .open(&lock_path)
             .expect("open lock file");
         file.lock().expect("exclusive flock");
+        held.send(()).expect("signal lock held");
         std::thread::sleep(HOLD);
         drop(file);
     })
@@ -107,15 +123,18 @@ async fn held_state_lock_must_not_starve_liveness() {
 
     let stop = Arc::new(AtomicBool::new(false));
     let latencies: Arc<Mutex<Vec<Duration>>> = Arc::new(Mutex::new(Vec::new()));
+    let (warmed_tx, warmed_rx) = mpsc::channel();
     let poller = spawn_kubelet_prober(
         server.endpoint_uri().to_string(),
         Arc::clone(&stop),
         Arc::clone(&latencies),
+        warmed_tx,
     );
-    std::thread::sleep(Duration::from_millis(500));
+    recv_signal(warmed_rx, "prober warm-up").await;
 
-    let holder = hold_lock_exclusively(config_dir.join(".lock"));
-    std::thread::sleep(Duration::from_millis(200));
+    let (held_tx, held_rx) = mpsc::channel();
+    let holder = hold_lock_exclusively(config_dir.join(".lock"), held_tx);
+    recv_signal(held_rx, "exclusive lock acquisition").await;
 
     // Two trivial queries. Each takes state_lock_shared on a runtime worker.
     let q = |sql: &str| {

--- a/crates/coral-app/tests/state_lock_liveness.rs
+++ b/crates/coral-app/tests/state_lock_liveness.rs
@@ -41,6 +41,46 @@ async fn probe_once(client: &AppClient) -> Duration {
     start.elapsed()
 }
 
+/// The kubelet's view: an OS thread with its own runtime and connection,
+/// probing the health service every 100ms and recording each round trip.
+fn spawn_kubelet_prober(
+    endpoint: String,
+    stop: Arc<AtomicBool>,
+    latencies: Arc<Mutex<Vec<Duration>>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("prober runtime");
+        rt.block_on(async move {
+            let client = AppClient::connect(&endpoint).await.expect("prober connect");
+            probe_once(&client).await; // warm the readiness cache
+            while !stop.load(Ordering::Relaxed) {
+                let elapsed = probe_once(&client).await;
+                latencies.lock().expect("latencies mutex").push(elapsed);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+    })
+}
+
+/// The slow exclusive holder: models a source install writing through the
+/// state lock on slow storage. Same flock, held from an OS thread.
+fn hold_lock_exclusively(lock_path: std::path::PathBuf) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .expect("open lock file");
+        file.lock().expect("exclusive flock");
+        std::thread::sleep(HOLD);
+        drop(file);
+    })
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn held_state_lock_must_not_starve_liveness() {
     let temp = TempDir::new().expect("temp dir");
@@ -65,45 +105,16 @@ async fn held_state_lock_must_not_starve_liveness() {
         .await
         .expect("create workspace");
 
-    // External prober on its own runtime + connection (the kubelet).
-    let endpoint = server.endpoint_uri().to_string();
     let stop = Arc::new(AtomicBool::new(false));
     let latencies: Arc<Mutex<Vec<Duration>>> = Arc::new(Mutex::new(Vec::new()));
-    let poller = {
-        let stop = Arc::clone(&stop);
-        let latencies = Arc::clone(&latencies);
-        std::thread::spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("prober runtime");
-            rt.block_on(async move {
-                let client = AppClient::connect(&endpoint).await.expect("prober connect");
-                probe_once(&client).await; // warm the readiness cache
-                while !stop.load(Ordering::Relaxed) {
-                    let elapsed = probe_once(&client).await;
-                    latencies.lock().unwrap().push(elapsed);
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-            });
-        })
-    };
+    let poller = spawn_kubelet_prober(
+        server.endpoint_uri().to_string(),
+        Arc::clone(&stop),
+        Arc::clone(&latencies),
+    );
     std::thread::sleep(Duration::from_millis(500));
 
-    // The slow exclusive holder: models a source install writing to EFS while
-    // holding state_lock_exclusive. Same flock, held from an OS thread.
-    let lock_path = config_dir.join(".lock");
-    let holder = std::thread::spawn(move || {
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(false)
-            .open(&lock_path)
-            .expect("open lock file");
-        file.lock().expect("exclusive flock");
-        std::thread::sleep(HOLD);
-        drop(file);
-    });
+    let holder = hold_lock_exclusively(config_dir.join(".lock"));
     std::thread::sleep(Duration::from_millis(200));
 
     // Two trivial queries. Each takes state_lock_shared on a runtime worker.
@@ -130,22 +141,33 @@ async fn held_state_lock_must_not_starve_liveness() {
     stop.store(true, Ordering::Relaxed);
     poller.join().expect("join poller");
 
-    let latencies = latencies.lock().unwrap();
-    let max = latencies.iter().max().copied().unwrap_or_default();
-    let over_budget = latencies.iter().filter(|l| **l > KUBELET_BUDGET).count();
-    eprintln!(
-        "queries: {:?}/{:?} in {query_elapsed:?}; probes={} max={max:?} over_1s={over_budget}",
-        r1.as_ref().map(|_| "ok").map_err(|e| e.code()),
-        r2.as_ref().map(|_| "ok").map_err(|e| e.code()),
-        latencies.len(),
-    );
+    // Read the shared vec before the awaits below: a MutexGuard must not be
+    // held across an await point (clippy::await_holding_lock).
+    let (polls, max, over_budget) = {
+        let latencies = latencies.lock().expect("latencies mutex");
+        (
+            latencies.len(),
+            latencies.iter().max().copied().unwrap_or_default(),
+            latencies.iter().filter(|l| **l > KUBELET_BUDGET).count(),
+        )
+    };
+    r1.expect("query behind the contended lock should still succeed");
+    r2.expect("query behind the contended lock should still succeed");
 
     shutdown_tracing();
     server.shutdown().await.expect("shutdown");
 
+    assert!(
+        query_elapsed >= Duration::from_millis(500),
+        "queries finished in {query_elapsed:?} without waiting for the lock; the hold never contended"
+    );
+    assert!(
+        polls > 3,
+        "prober produced only {polls} samples; harness broken"
+    );
     assert_eq!(
         over_budget, 0,
-        "{over_budget} health probes exceeded the kubelet budget (max {max:?}) while the state lock \
-         was contended — lock waiters starved the runtime"
+        "{over_budget} of {polls} health probes exceeded the kubelet budget (max {max:?}) while the \
+         state lock was contended — lock waiters starved the runtime"
     );
 }


### PR DESCRIPTION
## Intent

A server under ordinary concurrent load can go entirely dark — no health
endpoints, no readiness, not even TCP accept — and get killed by its own
liveness probe, because state-lock waits park Tokio runtime workers inside an
unpreemptible `flock(2)`.

The state lock is acquired on runtime workers: every query takes it shared
(`load_query_sources`), while source installs, deletes, and config writes hold
it exclusive **across filesystem I/O** — seconds at a time when `CORAL_CONFIG_DIR`
sits on network storage (EFS). Once as many shared waiters as the runtime has
workers pile up behind one slow exclusive holder, every worker is parked in the
syscall. On a two-CPU host — Tokio sizes its pool from `nproc` — **two concurrent
queries suffice**.

Observed in production (EKS Fargate, 2 vCPU, config on EFS): 15 liveness kills
in one morning, each preceded by `Liveness probe failed: ... context deadline
exceeded` and readiness `failed to connect within 3s` — the accept loop itself
starved. Query durations showed 22s averages that were lock wait, not work.

## The fix

`FileLock::acquire` now takes the lock in two steps: an uncontended `try_lock`
fast path, and — only on contention — the blocking wait routed through
`tokio::task::block_in_place` when the thread is a multi-thread-runtime worker.
`block_in_place` hands the worker's queue to a replacement thread, so lock
waiters no longer consume the worker pool. Off-runtime and on current-thread
runtimes (where `block_in_place` panics) the wait blocks the calling thread
exactly as before.

`spawn_blocking` would be the conventional shape but forces `async` through the
deliberately synchronous `ConfigStore` surface; `block_in_place` fixes the
starvation at the single seam where the blocking happens, with no signature
changes.

Also removes the vestigial `fs2` dependency from `coral-app`: since Rust 1.89
the inherent `std::fs::File` locking methods shadowed the `fs2::FileExt` trait
methods, so `fs2` was already unused in practice.

## Verification

New regression test `coral-app/tests/state_lock_liveness.rs` reproduces the
production topology in-process: a two-worker runtime, an external prober on its
own thread/runtime/connection (the kubelet's view), an exclusive lock held for
2s by an OS thread, and two concurrent queries.

- **Before this change**: probe max **3.82s** — the runtime is wedged for the
  full hold; the same scenario with sequential queries (one worker always free)
  probes at 9ms, isolating worker-pool exhaustion as the mechanism.
- **After**: probe max **5.6ms**, and the queries still correctly wait out the
  lock (their duration equals the remaining hold — semantics unchanged, only
  *who* waits changed).

A negative control was also run and kept out of the tree: 21.5s of pure
DataFusion compute on the same two-worker runtime never pushed a probe past
3.5ms — query *execution* yields correctly; only the lock wait starved.

`make rust-checks` passes.
