### PR TITLE
fix(app): enforce shared database safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,8 @@ POSTGRES_SUITE_CARGO = cargo test --locked -p coral-app --lib 'state::db::' -- -
 postgres-test-suite:
 	@test -n "$${CORAL_TEST_POSTGRES_URL:-}" || \
 	  { echo "CORAL_TEST_POSTGRES_URL is required" >&2; exit 1; }
-	$(POSTGRES_SUITE_CARGO)
+	@export CORAL_TEST_CREDENTIAL_KEK="v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; \
+	  $(POSTGRES_SUITE_CARGO)
 
 # Provision the local container through a prerequisite rather than a recursive
 # $(MAKE) call inside the recipe, for the reason described above.
@@ -277,6 +278,7 @@ postgres-tests: $(POSTGRES_TESTS_PREREQS)
 	echo "Running Postgres tests against $$url"; \
 	export CORAL_TEST_POSTGRES_URL="$$url"; \
 	export CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL="$${lifecycle_url:-$$url}"; \
+	export CORAL_TEST_CREDENTIAL_KEK="v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; \
 	$(POSTGRES_SUITE_CARGO)
 
 # ----------------------------------------------------------------------------

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -52,10 +52,10 @@ trust boundary:
   never written into `config.toml`.
 - Source secrets are encrypted before they are written to Coral's configured
   database. The database stores ciphertext, nonces, wrapped data-encryption
-  keys, and key identifiers. The local KEK comes from
+  keys, and key identifiers. SQLite can obtain its KEK from
   `[credentials].encryption_key_env`, the OS keychain, or
-  `credentials/encryption.key`, depending on
-  `[credentials].encryption_key_source`.
+  `credentials/encryption.key`. Postgres requires
+  `[credentials].encryption_key_env` so every server uses the same KEK.
 - Older file-backed and keychain-backed credential material is imported into
   encrypted database documents during startup when Coral can read and verify
   it. Coral retains the legacy material if the database write cannot be
@@ -164,6 +164,8 @@ you configure; it does not make an otherwise untrusted local agent safe.
 - Keep Postgres on a host and network path you trust. Remote Postgres URLs must
   use hostname-verified TLS; loopback Postgres without TLS is intended for
   local development and CI.
+- Set `[credentials].encryption_key_env` to the same KEK environment variable
+  on every Coral server before enabling Postgres.
 - Use `coral source list` or `coral source info <NAME>` to inspect whether a
   source has encrypted database-backed secret storage or a legacy keychain
   route.

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -100,8 +100,8 @@ Encrypted database credential documents are protected by a key-encryption key
 
 ```toml
 [credentials]
+storage = "database"
 encryption_key_env = "CORAL_CREDENTIAL_KEK"
-encryption_key_source = "auto"
 ```
 
 If `encryption_key_env` is set, Coral reads that environment variable first.
@@ -110,20 +110,22 @@ of key material. Missing or invalid environment material fails closed; Coral
 does not fall back to another KEK source after an explicit env key is
 configured.
 
-If no env key is configured, `encryption_key_source` controls local KEK
-selection:
+For SQLite, if no env key is configured, `encryption_key_source` controls local
+KEK selection:
 
 | Value | Behavior |
 | ----- | -------- |
 | `auto` | Reuses an existing `credentials/encryption.key` file if one exists. Otherwise prefers the OS keychain. If keychain access is unavailable, logs a warning and creates the file key. |
-| `keychain` | Uses the OS keychain and fails closed when keychain access is unavailable. Keychains are per host, so shared-Postgres deployments must pre-seed every server with the same key material before use. |
+| `keychain` | Uses the OS keychain and fails closed when keychain access is unavailable. |
 | `file` | Uses `credentials/encryption.key` under the local state directory. |
 | `vault` | Reserved for external vault-backed KEKs and currently fails closed because it is not implemented. |
 
-For shared Postgres, every Coral server that can read or write encrypted
-credential documents must use the same KEK before Postgres is enabled. If two
-servers create different auto-generated local keys, each server can create
-documents the other cannot decrypt.
+Postgres requires `encryption_key_env`; host-local keychain and file KEKs are
+rejected at startup. Every Coral server that can read or write encrypted
+credential documents must set the named environment variable to the same KEK.
+Omit `storage` or set it to `database`; legacy `file` and `keychain` storage
+preferences remain readable for startup import, but are rejected for new
+credential writes after database-backed state is active.
 
 ## Server
 

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -88,7 +88,8 @@ root.
   database write and readback are verified.
 - Keep raw trace spans and optional HTTP/MCP body captures out of the database.
   The database may index trace summaries derived from the local trace span
-  store.
+  store. Stamp each summary with opaque local-store provenance and prune a
+  missing local trace only when that provenance belongs to the current store.
 - Persist DSL v4 imported manifests as authored intent plus durability
   normalization only. Descriptor hashes, generated OpenAPI metadata, semantic
   IR, projections, and package fingerprints belong in materialized artifacts

--- a/crates/coral-app/migrations/0016_trace_summaries.sql
+++ b/crates/coral-app/migrations/0016_trace_summaries.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS trace_summaries (
     workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
     trace_id TEXT NOT NULL,
+    store_id TEXT NOT NULL,
     root_span_id TEXT NOT NULL,
     name TEXT NOT NULL,
     query TEXT NOT NULL,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -28,7 +28,6 @@ use tokio::task::{self, JoinHandle};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::service::Routes;
 use tonic::transport::Server;
-use tracing::warn;
 use zeroize::Zeroizing;
 
 use super::env::AppEnvironment;
@@ -40,9 +39,7 @@ use crate::auth::CoralAuthorizationServer;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
-use crate::credentials::encryption::{
-    CredentialEncryptionKey, CredentialEncryptionKeyOrigin, LocalFileCredentialKeyProvider,
-};
+use crate::credentials::encryption::{CredentialEncryptionKey, LocalFileCredentialKeyProvider};
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::features::service::FeatureService;
 use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
@@ -657,6 +654,7 @@ fn trace_components_for_store(
             service: Some(TraceService::with_db(
                 store.dir,
                 store.retention,
+                store.store_id,
                 Arc::clone(db),
                 workspaces,
                 workspace_authorizer,
@@ -679,10 +677,15 @@ async fn backfill_trace_summaries(
     let Some(store) = store else {
         return Ok(());
     };
-    TraceService::backfill_summaries(store.dir.clone(), store.retention, coral_db)
-        .await
-        .map(|_| ())
-        .map_err(|error| AppError::Database(format!("trace summary import failed: {error}")))
+    TraceService::backfill_summaries(
+        store.dir.clone(),
+        store.retention,
+        &store.store_id,
+        coral_db,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| AppError::Database(format!("trace summary import failed: {error}")))
 }
 
 fn init_credential_store(
@@ -693,24 +696,32 @@ fn init_credential_store(
     let provided_key = resolve_configured_credential_encryption_key(
         credential_config.encryption_key_env.as_deref(),
     )?;
+    require_shared_postgres_credential_key(coral_db.is_postgres(), provided_key.is_some())?;
     let key_provider = Arc::new(LocalFileCredentialKeyProvider::with_source(
         layout,
         provided_key,
         credential_config.encryption_key_source,
     ));
-    let key_origin = key_provider.active_key_origin()?;
-    if coral_db.is_postgres() && key_origin != CredentialEncryptionKeyOrigin::Provided {
-        warn!(
-            ?key_origin,
-            "database-backed credentials are using a host-local encryption key with Postgres; multiple servers can create split key domains and unreadable credential documents; set [credentials].encryption_key_env to the same KEK on every server"
-        );
-    }
-    Ok(CredentialStore::with_database(
+    let credential_store = CredentialStore::with_database(
         layout.clone(),
         credential_config.storage,
         Arc::clone(coral_db),
         key_provider,
-    ))
+    );
+    Ok(credential_store)
+}
+
+fn require_shared_postgres_credential_key(
+    postgres: bool,
+    provided_key: bool,
+) -> Result<(), AppError> {
+    if postgres && !provided_key {
+        return Err(AppError::FailedPrecondition(
+            "Postgres credential storage requires [credentials].encryption_key_env to name the same KEK environment variable on every Coral server"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Replaces one source's encrypted database credential document for integration tests.
@@ -1170,7 +1181,8 @@ mod tests {
     use super::{
         RunningServer, ServerBuilder, ServerDependencies, ServerMode, SessionAuthSettings,
         TraceServerComponents, inaccessible_workspaces_warning,
-        resolve_configured_credential_encryption_key, start_server,
+        require_shared_postgres_credential_key, resolve_configured_credential_encryption_key,
+        start_server,
     };
     use crate::auth::session::test_signing_key;
     use crate::bootstrap::AppError;
@@ -1345,6 +1357,16 @@ enabled = false
                 .expect("run non-UTF-8 subprocess");
             assert!(status.success());
         }
+    }
+
+    #[test]
+    fn postgres_credentials_require_a_shared_provided_key() {
+        require_shared_postgres_credential_key(true, true).expect("provided Postgres key");
+        require_shared_postgres_credential_key(false, false).expect("local SQLite key");
+        let error = require_shared_postgres_credential_key(true, false)
+            .expect_err("host-local Postgres key should fail closed");
+        assert!(error.to_string().contains("encryption_key_env"));
+        assert!(error.to_string().contains("every Coral server"));
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -539,7 +539,22 @@ impl CredentialStore {
 
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
         if self.database.is_some() {
-            return Ok(CredentialStorageKind::Database);
+            return match self.preference {
+                CredentialStoragePreference::Auto | CredentialStoragePreference::Database => {
+                    Ok(CredentialStorageKind::Database)
+                }
+                preference @ (CredentialStoragePreference::File
+                | CredentialStoragePreference::Keychain) => {
+                    let preference = match preference {
+                        CredentialStoragePreference::File => "file",
+                        CredentialStoragePreference::Keychain => "keychain",
+                        _ => unreachable!("database branch admits only legacy preferences"),
+                    };
+                    Err(CredentialsError::Unavailable(format!(
+                        "credential material is stored in the database, so legacy storage = \"{preference}\" is no longer supported; set storage = \"database\" (or remove it); encryption_key_source selects a local SQLite KEK, while Postgres requires encryption_key_env"
+                    )))
+                }
+            };
         }
         match self.preference {
             CredentialStoragePreference::Database => Err(CredentialsError::Unavailable(
@@ -2027,6 +2042,30 @@ mod tests {
                 .get("TOKEN")
                 .map(String::as_str),
             Some("winner")
+        );
+    }
+
+    #[tokio::test]
+    async fn database_rejects_legacy_keychain_write_preference() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("layout");
+        let db = Arc::new(open_sqlite(&layout).await);
+        let store = CredentialStore::with_database(
+            layout,
+            CredentialStoragePreference::Keychain,
+            db,
+            static_key_provider(19),
+        );
+
+        let error = store
+            .default_write_storage()
+            .expect_err("legacy keychain preference should be rejected");
+        assert!(error.to_string().contains("storage = \"database\""));
+        assert!(
+            error
+                .to_string()
+                .contains("Postgres requires encryption_key_env")
         );
     }
 

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -25,6 +25,11 @@ impl CoralDb {
         CoralTx::begin(&self.backend).await
     }
 
+    #[cfg(test)]
+    pub(crate) async fn begin_deferred(&self) -> Result<CoralTx<'_>, DbError> {
+        CoralTx::begin_deferred(&self.backend).await
+    }
+
     /// Begin a transaction that keeps multi-query reads on one coherent snapshot.
     pub(crate) async fn begin_read_snapshot(&self) -> Result<CoralTx<'_>, DbError> {
         CoralTx::begin_read_snapshot(&self.backend).await
@@ -133,6 +138,35 @@ fn postgres_ssl_mode_authenticates_server(ssl_mode: PgSslMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::postgres_connect_options;
+
+    #[tokio::test]
+    async fn sqlite_write_transactions_reserve_the_writer_before_reads() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let database_file = temp.path().join("coral.db");
+        let first = super::open_sqlite(&database_file)
+            .await
+            .expect("open first sqlite pool");
+        let second = super::open_sqlite(&database_file)
+            .await
+            .expect("open second sqlite pool");
+
+        let first_tx = first.begin().await.expect("reserve first sqlite writer");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), second.begin())
+                .await
+                .is_err(),
+            "a second writer must wait before either transaction takes a stale read snapshot",
+        );
+        first_tx.rollback().await.expect("release first writer");
+
+        second
+            .begin()
+            .await
+            .expect("reserve writer after release")
+            .rollback()
+            .await
+            .expect("release second writer");
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -331,7 +331,10 @@ mod tests {
             .expect("insert credential document row");
         session
             .trace_summaries()
-            .upsert(&migration_trace_summary(&workspace_id, &trace_id))
+            .upsert(
+                &migration_trace_summary(&workspace_id, &trace_id),
+                "migration-test-store",
+            )
             .await
             .expect("insert trace summary row");
         assert_eq!(

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -368,7 +368,11 @@ async fn replace_document(
     now: i64,
     barrier: &tokio::sync::Barrier,
 ) -> i64 {
-    let mut tx = db.begin().await.expect("begin document update");
+    // This contract deliberately lets both writers reach the repository's
+    // atomic version upsert together. Production write transactions reserve
+    // SQLite's writer before reads; use the deferred test seam to manufacture
+    // the repository-level race itself.
+    let mut tx = db.begin_deferred().await.expect("begin document update");
     barrier.wait().await;
     let version = tx
         .identity_spec_documents()

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -1347,7 +1347,7 @@ mod tests {
             .expect("upsert source with secret metadata");
         setup.commit().await.expect("commit setup");
 
-        let mut stale_upsert = db.begin().await.expect("begin stale upsert");
+        let mut stale_upsert = db.begin_deferred().await.expect("begin stale upsert");
         stale_upsert
             .sources()
             .source_created_at(&workspace, &source_name)

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -162,7 +162,11 @@ impl<S> TraceSummariesRepo<'_, S>
 where
     S: DbSession,
 {
-    pub(crate) async fn upsert(&mut self, summary: &TraceSummaryRecord) -> Result<(), DbError> {
+    pub(crate) async fn upsert(
+        &mut self,
+        summary: &TraceSummaryRecord,
+        store_id: &str,
+    ) -> Result<(), DbError> {
         let row_count = row_count_to_db(summary)?;
         let workspace_id = summary_workspace_id(summary)?;
         let span_count = i64::from(summary.span_count);
@@ -171,6 +175,7 @@ where
             .columns([
                 TraceSummaries::TraceId,
                 TraceSummaries::WorkspaceId,
+                TraceSummaries::StoreId,
                 TraceSummaries::RootSpanId,
                 TraceSummaries::Name,
                 TraceSummaries::Query,
@@ -187,6 +192,7 @@ where
             .values_panic([
                 Expr::val(summary.trace_id.clone()),
                 Expr::val(workspace_id),
+                Expr::val(store_id.to_string()),
                 Expr::val(summary.root_span_id.clone()),
                 Expr::val(summary.name.clone()),
                 Expr::val(summary.query.clone()),
@@ -204,6 +210,7 @@ where
                 OnConflict::columns([TraceSummaries::WorkspaceId, TraceSummaries::TraceId])
                     .update_columns([
                         TraceSummaries::RootSpanId,
+                        TraceSummaries::StoreId,
                         TraceSummaries::Name,
                         TraceSummaries::Query,
                         TraceSummaries::Status,
@@ -225,6 +232,21 @@ where
             )
             .to_owned();
         self.session.execute(statement).await
+    }
+
+    pub(crate) async fn delete_if_owned(
+        &mut self,
+        workspace_id: &str,
+        trace_id: &str,
+        store_id: &str,
+    ) -> Result<bool, DbError> {
+        let statement = Query::delete()
+            .from_table(TraceSummaries::Table)
+            .and_where(Expr::col(TraceSummaries::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TraceSummaries::TraceId).eq(trace_id))
+            .and_where(Expr::col(TraceSummaries::StoreId).eq(store_id))
+            .to_owned();
+        Ok(self.session.execute_rows_affected(statement).await? == 1)
     }
 }
 
@@ -494,11 +516,11 @@ mod tests {
         ensure_summary_workspace(&mut tx, first).await;
         ensure_summary_workspace(&mut tx, second).await;
         tx.trace_summaries()
-            .upsert(first)
+            .upsert(first, "repository-test-store")
             .await
             .expect("upsert first");
         tx.trace_summaries()
-            .upsert(second)
+            .upsert(second, "repository-test-store")
             .await
             .expect("upsert second");
         tx.commit().await.expect("commit trace summaries");
@@ -525,7 +547,7 @@ mod tests {
     async fn assert_update_and_failed_replacement(db: &CoralDb, updated: &TraceSummaryRecord) {
         let mut tx = db.begin().await.expect("begin update tx");
         tx.trace_summaries()
-            .upsert(updated)
+            .upsert(updated, "repository-test-store")
             .await
             .expect("upsert updated");
         let invalid = TraceSummaryRecord {
@@ -534,7 +556,9 @@ mod tests {
         };
         assert!(
             matches!(
-                tx.trace_summaries().upsert(&invalid).await,
+                tx.trace_summaries()
+                    .upsert(&invalid, "repository-test-store")
+                    .await,
                 Err(DbError::CorruptData(_))
             ),
             "invalid replacement should fail before deleting the existing summary"
@@ -550,6 +574,22 @@ mod tests {
                 .expect("get updated summary"),
             Some(updated.clone())
         );
+
+        let workspace_id = updated.workspace_id.as_deref().expect("updated workspace");
+        let mut tx = db.begin().await.expect("begin owner delete tx");
+        assert!(
+            !tx.trace_summaries()
+                .delete_if_owned(workspace_id, &updated.trace_id, "other-store")
+                .await
+                .expect("preserve foreign summary")
+        );
+        assert!(
+            tx.trace_summaries()
+                .delete_if_owned(workspace_id, &updated.trace_id, "repository-test-store")
+                .await
+                .expect("delete owned summary")
+        );
+        tx.commit().await.expect("commit owner delete");
     }
 
     async fn ensure_summary_workspace<S>(session: &mut S, summary: &TraceSummaryRecord)

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -221,6 +221,7 @@ pub(in crate::state::db) enum TraceSummaries {
     Table,
     TraceId,
     WorkspaceId,
+    StoreId,
     RootSpanId,
     Name,
     Query,

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -19,6 +19,23 @@ enum CoralTxBackend<'a> {
 impl<'a> CoralTx<'a> {
     pub(super) async fn begin(backend: &'a CoralDbBackend) -> Result<Self, DbError> {
         let backend = match backend {
+            // Every caller of `begin` opens a write transaction. Reserve the
+            // SQLite writer before taking a read snapshot so a background
+            // writer cannot make the later read-to-write upgrade fail with
+            // SQLITE_BUSY_SNAPSHOT. `begin_read_snapshot` remains deferred.
+            CoralDbBackend::Sqlite(db) => {
+                CoralTxBackend::Sqlite(db.pool.begin_with("BEGIN IMMEDIATE").await?)
+            }
+            CoralDbBackend::Postgres(db) => CoralTxBackend::Postgres(db.pool.begin().await?),
+        };
+        Ok(Self { backend })
+    }
+
+    /// Opens the old deferred transaction shape for tests that deliberately
+    /// manufacture a stale read-to-write race. Production writes use `begin`.
+    #[cfg(test)]
+    pub(super) async fn begin_deferred(backend: &'a CoralDbBackend) -> Result<Self, DbError> {
+        let backend = match backend {
             CoralDbBackend::Sqlite(db) => CoralTxBackend::Sqlite(db.pool.begin().await?),
             CoralDbBackend::Postgres(db) => CoralTxBackend::Postgres(db.pool.begin().await?),
         };

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -2,7 +2,8 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap};
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -35,6 +36,7 @@ pub(crate) mod service;
 
 use crate::bootstrap::AppError;
 use crate::state::db::{CoralDb, DbError, DbRepos};
+use crate::storage::fs as storage_fs;
 use crate::workspaces::WorkspaceName;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
@@ -53,6 +55,8 @@ static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
 const METRICS_INTERVAL: Duration = Duration::from_secs(5);
 const LOCAL_TRACE_BATCH_DELAY: Duration = Duration::from_millis(50);
 const LOCAL_TRACE_MAX_EXPORT_BATCH_SIZE: usize = 64;
+const LOCAL_TRACE_STORE_ID_FILE: &str = ".store-id";
+const LOCAL_TRACE_STORE_ID_LOCK_FILE: &str = ".store-id.lock";
 const OTLP_TRACE_DENIED_TARGETS: &[&str] = &["coral.http.body", "coral.mcp.body"];
 const OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES: &[&str] =
     &[coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX];
@@ -134,11 +138,17 @@ pub(crate) fn record_local_only_span_attribute(
 pub(crate) struct InstalledLocalTraceStore {
     pub(crate) dir: PathBuf,
     pub(crate) retention: Duration,
+    pub(crate) store_id: String,
 }
 
 impl InstalledLocalTraceStore {
-    fn new(dir: PathBuf, retention: Duration) -> Self {
-        Self { dir, retention }
+    fn new(dir: PathBuf, retention: Duration) -> Result<Self, AppError> {
+        let store_id = local_trace_store_id(&dir)?;
+        Ok(Self {
+            dir,
+            retention,
+            store_id,
+        })
     }
 }
 
@@ -169,6 +179,7 @@ struct TargetFilteringSpanExporter<E> {
 struct LocalTraceSpanExporter {
     inner: local_store::JsonlSpanExporter,
     trace_store: local_store::TraceStore,
+    store_id: String,
     db: Option<Arc<CoralDb>>,
 }
 
@@ -265,6 +276,7 @@ impl LocalTraceSpanExporter {
                 store.dir.clone(),
                 store.retention,
             ),
+            store_id: store.store_id.clone(),
             db,
         })
     }
@@ -284,7 +296,9 @@ impl SpanExporter for LocalTraceSpanExporter {
                 match self.trace_store.workspace_trace_summaries_sync(&trace_id) {
                     Ok(summaries) => {
                         for summary in summaries {
-                            if let Err(error) = upsert_trace_summary_blocking(db, &summary) {
+                            if let Err(error) =
+                                upsert_trace_summary_blocking(db, &summary, &self.store_id)
+                            {
                                 tracing::warn!(
                                     %trace_id,
                                     detail = %error,
@@ -322,9 +336,10 @@ impl SpanExporter for LocalTraceSpanExporter {
 async fn upsert_trace_summary(
     db: &CoralDb,
     summary: &local_store::TraceSummaryRecord,
+    store_id: &str,
 ) -> Result<(), DbError> {
     let mut tx = db.begin().await?;
-    tx.trace_summaries().upsert(summary).await?;
+    tx.trace_summaries().upsert(summary, store_id).await?;
     tx.commit().await?;
     Ok(())
 }
@@ -332,14 +347,38 @@ async fn upsert_trace_summary(
 fn upsert_trace_summary_blocking(
     db: &CoralDb,
     summary: &local_store::TraceSummaryRecord,
+    store_id: &str,
 ) -> Result<(), String> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|error| format!("failed to create trace summary export runtime: {error}"))?;
     runtime
-        .block_on(upsert_trace_summary(db, summary))
+        .block_on(upsert_trace_summary(db, summary, store_id))
         .map_err(|error| error.to_string())
+}
+
+fn local_trace_store_id(trace_store_dir: &Path) -> Result<String, AppError> {
+    storage_fs::ensure_private_dir(trace_store_dir)?;
+    let _lock =
+        storage_fs::FileLock::exclusive(&trace_store_dir.join(LOCAL_TRACE_STORE_ID_LOCK_FILE))?;
+    let id_path = trace_store_dir.join(LOCAL_TRACE_STORE_ID_FILE);
+    let raw = match std::fs::read_to_string(&id_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let id = uuid::Uuid::new_v4().to_string();
+            storage_fs::write_atomic(&id_path, format!("{id}\n").as_bytes())?;
+            id
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let id = uuid::Uuid::parse_str(raw.trim()).map_err(|error| {
+        AppError::InvalidInput(format!(
+            "invalid local trace store id in '{}': {error}",
+            id_path.display()
+        ))
+    })?;
+    Ok(format!("local-v1:{id}"))
 }
 
 fn span_matches_targets(span: &SpanData, targets: &Targets) -> bool {
@@ -478,9 +517,10 @@ fn configured_otlp_endpoint(config: &TelemetryConfig) -> Option<&str> {
 fn configured_local_trace_store(
     config: &TelemetryConfig,
     dir: Option<PathBuf>,
-) -> Option<InstalledLocalTraceStore> {
+) -> Result<Option<InstalledLocalTraceStore>, AppError> {
     dir.filter(|_| config.trace_history.enabled)
         .map(|dir| InstalledLocalTraceStore::new(dir, config.trace_history.retention()))
+        .transpose()
 }
 
 pub(crate) async fn delete_workspace_traces(
@@ -721,7 +761,7 @@ fn try_init_tracing(
             .with_filter(log_filter.clone())
     });
 
-    let local_trace_store = configured_local_trace_store(config, internal_trace_store_dir);
+    let local_trace_store = configured_local_trace_store(config, internal_trace_store_dir)?;
     let internal_trace_store_enabled = local_trace_store.is_some();
     let local_trace_attribute_marker_layer =
         internal_trace_store_enabled.then_some(LocalTraceAttributeMarkerLayer);
@@ -878,10 +918,26 @@ mod tests {
         DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER,
         LOCAL_TRACE_EXCLUDED_RPC_SERVICES, LocalTraceAttributeMarkerLayer,
         OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES, OTLP_TRACE_DENIED_TARGETS,
-        TargetFilteringSpanExporter, build_log_filter, build_trace_targets,
+        TargetFilteringSpanExporter, build_log_filter, build_trace_targets, local_trace_store_id,
         normalize_otlp_endpoint, parse_headers, record_local_only_span_attribute,
         trace_layer_filter,
     };
+
+    #[test]
+    fn local_trace_store_identity_is_stable_and_unique_per_store() {
+        let first = tempfile::tempdir().expect("first trace store");
+        let second = tempfile::tempdir().expect("second trace store");
+
+        let first_id = local_trace_store_id(first.path()).expect("first id");
+        assert_eq!(
+            local_trace_store_id(first.path()).expect("reloaded first id"),
+            first_id
+        );
+        assert_ne!(
+            local_trace_store_id(second.path()).expect("second id"),
+            first_id
+        );
+    }
 
     #[test]
     fn normalize_otlp_endpoint_handles_signal_paths() {

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -44,6 +44,7 @@ pub(crate) struct TraceService {
     workspaces: WorkspaceManager,
     authorizer: WorkspaceAuthorizer,
     db: Option<Arc<CoralDb>>,
+    local_store_id: Option<String>,
 }
 
 impl TraceService {
@@ -58,6 +59,7 @@ impl TraceService {
             workspaces,
             authorizer,
             db: None,
+            local_store_id: None,
         }
     }
 
@@ -116,6 +118,7 @@ impl TraceService {
     pub(crate) fn with_db(
         trace_store_file: PathBuf,
         retention: Duration,
+        local_store_id: String,
         db: Arc<CoralDb>,
         workspaces: WorkspaceManager,
         authorizer: WorkspaceAuthorizer,
@@ -125,16 +128,18 @@ impl TraceService {
             workspaces,
             authorizer,
             db: Some(db),
+            local_store_id: Some(local_store_id),
         }
     }
 
     pub(crate) async fn backfill_summaries(
         trace_store_file: PathBuf,
         retention: Duration,
+        store_id: &str,
         db: &CoralDb,
     ) -> Result<usize, DbError> {
         let traces = TraceStore::with_retention(trace_store_file, retention);
-        backfill_trace_summaries(db, &traces).await
+        backfill_trace_summaries(db, &traces, store_id).await
     }
 }
 
@@ -162,10 +167,17 @@ impl TraceServiceApi for TraceService {
             let view = trace_list_view_from_proto(request.view)?;
             let page = match (view, service.db.as_ref(), workspace_name.as_deref()) {
                 (TraceListView::All, Some(db), Some(workspace_name)) => {
+                    let local_store_id = service.local_store_id.as_deref().ok_or_else(|| {
+                        Status::new(
+                            Code::Internal,
+                            "database trace service has no local store id",
+                        )
+                    })?;
                     let mut summaries = list_database_traces(
                         &service.traces,
                         db.as_ref(),
                         workspace_name,
+                        local_store_id,
                         page_size.saturating_add(1),
                         offset,
                     )
@@ -241,7 +253,11 @@ impl TraceServiceApi for TraceService {
     }
 }
 
-async fn backfill_trace_summaries(db: &CoralDb, traces: &TraceStore) -> Result<usize, DbError> {
+async fn backfill_trace_summaries(
+    db: &CoralDb,
+    traces: &TraceStore,
+    store_id: &str,
+) -> Result<usize, DbError> {
     let mut session = db;
     let workspaces = session.workspaces().list().await?;
     let mut imported = 0;
@@ -266,7 +282,7 @@ async fn backfill_trace_summaries(db: &CoralDb, traces: &TraceStore) -> Result<u
                 );
                 continue;
             }
-            upsert_trace_summary(db, &summary).await?;
+            upsert_trace_summary(db, &summary, store_id).await?;
             imported += 1;
         }
     }
@@ -277,6 +293,7 @@ async fn list_database_traces(
     traces: &TraceManager,
     db: &CoralDb,
     workspace_name: &str,
+    local_store_id: &str,
     limit: usize,
     offset: usize,
 ) -> Result<Vec<TraceSummaryRecord>, Status> {
@@ -328,10 +345,21 @@ async fn list_database_traces(
                     valid_seen = valid_seen.saturating_add(1);
                     retained_rows += 1;
                 }
-                // Raw spans are host-local even when the database is shared.
-                // A local miss therefore cannot prove that the summary is
-                // stale: another server may still own the trace detail.
-                Err(TraceManagerError::NotFound { .. }) => retained_rows += 1,
+                Err(TraceManagerError::NotFound { .. }) => {
+                    let mut tx = db.begin().await.map_err(trace_database_status)?;
+                    let deleted = tx
+                        .trace_summaries()
+                        .delete_if_owned(workspace.as_str(), &summary.trace_id, local_store_id)
+                        .await
+                        .map_err(trace_database_status)?;
+                    tx.commit().await.map_err(trace_database_status)?;
+                    if !deleted {
+                        // Raw spans are host-local even when the database is
+                        // shared. A miss only proves staleness for a summary
+                        // this exact local store wrote.
+                        retained_rows += 1;
+                    }
+                }
                 Err(error) => return Err(trace_manager_status(error)),
             }
             if summaries.len() == limit {
@@ -517,7 +545,7 @@ mod tests {
     use crate::telemetry::local_store::TraceScope;
     use crate::telemetry::{
         StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceManager,
-        TraceSummaryRecord,
+        TraceSummaryRecord, local_trace_store_id,
     };
     use crate::workspaces::authorization::{LocalPrincipalPolicy, WorkspaceAuthorizer};
     use crate::workspaces::{MemberRole, WorkspaceManager, WorkspaceName};
@@ -1148,8 +1176,9 @@ mod tests {
         insert_summary(&db, &remote).await;
 
         let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
+        let local_store_id = local_trace_store_id(&trace_dir).expect("local store id");
         assert_eq!(
-            backfill_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces, &local_store_id)
                 .await
                 .expect("backfill trace summaries"),
             1
@@ -1170,7 +1199,7 @@ mod tests {
 
         fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
         assert_eq!(
-            backfill_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces, &local_store_id)
                 .await
                 .expect("backfill empty trace store"),
             0
@@ -1187,7 +1216,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exported_summary_is_hidden_but_retained_without_local_details() {
+    async fn exported_summary_is_pruned_without_local_details() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = Arc::new(open_sqlite(&layout).await);
@@ -1199,7 +1228,8 @@ mod tests {
             .get_trace("trace-1".to_string(), TraceScope::workspaces(["work"]))
             .await
             .expect("trace detail");
-        super::super::upsert_trace_summary(db.as_ref(), &trace.summary)
+        let local_store_id = local_trace_store_id(&trace_dir).expect("local store id");
+        super::super::upsert_trace_summary(db.as_ref(), &trace.summary, &local_store_id)
             .await
             .expect("upsert exported summary");
 
@@ -1213,6 +1243,7 @@ mod tests {
         let service = TraceService::with_db(
             trace_dir.clone(),
             Duration::from_mins(1),
+            local_store_id,
             Arc::clone(&db),
             workspaces,
             WorkspaceAuthorizer::with_local_principal_policy(
@@ -1262,7 +1293,60 @@ mod tests {
                 .into_iter()
                 .map(|summary| summary.trace_id)
                 .collect::<Vec<_>>(),
-            vec!["trace-1"]
+            Vec::<String>::new()
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_summary_is_hidden_but_retained_without_local_details() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = Arc::new(open_sqlite(&layout).await);
+        let trace_dir = temp.path().join("traces");
+        let local_store_id = local_trace_store_id(&trace_dir).expect("local store id");
+        let remote = summary("remote-trace", "work", 10);
+        insert_summary(db.as_ref(), &remote).await;
+
+        let workspaces = WorkspaceManager::new_for_tests(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            None,
+            Arc::clone(&db),
+        );
+        let service = TraceService::with_db(
+            trace_dir,
+            Duration::from_mins(1),
+            local_store_id,
+            Arc::clone(&db),
+            workspaces,
+            WorkspaceAuthorizer::with_local_principal_policy(
+                Arc::clone(&db),
+                LocalPrincipalPolicy::ImplicitOwner,
+            ),
+        );
+        let response = TraceServiceApi::list_traces(
+            &service,
+            local(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+                workspace: Some(workspace_proto("work")),
+                view: TraceView::Unspecified as i32,
+            }),
+        )
+        .await
+        .expect("list traces")
+        .into_inner();
+
+        assert!(response.traces.is_empty());
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .trace_summaries()
+                .get("remote-trace")
+                .await
+                .expect("get remote summary")
+                .is_some()
         );
     }
 
@@ -1287,9 +1371,10 @@ mod tests {
         ensure_workspace(&db, &local_workspace).await;
         insert_summary(&db, &summary(&remote_trace, &remote_workspace, 10)).await;
 
+        let local_store_id = local_trace_store_id(&trace_dir).expect("local store id");
         let traces = TraceStore::with_retention(trace_dir, Duration::from_mins(1));
         assert_eq!(
-            backfill_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces, &local_store_id)
                 .await
                 .expect("backfill trace summaries"),
             1
@@ -1334,7 +1419,7 @@ mod tests {
         ensure_workspace_in_session(&mut tx, summary.workspace_id.as_deref().expect("workspace"))
             .await;
         tx.trace_summaries()
-            .upsert(summary)
+            .upsert(summary, "remote-test-store")
             .await
             .expect("upsert trace summary");
         tx.commit().await.expect("commit trace summary");

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use coral_api::v1::{
     AddWorkspaceMemberRequest, AddWorkspaceMemberResponse, CreateWorkspaceRequest,
@@ -130,7 +131,7 @@ impl GrpcHarness {
         feature_overrides: FeatureOverrides,
         server_builder: ServerBuilder,
     ) -> Self {
-        ensure_file_credentials_config(&config_dir);
+        ensure_database_credentials_config(&config_dir);
         let server = server_builder
             .with_config_dir(&config_dir)
             .with_feature_overrides(feature_overrides)
@@ -323,7 +324,8 @@ impl GrpcHarness {
 
 /// The configuration an unauthenticated deployment reads: no `[auth]` at all,
 /// which is what leaves the local principal owning everything.
-const LOCAL_PRINCIPAL_CONFIG: &str = "[credentials]\nstorage = \"file\"\n";
+const LOCAL_PRINCIPAL_CONFIG: &str =
+    "[credentials]\nstorage = \"database\"\nencryption_key_source = \"file\"\n";
 
 /// Rewrites `config.toml` so the install runs under `mode`, keeping the rest of
 /// the file.
@@ -471,7 +473,7 @@ mod write_config_tests {
     }
 }
 
-fn ensure_file_credentials_config(config_dir: &Path) {
+fn ensure_database_credentials_config(config_dir: &Path) {
     std::fs::create_dir_all(config_dir).expect("create config dir");
     let config_file = config_dir.join("config.toml");
     let raw = std::fs::read_to_string(&config_file).unwrap_or_default();
@@ -483,7 +485,9 @@ fn ensure_file_credentials_config(config_dir: &Path) {
     } else {
         "\n"
     };
-    let updated = format!("{raw}{separator}\n[credentials]\nstorage = \"file\"\n");
+    let updated = format!(
+        "{raw}{separator}\n[credentials]\nstorage = \"database\"\nencryption_key_source = \"file\"\n"
+    );
     std::fs::write(config_file, updated).expect("write test credential config");
 }
 
@@ -704,7 +708,7 @@ impl SharedDeployment {
 
     pub(crate) async fn seed_trace_summary(&self, workspace_id: &str, trace_id: &str) {
         let pool = self.app_database().await;
-        sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count, operation_kind, operation_name, invocation_kind) VALUES (?, ?, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1, 'unspecified', '', 'unspecified')")
+        sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, store_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count, operation_kind, operation_name, invocation_kind) VALUES (?, ?, 'grpc-test-store', 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1, 'unspecified', '', 'unspecified')")
             .bind(trace_id)
             .bind(workspace_id)
             .execute(&pool)
@@ -840,6 +844,34 @@ impl SharedDeployment {
             queries,
             attributed_spans: self.attributed_spans(workspace_name),
         }
+    }
+
+    /// Waits until both the database counters and the batched local trace
+    /// exporter have stopped changing. An immediate snapshot can otherwise
+    /// attribute earlier work to whichever request follows its delayed export.
+    pub(crate) async fn settled_workspace_work(&self, workspace_name: &str) -> WorkspaceWork {
+        const SAMPLE_INTERVAL: Duration = Duration::from_millis(50);
+        const QUIET_PERIOD: Duration = Duration::from_millis(250);
+        const SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+
+        tokio::time::timeout(SETTLE_TIMEOUT, async {
+            let mut last = self.workspace_work(workspace_name).await;
+            let mut unchanged_since = Instant::now();
+            loop {
+                tokio::time::sleep(SAMPLE_INTERVAL).await;
+                let current = self.workspace_work(workspace_name).await;
+                if current == last {
+                    if unchanged_since.elapsed() >= QUIET_PERIOD {
+                        return current;
+                    }
+                } else {
+                    last = current;
+                    unchanged_since = Instant::now();
+                }
+            }
+        })
+        .await
+        .expect("workspace work and its batched trace export should settle")
     }
 
     /// Counts exported spans carrying this workspace's attribution. Every

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -363,7 +363,7 @@ async fn postgres_database_credentials_survive_restart_and_query() {
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(
         config_dir.join("config.toml"),
-        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n\n[credentials]\nstorage = \"database\"\nencryption_key_source = \"file\"\n",
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n\n[credentials]\nstorage = \"database\"\nencryption_key_env = \"CORAL_TEST_CREDENTIAL_KEK\"\n",
     )
     .expect("write postgres credential config");
     let source_name = format!("secured_messages_{}", uuid::Uuid::new_v4().simple());

--- a/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_access_read_tests.rs
@@ -246,7 +246,7 @@ async fn workspace_access_read_harness_seats_two_people_around_one_workspace() {
     // all: without this, an emptiness assertion would pass on a blind observer.
     assert!(
         deployment
-            .workspace_work("read-harness")
+            .settled_workspace_work("read-harness")
             .await
             .attributed_spans
             > 0,
@@ -366,7 +366,7 @@ async fn refused_reads_leave_the_workspace_no_record_of_them() {
         "every read surface must refuse before it does anything: {refused:?}",
     );
     assert_eq!(
-        deployment.workspace_work("read-record").await,
+        deployment.settled_workspace_work("read-record").await,
         WorkspaceWork::default(),
         "refused work must create no task row, no recorded query, and no attributed span",
     );
@@ -377,7 +377,7 @@ async fn refused_reads_leave_the_workspace_no_record_of_them() {
     execute_sql_in_task(&owner, "read-record", &task_id, "select 1")
         .await
         .expect("the owner runs a statement under it");
-    let recorded = deployment.workspace_work("read-record").await;
+    let recorded = deployment.settled_workspace_work("read-record").await;
     assert!(
         recorded.tasks > 0 && recorded.queries > 0 && recorded.attributed_spans > 0,
         "permitted work must move every counter the refusals left at zero: {recorded:?}",

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -1323,7 +1323,7 @@ async fn insert_trace_summary(config_dir: &Path, workspace_id: &str, trace_id: &
         .execute(&pool)
         .await
         .expect("insert workspace");
-    sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count, operation_kind, operation_name, invocation_kind) VALUES (?1, ?2, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1, 'unspecified', '', 'unspecified')")
+    sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, store_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count, operation_kind, operation_name, invocation_kind) VALUES (?1, ?2, 'grpc-test-store', 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1, 'unspecified', '', 'unspecified')")
         .bind(trace_id)
         .bind(workspace_id)
     .execute(&pool)

--- a/crates/coral-app/tests/grpc_workspace_source_access.rs
+++ b/crates/coral-app/tests/grpc_workspace_source_access.rs
@@ -468,7 +468,7 @@ async fn refused_source_requests_leave_the_workspace_untouched() {
     let task_id = start_task(&owner, "source-record")
         .await
         .expect("the owner opens a task");
-    let before = deployment.workspace_work("source-record").await;
+    let before = deployment.settled_workspace_work("source-record").await;
     assert!(
         before.tasks > 0,
         "the attributed refusal below only probes anything if that task really is on this workspace's record: {before:?}",
@@ -511,7 +511,7 @@ async fn refused_source_requests_leave_the_workspace_untouched() {
     );
 
     assert_eq!(
-        deployment.workspace_work("source-record").await,
+        deployment.settled_workspace_work("source-record").await,
         before,
         "refused work must add no task row, no recorded query, and no attributed span — not even when the statement names a task that really is in this workspace",
     );
@@ -532,7 +532,7 @@ async fn refused_source_requests_leave_the_workspace_untouched() {
     execute_sql_in_task(&owner, "source-record", &task_id, "select 1")
         .await
         .expect("the owner runs a statement under their own task");
-    let recorded = deployment.workspace_work("source-record").await;
+    let recorded = deployment.settled_workspace_work("source-record").await;
     assert!(
         recorded.queries > before.queries && recorded.attributed_spans > before.attributed_spans,
         "permitted work must move the counters the refusals left where they were: {recorded:?} after {before:?}",

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -59,7 +59,7 @@ async fn start_server_with_postgres_config(database_url: &str) -> PostgresServer
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(
         config_dir.join("config.toml"),
-        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n\n[credentials]\nstorage = \"database\"\nencryption_key_env = \"CORAL_TEST_CREDENTIAL_KEK\"\n",
     )
     .expect("write config");
 

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -134,7 +134,7 @@ fn prepare_config_dir(temp_dir: &Path) -> Result<PathBuf> {
         .with_context(|| format!("creating {}", config_dir.display()))?;
     fs::write(
         config_dir.join("config.toml"),
-        "[credentials]\nstorage = \"file\"\n",
+        "[credentials]\nstorage = \"database\"\nencryption_key_source = \"file\"\n",
     )
     .with_context(|| format!("writing {}", config_dir.join("config.toml").display()))?;
     Ok(config_dir)


### PR DESCRIPTION
## Intent

Fail closed for obsolete credential-storage settings and inconsistent Postgres encryption keys while protecting shared trace data and SQLite writes from cross-task interference.

## What it enables

Shared deployments use one explicit credential-key domain, trace retention deletes only summaries owned by the local store, and foreground SQLite write transactions remain valid while background trace exports are active.

## Usage examples

For SQLite, omit `storage` or set `storage = "database"` and choose a local `encryption_key_source`. For Postgres, set `encryption_key_env` to the same key on every server. Existing `storage = "file"` configurations now fail at startup with migration guidance.