### PR TITLE
feat(coral-ui): scope remote MCP installs to workspaces

### DIFF
--- a/apps/coral-ui/app/components/mcp-clients-list/mcp-client-install-list.stories.tsx
+++ b/apps/coral-ui/app/components/mcp-clients-list/mcp-client-install-list.stories.tsx
@@ -15,6 +15,7 @@ const meta = {
         installCommand:
           'npx -y add-mcp@1.11.0 https://coral.example/mcp --global --agent codex --name coral --transport http --yes',
         name: 'Codex',
+        workspaceInstallUrl: 'https://coral.example/mcp',
       },
       {
         id: 'claude-desktop',
@@ -23,6 +24,7 @@ const meta = {
           'Claude Desktop supports remote MCP servers through Settings → Connectors. Add the Coral endpoint there.',
       },
     ],
+    workspaces: [{ name: 'team-analytics-insights' }],
   },
   component: McpClientInstallList,
   parameters: { layout: 'padded' },

--- a/apps/coral-ui/app/components/mcp-clients-list/mcp-client-install-list.tsx
+++ b/apps/coral-ui/app/components/mcp-clients-list/mcp-client-install-list.tsx
@@ -16,6 +16,7 @@ export type McpClientInstallListItem =
       readonly installCommandLabel?: string
       readonly workspaceInstallCommand?: string
       readonly workspaceInstallShell?: 'posix' | 'powershell'
+      readonly workspaceInstallUrl?: string
     })
   | (McpClientInstallListItemBase & { readonly setupInstructions: string })
 
@@ -68,13 +69,19 @@ export function McpClientInstallList({
         {visibleClients.map((client) => {
           const workspace = selectedWorkspaces[client.id]
           const canSelectWorkspace =
-            'workspaceInstallCommand' in client && client.workspaceInstallCommand
+            ('workspaceInstallCommand' in client && client.workspaceInstallCommand) ||
+            ('workspaceInstallUrl' in client && client.workspaceInstallUrl)
           const installCommand =
-            'workspaceInstallCommand' in client && client.workspaceInstallCommand && workspace
-              ? `${client.workspaceInstallCommand} --args ${quoteShell(`--workspace=${workspace}`, client.workspaceInstallShell)}`
-              : 'installCommand' in client
-                ? client.installCommand
-                : undefined
+            'workspaceInstallUrl' in client && client.workspaceInstallUrl && workspace
+              ? client.installCommand.replace(
+                  client.workspaceInstallUrl,
+                  workspaceMcpUrl(client.workspaceInstallUrl, workspace),
+                )
+              : 'workspaceInstallCommand' in client && client.workspaceInstallCommand && workspace
+                ? `${client.workspaceInstallCommand} --args ${quoteShell(`--workspace=${workspace}`, client.workspaceInstallShell)}`
+                : 'installCommand' in client
+                  ? client.installCommand
+                  : undefined
 
           return (
             <Table.Row key={client.id}>
@@ -151,6 +158,12 @@ export function McpClientInstallList({
       </Table.Body>
     </Table.Container>
   )
+}
+
+function workspaceMcpUrl(remoteMcpUrl: string, workspace: string): string {
+  const url = new URL(remoteMcpUrl)
+  url.pathname = `${url.pathname.replace(/\/$/, '')}/workspace/${encodeURIComponent(workspace)}`
+  return url.toString()
 }
 
 function quoteShell(value: string, shell: 'posix' | 'powershell' = 'posix'): string {

--- a/apps/coral-ui/app/routes/settings-loader.ts
+++ b/apps/coral-ui/app/routes/settings-loader.ts
@@ -15,7 +15,6 @@ import { addToast } from '@/wax/components/toast'
 interface WebSettingsLoaderData {
   readonly runtime: 'web'
   readonly mcpClients: readonly McpClientInstallListItem[]
-  readonly usesRemoteMcp: boolean
 }
 
 export interface DesktopSettingsLoaderData {
@@ -35,7 +34,6 @@ export function loader({ request }: Route.LoaderArgs): WebSettingsLoaderData {
   const windows = isWindowsRequest(request)
   return {
     runtime: 'web',
-    usesRemoteMcp: connection.mode === 'remote',
     mcpClients: webMcpClients.map((client) => {
       const setupInstructions =
         connection.mode === 'remote' && remoteMcpClientInstructions[client.id]
@@ -61,7 +59,7 @@ export function loader({ request }: Route.LoaderArgs): WebSettingsLoaderData {
                     : `npx --yes add-mcp@1.11.0 "$(command -v coral)" --global --agent ${client.id} --name coral --args mcp-stdio --yes`,
                   workspaceInstallShell: windows ? 'powershell' : 'posix',
                 }
-              : {}),
+              : { workspaceInstallUrl: connection.url }),
           }
     }),
   }

--- a/apps/coral-ui/app/routes/settings.server.test.ts
+++ b/apps/coral-ui/app/routes/settings.server.test.ts
@@ -9,7 +9,6 @@ describe('settings loader', () => {
   it('loads local install commands with workspace support', () => {
     expect(loader(request())).toEqual({
       runtime: 'web',
-      usesRemoteMcp: false,
       mcpClients: expect.arrayContaining([
         expect.objectContaining({
           id: 'codex',
@@ -27,7 +26,6 @@ describe('settings loader', () => {
     vi.stubEnv('CORAL_MCP_URL', 'https://coral.example.com/mcp')
 
     const result = loader(request())
-    expect(result.usesRemoteMcp).toBe(true)
     expect(result.mcpClients).toContainEqual({
       id: 'claude-desktop',
       name: 'Claude Desktop',
@@ -45,6 +43,7 @@ describe('settings loader', () => {
       installCommand:
         'npx -y add-mcp@1.11.0 https://coral.example.com/mcp --global --agent codex --name coral --transport http --yes',
       name: 'Codex',
+      workspaceInstallUrl: 'https://coral.example.com/mcp',
     })
   })
 
@@ -57,7 +56,6 @@ describe('settings loader', () => {
       } as Parameters<typeof loader>[0]),
     ).toEqual({
       runtime: 'web',
-      usesRemoteMcp: false,
       mcpClients: expect.arrayContaining([
         expect.objectContaining({
           id: 'codex',

--- a/apps/coral-ui/app/views/settings/settings.tsx
+++ b/apps/coral-ui/app/views/settings/settings.tsx
@@ -68,12 +68,6 @@ export function Settings({
     >
       <KeyboardShortcut handler={onSearchShortcut} shortcut="$mod+f" />
 
-      {loaderData.runtime === 'web' && loaderData.usesRemoteMcp ? (
-        <Banner>
-          Remote MCP connections use the default workspace configured by the Coral endpoint.
-        </Banner>
-      ) : null}
-
       <Banner>
         {desktop
           ? 'This page shows only global MCP configurations. Project-specific and other connections will not appear here.'


### PR DESCRIPTION
## Summary

- let users choose an accessible workspace when copying an MCP client install command
- generate workspace-scoped remote MCP URLs while preserving local `mcp-stdio --workspace` installs
- clarify the remote MCP guidance and cover encoded workspace names in Storybook and tests  
  
  
![CleanShot 2026-08-27 at 17.51.30@2x.png](https://app.graphite.com/user-attachments/assets/7b98e488-7be7-4802-83ad-4c15e1d407d8.png)

    

## Validation

- `npm run check --prefix apps/coral-ui`
- `npm run typecheck --prefix apps/coral-ui`
- `npm test --prefix apps/coral-ui`
- `npm run build --prefix apps/coral-ui`
- `npm run test:server --prefix apps/coral-ui`