### PR TITLE
feat(search): rank Postgres catalog search with BM25 over corpus statistics

### DIFF
--- a/crates/coral-app/src/search/store/postgres/catalog.rs
+++ b/crates/coral-app/src/search/store/postgres/catalog.rs
@@ -1,10 +1,15 @@
 //! Catalog projection and retrieval on the Postgres store.
 //!
-//! Retrieval is the engine the benchmark locked: trigram-accelerated `ILIKE`
-//! per term for candidates (exact substring semantics; the executor's recheck
-//! makes false positives impossible), then a deterministic total order —
-//! field-weighted whole-phrase boost, weighted `ts_rank_cd`, trigram
-//! similarity, primary key.
+//! Retrieval is BM25 in plain SQL (research memo 11): corpus IDF from the
+//! per-Workspace `catalog_terms` statistics, FTS5's constants and negative-IDF
+//! clamp, and the same 8/6/2/1 field weights the `SQLite` side passes to
+//! `bm25()`. Candidates come from a prefix `tsquery` over the query's words
+//! OR-ed with trigram `ILIKE` patterns (exact substring semantics; the
+//! executor's recheck makes false positives impossible), both restricted to
+//! words below the document-frequency cap — FTS5's own `idf <= 0` clamp made
+//! explicit, applied where it also buys latency. The whole-query phrase boost
+//! leads the order so a whole-phrase match outranks a co-occurrence match;
+//! `doc_id` closes the deterministic total order.
 
 use std::collections::BTreeSet;
 
@@ -26,10 +31,27 @@ const INSERT_CHUNK_ROWS: usize = 2_000;
 /// Terms shorter than this cannot match a trigram index; the `SQLite` side
 /// applies the same floor.
 const MIN_TERM_CHARS: usize = 3;
-const PHRASE_WEIGHT_QUALIFIED_NAME: u8 = 8;
-const PHRASE_WEIGHT_TITLE: u8 = 6;
-const PHRASE_WEIGHT_DESCRIPTION: u8 = 2;
-const PHRASE_WEIGHT_SEARCHABLE_TEXT: u8 = 1;
+/// Field weights, identical to what the `SQLite` side passes to `bm25()`:
+/// qualified name, title, description, searchable text. They weight both the
+/// whole-query phrase boost and each lexeme occurrence in the BM25 score.
+const FIELD_WEIGHT_QUALIFIED_NAME: u8 = 8;
+const FIELD_WEIGHT_TITLE: u8 = 6;
+const FIELD_WEIGHT_DESCRIPTION: u8 = 2;
+const FIELD_WEIGHT_SEARCHABLE_TEXT: u8 = 1;
+/// FTS5's hard-coded BM25 constants (`fts5_aux.c`), kept so both backends
+/// saturate term frequency and normalize length the same way.
+const BM25_K1: f64 = 1.2;
+const BM25_B: f64 = 0.75;
+/// FTS5 clamps a non-positive IDF to this instead of letting a term that
+/// appears in more than half the corpus push results around.
+const IDF_FLOOR: f64 = 1e-6;
+/// Words in more of the corpus than this share are dropped from candidates
+/// and scoring. Measured (memo 11, design D7): the cap is what keeps the
+/// candidate set selective; without it the same relevance costs 5× the time.
+const DOCUMENT_FREQUENCY_CAP: f64 = 0.05;
+/// When every word is above the cap, keep this many rarest words instead of
+/// searching for nothing.
+const RARE_WORD_KEEP: usize = 3;
 
 impl CatalogStore for PostgresSearchStore {
     fn projection_is_current(&self, fingerprint: &str) -> Result<bool, SearchStoreError> {
@@ -141,6 +163,10 @@ impl CatalogStore for PostgresSearchStore {
                 .execute(&mut *tx)
                 .await?
                 .rows_affected();
+            // The ranking statistics stay: rows remain, and the cleared
+            // fingerprint makes the next search rebuild the projection, which
+            // rewrites them. Stale-but-present beats absent for a search that
+            // races the rebuild.
             clear_fingerprint(&mut tx).await?;
             tx.commit().await?;
             Ok::<_, PostgresSearchError>(CatalogClearResult {
@@ -156,6 +182,12 @@ impl CatalogStore for PostgresSearchStore {
                 .execute(&mut *tx)
                 .await?
                 .rows_affected();
+            sqlx::query("DELETE FROM catalog_terms")
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM catalog_stats")
+                .execute(&mut *tx)
+                .await?;
             clear_fingerprint(&mut tx).await?;
             tx.commit().await?;
             Ok::<_, PostgresSearchError>(CatalogClearResult {
@@ -165,8 +197,6 @@ impl CatalogStore for PostgresSearchStore {
     }
 }
 
-/// The stored fingerprint, or `None` when any row disagrees with it — a
-/// half-written projection is treated as absent, as on the `SQLite` side.
 /// The stored fingerprint. Replacement is one transaction, so the rows always
 /// match it; there is no per-row copy to reconcile.
 async fn current_fingerprint(
@@ -199,6 +229,7 @@ async fn replace_documents(
     for chunk in snapshot.documents.chunks(INSERT_CHUNK_ROWS) {
         insert_documents(tx, chunk).await?;
     }
+    refresh_ranking_stats(tx).await?;
     sqlx::query(
         "INSERT INTO search_meta (key, value) VALUES ($1, $2)
          ON CONFLICT (key) DO UPDATE SET value = excluded.value",
@@ -259,6 +290,40 @@ async fn insert_documents(
     Ok(())
 }
 
+/// Rewrites the BM25 corpus statistics from the rows just inserted, inside the
+/// same transaction, so statistics and projection can never disagree.
+async fn refresh_ranking_stats(
+    tx: &mut Transaction<'static, Postgres>,
+) -> Result<(), PostgresSearchError> {
+    sqlx::query(
+        "UPDATE catalog_documents AS d SET doc_len = coalesce((
+             SELECT sum(coalesce(array_length(u.positions, 1), 1))
+             FROM unnest(d.tsv) AS u(lexeme, positions, weights)
+         ), 0)",
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query("DELETE FROM catalog_terms")
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO catalog_terms (term, ndoc)
+         SELECT word, ndoc FROM ts_stat('SELECT tsv FROM catalog_documents')",
+    )
+    .execute(&mut **tx)
+    .await?;
+    sqlx::query("DELETE FROM catalog_stats")
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query(
+        "INSERT INTO catalog_stats (total_docs, avgdl)
+         SELECT count(*), coalesce(avg(doc_len), 1.0) FROM catalog_documents",
+    )
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 async fn clear_fingerprint(
     tx: &mut Transaction<'static, Postgres>,
 ) -> Result<(), PostgresSearchError> {
@@ -270,21 +335,44 @@ async fn clear_fingerprint(
 }
 
 /// One retrieval, fully parameterized: every value travels as a bind, and the
-/// only interpolated fragments are fixed SQL (`doc_kind_predicate`) and
-/// placeholder numbers.
+/// only interpolated fragments are fixed SQL (`doc_kind_predicate`, the BM25
+/// constants) and placeholder numbers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CatalogQueryPlan {
-    /// `%term%` per term, `LIKE` metacharacters escaped, for candidates.
-    patterns: Vec<String>,
     /// The whole normalized query as a `%phrase%` pattern for the boost. It is
     /// the longest term: query construction appends the whole query as a term,
     /// and it contains every other token.
     phrase_pattern: String,
-    /// `word | word` for `to_tsquery('simple', …)`; `None` when no term yields
-    /// a lexeme, which drops the rank tier instead of erroring.
-    words_query: Option<String>,
-    /// All terms joined for `similarity()`.
-    joined_terms: String,
+    /// Lexeme words of every term (runs of alphanumerics and `_`), the floor
+    /// applied, sorted and deduplicated. They key the statistics lookup and,
+    /// after the document-frequency cap, drive candidates and scoring.
+    words: Vec<String>,
+    /// `%term%` per term that yields no word above the floor
+    /// (punctuation-heavy identifiers), so its substring semantics survive
+    /// the word derivation.
+    wordless_patterns: Vec<String>,
+}
+
+/// One query word's document frequency, read from `catalog_terms`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WordStat {
+    word: String,
+    ndoc: i64,
+}
+
+/// What the statistics lookup resolved the plan's words into.
+#[derive(Debug, Clone, PartialEq)]
+struct ScoringPlan {
+    /// Words under the document-frequency cap (or the rarest few when nothing
+    /// is), with their IDF.
+    words: Vec<ScoredWord>,
+    avgdl: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ScoredWord {
+    word: String,
+    idf: f64,
 }
 
 impl CatalogQueryPlan {
@@ -298,51 +386,24 @@ impl CatalogQueryPlan {
             .iter()
             .max_by_key(|term| term.chars().count())?
             .clone();
-        let words = terms
-            .iter()
-            .flat_map(|term| lexeme_words(term))
-            .collect::<BTreeSet<_>>();
+        let mut words = BTreeSet::new();
+        let mut wordless = BTreeSet::new();
+        for term in &terms {
+            let term_words = lexeme_words(term)
+                .into_iter()
+                .filter(|word| word.chars().count() >= MIN_TERM_CHARS)
+                .collect::<Vec<_>>();
+            if term_words.is_empty() {
+                wordless.insert(contains_pattern(term));
+            } else {
+                words.extend(term_words);
+            }
+        }
         Some(Self {
-            patterns: terms.iter().map(|term| contains_pattern(term)).collect(),
             phrase_pattern: contains_pattern(&phrase),
-            words_query: (!words.is_empty())
-                .then(|| words.into_iter().collect::<Vec<_>>().join(" | ")),
-            joined_terms: terms.join(" "),
+            words: words.into_iter().collect(),
+            wordless_patterns: wordless.into_iter().collect(),
         })
-    }
-
-    fn sql(&self, class: CatalogDocumentClass) -> String {
-        let candidates = (1..=self.patterns.len())
-            .map(|index| format!("d.all_text ILIKE ${index}"))
-            .collect::<Vec<_>>()
-            .join(" OR ");
-        let phrase = self.patterns.len() + 1;
-        let mut next = phrase + 1;
-        let rank = if self.words_query.is_some() {
-            let words = next;
-            next += 1;
-            format!("ts_rank_cd(d.tsv, to_tsquery('simple', ${words}))")
-        } else {
-            "0".to_string()
-        };
-        let joined = next;
-        let limit = next + 1;
-        format!(
-            "SELECT d.doc_id, d.source_name, d.surface_kind, d.surface_name, d.field_name,
-                    d.field_role, d.catalog_name
-             FROM catalog_documents AS d
-             WHERE {predicate} AND ({candidates})
-             ORDER BY
-                 (d.qualified_name ILIKE ${phrase})::int * {PHRASE_WEIGHT_QUALIFIED_NAME}
-                 + (d.title ILIKE ${phrase})::int * {PHRASE_WEIGHT_TITLE}
-                 + (d.description ILIKE ${phrase})::int * {PHRASE_WEIGHT_DESCRIPTION}
-                 + (d.searchable_text ILIKE ${phrase})::int * {PHRASE_WEIGHT_SEARCHABLE_TEXT} DESC,
-                 {rank} DESC,
-                 similarity(d.all_text, ${joined}) DESC,
-                 d.doc_id ASC
-             LIMIT ${limit}",
-            predicate = doc_kind_predicate(class),
-        )
     }
 
     async fn fetch(
@@ -351,23 +412,221 @@ impl CatalogQueryPlan {
         class: CatalogDocumentClass,
         limit: usize,
     ) -> Result<Vec<CatalogSearchHit>, PostgresSearchError> {
-        // Audited: the only dynamic fragments are `doc_kind_predicate`, a
-        // fixed literal, and placeholder numbers; every value is a bind.
-        let mut query = sqlx::query(sqlx::AssertSqlSafe(self.sql(class)));
-        for pattern in &self.patterns {
+        let scoring = if self.words.is_empty() {
+            ScoringPlan {
+                words: Vec::new(),
+                avgdl: 1.0,
+            }
+        } else {
+            let (stats, total_docs, avgdl) = fetch_word_stats(tx, &self.words).await?;
+            scoring_plan(&stats, total_docs, avgdl)
+        };
+        // Audited: the only dynamic fragments are `doc_kind_predicate`, fixed
+        // literals, and placeholder numbers; every value is a bind.
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(self.sql(&scoring, class)));
+        if !scoring.words.is_empty() {
+            query = query.bind(tsquery(&scoring.words));
+            for word in &scoring.words {
+                query = query.bind(prefix_pattern(&word.word));
+                query = query.bind(word.idf);
+            }
+            for word in &scoring.words {
+                query = query.bind(contains_pattern(&word.word));
+            }
+        }
+        for pattern in &self.wordless_patterns {
             query = query.bind(pattern);
         }
-        query = query.bind(&self.phrase_pattern);
-        if let Some(words_query) = &self.words_query {
-            query = query.bind(words_query);
+        if !scoring.words.is_empty() {
+            query = query.bind(scoring.avgdl);
         }
         let rows = query
-            .bind(&self.joined_terms)
+            .bind(&self.phrase_pattern)
             .bind(i64::try_from(limit).unwrap_or(i64::MAX))
             .fetch_all(&mut **tx)
             .await?;
         rows.iter().map(hit_from_row).collect()
     }
+
+    fn sql(&self, scoring: &ScoringPlan, class: CatalogDocumentClass) -> String {
+        let word_count = scoring.words.len();
+        let mut next = 1_usize;
+        let mut take = |count: usize| {
+            let start = next;
+            next += count;
+            start
+        };
+        let tsquery = (word_count > 0).then(|| take(1));
+        let values_start = take(word_count * 2);
+        let word_pattern_start = take(word_count);
+        let wordless_start = take(self.wordless_patterns.len());
+        let avgdl = (word_count > 0).then(|| take(1));
+        let phrase = take(1);
+        let limit = take(1);
+
+        let mut candidates = Vec::new();
+        if let Some(tsquery) = tsquery {
+            candidates.push(format!("d.tsv @@ to_tsquery('simple', ${tsquery})"));
+        }
+        for index in 0..word_count {
+            candidates.push(format!("d.all_text ILIKE ${}", word_pattern_start + index));
+        }
+        for index in 0..self.wordless_patterns.len() {
+            candidates.push(format!("d.all_text ILIKE ${}", wordless_start + index));
+        }
+        let candidates = candidates.join(" OR ");
+
+        let score = match avgdl {
+            Some(avgdl) => {
+                let values = (0..word_count)
+                    .map(|index| {
+                        let pattern = values_start + 2 * index;
+                        let idf = pattern + 1;
+                        format!("(${pattern}::text, ${idf}::float8)")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "CROSS JOIN LATERAL (
+                         SELECT coalesce(sum(
+                             q.idf * (tf.f * ({BM25_K1} + 1))
+                             / (tf.f + {BM25_K1} * (1 - {BM25_B} + {BM25_B} * coalesce(c.doc_len::float8, ${avgdl}) / ${avgdl}))
+                         ), 0)::float8 AS score
+                         FROM (VALUES {values}) AS q(pattern, idf)
+                         JOIN unnest(c.tsv) AS u(lexeme, positions, weights)
+                           ON u.lexeme LIKE q.pattern
+                         CROSS JOIN LATERAL (
+                             SELECT sum(CASE w
+                                 WHEN 'A' THEN {FIELD_WEIGHT_QUALIFIED_NAME}::float8
+                                 WHEN 'B' THEN {FIELD_WEIGHT_TITLE}
+                                 WHEN 'C' THEN {FIELD_WEIGHT_DESCRIPTION}
+                                 ELSE {FIELD_WEIGHT_SEARCHABLE_TEXT} END) AS f
+                             FROM unnest(u.weights) AS w
+                         ) AS tf
+                     ) AS s"
+                )
+            }
+            None => "CROSS JOIN LATERAL (SELECT 0::float8 AS score) AS s".to_string(),
+        };
+        // `MATERIALIZED` walls candidate selection off from the scoring join
+        // and the sort: planned together, the planner abandons the trigram/tsv
+        // bitmap scans for a sequential scan (measured 2x the median). The
+        // score joins through a LATERAL with `coalesce` so a candidate no
+        // scored word reaches — a mid-word substring match — keeps rank
+        // instead of vanishing, which an inner-join GROUP BY shape gets wrong.
+        format!(
+            "WITH candidates AS MATERIALIZED (
+                 SELECT d.doc_id, d.source_name, d.surface_kind, d.surface_name, d.field_name,
+                        d.field_role, d.catalog_name, d.qualified_name, d.title, d.description,
+                        d.searchable_text, d.tsv, d.doc_len
+                 FROM catalog_documents AS d
+                 WHERE {predicate} AND ({candidates})
+             )
+             SELECT c.doc_id, c.source_name, c.surface_kind, c.surface_name, c.field_name,
+                    c.field_role, c.catalog_name
+             FROM candidates AS c
+             {score}
+             ORDER BY
+                 (c.qualified_name ILIKE ${phrase})::int * {FIELD_WEIGHT_QUALIFIED_NAME}
+                 + (c.title ILIKE ${phrase})::int * {FIELD_WEIGHT_TITLE}
+                 + (c.description ILIKE ${phrase})::int * {FIELD_WEIGHT_DESCRIPTION}
+                 + (c.searchable_text ILIKE ${phrase})::int * {FIELD_WEIGHT_SEARCHABLE_TEXT} DESC,
+                 s.score DESC,
+                 c.doc_id ASC
+             LIMIT ${limit}",
+            predicate = doc_kind_predicate(class),
+        )
+    }
+}
+
+/// Document frequency per word plus the corpus totals, in one statement. A
+/// schema whose statistics were never built reads as an empty corpus and
+/// degrades to unweighted scoring instead of failing.
+async fn fetch_word_stats(
+    tx: &mut Transaction<'static, Postgres>,
+    words: &[String],
+) -> Result<(Vec<WordStat>, i64, f64), PostgresSearchError> {
+    let rows = sqlx::query(
+        "SELECT w.term, coalesce(t.ndoc, 0) AS ndoc,
+                coalesce(s.total_docs, 0) AS total_docs,
+                coalesce(s.avgdl, 0) AS avgdl
+         FROM unnest($1::text[]) AS w(term)
+         LEFT JOIN catalog_terms AS t ON t.term = w.term
+         LEFT JOIN catalog_stats AS s ON true",
+    )
+    .bind(words)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut stats = Vec::with_capacity(rows.len());
+    let mut total_docs = 0_i64;
+    let mut avgdl = 0.0_f64;
+    for row in &rows {
+        let ndoc: i32 = row.try_get("ndoc")?;
+        stats.push(WordStat {
+            word: row.try_get("term")?,
+            ndoc: i64::from(ndoc),
+        });
+        total_docs = row.try_get("total_docs")?;
+        avgdl = row.try_get("avgdl")?;
+    }
+    Ok((stats, total_docs, avgdl))
+}
+
+/// Applies the document-frequency cap and computes each surviving word's IDF
+/// with FTS5's formula and clamp.
+fn scoring_plan(stats: &[WordStat], total_docs: i64, avgdl: f64) -> ScoringPlan {
+    let total = total_docs.max(0);
+    let cap = DOCUMENT_FREQUENCY_CAP * precise_f64(total.max(1));
+    let mut kept = stats
+        .iter()
+        .filter(|stat| precise_f64(stat.ndoc.max(0)) <= cap)
+        .collect::<Vec<_>>();
+    if kept.is_empty() {
+        let mut by_rarity = stats.iter().collect::<Vec<_>>();
+        by_rarity.sort_by_key(|stat| (stat.ndoc, stat.word.clone()));
+        by_rarity.truncate(RARE_WORD_KEEP);
+        kept = by_rarity;
+    }
+    ScoringPlan {
+        words: kept
+            .into_iter()
+            .map(|stat| ScoredWord {
+                word: stat.word.clone(),
+                idf: inverse_document_frequency(total, stat.ndoc),
+            })
+            .collect(),
+        avgdl: if avgdl > 0.0 { avgdl } else { 1.0 },
+    }
+}
+
+/// FTS5's IDF (`fts5_aux.c`): `log((N - n + 0.5) / (n + 0.5))`, clamped to a
+/// small positive floor so a word in more than half the corpus scores nothing
+/// instead of scoring negative.
+fn inverse_document_frequency(total_docs: i64, ndoc: i64) -> f64 {
+    let total = precise_f64(total_docs.max(0));
+    let matched = precise_f64(ndoc.clamp(0, total_docs.max(0)));
+    ((total - matched + 0.5) / (matched + 0.5))
+        .ln()
+        .max(IDF_FLOOR)
+}
+
+/// Catalog corpora stay far below `f64`'s exact-integer range; spelled out so
+/// the cast reads as a decision rather than an accident.
+#[expect(clippy::cast_precision_loss, reason = "document counts fit in f64")]
+fn precise_f64(value: i64) -> f64 {
+    value as f64
+}
+
+/// `word:* | word:*` over the scored words for candidate selection. Words are
+/// runs of alphanumerics and `_`, so the tsquery parser accepts them without
+/// quoting; a word with `_` parses as a prefix phrase, which is stricter, not
+/// broken.
+fn tsquery(words: &[ScoredWord]) -> String {
+    words
+        .iter()
+        .map(|word| format!("{}:*", word.word))
+        .collect::<Vec<_>>()
+        .join(" | ")
 }
 
 /// Fixed SQL over the `d` alias; the kind names are the vocabulary's own
@@ -408,24 +667,33 @@ fn hit_from_row(row: &sqlx::postgres::PgRow) -> Result<CatalogSearchHit, Postgre
     })
 }
 
-/// `%term%` with `\`, `%`, and `_` escaped, so identifiers such as
-/// `deploy_url` match literally.
-fn contains_pattern(term: &str) -> String {
-    let mut escaped = String::with_capacity(term.len() + 2);
-    escaped.push('%');
+/// `\`, `%`, and `_` escaped, so identifiers such as `deploy_url` match
+/// literally under `LIKE`.
+fn escape_like(term: &str) -> String {
+    let mut escaped = String::with_capacity(term.len());
     for ch in term.chars() {
         if matches!(ch, '\\' | '%' | '_') {
             escaped.push('\\');
         }
         escaped.push(ch);
     }
-    escaped.push('%');
     escaped
 }
 
-/// Lexeme candidates for the rank tier: runs of alphanumerics (any script,
-/// terms are already lowercased) and `_`, which the `simple` parser accepts
-/// without operators or quoting.
+/// `%term%` for substring candidates.
+fn contains_pattern(term: &str) -> String {
+    format!("%{}%", escape_like(term))
+}
+
+/// `term%` for the lexeme-prefix join in the score, mirroring the candidate
+/// tsquery's `:*`.
+fn prefix_pattern(term: &str) -> String {
+    format!("{}%", escape_like(term))
+}
+
+/// Lexeme candidates: runs of alphanumerics (any script, terms are already
+/// lowercased) and `_`, which the `simple` parser accepts without operators
+/// or quoting.
 fn lexeme_words(term: &str) -> Vec<String> {
     term.split(|ch: char| !(ch.is_alphanumeric() || ch == '_'))
         .filter(|word| !word.is_empty())
@@ -435,8 +703,24 @@ fn lexeme_words(term: &str) -> Vec<String> {
 
 #[cfg(test)]
 pub(super) mod plan_tests {
-    use super::{CatalogQueryPlan, contains_pattern};
+    use super::{
+        CatalogQueryPlan, ScoredWord, ScoringPlan, WordStat, contains_pattern,
+        inverse_document_frequency, scoring_plan,
+    };
     use crate::search::catalog::index::CatalogDocumentClass;
+
+    fn scored(words: &[&str]) -> ScoringPlan {
+        ScoringPlan {
+            words: words
+                .iter()
+                .map(|word| ScoredWord {
+                    word: (*word).to_string(),
+                    idf: 1.0,
+                })
+                .collect(),
+            avgdl: 10.0,
+        }
+    }
 
     #[test]
     fn patterns_escape_like_metacharacters_and_drop_short_terms() {
@@ -447,12 +731,14 @@ pub(super) mod plan_tests {
         ])
         .expect("plan");
 
-        assert_eq!(plan.patterns, vec!["%deploy\\_url%", "%100\\%%"]);
+        assert_eq!(plan.words, vec!["100", "deploy_url"]);
+        assert_eq!(plan.phrase_pattern, "%deploy\\_url%");
+        assert!(plan.wordless_patterns.is_empty());
         assert_eq!(contains_pattern("a\\b"), "%a\\\\b%");
     }
 
     #[test]
-    fn the_phrase_is_the_longest_term_and_words_feed_the_rank_tier() {
+    fn the_phrase_is_the_longest_term_and_terms_split_into_words() {
         let plan = CatalogQueryPlan::build(&[
             "issue".to_string(),
             "issue labels".to_string(),
@@ -461,28 +747,26 @@ pub(super) mod plan_tests {
         .expect("plan");
 
         assert_eq!(plan.phrase_pattern, "%issue labels%");
-        assert_eq!(plan.words_query.as_deref(), Some("issue | labels"));
-        assert_eq!(plan.joined_terms, "issue issue labels labels");
+        assert_eq!(plan.words, vec!["issue", "labels"]);
     }
 
     #[test]
-    fn lexemes_keep_non_ascii_letters() {
+    fn words_keep_non_ascii_letters() {
         let plan = CatalogQueryPlan::build(&["über-café".to_string()]).expect("plan");
 
-        assert_eq!(plan.words_query.as_deref(), Some("café | über"));
+        assert_eq!(plan.words, vec!["café", "über"]);
     }
 
     #[test]
-    fn terms_without_lexemes_drop_the_rank_tier_instead_of_erroring() {
-        let plan = CatalogQueryPlan::build(&["---".to_string()]).expect("plan");
+    fn terms_without_words_keep_substring_patterns_and_skip_scoring() {
+        let plan = CatalogQueryPlan::build(&["---".to_string(), "a-b".to_string()]).expect("plan");
 
-        assert_eq!(plan.words_query, None);
-        assert!(plan.sql(CatalogDocumentClass::Entries).contains("0 DESC"));
-        assert!(
-            !plan
-                .sql(CatalogDocumentClass::Entries)
-                .contains("to_tsquery")
-        );
+        assert!(plan.words.is_empty());
+        assert_eq!(plan.wordless_patterns, vec!["%---%", "%a-b%"]);
+        let sql = plan.sql(&scored(&[]), CatalogDocumentClass::Entries);
+        assert!(sql.contains("0::float8 AS score"));
+        assert!(!sql.contains("to_tsquery"));
+        assert!(sql.contains("d.all_text ILIKE $1 OR d.all_text ILIKE $2"));
     }
 
     #[test]
@@ -496,13 +780,89 @@ pub(super) mod plan_tests {
         let plan =
             CatalogQueryPlan::build(&["alpha".to_string(), "beta".to_string()]).expect("plan");
 
-        let sql = plan.sql(CatalogDocumentClass::Fields);
+        let sql = plan.sql(&scored(&["alpha", "beta"]), CatalogDocumentClass::Fields);
 
-        assert!(sql.contains("d.all_text ILIKE $1 OR d.all_text ILIKE $2"));
-        assert!(sql.contains("d.qualified_name ILIKE $3"));
-        assert!(sql.contains("to_tsquery('simple', $4)"));
-        assert!(sql.contains("similarity(d.all_text, $5)"));
-        assert!(sql.contains("LIMIT $6"));
+        assert!(sql.contains("to_tsquery('simple', $1)"));
+        assert!(sql.contains("($2::text, $3::float8), ($4::text, $5::float8)"));
+        assert!(sql.contains("d.all_text ILIKE $6 OR d.all_text ILIKE $7"));
+        assert!(sql.contains("coalesce(c.doc_len::float8, $8) / $8"));
+        assert!(sql.contains("c.qualified_name ILIKE $9"));
+        assert!(sql.contains("LIMIT $10"));
         assert!(sql.contains("d.doc_kind IN ('column_hint')"));
+        assert!(sql.contains("WITH candidates AS MATERIALIZED"));
+    }
+
+    #[test]
+    fn the_document_frequency_cap_drops_common_words() {
+        let stats = [
+            WordStat {
+                word: "github".to_string(),
+                ndoc: 950,
+            },
+            WordStat {
+                word: "slack".to_string(),
+                ndoc: 40,
+            },
+        ];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0);
+
+        assert_eq!(
+            plan.words
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["slack"]
+        );
+        assert!((plan.avgdl - 23.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn all_common_words_fall_back_to_the_rarest_few() {
+        let stats = ["delta", "alpha", "bravo", "charlie"]
+            .iter()
+            .zip([400_i64, 100, 200, 300])
+            .map(|(word, ndoc)| WordStat {
+                word: (*word).to_string(),
+                ndoc,
+            })
+            .collect::<Vec<_>>();
+
+        let plan = scoring_plan(&stats, 1_000, 23.0);
+
+        assert_eq!(
+            plan.words
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "bravo", "charlie"],
+            "the rarest words survive, rarest first"
+        );
+    }
+
+    #[test]
+    fn idf_follows_fts5_including_the_negative_clamp() {
+        // A word in most of the corpus is clamped off, not negative.
+        assert!((inverse_document_frequency(1_000, 977) - 1e-6).abs() < f64::EPSILON);
+        // A rare word scores by the FTS5 formula.
+        let expected = ((1_000.0_f64 - 40.0 + 0.5) / 40.5).ln();
+        assert!((inverse_document_frequency(1_000, 40) - expected).abs() < 1e-12);
+        // Degenerate inputs stay finite.
+        assert!((inverse_document_frequency(0, 0) - 1e-6).abs() < f64::EPSILON);
+        assert!(inverse_document_frequency(10, 20).is_finite());
+    }
+
+    #[test]
+    fn a_statistics_free_schema_degrades_to_unweighted_scoring() {
+        let stats = [WordStat {
+            word: "github".to_string(),
+            ndoc: 0,
+        }];
+
+        let plan = scoring_plan(&stats, 0, 0.0);
+
+        let word = plan.words.first().expect("the only word survives");
+        assert!((word.idf - 1e-6).abs() < f64::EPSILON);
+        assert!((plan.avgdl - 1.0).abs() < f64::EPSILON);
     }
 }

--- a/crates/coral-app/src/search/store/postgres/migrations/0002_catalog_ranking_stats.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0002_catalog_ranking_stats.sql
@@ -1,0 +1,26 @@
+-- Corpus statistics for BM25 catalog ranking: per-lexeme document frequency
+-- and the per-document length the score normalizes by. `replace_documents`
+-- rewrites all three in the projection's own transaction, so they can never
+-- disagree with the rows.
+--
+-- Runs with `search_path` set to the Workspace's surrogate schema; names are
+-- unqualified on purpose. Not idempotent on purpose (see 0001).
+ALTER TABLE catalog_documents
+    ADD COLUMN doc_len integer;
+
+CREATE TABLE catalog_terms (
+    term text PRIMARY KEY,
+    ndoc integer NOT NULL
+);
+
+CREATE TABLE catalog_stats (
+    singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+    total_docs bigint NOT NULL,
+    avgdl double precision NOT NULL
+);
+
+-- The key `replace_documents` maintains (`CATALOG_SNAPSHOT_FINGERPRINT_META_KEY`).
+-- Dropping it makes the next search rebuild the projection, which is what
+-- populates `doc_len` and the two tables above for a schema that already
+-- holds documents.
+DELETE FROM search_meta WHERE key = 'catalog_snapshot_fingerprint';

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -24,7 +24,7 @@ use tokio::runtime::Handle;
 use crate::state::db::{DbError, connect_postgres_pool};
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 1;
+pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 2;
 
 struct SearchPostgresMigration {
     version: i32,
@@ -35,10 +35,16 @@ const REGISTRY_BOOTSTRAP_SQL: &str = include_str!("migrations/0001_search_regist
 
 /// Per-Workspace schema stream, versioned in the registry ledger. Every
 /// statement is idempotent so a replay after a partial failure converges.
-const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[SearchPostgresMigration {
-    version: 1,
-    sql: include_str!("migrations/0001_catalog_documents.sql"),
-}];
+const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[
+    SearchPostgresMigration {
+        version: 1,
+        sql: include_str!("migrations/0001_catalog_documents.sql"),
+    },
+    SearchPostgresMigration {
+        version: 2,
+        sql: include_str!("migrations/0002_catalog_ranking_stats.sql"),
+    },
+];
 
 const SEARCH_POOL_MAX_CONNECTIONS: u32 = 4;
 /// Serializes registry bootstrap across processes; per-Workspace work locks

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -516,6 +516,27 @@ async fn boot_prune_removes_workspaces_missing_from_the_live_set_against_postgre
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run IDF ranking against Postgres"]
+async fn common_word_noise_is_discounted_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("idf");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        contract::assert_rare_terms_outrank_common_noise(&store);
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
 async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     let Some(storage) = open_storage().await else {

--- a/crates/coral-app/src/search/store/tests.rs
+++ b/crates/coral-app/src/search/store/tests.rs
@@ -179,6 +179,74 @@ pub(super) mod contract {
         assert_eq!(entries(&["issue"]), entries(&["issue"]));
     }
 
+    /// The duel regression (research memo 11): a query word present in nearly
+    /// every document must not outrank the query's rare words. Both engines
+    /// discount it through corpus statistics — FTS5's negative-IDF clamp,
+    /// Postgres' document-frequency cap — so the document the rare words name
+    /// comes first. Only the top position is asserted: how far a
+    /// common-word-only match ranks (or whether it is retrieved at all)
+    /// legitimately differs by engine.
+    pub(crate) fn assert_rare_terms_outrank_common_noise(store: &SearchStore) {
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&noise_snapshot())
+            .expect("refresh");
+
+        let terms = ["github", "slack", "messages"]
+            .iter()
+            .map(|term| (*term).to_string())
+            .collect::<Vec<_>>();
+        let hits = catalog
+            .search(&terms, 10, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+
+        assert_eq!(
+            hits.first().map(|hit| hit.doc_id.as_str()),
+            Some("table:slack_messages"),
+            "the rare words must beat twelve documents dense in the common word"
+        );
+    }
+
+    fn noise_snapshot() -> CatalogIndexSnapshot {
+        let table = |doc_id: &str, surface_name: &str, title: &str, description: &str| {
+            CatalogIndexDocument {
+                doc_id: doc_id.to_string(),
+                doc_kind: CatalogIndexDocumentKind::CatalogTable,
+                source_name: "github".to_string(),
+                catalog_name: None,
+                surface_kind: "table".to_string(),
+                surface_name: surface_name.to_string(),
+                field_name: String::new(),
+                field_role: String::new(),
+                qualified_name: format!("github.{surface_name}"),
+                title: title.to_string(),
+                description: description.to_string(),
+                searchable_text: format!("github {surface_name}"),
+            }
+        };
+        let mut documents = (0..12)
+            .map(|index| {
+                table(
+                    &format!("table:github_noise_{index:02}"),
+                    &format!("github_events_{index:02}"),
+                    "github events",
+                    "github events from the github firehose about github activity",
+                )
+            })
+            .collect::<Vec<_>>();
+        documents.push(table(
+            "table:slack_messages",
+            "slack_messages",
+            "slack messages",
+            "Messages posted to Slack channels",
+        ));
+        CatalogIndexSnapshot {
+            fingerprint: "noise-v1".to_string(),
+            documents,
+        }
+    }
+
     fn semantics_snapshot() -> CatalogIndexSnapshot {
         let table = |doc_id: &str, surface_name: &str, title: &str, description: &str| {
             CatalogIndexDocument {
@@ -346,6 +414,16 @@ fn sqlite_store_follows_the_benchmark_match_strata() {
         .expect("open workspace store");
 
     contract::assert_match_semantics(&store);
+}
+
+#[test]
+fn sqlite_store_discounts_common_word_noise() {
+    let (_temp, storage) = sqlite_storage();
+    let store = storage
+        .open_workspace(&WorkspaceName::default())
+        .expect("open workspace store");
+
+    contract::assert_rare_terms_outrank_common_noise(&store);
 }
 
 #[test]


### PR DESCRIPTION
## Why

The duel benchmark (`coral-benchmarks/docs/findings/postgres-search-duel.md`, 2026-08-27) measured the Postgres catalog search engine against the SQLite baseline on the agents' own 448 search queries:

- the table the agent goes on to use lands in the top-3 **14 %** of the time vs SQLite's **54 %** (at #1: 3 % vs 29 %)
- warm `search` is **2.3–3× slower**, with the whole gap inside the two candidate `SELECT`s (~463 ms of SQL per search over 21k documents)

Root-cause research (`coral/.scratch/universal-search-postgres/research/11-postgres-ranking-fix.md`, replay harness validated byte-identical against the duel's recorded output): `ts_rank_cd` has no corpus statistics, and under the disjunctive tsquery coral issues its cover-density machinery never engages — the tier degenerates to an unbounded weighted term-frequency count. On the duel catalog the word `github` appears in **97.7 %** of documents; SQLite's `bm25()` clamps it to nothing, the shipped expression ranks on it. Two further dead weights: the whole-query phrase tier fires on **0 of 448** queries (no document contains an 8–19-word string), and `similarity()` over the fat `all_text` is the single most expensive sort key while acting only as a rarely-reached tie-break.

## What

The engine is unchanged (`pg_trgm` + tsvector on vanilla RDS, per the locked plan) — the ranking expression and candidate clause move to BM25 with real corpus statistics, FTS5's own constants and clamps, and the same 8/6/2/1 field weights the SQLite side passes to `bm25()`:

- **Migration `0002_catalog_ranking_stats.sql`** (schema version 2): `catalog_documents.doc_len`, `catalog_terms(term, ndoc)` (filled by `ts_stat`), one-row `catalog_stats(total_docs, avgdl)`, and a fingerprint wipe so the next search rebuilds the projection and populates them. `replace_documents` rewrites all three inside the projection's transaction (~150 ms at 21k docs), so statistics and rows can never disagree.
- **Per query**: one statement resolves the query words' document frequencies; words in more than 5 % of the workspace's documents are dropped from candidates and scoring (FTS5's negative-IDF clamp made explicit — and what keeps the candidate set selective); if every word is common, the 3 rarest survive.
- **Candidates**: prefix `tsquery` (`word:*`) OR trigram `ILIKE '%word%'` per surviving word — substring semantics preserved — inside a `WITH candidates AS MATERIALIZED` wall. Measured: planned together with the scoring join, the planner abandons the bitmap index scans for a seq scan and the median doubles.
- **Order**: whole-query phrase boost (unchanged tier, now over the small candidate set; it is what keeps `"issue labels"` ahead of co-occurrence matches and it costs nothing on long queries), then the BM25 score via `unnest(tsv)` with a lexeme-prefix join (`pull` scores `pulls`), then `doc_id`. The `similarity()` tier is deleted.
- Zero-score candidates (mid-word substring matches like `enchmark` → `benchmark_runs`) keep their rank through a `LATERAL` + `coalesce(sum(…), 0)` — an inner-join `GROUP BY` shape would silently drop them.

## Measured (448 real agent queries, duel used-table labels)

| | used table top-k | at #1 | top-3 | median rank | SQL per search |
|---|---|---|---|---|---|
| SQLite baseline (duel report) | 81 % | 29 % | 54 % | 2 | (237 ms e2e) |
| shipped `a01f93d02` | 51 % | 3 % | 14 % | 8.0 | 463 ms |
| **this PR** | **82 %** | **29 %** | **48 %** | **3.0** | **59 ms** |

Acceptance: the real branch binary against the duel database — the boot ledger sweep migrated `search_ws_1` v1→v2, the first search rebuilt the projection with statistics, and the 448-query replay through `coral mcp-stdio` reproduced the relevance figures exactly (423/448 result lists byte-identical to the offline harness; the diffs agree on top-3 and track live-source catalog drift). Warm `search` through the release binary: **262 ms median / 590 ms p90**, against the duel's recorded replay medians of 237 ms (SQLite) and 755 ms (shipped Postgres) — ratio **1.11** vs SQLite, inside the duel's ≤ 1.3 warm-latency rule that the shipped engine failed at 2.31. (Host-to-Docker replay on the same laptop; the duel's figures came from its in-container replay, so treat the comparison as directional.)

## Validation

- `make rust-checks` green.
- `make postgres-tests` green against Postgres 17.10 (the full store contract: substring/word/phrase/floor/negative strata, registry isolation, ledger sweep v0→v2, contention, deletion).
- New backend-neutral contract test `assert_rare_terms_outrank_common_noise`: twelve documents dense in a common word must lose to the one document the query's rare words name. Passes on FTS5 and Postgres; the shipped Postgres expression fails it.
- Offline iteration loop and acceptance scripts preserved at `coral/.scratch/universal-search-postgres/prototypes/06-retrieval-benchmark/11-ranking-replay/`.

## Accepted limits and follow-ups

- Top-3 trails SQLite by ~6 points; the researched next step is a `strict_word_similarity` re-rank over the top ~50 fused candidates (memo 11, open question 1), and `b`/`k1` are FTS5's constants, not tuned for this corpus.
- A word above the 5 % document-frequency cap no longer retrieves by itself (it still scores nothing on both engines).
- Round-trip consolidation (merge the fingerprint/count transactions, drop the per-search `count(*)`; ~17 round trips per search today) is an independent follow-up the memo sizes as small — kept out of this PR to hold its scope to the ranking expression.
