### PR TITLE
fix(release): create a workspace before smoking `source discover`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,9 +113,21 @@ jobs:
         shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
+        # Strict mode, because GitHub's pwsh shell only propagates the LAST
+        # command's exit code: a failing command followed by a passing one
+        # reads as a green step. That masking hid the fresh-install workspace
+        # regression in validate's smoke until this workflow — where the same
+        # command happens to come last — failed the v0.15.0 tag build.
+        #
+        # The workspace is created first because that is what a fresh install
+        # requires since workspace access control: `source discover` on a
+        # stateless machine exits 1 by design, telling the user to create one.
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           $coral = "target\$env:TARGET\release\coral.exe"
           & $coral --version
+          & $coral workspace create smoke
           & $coral source discover
 
       - name: Package Linux

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -284,8 +284,17 @@ jobs:
 
       - name: Smoke CLI
         shell: pwsh
+        # Strict mode: without it only the final command's exit code decides
+        # the step, and this step passed for days while `source discover` was
+        # failing on every run — the trailing completion call reset the exit
+        # code. The workspace is created first because a fresh install has
+        # none since workspace access control, and `source discover` without
+        # one exits 1 by design.
         run: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           .\target\debug\coral.exe --version
+          .\target\debug\coral.exe workspace create smoke
           .\target\debug\coral.exe source discover
           .\target\debug\coral.exe completion powershell > $null
 


### PR DESCRIPTION
## Intent

Unblock the 0.15.0 release line. The `v0.15.0` tag build failed at **Smoke Windows release binary** and never reached `publish-docker`, so no 0.15.0 images exist.

## Root cause, two layers

1. **Product (intended)**: since workspace access control, a fresh install has no implicit workspace — `coral source discover` exits 1 with instructions. The smoke tests still modelled the pre-0.15 world.
2. **CI (masking)**: GitHub pwsh steps fail only on the *last* command's exit code. Validate's Windows smoke has `completion powershell` after `source discover`, so its runs were green **with the failure in their logs** since the access-control merge. The release smoke ends on `source discover`, which is why the tag build was the first red.

## Fix

Both smoke steps create a workspace first (what a fresh install requires by design) and run under `$ErrorActionPreference = 'Stop'` + `$PSNativeCommandUseErrorActionPreference = $true`, so no command's failure can hide again. Sequence verified locally against a fresh `CORAL_CONFIG_DIR`.

## Release mechanics

Re-running the v0.15.0 Release re-runs the workflow **frozen at that tag** — it cannot be fixed retroactively. This lands as `fix(...)` so release-please cuts **v0.15.1**, whose tag carries the corrected workflow and publishes the images.