### PR TITLE
feat(app): persist source catalog and artifacts in the database

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -9,7 +9,7 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 
 Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
 
-This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
+This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary. For installed sources the file is a mirror of Coral's database — see [Source persistence](#source-persistence).
 
 <Note>
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
@@ -73,6 +73,95 @@ shell default or `--workspace <NAME>` for one command, as described in
 Source specs imported from files and source credential material remain scoped
 to the source installation in a workspace. Reusable global source specs and
 reusable credential references are not config objects today.
+
+## Source persistence
+
+Which sources are installed, the manifests Coral imported for them, and the
+artifacts Coral materialized from those manifests are recorded in Coral's
+[database](#database). The `[workspaces.<name>.sources.<name>]` entries above are
+a mirror of that record, kept current so earlier Coral versions and
+hand-maintained setups keep working, and the imported `manifest.yaml` and
+`materialized/` files stay on disk as a per-host cache. Managing sources is
+unchanged: keep using `coral source add`, `list`, `info`, and `remove`.
+
+### Every boot imports what it finds
+
+On each start, Coral imports the source entries in `config.toml` that its
+database does not already have, then brings the mirror and the on-disk caches
+back in line. The pass is additive and never fails startup: legacy data Coral
+cannot read is reported and skipped, and no boot empties a catalog you
+populated. A source added by hand or by an older Coral appears the next time you
+start Coral, with no migration step to run and no version stamp to satisfy.
+
+### How Coral tells its own files apart
+
+Coral records what it last wrote to this host's files in `config.toml.ledger`,
+beside `config.toml`. Other Coral versions ignore that file; if it goes missing,
+Coral rebuilds it and treats the next start as this host's first. Every
+file-versus-database decision follows one rule:
+
+- Content **matching** the record is provably Coral's own, so Coral leaves it or
+  refreshes it silently.
+- Content **differing** from the record was rewritten locally, by you or by an
+  older binary, so the file wins and Coral imports it.
+- Content Coral has **no record of** cannot be proven either way, so Coral never
+  guesses: it keeps what is on disk and tells you.
+
+An upgrade that adds a field to a stored source entry changes every recorded
+hash with it, so the first boot on that version reads every mirrored entry as
+locally rewritten and re-imports it from `config.toml` once. Entries and rows
+agree at that point, so nothing changes but the record.
+
+### Coral owns the installed manifest copy
+
+Once a source is imported, the `manifest.yaml` under
+`workspaces/<workspace>/sources/<source>/` is Coral's copy to maintain. To change
+a source, edit your own manifest and re-import it with `coral source add --file`.
+A copy Coral cannot prove it wrote is never overwritten in place: Coral renames
+it to `manifest.yaml.diverged-<timestamp>` beside the original, restores the
+database copy, and warns with both paths.
+
+### Running an older version again
+
+An earlier Coral reads `config.toml` as it always did — there is no gate that
+refuses to start — and the mirror keeps its catalog current rather than frozen.
+One asymmetry: the entry for a source deleted through another host lingers in
+this host's file, inert to the current version but still listed by an older one.
+Four more consequences are worth knowing, all resolved toward restoring data
+rather than losing it:
+
+- A source an older binary **deletes** comes back on the next boot of the current
+  version, usually reporting missing credentials because the old binary removed
+  its secrets.
+- A deletion made by the current version sticks across reboots and across hosts
+  sharing one database — except on a host whose *first* boot on the current
+  version happens after that deletion. With no record of the entry, that host
+  restores the source once; the same applies to a deleted workspace and its
+  sources.
+- A source **re-added** with an older binary is imported on the next boot, unless
+  the entry that binary writes is identical to the stale one already in the file.
+  Re-import the source with the current version to bring it back.
+- On a host's first boot on the current version, a config entry or manifest cache
+  that differs from the database is left in place with a warning, or set aside
+  once. From then on, routine cross-host updates are refreshed silently.
+
+### Credentials and what stays in files
+
+Credential material is untouched by all of this: it is stored, provided, and
+secured exactly as before, which also means it stays on the host that holds it.
+A second host reading the same database lists and inspects a source normally,
+but its queries fail with a missing-credentials error until you provision that
+host's credentials.
+
+Each host keeps these in files rather than in the database:
+
+- every non-source section of `config.toml`, plus the source mirror itself
+- credential material and its encryption key
+- `overrides/` files, which take precedence over what Coral restores and are
+  never rewritten by it
+- installed functions and their `function.sql`
+- the search index, trace history, and lock files
+- `config.toml.ledger`, the host-local record described above
 
 ## Server
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -87,8 +87,8 @@ unchanged: keep using `coral source add`, `list`, `info`, and `remove`.
 ### Every boot imports what it finds
 
 On each start, Coral imports the source entries in `config.toml` that its
-database does not already have, then brings the mirror and the on-disk caches
-back in line. The pass is additive and never fails startup: legacy data Coral
+database does not already have — or that changed on this host since Coral last
+wrote them — then brings the mirror and the on-disk caches back in line. The pass is additive and never fails startup: legacy data Coral
 cannot read is reported and skipped, and no boot empties a catalog you
 populated. A source added by hand or by an older Coral appears the next time you
 start Coral, with no migration step to run and no version stamp to satisfy.
@@ -127,7 +127,7 @@ An earlier Coral reads `config.toml` as it always did — there is no gate that
 refuses to start — and the mirror keeps its catalog current rather than frozen.
 One asymmetry: the entry for a source deleted through another host lingers in
 this host's file, inert to the current version but still listed by an older one.
-Four more consequences are worth knowing, all resolved toward restoring data
+Four more consequences are worth knowing, all resolved toward preserving data
 rather than losing it:
 
 - A source an older binary **deletes** comes back on the next boot of the current
@@ -141,9 +141,10 @@ rather than losing it:
 - A source **re-added** with an older binary is imported on the next boot, unless
   the entry that binary writes is identical to the stale one already in the file.
   Re-import the source with the current version to bring it back.
-- On a host's first boot on the current version, a config entry or manifest cache
-  that differs from the database is left in place with a warning, or set aside
-  once. From then on, routine cross-host updates are refreshed silently.
+- On a host's first boot on the current version, a config entry that differs
+  from the database is left in place with a warning, and a manifest cache that
+  differs is set aside once. From then on, routine cross-host updates are
+  refreshed silently.
 
 ### Credentials and what stays in files
 

--- a/crates/coral-app/migrations/0020_source_catalog.sql
+++ b/crates/coral-app/migrations/0020_source_catalog.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS sources (
+    workspace_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version TEXT,
+    origin_kind TEXT NOT NULL,
+    -- Metadata only: the credential material itself stays in the store named
+    -- here (file or keychain), never in this database.
+    credential_storage TEXT,
+    credential_revision TEXT NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000',
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, name),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS source_variables (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name, key),
+    FOREIGN KEY (workspace_id, source_name)
+        REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS source_secret_keys (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    key TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name, key),
+    FOREIGN KEY (workspace_id, source_name)
+        REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);
+
+-- Deletion record: written in the same transaction as a delete by this binary,
+-- so deletions stick across hosts sharing one database (the boot import skips
+-- tombstoned entries the mirror ledger proves are stale mirrors). No foreign
+-- key to sources -- the source row is gone by design; the workspace cascade is
+-- the only one that applies.
+CREATE TABLE IF NOT EXISTS source_tombstones (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    deleted_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0021_source_artifacts.sql
+++ b/crates/coral-app/migrations/0021_source_artifacts.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS source_manifests (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    manifest_yaml TEXT NOT NULL,
+    -- sha256 of manifest_yaml; the on-disk manifest.yaml is a per-host cache
+    -- and this is what its freshness is decided against.
+    manifest_hash TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name),
+    FOREIGN KEY (workspace_id, source_name)
+        REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);
+
+-- Singular by construction: v4 is single-surface with a flat file layout, so
+-- one row reproduces one materialized directory. No child table, no surface id.
+CREATE TABLE IF NOT EXISTS materializations (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    materialization_version TEXT NOT NULL,
+    -- Nullable because the v4 loader treats fingerprints as optional.
+    fingerprint_yaml TEXT,
+    projections_yaml TEXT NOT NULL,
+    -- Nullable for the same reason as fingerprint_yaml.
+    diagnostics_yaml TEXT,
+    -- SQLite stores this as BLOB (its type names are advisory), Postgres as bytea.
+    source_document_raw BYTEA NOT NULL,
+    source_document_yaml TEXT NOT NULL,
+    semantic_ir_yaml TEXT NOT NULL,
+    operation_metadata_yaml TEXT NOT NULL DEFAULT '',
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name),
+    FOREIGN KEY (workspace_id, source_name)
+        REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -404,6 +404,7 @@ impl ServerBuilder {
             diagnostic_reporter.clone(),
         )
         .with_pool_registry(Arc::clone(&workspace_pool_registry))
+        .with_database(Arc::clone(&coral_db))
         .with_database_sources_enabled(database_sources_enabled);
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),

--- a/crates/coral-app/src/query/input_resolver.rs
+++ b/crates/coral-app/src/query/input_resolver.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::sources::model::InstalledSource;
-use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DbRepos as _};
 use crate::workspaces::WorkspaceName;
 
 type SourceCredentialMaterial = BTreeMap<String, String>;
@@ -33,7 +33,7 @@ struct SharedSourceCredentialSnapshot {
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
-    config_store: ConfigStore,
+    db: Arc<CoralDb>,
     credential_manager: CredentialManager,
     source_credentials: Arc<SourceCredentialSnapshotByName>,
     delegate: Option<Arc<dyn SourceInputResolver>>,
@@ -42,14 +42,14 @@ pub(crate) struct CredentialRefreshingInputResolver {
 impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
-        config_store: ConfigStore,
+        db: Arc<CoralDb>,
         credential_manager: CredentialManager,
         source_credentials: BTreeMap<String, SourceCredentialSnapshot>,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
         Self {
             workspace_name,
-            config_store,
+            db,
             credential_manager,
             source_credentials: shared_source_credentials(source_credentials),
             delegate,
@@ -152,7 +152,7 @@ impl CredentialRefreshingInputResolver {
             .credential_refresh_lock(&self.workspace_name, &credential_set_id)
             .await
             .map_err(source_input_error)?;
-        if !self.source_config_still_matches_snapshot(&snapshot.source)? {
+        if !self.source_still_matches_snapshot(&snapshot.source).await? {
             return self
                 .credential_manager
                 .refresh_material_for_inputs(source.declared_inputs(), material)
@@ -178,18 +178,23 @@ impl CredentialRefreshingInputResolver {
         Ok(())
     }
 
-    fn source_config_still_matches_snapshot(
+    /// Whether the catalog still holds the source this snapshot was taken from.
+    ///
+    /// The database is awaited directly rather than bridged through a blocking
+    /// thread: this runs on the query hot path, under the credential refresh
+    /// lock, and a bridge would spawn a thread and a runtime per call while
+    /// blocking a tokio worker.
+    async fn source_still_matches_snapshot(
         &self,
         snapshot: &InstalledSource,
     ) -> Result<bool, SourceInputResolverError> {
-        match self
-            .config_store
+        let mut session = self.db.as_ref();
+        let current = session
+            .sources()
             .get_source(&self.workspace_name, &snapshot.name)
-        {
-            Ok(current) => Ok(current == *snapshot),
-            Err(AppError::SourceNotFound(_)) => Ok(false),
-            Err(error) => Err(source_input_error(error)),
-        }
+            .await
+            .map_err(|error| source_input_error(AppError::from(error)))?;
+        Ok(current.as_ref() == Some(snapshot))
     }
 }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -39,6 +39,7 @@ use crate::sources::runtime_package::{
     RuntimeContractFingerprint, query_source_from_installed_manifest,
 };
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
+use crate::state::db::DbRepos as _;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::activity::{
     PendingTaskQuery, TaskActivityRecorder, TaskQueryRelation, TaskQueryStatus,
@@ -575,9 +576,9 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source = config
-                .get_source(workspace_name, source_name)
-                .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+            let source = self
+                .catalog_source(workspace_name, source_name)
+                .await
                 .map_err(QueryManagerError::App)?;
             let (loaded_source, version) = self
                 .load_query_source(workspace_name, &source)
@@ -611,7 +612,8 @@ impl QueryManager {
         self.require_workspace(workspace_name).await?;
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources_from_config(workspace_name, &config);
+        let catalog = self.catalog_sources(workspace_name).await?;
+        let sources = self.load_query_sources_from_catalog(workspace_name, catalog);
         Ok((sources, config))
     }
 
@@ -621,10 +623,40 @@ impl QueryManager {
             .await
     }
 
-    fn load_query_sources_from_config(
+    /// One workspace's installed sources, from the authoritative catalog.
+    ///
+    /// Awaited directly rather than bridged through a blocking thread: every
+    /// caller here already runs on a tokio task, and blocking one on database
+    /// I/O is the starvation class the state-lock waits were moved off.
+    async fn catalog_sources(
         &self,
         workspace_name: &WorkspaceName,
-        config: &AppConfig,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let mut session = self.workspace_manager.database().as_ref();
+        Ok(session
+            .sources()
+            .list_workspace_sources(workspace_name)
+            .await?)
+    }
+
+    /// One installed source from the authoritative catalog.
+    async fn catalog_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        let mut session = self.workspace_manager.database().as_ref();
+        session
+            .sources()
+            .get_source(workspace_name, source_name)
+            .await?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
+    }
+
+    fn load_query_sources_from_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        sources: Vec<InstalledSource>,
     ) -> QuerySourceLoad {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
@@ -638,7 +670,7 @@ impl QueryManager {
         let _guard = span.enter();
         let mut loaded_sources = Vec::new();
         let mut failed_source_names = BTreeSet::new();
-        for source in config.workspace_sources(workspace_name) {
+        for source in sources {
             match self.load_query_source(workspace_name, &source) {
                 Ok((loaded_source, _version)) => {
                     self.diagnostic_reporter.clear_source_load_failure(
@@ -805,7 +837,7 @@ impl QueryManager {
             CredentialResolutionMode::Refreshing => {
                 Arc::new(CredentialRefreshingInputResolver::new(
                     workspace_name.clone(),
-                    self.config_store.clone(),
+                    Arc::clone(self.workspace_manager.database()),
                     self.credential_manager.clone(),
                     source_credentials,
                     provider_input_resolver,
@@ -865,7 +897,9 @@ impl QueryManager {
             .await
             .map_err(QueryManagerError::App)?;
         let _lifecycle_snapshot = self.lifecycle_lock.snapshot_async().await;
-        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        let (loaded_sources, config) = self
+            .load_function_validation_sources(workspace_name)
+            .await?;
         self.validate_udf_sql_against_snapshot(workspace_name, artifact, &loaded_sources, &config)
             .await
     }
@@ -934,11 +968,13 @@ impl QueryManager {
         if lifecycle_snapshot.revision() != revision {
             return Ok(None);
         }
-        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        let (loaded_sources, config) = self
+            .load_function_validation_sources(workspace_name)
+            .await?;
         Ok(Some((loaded_sources, config)))
     }
 
-    fn load_function_validation_sources(
+    async fn load_function_validation_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<(Vec<LoadedQuerySource>, AppConfig), QueryManagerError> {
@@ -951,7 +987,11 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source_load = self.load_query_sources_from_config(workspace_name, &config);
+            let catalog = self
+                .catalog_sources(workspace_name)
+                .await
+                .map_err(QueryManagerError::App)?;
+            let source_load = self.load_query_sources_from_catalog(workspace_name, catalog);
             (source_load.loaded, config)
         };
         Ok((loaded_sources, config))
@@ -1469,7 +1509,9 @@ mod tests {
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::identity::Principal;
     use crate::request_context::RequestContext;
-    use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
+    use crate::sources::manager::{
+        ImportSourceCommand, SourceBindings, SourceManager, run_source_db_operation,
+    };
     use crate::sources::model::SourceOrigin;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::task::activity::TaskActivityRecorder;
@@ -1558,21 +1600,44 @@ mod tests {
         }
     }
 
-    fn install_keychain_github_source(config_store: &ConfigStore, workspace_name: &WorkspaceName) {
-        config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: SourceName::parse("github").expect("source name"),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["GITHUB_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::Keychain),
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
+    async fn install_keychain_github_source(
+        manager: &QueryManager,
+        workspace_name: &WorkspaceName,
+    ) {
+        let source = InstalledSource {
+            name: SourceName::parse("github").expect("source name"),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: vec!["GITHUB_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::Keychain),
+            credential_revision: uuid::Uuid::default(),
+            origin: SourceOrigin::Bundled,
+        };
+        manager
+            .config_store
+            .upsert_source(workspace_name, source.clone())
             .expect("persist source");
+        seed_source_row(manager, workspace_name, &source).await;
+    }
+
+    /// Writes the catalog row the query path enumerates from, for a fixture
+    /// that stages its source files by hand rather than through an install.
+    async fn seed_source_row(
+        manager: &QueryManager,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) {
+        let mut tx = manager
+            .workspace_manager
+            .database()
+            .begin()
+            .await
+            .expect("begin source seed");
+        tx.sources()
+            .upsert_source(workspace_name, source, 1)
+            .await
+            .expect("seed source row");
+        tx.commit().await.expect("commit source seed");
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
@@ -3197,6 +3262,7 @@ paths:
         let calls = Arc::new(AtomicUsize::new(0));
         let config_store = fixture.manager.config_store.clone();
         let lifecycle_lock = fixture.manager.lifecycle_lock.clone();
+        let db = Arc::clone(fixture.manager.workspace_manager.database());
         let workspace = workspace_name.clone();
         let source_name = SourceName::parse("function_demo").expect("source name");
         fixture.manager.engine_extensions_providers.push(Arc::new(
@@ -3207,6 +3273,16 @@ paths:
                     config_store
                         .remove_source(&workspace, &source_name)
                         .expect("remove source during function validation");
+                    run_source_db_operation(async {
+                        let mut tx = db.begin().await.expect("begin source removal");
+                        tx.sources()
+                            .remove_source(&workspace, &source_name, 1)
+                            .await
+                            .expect("remove source row");
+                        tx.commit().await.expect("commit source removal");
+                        Ok(())
+                    })
+                    .expect("remove source row during function validation");
                 })),
             },
         ));
@@ -3408,7 +3484,7 @@ tables:
             .expect("import source");
     }
 
-    fn install_missing_v4_materialization_source(
+    async fn install_missing_v4_materialization_source(
         manager: &QueryManager,
         workspace_name: &WorkspaceName,
     ) -> SourceName {
@@ -3427,25 +3503,24 @@ surface:
 ",
         )
         .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: uuid::Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
         manager
             .config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
+            .upsert_source(workspace_name, source.clone())
             .expect("persist source");
+        seed_source_row(manager, workspace_name, &source).await;
         source_name
     }
 
-    fn install_corrupt_parquet_source(
+    async fn install_corrupt_parquet_source(
         manager: &QueryManager,
         workspace_name: &WorkspaceName,
         fake_home: &std::path::Path,
@@ -3477,21 +3552,20 @@ tables:
 "#,
         )
         .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: uuid::Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
         manager
             .config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: Some("0.1.0".to_string()),
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
+            .upsert_source(workspace_name, source.clone())
             .expect("persist source");
+        seed_source_row(manager, workspace_name, &source).await;
         source_name
     }
 
@@ -3501,7 +3575,7 @@ tables:
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = test_workspace();
         let source_name =
-            install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
+            install_missing_v4_materialization_source(&fixture.manager, &workspace_name).await;
 
         let (source_load, _) = fixture
             .manager
@@ -3530,7 +3604,7 @@ tables:
         let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let failed_source =
-            install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
+            install_missing_v4_materialization_source(&fixture.manager, &workspace_name).await;
 
         let resolution = fixture
             .manager
@@ -3617,7 +3691,8 @@ tables:
         let workspace_name = test_workspace();
         install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let failed_source =
-            install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path());
+            install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path())
+                .await;
 
         let resolution = fixture
             .manager
@@ -3645,7 +3720,7 @@ tables:
     async fn load_query_sources_skips_unavailable_keychain_source() {
         let fixture = query_manager_with_unavailable_keychain().await;
         let workspace_name = test_workspace();
-        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+        install_keychain_github_source(&fixture.manager, &workspace_name).await;
 
         let (source_load, _) = fixture
             .manager
@@ -3681,7 +3756,7 @@ select 1 as value
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated)
             .expect("install constant function");
-        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+        install_keychain_github_source(&fixture.manager, &workspace_name).await;
 
         let functions = fixture
             .manager

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -1,6 +1,7 @@
 //! App-level Universal Search manager.
 
 use std::future::Future;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use opentelemetry::trace::Status as OtelStatus;
@@ -117,6 +118,7 @@ impl SearchManager {
         let observed_scope_loader = ObservedValuesLiveScopeLoader::new(
             layout.clone(),
             config_store.clone(),
+            Arc::clone(workspace_manager.database()),
             diagnostic_reporter,
         );
         Self {

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -473,8 +473,9 @@ tables:
         credential_revision: Uuid,
     ) {
         let mut source = config_store
-            .list_workspace_sources(workspace)
-            .expect("list sources")
+            .load_catalog_unlocked()
+            .expect("load mirrored catalog")
+            .workspace_sources(workspace)
             .into_iter()
             .find(|source| &source.name == source_name)
             .expect("installed source");

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -1,20 +1,24 @@
 //! Live observed-value source-scope loading.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use crate::bootstrap::AppError;
 use crate::search::observed::source_scope::{SourceScopeSeed, source_surface_scopes};
 use crate::search::observed::{ObservedValuesLiveScope, ObservedValuesLiveScopeLoadFailure};
 use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::manager::run_source_db_operation;
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::query_source_from_installed_manifest;
+use crate::state::db::{CoralDb, DbRepos as _};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValuesLiveScopeLoader {
     config_store: ConfigStore,
+    db: Arc<CoralDb>,
     diagnostic_reporter: SourceDiagnosticReporter,
     layout: AppStateLayout,
 }
@@ -29,15 +33,23 @@ impl ObservedValuesLiveScopeLoader {
     pub(crate) fn new(
         layout: AppStateLayout,
         config_store: ConfigStore,
+        db: Arc<CoralDb>,
         diagnostic_reporter: SourceDiagnosticReporter,
     ) -> Self {
         Self {
             config_store,
+            db,
             diagnostic_reporter,
             layout,
         }
     }
 
+    /// Loads the live observed-value scopes of one workspace's sources.
+    ///
+    /// Synchronous, and bridged onto the database accordingly: the caller runs
+    /// this whole load inside the search manager's `spawn_blocking`, because
+    /// rebuilding each runtime package reads manifests and materialized
+    /// artifacts off disk.
     pub(crate) fn load(
         &self,
         workspace_name: &WorkspaceName,
@@ -47,8 +59,13 @@ impl ObservedValuesLiveScopeLoader {
         // a separate cache key would duplicate that dependency graph and risk
         // admitting observations under a stale scope.
         let _state_lock = self.config_store.state_lock_shared()?;
-        let config = self.config_store.load_config_unlocked()?;
-        let sources = config.workspace_sources(workspace_name);
+        let sources = run_source_db_operation(async {
+            let mut session = self.db.as_ref();
+            Ok(session
+                .sources()
+                .list_workspace_sources(workspace_name)
+                .await?)
+        })?;
         Ok(self.load_sources(workspace_name, sources))
     }
 
@@ -112,6 +129,7 @@ impl ObservedValuesLiveScopeLoader {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     use tempfile::tempdir;
     use uuid::Uuid;
@@ -121,11 +139,54 @@ mod tests {
     use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
     use crate::sources::SourceName;
     use crate::sources::catalog::resolve_installed_manifest;
+    use crate::sources::manager::run_source_db_operation;
     use crate::sources::materialization::SourceDiagnosticReporter;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::sources::runtime_package::query_source_from_installed_manifest;
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, now_unix_nanos_i64,
+    };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
+
+    /// One migrated database holding the workspace a test seeds sources into.
+    fn test_db(layout: &AppStateLayout, workspace: &WorkspaceName) -> Arc<CoralDb> {
+        layout.ensure().expect("ensure layout");
+        let DatabaseConfig::Sqlite { path } =
+            DatabaseConfig::load(layout).expect("database config")
+        else {
+            panic!("the default test database is sqlite")
+        };
+        let workspace = workspace.clone();
+        run_source_db_operation(async move {
+            let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite");
+            db.migrate().await.expect("migrate sqlite");
+            let mut tx = db.begin().await.expect("begin workspace seed");
+            tx.workspaces()
+                .ensure(workspace.as_str(), now_unix_nanos_i64().expect("timestamp"))
+                .await
+                .expect("seed workspace");
+            tx.commit().await.expect("commit workspace seed");
+            Ok(Arc::new(db))
+        })
+        .expect("test database")
+    }
+
+    /// Writes the catalog row the loader now enumerates from.
+    fn seed_source_row(db: &CoralDb, workspace: &WorkspaceName, source: &InstalledSource) {
+        run_source_db_operation(async {
+            let mut tx = db.begin().await.expect("begin source seed");
+            tx.sources()
+                .upsert_source(workspace, source, now_unix_nanos_i64().expect("timestamp"))
+                .await
+                .expect("seed source row");
+            tx.commit().await.expect("commit source seed");
+            Ok(())
+        })
+        .expect("seed source row");
+    }
 
     #[test]
     fn workspace_without_legacy_config_membership_has_empty_live_scope() {
@@ -134,9 +195,11 @@ mod tests {
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("db-only").expect("workspace");
+        let db = test_db(&layout, &workspace);
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store,
+            db,
             SourceDiagnosticReporter::default(),
         );
 
@@ -154,10 +217,19 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("work").expect("workspace");
         let source = SourceName::parse("github").expect("source");
-        install_source(&layout, &config_store, &workspace, &source, "/repos/issues");
+        let db = test_db(&layout, &workspace);
+        install_source(
+            &layout,
+            &config_store,
+            &db,
+            &workspace,
+            &source,
+            "/repos/issues",
+        );
         let loader = ObservedValuesLiveScopeLoader::new(
             layout.clone(),
             config_store.clone(),
+            Arc::clone(&db),
             SourceDiagnosticReporter::default(),
         );
 
@@ -165,6 +237,7 @@ mod tests {
         install_source(
             &layout,
             &config_store,
+            &db,
             &workspace,
             &source,
             "/search/issues",
@@ -192,9 +265,11 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("work").expect("workspace");
         let source = SourceName::parse("github").expect("source");
+        let db = test_db(&layout, &workspace);
         install_source(
             &layout,
             &config_store,
+            &db,
             &workspace,
             &source,
             "/search/issues",
@@ -202,11 +277,12 @@ mod tests {
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store.clone(),
+            Arc::clone(&db),
             SourceDiagnosticReporter::default(),
         );
 
         let first = loader.load(&workspace).expect("first live scope");
-        set_credential_revision(&config_store, &workspace, &source, Uuid::from_u128(1));
+        set_credential_revision(&config_store, &db, &workspace, &source, Uuid::from_u128(1));
         let second = loader.load(&workspace).expect("second live scope");
 
         assert!(first.failed_sources.is_empty());
@@ -227,9 +303,11 @@ mod tests {
         let workspace = WorkspaceName::parse("work").expect("workspace");
         let source_name = SourceName::parse("secured_messages").expect("source");
         let credential_revision = Uuid::from_u128(42);
+        let db = test_db(&layout, &workspace);
         let installed_source = install_secured_source(
             &layout,
             &config_store,
+            &db,
             &workspace,
             &source_name,
             credential_revision,
@@ -272,6 +350,7 @@ mod tests {
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store,
+            db,
             SourceDiagnosticReporter::default(),
         );
         let live_load = loader.load(&workspace).expect("live scope");
@@ -289,17 +368,20 @@ mod tests {
         let workspace = WorkspaceName::parse("work").expect("workspace");
         let github = SourceName::parse("github").expect("source");
         let broken = SourceName::parse("broken").expect("source");
+        let db = test_db(&layout, &workspace);
         install_source(
             &layout,
             &config_store,
+            &db,
             &workspace,
             &github,
             "/search/issues",
         );
-        install_broken_source(&layout, &config_store, &workspace, &broken);
+        install_broken_source(&layout, &config_store, &db, &workspace, &broken);
         let loader = ObservedValuesLiveScopeLoader::new(
             layout,
             config_store,
+            db,
             SourceDiagnosticReporter::default(),
         );
 
@@ -316,6 +398,7 @@ mod tests {
     fn install_source(
         layout: &AppStateLayout,
         config_store: &ConfigStore,
+        db: &CoralDb,
         workspace: &WorkspaceName,
         source: &SourceName,
         path: &str,
@@ -343,48 +426,48 @@ tables:
             ),
         )
         .expect("write manifest");
+        let installed = InstalledSource {
+            name: source.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
         config_store
-            .upsert_source(
-                workspace,
-                InstalledSource {
-                    name: source.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
+            .upsert_source(workspace, installed.clone())
             .expect("upsert source");
+        seed_source_row(db, workspace, &installed);
     }
 
     fn install_broken_source(
         layout: &AppStateLayout,
         config_store: &ConfigStore,
+        db: &CoralDb,
         workspace: &WorkspaceName,
         source: &SourceName,
     ) {
         std::fs::create_dir_all(layout.source_dir(workspace, source)).expect("source dir");
         std::fs::write(layout.manifest_file(workspace, source), "name: [").expect("write manifest");
+        let installed = InstalledSource {
+            name: source.clone(),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::default(),
+            origin: SourceOrigin::Imported,
+        };
         config_store
-            .upsert_source(
-                workspace,
-                InstalledSource {
-                    name: source.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
+            .upsert_source(workspace, installed.clone())
             .expect("upsert source");
+        seed_source_row(db, workspace, &installed);
     }
 
     fn set_credential_revision(
         config_store: &ConfigStore,
+        db: &CoralDb,
         workspace: &WorkspaceName,
         source_name: &SourceName,
         credential_revision: Uuid,
@@ -397,13 +480,15 @@ tables:
             .expect("installed source");
         source.credential_revision = credential_revision;
         config_store
-            .upsert_source(workspace, source)
+            .upsert_source(workspace, source.clone())
             .expect("update credential revision");
+        seed_source_row(db, workspace, &source);
     }
 
     fn install_secured_source(
         layout: &AppStateLayout,
         config_store: &ConfigStore,
+        db: &CoralDb,
         workspace: &WorkspaceName,
         source: &SourceName,
         credential_revision: Uuid,
@@ -452,6 +537,7 @@ tables:
         config_store
             .upsert_source(workspace, installed.clone())
             .expect("upsert source");
+        seed_source_row(db, workspace, &installed);
         installed
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -250,17 +250,49 @@ where
 /// Runs one database operation from a synchronous source-lifecycle step.
 ///
 /// Reserved for code that is already blocking — the lifecycle writes that run
-/// under `spawn_blocking`, and the synchronous test entry points. It is
-/// expensive by construction (a thread and a runtime per call), and calling it
-/// from an async task would block a runtime worker on database I/O, which is
-/// the starvation class the state-lock waits were just moved off. Async callers
-/// await the database directly instead.
-fn run_source_db_operation<T, F>(operation: F) -> Result<T, AppError>
+/// under `spawn_blocking`, the observed-value live-scope load that runs under
+/// the search crate's own `spawn_blocking`, and the synchronous test entry
+/// points. It is expensive by construction (a thread and a runtime per call),
+/// and calling it from an async task would block a runtime worker on database
+/// I/O, which is the starvation class the state-lock waits were just moved
+/// off. Async callers await the database directly instead, through the async
+/// twin every bridged read here has;
+/// `async_source_reads_never_cross_the_database_bridge` is the standing guard
+/// that they keep doing so.
+pub(crate) fn run_source_db_operation<T, F>(operation: F) -> Result<T, AppError>
 where
     T: Send,
     F: Future<Output = Result<T, AppError>> + Send,
 {
+    #[cfg(test)]
+    record_source_db_bridge_crossing();
     block_on_runtime_aware(operation)
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Counts the synchronous bridge crossings made on this thread.
+    ///
+    /// A thread-local is what makes the count usable as an assertion: the
+    /// increment happens on the caller's own thread, and a default-flavor
+    /// `#[tokio::test]` drives its future on the test thread, so a test's
+    /// reading is never perturbed by a sibling test.
+    static SOURCE_DB_BRIDGE_CROSSINGS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_source_db_bridge_crossing() {
+    SOURCE_DB_BRIDGE_CROSSINGS.with(|crossings| crossings.set(crossings.get() + 1));
+}
+
+/// How many times this thread has crossed the synchronous database bridge.
+///
+/// Async paths must never move this number: the bridge spawns a thread and a
+/// runtime per call and blocks the caller until they finish, which on a tokio
+/// worker is the starvation class #2265 removed.
+#[cfg(test)]
+fn source_db_bridge_crossings() -> usize {
+    SOURCE_DB_BRIDGE_CROSSINGS.with(std::cell::Cell::get)
 }
 
 /// Opens, migrates, and seeds the database a test's source manager reads
@@ -610,7 +642,7 @@ impl SourceManager {
     /// Best effort: the ledger only lets a later boot tell content Coral wrote
     /// from content an operator wrote, and losing that proof costs a warning
     /// and a preserved file, never a silent overwrite.
-    fn record_source_mirror_in_ledger(
+    fn record_source_mirror_in_ledger_with_state_lock_held(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
@@ -632,7 +664,11 @@ impl SourceManager {
     }
 
     /// Drops this host's record of a source it just removed from the mirror.
-    fn forget_source_in_ledger(&self, workspace_name: &WorkspaceName, source_name: &SourceName) {
+    fn forget_source_in_ledger_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
         let config_path = self.layout.config_file();
         let mut ledger = MirrorLedger::load(config_path);
         ledger.remove(workspace_name, source_name);
@@ -641,46 +677,123 @@ impl SourceManager {
         }
     }
 
-    pub(crate) fn list_workspace_sources(
+    /// Reads one workspace's installed sources from the authoritative catalog.
+    async fn read_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
-        Ok(self
+        let mut session = self.database()?.as_ref();
+        Ok(session
+            .sources()
+            .list_workspace_sources(workspace_name)
+            .await?)
+    }
+
+    /// Reads one installed source from the authoritative catalog, or `None` when
+    /// the workspace has no such row.
+    async fn read_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        let mut session = self.database()?.as_ref();
+        Ok(session
+            .sources()
+            .get_source(workspace_name, source_name)
+            .await?)
+    }
+
+    /// The bridge-backed listing seam, for the synchronous lifecycle steps and
+    /// the synchronous entry points below. Async callers await
+    /// [`Self::read_workspace_sources`] on their own task instead.
+    fn load_workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        run_source_db_operation(self.read_workspace_sources(workspace_name))
+    }
+
+    /// The bridge-backed single-source seam, for the same callers
+    /// [`Self::load_workspace_sources`] serves.
+    fn load_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        run_source_db_operation(self.read_source(workspace_name, source_name))
+    }
+
+    /// Reads the source a lifecycle write is about to overwrite or remove,
+    /// from the rows first and the mirror second.
+    ///
+    /// Each direction covers what the other cannot. The rows carry a source
+    /// this host has no config entry for — one a peer installed against the
+    /// shared database, or one whose mirror write never landed after the
+    /// transaction committed — which the reads already list and which
+    /// therefore has to be deletable, and whose re-import has to compensate as
+    /// an update rather than cascading the existing row set away. The mirror
+    /// carries the opposite case: a source an older binary added since the
+    /// last boot, whose entry exists and whose row does not.
+    fn load_source_for_lifecycle_write_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        if let Some(source) = self.load_source(workspace_name, source_name)? {
+            return Ok(Some(source));
+        }
+        match self
             .config_store
-            .list_workspace_sources(workspace_name)?
+            .get_source_unlocked(workspace_name, source_name)
+        {
+            Ok(source) => Ok(Some(source)),
+            Err(AppError::SourceNotFound(_)) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Restates each row's version from the manifest actually installed on this
+    /// host, which is where a source's version lives.
+    fn with_installed_versions(
+        &self,
+        workspace_name: &WorkspaceName,
+        sources: Vec<InstalledSource>,
+    ) -> Vec<InstalledSource> {
+        sources
             .into_iter()
             .map(|source| self.populate_source_version_or_keep(workspace_name, source))
-            .collect())
+            .collect()
     }
 
-    pub(crate) fn get_source(
+    fn require_source(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
+        source: Option<InstalledSource>,
     ) -> Result<InstalledSource, AppError> {
-        Ok(self.populate_source_version_or_keep(
-            workspace_name,
-            self.config_store.get_source(workspace_name, source_name)?,
-        ))
+        source
+            .map(|source| self.populate_source_version_or_keep(workspace_name, source))
+            .ok_or_else(|| AppError::SourceNotFound(source_name.to_string()))
     }
 
-    pub(crate) fn get_source_info(
+    /// Describes one source: the effective manifest of the installed row when
+    /// there is one, the bundled manifest of the same name otherwise.
+    ///
+    /// The bundled description is never marked installed — `load_bundled_source`
+    /// matches on the very name the catalog read just missed.
+    fn describe_source(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
+        installed: Option<InstalledSource>,
     ) -> Result<CandidateSource, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
-            }
-            Err(AppError::SourceNotFound(_)) => {}
-            Err(error) => return Err(error),
+        if let Some(source) = installed {
+            return Ok(
+                resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
+            );
         }
-
         match load_bundled_source(source_name) {
-            Ok(bundled) => self.describe_bundled_source(workspace_name, &bundled.manifest_yaml),
+            Ok(bundled) => describe_manifest(&bundled.manifest_yaml, SourceOrigin::Bundled, false),
             Err(AppError::InvalidInput(_)) => {
                 Err(AppError::SourceNotFound(source_name.to_string()))
             }
@@ -688,11 +801,11 @@ impl SourceManager {
         }
     }
 
-    pub(crate) fn discover_sources(
-        &self,
-        workspace_name: &WorkspaceName,
+    /// Lists the bundled catalog against what is installed, carrying over the
+    /// credential storage of the entries that are.
+    fn bundled_candidates(
+        installed_sources: &[InstalledSource],
     ) -> Result<Vec<CandidateSource>, AppError> {
-        let installed_sources = self.config_store.list_workspace_sources(workspace_name)?;
         let installed = installed_sources
             .iter()
             .map(|source| source.name.clone())
@@ -713,6 +826,88 @@ impl SourceManager {
         }
 
         Ok(candidates)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "sync test-harness entry points")
+    )]
+    pub(crate) fn list_workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let sources = self.load_workspace_sources(workspace_name)?;
+        Ok(self.with_installed_versions(workspace_name, sources))
+    }
+
+    pub(crate) async fn list_workspace_sources_async(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let sources = self.read_workspace_sources(workspace_name).await?;
+        Ok(self.with_installed_versions(workspace_name, sources))
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "sync test-harness entry points")
+    )]
+    pub(crate) fn get_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        let source = self.load_source(workspace_name, source_name)?;
+        self.require_source(workspace_name, source_name, source)
+    }
+
+    pub(crate) async fn get_source_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        let source = self.read_source(workspace_name, source_name).await?;
+        self.require_source(workspace_name, source_name, source)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "sync test-harness entry points")
+    )]
+    pub(crate) fn get_source_info(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<CandidateSource, AppError> {
+        let installed = self.load_source(workspace_name, source_name)?;
+        self.describe_source(workspace_name, source_name, installed)
+    }
+
+    pub(crate) async fn get_source_info_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<CandidateSource, AppError> {
+        let installed = self.read_source(workspace_name, source_name).await?;
+        self.describe_source(workspace_name, source_name, installed)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "sync test-harness entry points")
+    )]
+    pub(crate) fn discover_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<CandidateSource>, AppError> {
+        Self::bundled_candidates(&self.load_workspace_sources(workspace_name)?)
+    }
+
+    pub(crate) async fn discover_sources_async(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<CandidateSource>, AppError> {
+        Self::bundled_candidates(&self.read_workspace_sources(workspace_name).await?)
     }
 
     pub(crate) async fn create_bundled_source_async(
@@ -754,7 +949,9 @@ impl SourceManager {
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
-        let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
+        let candidate = self
+            .describe_bundled_source_async(workspace_name, &bundled.manifest_yaml)
+            .await?;
         self.install_source_with_oauth(
             workspace_name.clone(),
             revision,
@@ -817,8 +1014,9 @@ impl SourceManager {
         command: ImportSourceWithCredentialsCommand,
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
-        let (manifest_yaml, candidate) =
-            self.prepare_imported_manifest(workspace_name, &command.manifest_yaml)?;
+        let (manifest_yaml, candidate) = self
+            .prepare_imported_manifest_async(workspace_name, &command.manifest_yaml)
+            .await?;
         self.install_source_with_oauth(
             workspace_name.clone(),
             revision,
@@ -903,21 +1101,27 @@ impl SourceManager {
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
         self.validate_source_features(&materialization_manifest_yaml)?;
-        self.validate_runtime_schema_names_available(
+        // This preamble runs on the caller's tokio task, so both catalog reads
+        // await the database directly; the lifecycle closure below re-runs them
+        // through the synchronous seams under its own state lock.
+        self.validate_runtime_schema_names_available_async(
             &workspace_name,
             &candidate.name,
             &materialization_manifest_yaml,
-        )?;
+        )
+        .await?;
         let oauth_input_keys = oauth_credential_retrievals
             .iter()
             .map(|credential| credential.input_key.clone())
             .collect::<BTreeSet<_>>();
-        let stored_material = self.source_stored_material_for_validation(
-            &workspace_name,
-            &candidate,
-            &bindings,
-            &oauth_input_keys,
-        )?;
+        let stored_material = self
+            .source_stored_material_for_validation_async(
+                &workspace_name,
+                &candidate,
+                &bindings,
+                &oauth_input_keys,
+            )
+            .await?;
         let preflight_bindings = Self::validate_oauth_import_preflight(
             &candidate,
             &bindings,
@@ -1039,8 +1243,8 @@ impl SourceManager {
             .material_guard(workspace_name, &credential_set_id)?;
         let state_lock = self.config_store.state_lock_exclusive()?;
         let stored = self
-            .config_store
-            .get_source_unlocked(workspace_name, source_name)?;
+            .load_source_for_lifecycle_write_with_state_lock_held(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(source_name.to_string()))?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let credential_storage = stored.credential_storage_for_material();
         let credential_material = credential_storage
@@ -1084,7 +1288,7 @@ impl SourceManager {
                 error,
             ));
         }
-        self.forget_source_in_ledger(workspace_name, source_name);
+        self.forget_source_in_ledger_with_state_lock_held(workspace_name, source_name);
         self.pool_registry
             .remove_catalog(workspace_name, source_name.as_str());
         source_dir_backup.commit()?;
@@ -1109,24 +1313,52 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         manifest_yaml: &str,
     ) -> Result<(String, CandidateSource), AppError> {
+        let (manifest_yaml, mut candidate) = Self::canonicalize_imported_manifest(manifest_yaml)?;
+        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        Ok((manifest_yaml, candidate))
+    }
+
+    /// [`Self::prepare_imported_manifest`] for an async caller: the same
+    /// canonicalization, with the installed-name lookup awaited directly.
+    async fn prepare_imported_manifest_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        manifest_yaml: &str,
+    ) -> Result<(String, CandidateSource), AppError> {
+        let (manifest_yaml, mut candidate) = Self::canonicalize_imported_manifest(manifest_yaml)?;
+        candidate.installed = self
+            .source_exists_async(workspace_name, &candidate.name)
+            .await?;
+        Ok((manifest_yaml, candidate))
+    }
+
+    /// The catalog-free half of [`Self::prepare_imported_manifest`]: parse,
+    /// canonicalize, describe. Leaves `installed` for the caller to fill in
+    /// through whichever seam its context allows.
+    fn canonicalize_imported_manifest(
+        manifest_yaml: &str,
+    ) -> Result<(String, CandidateSource), AppError> {
         let manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(manifest_yaml, &manifest)?;
-        let mut candidate =
-            describe_manifest(manifest_yaml.as_str(), SourceOrigin::Imported, false)?;
-        candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let candidate = describe_manifest(manifest_yaml.as_str(), SourceOrigin::Imported, false)?;
         Ok((manifest_yaml, candidate))
     }
 
     /// Describes one user-supplied manifest without installing it. Import applies
     /// the same descriptor canonicalization, so running it here surfaces a relative
     /// file descriptor while the user still has the manifest in front of them.
-    pub(crate) fn describe_source_manifest(
+    ///
+    /// Async because its only catalog touch is the installed-name lookup, which
+    /// the gRPC handler's task awaits directly.
+    pub(crate) async fn describe_source_manifest(
         &self,
         workspace_name: &WorkspaceName,
         manifest_yaml: &str,
     ) -> Result<CandidateSource, AppError> {
-        let (_, candidate) = self.prepare_imported_manifest(workspace_name, manifest_yaml)?;
+        let (_, candidate) = self
+            .prepare_imported_manifest_async(workspace_name, manifest_yaml)
+            .await?;
         Ok(candidate)
     }
 
@@ -1137,6 +1369,20 @@ impl SourceManager {
     ) -> Result<CandidateSource, AppError> {
         let mut candidate = describe_manifest(manifest_yaml, SourceOrigin::Bundled, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        Ok(candidate)
+    }
+
+    /// [`Self::describe_bundled_source`] for an async caller, which awaits the
+    /// installed-name lookup instead of crossing the synchronous bridge.
+    async fn describe_bundled_source_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        manifest_yaml: &str,
+    ) -> Result<CandidateSource, AppError> {
+        let mut candidate = describe_manifest(manifest_yaml, SourceOrigin::Bundled, false)?;
+        candidate.installed = self
+            .source_exists_async(workspace_name, &candidate.name)
+            .await?;
         Ok(candidate)
     }
 
@@ -1323,7 +1569,11 @@ impl SourceManager {
             }
             return Err(error);
         }
-        self.record_source_mirror_in_ledger(workspace_name, &stored, request.manifest_yaml);
+        self.record_source_mirror_in_ledger_with_state_lock_held(
+            workspace_name,
+            &stored,
+            request.manifest_yaml,
+        );
         cleanup_materialization_backup(materialization_backup);
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
@@ -1437,16 +1687,22 @@ impl SourceManager {
         ensure_database_source_feature_enabled(&manifest, self.database_sources_enabled)
     }
 
-    fn validate_runtime_schema_names_available(
+    /// Rejects `manifest_yaml` when a runtime schema name it declares is
+    /// already claimed by another source in `installed_sources`.
+    ///
+    /// The catalog read is the caller's, so the two wrappers below can reach it
+    /// through whichever seam their context allows.
+    fn check_runtime_schema_names_available(
         &self,
         workspace_name: &WorkspaceName,
         candidate_name: &SourceName,
         manifest_yaml: &str,
+        installed_sources: Vec<InstalledSource>,
     ) -> Result<(), AppError> {
         let candidate_manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let candidate_schema_names = runtime_schema_names(&candidate_manifest);
-        for installed in self.config_store.list_workspace_sources(workspace_name)? {
+        for installed in installed_sources {
             if installed.name == *candidate_name {
                 continue;
             }
@@ -1466,15 +1722,59 @@ impl SourceManager {
         Ok(())
     }
 
+    /// The synchronous schema-name check, for the lifecycle steps that already
+    /// run under `spawn_blocking`.
+    fn validate_runtime_schema_names_available(
+        &self,
+        workspace_name: &WorkspaceName,
+        candidate_name: &SourceName,
+        manifest_yaml: &str,
+    ) -> Result<(), AppError> {
+        let installed_sources = self.load_workspace_sources(workspace_name)?;
+        self.check_runtime_schema_names_available(
+            workspace_name,
+            candidate_name,
+            manifest_yaml,
+            installed_sources,
+        )
+    }
+
+    /// The same check for an async caller, which awaits the catalog directly
+    /// rather than parking a runtime worker on the synchronous bridge.
+    async fn validate_runtime_schema_names_available_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        candidate_name: &SourceName,
+        manifest_yaml: &str,
+    ) -> Result<(), AppError> {
+        let installed_sources = self.read_workspace_sources(workspace_name).await?;
+        self.check_runtime_schema_names_available(
+            workspace_name,
+            candidate_name,
+            manifest_yaml,
+            installed_sources,
+        )
+    }
+
     fn source_exists(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<bool, AppError> {
+        Ok(self.load_source(workspace_name, source_name)?.is_some())
+    }
+
+    /// The installed-name lookup for an async caller, which awaits the catalog
+    /// directly instead of crossing the synchronous bridge.
+    async fn source_exists_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<bool, AppError> {
         Ok(self
-            .config_store
-            .load_catalog()?
-            .contains(workspace_name, source_name))
+            .read_source(workspace_name, source_name)
+            .await?
+            .is_some())
     }
 
     fn read_source_material(
@@ -1499,31 +1799,29 @@ impl SourceManager {
         }
     }
 
-    fn source_stored_material_for_validation(
+    /// Reads whatever stored credential material `candidate`'s validation still
+    /// needs, given the catalog row `installed` its caller already read.
+    fn stored_material_for_validation(
         &self,
         workspace_name: &WorkspaceName,
         candidate: &CandidateSource,
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
+        installed: Option<InstalledSource>,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let (credential_storage, persisted_secret_keys) = match self
-            .config_store
-            .get_source(workspace_name, &candidate.name)
-        {
-            Ok(source) => (
+        let (credential_storage, persisted_secret_keys) = match installed {
+            Some(source) => (
                 source.credential_storage_for_material(),
                 Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
             ),
-            Err(AppError::SourceNotFound(_))
-                if self
-                    .layout
-                    .secret_file(workspace_name, &candidate.name)
-                    .exists() =>
+            None if self
+                .layout
+                .secret_file(workspace_name, &candidate.name)
+                .exists() =>
             {
                 (Some(CredentialStorageKind::File), None)
             }
-            Err(AppError::SourceNotFound(_)) => (None, Some(BTreeSet::new())),
-            Err(error) => return Err(error),
+            None => (None, Some(BTreeSet::new())),
         };
 
         if !source_needs_stored_material_for_validation(
@@ -1543,6 +1841,44 @@ impl SourceManager {
         }
     }
 
+    /// The synchronous stored-material read, for the lifecycle steps that
+    /// already run under `spawn_blocking`.
+    fn source_stored_material_for_validation(
+        &self,
+        workspace_name: &WorkspaceName,
+        candidate: &CandidateSource,
+        bindings: &SourceBindings,
+        filled_secret_keys: &BTreeSet<String>,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        let installed = self.load_source(workspace_name, &candidate.name)?;
+        self.stored_material_for_validation(
+            workspace_name,
+            candidate,
+            bindings,
+            filled_secret_keys,
+            installed,
+        )
+    }
+
+    /// The same read for an async caller, which awaits the catalog directly
+    /// rather than parking a runtime worker on the synchronous bridge.
+    async fn source_stored_material_for_validation_async(
+        &self,
+        workspace_name: &WorkspaceName,
+        candidate: &CandidateSource,
+        bindings: &SourceBindings,
+        filled_secret_keys: &BTreeSet<String>,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        let installed = self.read_source(workspace_name, &candidate.name).await?;
+        self.stored_material_for_validation(
+            workspace_name,
+            candidate,
+            bindings,
+            filled_secret_keys,
+            installed,
+        )
+    }
+
     fn source_persist_storage_with_state_lock_held(
         &self,
         workspace_name: &WorkspaceName,
@@ -1554,12 +1890,9 @@ impl SourceManager {
                 && input.required
                 && !bindings.secrets.contains_key(&input.key)
         });
-        let existing_storage = match self
-            .config_store
-            .get_source_unlocked(workspace_name, &candidate.name)
-        {
-            Ok(source) => source.credential_storage_for_material(),
-            Err(AppError::SourceNotFound(_)) if needs_stored_material => {
+        let existing_storage = match self.load_source(workspace_name, &candidate.name)? {
+            Some(source) => source.credential_storage_for_material(),
+            None if needs_stored_material => {
                 let legacy_secret_file = self.layout.secret_file(workspace_name, &candidate.name);
                 if legacy_secret_file.is_file() {
                     Some(CredentialStorageKind::File)
@@ -1567,8 +1900,7 @@ impl SourceManager {
                     None
                 }
             }
-            Err(AppError::SourceNotFound(_)) => None,
-            Err(error) => return Err(error),
+            None => None,
         };
         let stored_material = match existing_storage {
             Some(storage) => self.read_source_material(workspace_name, &candidate.name, storage)?,
@@ -1718,13 +2050,10 @@ impl SourceManager {
         source_name: &SourceName,
         credential_material: &CredentialMaterialGuard<'_>,
     ) -> Result<Option<SourceRollbackState>, AppError> {
-        let source = match self
-            .config_store
-            .get_source_unlocked(workspace_name, source_name)
-        {
-            Ok(source) => source,
-            Err(AppError::SourceNotFound(_)) => return Ok(None),
-            Err(error) => return Err(error),
+        let Some(source) =
+            self.load_source_for_lifecycle_write_with_state_lock_held(workspace_name, source_name)?
+        else {
+            return Ok(None);
         };
         let credential_material = source
             .credential_storage_for_material()
@@ -2232,6 +2561,7 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    use sea_query::{Alias, Expr, ExprTrait as _, Query};
     use tempfile::TempDir;
     use tokio::net::{TcpListener as TokioTcpListener, TcpStream as TokioTcpStream};
     use tokio::sync::mpsc;
@@ -2244,7 +2574,7 @@ mod tests {
         ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent,
         PersistSourceRequest, SourceBinding, SourceBindings, SourceManager,
         SourceOAuthCredentialRetrieval, ValidatedBindings, block_on_runtime_aware,
-        materialization_inputs_from_bindings, normalize_binding_key,
+        materialization_inputs_from_bindings, normalize_binding_key, source_db_bridge_crossings,
         source_needs_stored_material_for_validation,
     };
     use crate::bootstrap::AppError;
@@ -2259,7 +2589,9 @@ mod tests {
         FINGERPRINT_FILENAME, MaterializationInputs, PROJECTIONS_FILENAME,
     };
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-    use crate::state::db::{DbRepos as _, MaterializationRecord, SourceManifestRecord};
+    use crate::state::db::{
+        DbRepos as _, DbSession as _, MaterializationRecord, SourceManifestRecord,
+    };
     use crate::state::mirror_ledger::MirrorLedger;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
@@ -2541,8 +2873,8 @@ tables:
         (manager, layout)
     }
 
-    #[test]
-    fn describe_source_manifest_reports_credential_methods_in_authored_order() {
+    #[tokio::test]
+    async fn describe_source_manifest_reports_credential_methods_in_authored_order() {
         let temp = TempDir::new().expect("temp dir");
         let (manager, _layout) = test_manager(&temp);
 
@@ -2551,6 +2883,7 @@ tables:
                 &default_workspace(),
                 &manifest_with_oauth_credential_methods(),
             )
+            .await
             .expect("describe manifest");
 
         assert_eq!(candidate.name.as_str(), "oauth_demo");
@@ -2577,8 +2910,8 @@ tables:
         assert_eq!(oauth.flow.kind, ManifestOAuthFlowKind::AuthorizationCode);
     }
 
-    #[test]
-    fn describe_source_manifest_marks_an_installed_name() {
+    #[tokio::test]
+    async fn describe_source_manifest_marks_an_installed_name() {
         let temp = TempDir::new().expect("temp dir");
         let (manager, _layout) = test_manager(&temp);
         let workspace_name = default_workspace();
@@ -2596,12 +2929,64 @@ tables:
 
         let candidate = manager
             .describe_source_manifest(&workspace_name, &manifest_yaml)
+            .await
             .expect("describe manifest");
         assert!(candidate.installed);
     }
 
-    #[test]
-    fn describe_source_manifest_rejects_a_relative_file_descriptor() {
+    /// The standing guard behind the design's "no thread-spawn on the read
+    /// path" verify step. Every catalog read reachable from a tokio task must
+    /// go through the async seams: the synchronous bridge spawns a thread and a
+    /// runtime per call and blocks the caller on the join, which on a runtime
+    /// worker is the starvation class #2265 removed.
+    #[tokio::test]
+    async fn async_source_reads_never_cross_the_database_bridge() {
+        let temp = TempDir::new().expect("temp dir");
+        let (manager, _layout) = test_manager(&temp);
+        let workspace_name = default_workspace();
+        let manifest_yaml = manifest_without_secrets();
+        let candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)
+            .expect("describe candidate");
+
+        // Building the manager is synchronous by design, so only the reads that
+        // follow it are under test.
+        let baseline = source_db_bridge_crossings();
+
+        manager
+            .describe_source_manifest(&workspace_name, &manifest_yaml)
+            .await
+            .expect("describe manifest");
+        manager
+            .describe_bundled_source_async(&workspace_name, &manifest_yaml)
+            .await
+            .expect("describe bundled source");
+        manager
+            .validate_runtime_schema_names_available_async(
+                &workspace_name,
+                &candidate.name,
+                &manifest_yaml,
+            )
+            .await
+            .expect("validate runtime schema names");
+        manager
+            .source_stored_material_for_validation_async(
+                &workspace_name,
+                &candidate,
+                &SourceBindings::default(),
+                &BTreeSet::new(),
+            )
+            .await
+            .expect("read stored material");
+
+        assert_eq!(
+            source_db_bridge_crossings(),
+            baseline,
+            "an async source read crossed the synchronous database bridge"
+        );
+    }
+
+    #[tokio::test]
+    async fn describe_source_manifest_rejects_a_relative_file_descriptor() {
         let temp = TempDir::new().expect("temp dir");
         let (manager, _layout) = test_manager(&temp);
 
@@ -2616,6 +3001,7 @@ surface:
   file: ./openapi.yaml
 ",
             )
+            .await
             .expect_err("relative descriptor must be rejected");
         let AppError::InvalidInput(message) = error else {
             panic!("expected InvalidInput, got {error:?}");
@@ -2626,13 +3012,14 @@ surface:
         );
     }
 
-    #[test]
-    fn describe_source_manifest_rejects_unparseable_yaml() {
+    #[tokio::test]
+    async fn describe_source_manifest_rejects_unparseable_yaml() {
         let temp = TempDir::new().expect("temp dir");
         let (manager, _layout) = test_manager(&temp);
 
         let error = manager
             .describe_source_manifest(&default_workspace(), "name: [unclosed")
+            .await
             .expect_err("invalid yaml must be rejected");
         assert!(matches!(error, AppError::InvalidInput(_)), "got {error:?}");
     }
@@ -3466,6 +3853,35 @@ surface:
             })
         }
 
+        /// Drops the source's database row without recording a deletion — the
+        /// shape a source added by an older binary has, whose config entry
+        /// exists but which this database has never seen.
+        fn forget_database_row(&self) {
+            let db = Arc::clone(self.manager.database().expect("database"));
+            block_on_runtime_aware(async move {
+                let mut session = db.as_ref();
+                let delete = Query::delete()
+                    .from_table(Alias::new("sources"))
+                    .and_where(
+                        Expr::col(Alias::new("workspace_id")).eq(default_workspace().as_str()),
+                    )
+                    .and_where(Expr::col(Alias::new("name")).eq(Self::source_name().as_str()))
+                    .to_owned();
+                session.execute(delete).await.expect("forget source row");
+            });
+        }
+
+        /// Drops the source's `config.toml` entry while its rows stay put —
+        /// the shape a source has when a peer installed it against the shared
+        /// database, or when a crash landed between the transaction and the
+        /// mirror write.
+        fn forget_config_entry(&self) {
+            self.manager
+                .config_store
+                .remove_source(&default_workspace(), &Self::source_name())
+                .expect("forget config entry");
+        }
+
         fn ledger(&self) -> MirrorLedger {
             MirrorLedger::load(self.layout.config_file())
         }
@@ -3579,6 +3995,169 @@ surface:
             fixture
                 .ledger()
                 .entry_recorded(&default_workspace(), &installed.name)
+        );
+    }
+
+    /// The read entry points answer from the catalog rows. Forgetting the row
+    /// while the mirror entry stays put is what tells the two apart.
+    #[test]
+    fn catalog_reads_answer_from_the_database_not_the_config_mirror() {
+        let fixture = DualWriteFixture::new();
+        let installed = fixture.import();
+        let workspace = default_workspace();
+        let manager = &fixture.manager;
+
+        assert_eq!(
+            manager
+                .list_workspace_sources(&workspace)
+                .expect("list sources")
+                .into_iter()
+                .map(|source| source.name)
+                .collect::<Vec<_>>(),
+            vec![installed.name.clone()]
+        );
+        assert_eq!(
+            manager
+                .get_source(&workspace, &installed.name)
+                .expect("get source")
+                .name,
+            installed.name
+        );
+        assert!(
+            manager
+                .get_source_info(&workspace, &installed.name)
+                .expect("get source info")
+                .installed
+        );
+
+        fixture.forget_database_row();
+
+        assert!(
+            fixture.config_entry().is_some(),
+            "the mirror entry must survive, or the reads below prove nothing"
+        );
+        assert!(
+            manager
+                .list_workspace_sources(&workspace)
+                .expect("list sources without a row")
+                .is_empty()
+        );
+        assert!(matches!(
+            manager.get_source(&workspace, &installed.name),
+            Err(AppError::SourceNotFound(_))
+        ));
+        assert!(matches!(
+            manager.get_source_info(&workspace, &installed.name),
+            Err(AppError::SourceNotFound(_))
+        ));
+    }
+
+    /// A source an older binary added has a config entry this database has
+    /// never seen. Deleting it still has to work, and still has to record the
+    /// deletion so a peer's boot import does not put it back.
+    #[test]
+    fn a_source_without_a_database_row_deletes_from_its_config_entry() {
+        let fixture = DualWriteFixture::new();
+        let installed = fixture.import();
+        fixture.forget_database_row();
+
+        fixture
+            .manager
+            .delete_source(&default_workspace(), &installed.name)
+            .expect("delete a source the database never saw");
+
+        let deleted = fixture.db_state();
+        assert!(deleted.source.is_none());
+        assert!(deleted.tombstoned, "the deletion must still be recorded");
+        assert!(fixture.config_entry().is_none());
+    }
+
+    /// The same source re-imported is an update, because the rollback state is
+    /// captured from the config entry — so a failed mirror write puts a row
+    /// back rather than removing and tombstoning one.
+    #[test]
+    fn a_failed_mirror_write_on_a_source_without_a_row_compensates_as_an_update() {
+        let fixture = DualWriteFixture::new();
+        fixture.import();
+        fixture.forget_database_row();
+        let failing = fixture.manager.clone().with_failing_config_mirror();
+
+        fixture.change_descriptor();
+        let error = fixture
+            .import_with(&failing)
+            .expect_err("a failed mirror write must fail the update");
+
+        assert!(
+            error.to_string().contains("source config mirror failed"),
+            "unexpected error: {error}"
+        );
+        let after = fixture.db_state();
+        assert!(
+            after.source.is_some(),
+            "the config entry made this an update, so the compensation must restore a row"
+        );
+        assert!(
+            !after.tombstoned,
+            "compensating an update must not tombstone the source"
+        );
+    }
+
+    /// A source with a row and no config entry is one the reads already list,
+    /// so the delete path has to find it too — otherwise the API shows a source
+    /// that can never be deleted or tombstoned.
+    #[test]
+    fn a_source_without_a_config_entry_deletes_from_its_database_row() {
+        let fixture = DualWriteFixture::new();
+        let installed = fixture.import();
+        fixture.forget_config_entry();
+
+        fixture
+            .manager
+            .delete_source(&default_workspace(), &installed.name)
+            .expect("delete a source the config mirror never saw");
+
+        let deleted = fixture.db_state();
+        assert!(deleted.source.is_none());
+        assert!(deleted.tombstoned, "the deletion must still be recorded");
+        assert!(fixture.config_entry().is_none());
+    }
+
+    /// Re-importing over that same source is an update, because the rollback
+    /// state is captured from the row — so a failed mirror write puts the
+    /// previous row set back instead of removing and tombstoning a source that
+    /// was working a moment ago.
+    #[test]
+    fn a_failed_mirror_write_on_a_source_without_a_config_entry_compensates_as_an_update() {
+        let fixture = DualWriteFixture::new();
+        fixture.import();
+        fixture.forget_config_entry();
+        let before = fixture.db_state();
+        let failing = fixture.manager.clone().with_failing_config_mirror();
+
+        fixture.change_descriptor();
+        let error = fixture
+            .import_with(&failing)
+            .expect_err("a failed mirror write must fail the update");
+
+        assert!(
+            error.to_string().contains("source config mirror failed"),
+            "unexpected error: {error}"
+        );
+        let after = fixture.db_state();
+        assert_eq!(
+            after.source.as_ref(),
+            before.source.as_ref(),
+            "the row made this an update, so the compensation must restore it"
+        );
+        assert_eq!(
+            after.manifest.map(|manifest| manifest.manifest_yaml),
+            before.manifest.map(|manifest| manifest.manifest_yaml),
+            "an update's compensation must restore the previous manifest row"
+        );
+        assert_eq!(after.materialization, before.materialization);
+        assert!(
+            !after.tombstoned,
+            "compensating an update must not tombstone the source"
         );
     }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -3343,7 +3343,7 @@ surface:
         );
         assert!(
             config_store
-                .get_source(&workspace_name, &source_name)
+                .get_source_unlocked(&workspace_name, &source_name)
                 .is_ok(),
             "source config should be preserved when directory staging fails"
         );
@@ -3814,7 +3814,7 @@ surface:
             match self
                 .manager
                 .config_store
-                .get_source(&default_workspace(), &Self::source_name())
+                .get_source_unlocked(&default_workspace(), &Self::source_name())
             {
                 Ok(source) => Some(source),
                 Err(AppError::SourceNotFound(_)) => None,
@@ -5161,8 +5161,9 @@ surface:
         );
         assert!(
             config_store
-                .list_workspace_sources(&workspace_name)
-                .expect("list sources")
+                .load_catalog_unlocked()
+                .expect("load mirrored catalog")
+                .workspace_sources(&workspace_name)
                 .is_empty()
         );
         let source_name = SourceName::parse("public_messages").expect("source");
@@ -5251,8 +5252,9 @@ surface:
         fixture.token_server.await.expect("token server");
         assert!(
             config_store
-                .list_workspace_sources(&workspace_name)
-                .expect("list sources")
+                .load_catalog_unlocked()
+                .expect("load mirrored catalog")
+                .workspace_sources(&workspace_name)
                 .is_empty()
         );
         let source_name = SourceName::parse("secured_messages").expect("source");

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -30,6 +30,10 @@ use crate::sources::materialization::{
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
 use crate::state::db::CoralDb;
+#[cfg(test)]
+use crate::state::db::{
+    DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, run_state_migrations,
+};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{
@@ -194,6 +198,73 @@ fn materialization_inputs_from_bindings(
     }
 }
 
+/// Drives `future` to completion from a synchronous caller, whether or not a
+/// tokio runtime is already running on this thread.
+///
+/// `block_in_place` cannot do this: it panics on the current-thread runtime
+/// `#[tokio::test]` builds by default, which most of this crate's async tests
+/// run on. A fresh current-thread runtime on a borrowed scoped thread is the
+/// one shape that holds under every flavor — the work never touches the
+/// ambient runtime, so the caller only ever waits on the join.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "the dual-write bridge blocks through this next")
+)]
+fn block_on_runtime_aware<F>(future: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    fn drive<F: Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime")
+            .block_on(future)
+    }
+
+    if tokio::runtime::Handle::try_current().is_err() {
+        return drive(future);
+    }
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| drive(future))
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    })
+}
+
+/// Opens, migrates, and seeds the database a test's source manager reads
+/// through.
+///
+/// The file under the test's own layout is the only workable shape: in-memory
+/// `SQLite` is unreachable through `ResolvedDatabaseConfig`, and it is per
+/// connection anyway, so a pooled one would hand each checkout a different
+/// empty schema.
+#[cfg(test)]
+async fn test_database(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
+    let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(layout).expect("database config")
+    else {
+        panic!("the default test database is sqlite")
+    };
+    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+        .await
+        .expect("open sqlite");
+    db.migrate().await.expect("migrate sqlite");
+    run_state_migrations(&db, config_store, layout)
+        .await
+        .expect("run state migrations");
+    // A fresh layout carries no legacy workspaces for the cutover to import,
+    // so the workspace these tests address has to be seeded outright.
+    let mut tx = db.begin().await.expect("begin workspace seed");
+    tx.workspaces()
+        .ensure(WorkspaceName::default().as_str(), 1)
+        .await
+        .expect("seed default workspace");
+    tx.commit().await.expect("commit workspace seed");
+    Arc::new(db)
+}
+
 impl SourceManager {
     #[cfg(test)]
     pub(crate) fn new_for_tests(
@@ -216,6 +287,7 @@ impl SourceManager {
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
+        let db = block_on_runtime_aware(test_database(&layout, &config_store));
         Self::with_diagnostic_reporter(
             config_store,
             credential_manager,
@@ -224,6 +296,7 @@ impl SourceManager {
             SourceDiagnosticReporter::default(),
         )
         .with_database_sources_enabled(true)
+        .with_database(db)
     }
 
     pub(crate) fn with_diagnostic_reporter(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -16,24 +16,28 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
+use crate::hash::sha256_hex;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::sqlite_store::SqliteSearchStore;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
 use crate::sources::materialization::{
-    MaterializationBuild, MaterializationInputs, SourceDiagnosticReporter,
+    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, MaterializationBuild, MaterializationInputs,
+    OPERATION_METADATA_FILENAME, PROJECTIONS_FILENAME, SEMANTIC_IR_FILENAME,
+    SOURCE_DOCUMENT_RAW_FILENAME, SOURCE_DOCUMENT_YAML_FILENAME, SourceDiagnosticReporter,
     build_v4_materialization_tmp, canonicalize_file_descriptor, cleanup_materialization_backup,
     cleanup_materialization_tmp, new_materialization_suffix, replace_or_retire_v4_materialization,
     restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
-use crate::state::db::CoralDb;
-#[cfg(test)]
 use crate::state::db::{
-    DatabaseConfig, DbRepos as _, ResolvedDatabaseConfig, run_state_migrations,
+    CoralDb, DbRepos as _, MaterializationRecord, SourceManifestRecord, now_unix_nanos_i64,
 };
+#[cfg(test)]
+use crate::state::db::{DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
+use crate::state::mirror_ledger::MirrorLedger;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{
@@ -44,6 +48,10 @@ use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 use uuid::Uuid;
+
+/// The only materialization shape this manager stores; v4 is single-surface
+/// with a flat file layout, so one installed directory is one row.
+const V4_MATERIALIZATION_VERSION: &str = "v4";
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
@@ -57,6 +65,14 @@ pub(crate) struct SourceManager {
     pool_registry: Arc<WorkspacePoolRegistry>,
     db: Option<Arc<CoralDb>>,
     database_sources_enabled: bool,
+    /// Makes the authoritative source transaction fail, so a test can drive the
+    /// recovery that puts the files and the config entry back.
+    #[cfg(test)]
+    db_write_fails: bool,
+    /// Makes the `config.toml` mirror write fail after the transaction has
+    /// committed, so a test can drive the compensation that puts the rows back.
+    #[cfg(test)]
+    config_mirror_fails: bool,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -180,10 +196,17 @@ struct OAuthSourceInstallRequest {
     origin: SourceOrigin,
 }
 
+/// Everything a lifecycle write has to be able to put back.
+///
+/// The two artifact rows are captured before the transaction overwrites them:
+/// once it commits, the previous manifest and materialization are gone from the
+/// database, and the files that mirrored them have already been replaced.
 struct SourceRollbackState {
     source: InstalledSource,
     manifest_yaml: Option<String>,
     credential_material: Option<CredentialMaterialSnapshot>,
+    previous_manifest: Option<SourceManifestRecord>,
+    previous_materialization: Option<MaterializationRecord>,
 }
 
 fn materialization_inputs_from_bindings(
@@ -206,10 +229,6 @@ fn materialization_inputs_from_bindings(
 /// run on. A fresh current-thread runtime on a borrowed scoped thread is the
 /// one shape that holds under every flavor — the work never touches the
 /// ambient runtime, so the caller only ever waits on the join.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "the dual-write bridge blocks through this next")
-)]
 fn block_on_runtime_aware<F>(future: F) -> F::Output
 where
     F: Future + Send,
@@ -232,6 +251,22 @@ where
             .join()
             .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
     })
+}
+
+/// Runs one database operation from a synchronous source-lifecycle step.
+///
+/// Reserved for code that is already blocking — the lifecycle writes that run
+/// under `spawn_blocking`, and the synchronous test entry points. It is
+/// expensive by construction (a thread and a runtime per call), and calling it
+/// from an async task would block a runtime worker on database I/O, which is
+/// the starvation class the state-lock waits were just moved off. Async callers
+/// await the database directly instead.
+fn run_source_db_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send,
+    F: Future<Output = Result<T, AppError>> + Send,
+{
+    block_on_runtime_aware(operation)
 }
 
 /// Opens, migrates, and seeds the database a test's source manager reads
@@ -317,7 +352,23 @@ impl SourceManager {
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
             db: None,
             database_sources_enabled: false,
+            #[cfg(test)]
+            db_write_fails: false,
+            #[cfg(test)]
+            config_mirror_fails: false,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_failing_database_write(mut self) -> Self {
+        self.db_write_fails = true;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_failing_config_mirror(mut self) -> Self {
+        self.config_mirror_fails = true;
+        self
     }
 
     pub(crate) fn with_database_sources_enabled(mut self, enabled: bool) -> Self {
@@ -349,11 +400,292 @@ impl SourceManager {
     /// constructed the manager without one and then reached a DB-backed path.
     /// That is a wiring defect, not a deployment shape: reporting it keeps the
     /// gap loud instead of silently degrading to file-only behavior.
-    #[expect(dead_code, reason = "the source manager reads through this next")]
     fn database(&self) -> Result<&Arc<CoralDb>, AppError> {
         self.db.as_ref().ok_or_else(|| {
             AppError::Internal("source manager was constructed without a database".to_string())
         })
+    }
+
+    /// Commits one source and its artifacts as a single transaction.
+    ///
+    /// The three rows move together because they describe one installation: a
+    /// catalog entry whose manifest or materialization belongs to a different
+    /// version of the source is worse than either write failing outright.
+    ///
+    /// `manifest_yaml` is `None` for a bundled source, whose manifest ships with
+    /// the binary rather than being stored, and `materialization` is `None` for
+    /// anything that does not materialize; both cases drop whatever row an
+    /// earlier install of the same name left behind.
+    ///
+    /// Callers hold the state lock, and the transaction nests strictly inside
+    /// it: it opens after the files are staged and commits before the mirror
+    /// write, so it never spans a filesystem write.
+    fn upsert_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        manifest_yaml: Option<&str>,
+        materialization: Option<&MaterializationRecord>,
+    ) -> Result<(), AppError> {
+        #[cfg(test)]
+        if self.db_write_fails {
+            return Err(AppError::Internal(
+                "source database write failed for tests".to_string(),
+            ));
+        }
+        let db = Arc::clone(self.database()?);
+        let workspace_name = workspace_name.clone();
+        let source = source.clone();
+        let manifest_yaml = manifest_yaml.map(str::to_owned);
+        let materialization = materialization.cloned();
+        let now_unix_nanos = now_unix_nanos_i64()?;
+        run_source_db_operation(async move {
+            let source_name = &source.name;
+            let mut tx = db.begin().await?;
+            if tx
+                .workspaces()
+                .get(workspace_name.as_str())
+                .await?
+                .is_none()
+            {
+                return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+            }
+            tx.sources()
+                .upsert_source(&workspace_name, &source, now_unix_nanos)
+                .await?;
+            match manifest_yaml.as_deref() {
+                Some(manifest_yaml) => {
+                    tx.source_manifests()
+                        .upsert(&workspace_name, source_name, manifest_yaml, now_unix_nanos)
+                        .await?;
+                }
+                None => {
+                    tx.source_manifests()
+                        .remove(&workspace_name, source_name)
+                        .await?;
+                }
+            }
+            match materialization.as_ref() {
+                Some(materialization) => {
+                    tx.materializations()
+                        .upsert(
+                            &workspace_name,
+                            source_name,
+                            materialization,
+                            now_unix_nanos,
+                        )
+                        .await?;
+                }
+                None => {
+                    tx.materializations()
+                        .remove(&workspace_name, source_name)
+                        .await?;
+                }
+            }
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    /// Removes one source and records the deletion, as a single transaction.
+    ///
+    /// The artifact rows go with it through the schema's cascade, and the
+    /// tombstone the same statement writes is what keeps the deletion from
+    /// being undone by another host's stale config mirror at its next boot.
+    fn remove_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        #[cfg(test)]
+        if self.db_write_fails {
+            return Err(AppError::Internal(
+                "source database write failed for tests".to_string(),
+            ));
+        }
+        let db = Arc::clone(self.database()?);
+        let workspace_name = workspace_name.clone();
+        let source_name = source_name.clone();
+        let now_unix_nanos = now_unix_nanos_i64()?;
+        run_source_db_operation(async move {
+            let mut tx = db.begin().await?;
+            tx.sources()
+                .remove_source(&workspace_name, &source_name, now_unix_nanos)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    /// Reads the artifact rows a compensation would have to put back.
+    fn load_source_artifact_rows(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(Option<SourceManifestRecord>, Option<MaterializationRecord>), AppError> {
+        let db = Arc::clone(self.database()?);
+        let workspace_name = workspace_name.clone();
+        let source_name = source_name.clone();
+        run_source_db_operation(async move {
+            let mut session = db.as_ref();
+            let manifest = session
+                .source_manifests()
+                .get(&workspace_name, &source_name)
+                .await?;
+            let materialization = session
+                .materializations()
+                .get(&workspace_name, &source_name)
+                .await?;
+            Ok((manifest, materialization))
+        })
+    }
+
+    /// Puts the database back the way a failed mirror write found it.
+    ///
+    /// The direction is what matters. A fresh install's rows have to go away,
+    /// while an update's have to return to the set captured before the
+    /// transaction — removing those would cascade away a source that was
+    /// working a moment ago and tombstone it into the bargain.
+    ///
+    /// Best effort, like the file and config restores it runs beside: what is
+    /// left when it fails is a database ahead of the mirror, which the next
+    /// boot's reconciliation pass is there to close.
+    fn compensate_source_rows_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        previous: Option<&SourceRollbackState>,
+    ) {
+        let restored = match previous {
+            Some(previous) => self.upsert_source_with_state_lock_held(
+                workspace_name,
+                &previous.source,
+                previous
+                    .previous_manifest
+                    .as_ref()
+                    .map(|manifest| manifest.manifest_yaml.as_str()),
+                previous.previous_materialization.as_ref(),
+            ),
+            None => self.remove_source_with_state_lock_held(workspace_name, source_name),
+        };
+        if let Err(error) = restored {
+            warn!("rollback: failed to restore the source's database rows: {error}");
+        }
+    }
+
+    /// Reads the installed `materialized/v4` file set back as the row that
+    /// reproduces it.
+    ///
+    /// Reads the materialized directory rather than the layout's accessors,
+    /// which prefer an operator's override file: the row records what Coral
+    /// materialized, and an override is host-local by design.
+    fn read_v4_materialization_record(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<MaterializationRecord>, AppError> {
+        let materialized_dir = self.layout.v4_materialized_dir(workspace_name, source_name);
+        if !materialized_dir.exists() {
+            return Ok(None);
+        }
+        let optional_artifact = |file: &str| -> Result<Option<String>, AppError> {
+            let path = materialized_dir.join(file);
+            if path.exists() {
+                Ok(Some(std::fs::read_to_string(path)?))
+            } else {
+                Ok(None)
+            }
+        };
+        Ok(Some(MaterializationRecord {
+            materialization_version: V4_MATERIALIZATION_VERSION.to_string(),
+            fingerprint_yaml: optional_artifact(FINGERPRINT_FILENAME)?,
+            projections_yaml: std::fs::read_to_string(materialized_dir.join(PROJECTIONS_FILENAME))?,
+            diagnostics_yaml: optional_artifact(DIAGNOSTICS_FILENAME)?,
+            source_document_raw: std::fs::read(
+                materialized_dir.join(SOURCE_DOCUMENT_RAW_FILENAME),
+            )?,
+            source_document_yaml: std::fs::read_to_string(
+                materialized_dir.join(SOURCE_DOCUMENT_YAML_FILENAME),
+            )?,
+            semantic_ir_yaml: std::fs::read_to_string(materialized_dir.join(SEMANTIC_IR_FILENAME))?,
+            operation_metadata_yaml: std::fs::read_to_string(
+                materialized_dir.join(OPERATION_METADATA_FILENAME),
+            )?,
+        }))
+    }
+
+    /// Writes the `config.toml` mirror of one persisted source.
+    ///
+    /// A seam rather than a call at the one site that needs it, because nothing
+    /// a test can do to the real file makes this write fail on demand, and the
+    /// compensation that failure drives — putting the database rows back — is
+    /// the part worth pinning.
+    fn mirror_persisted_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+    ) -> Result<(), AppError> {
+        #[cfg(test)]
+        if self.config_mirror_fails {
+            return Err(AppError::Internal(
+                "source config mirror failed for tests".to_string(),
+            ));
+        }
+        self.config_store
+            .upsert_source_unlocked(workspace_name, source)
+    }
+
+    /// Removes one source from the `config.toml` mirror. A seam for the same
+    /// reason [`Self::mirror_persisted_source_with_state_lock_held`] is.
+    fn mirror_source_removal_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        #[cfg(test)]
+        if self.config_mirror_fails {
+            return Err(AppError::Internal(
+                "source config mirror failed for tests".to_string(),
+            ));
+        }
+        self.config_store
+            .remove_source_unlocked(workspace_name, source_name)
+    }
+
+    /// Records the content this host just mirrored, after the writes it records.
+    ///
+    /// Best effort: the ledger only lets a later boot tell content Coral wrote
+    /// from content an operator wrote, and losing that proof costs a warning
+    /// and a preserved file, never a silent overwrite.
+    fn record_source_mirror_in_ledger(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        manifest_yaml: Option<&str>,
+    ) {
+        let config_path = self.layout.config_file();
+        let mut ledger = MirrorLedger::load(config_path);
+        ledger.record_entry(workspace_name, &source.name, source);
+        if let Some(manifest_yaml) = manifest_yaml {
+            ledger.record_manifest(
+                workspace_name,
+                &source.name,
+                &sha256_hex(manifest_yaml.as_bytes()),
+            );
+        }
+        if let Err(error) = ledger.save(config_path) {
+            warn!("source persisted, but failed to record it in the mirror ledger: {error}");
+        }
+    }
+
+    /// Drops this host's record of a source it just removed from the mirror.
+    fn forget_source_in_ledger(&self, workspace_name: &WorkspaceName, source_name: &SourceName) {
+        let config_path = self.layout.config_file();
+        let mut ledger = MirrorLedger::load(config_path);
+        ledger.remove(workspace_name, source_name);
+        if let Err(error) = ledger.save(config_path) {
+            warn!("source deleted, but failed to drop it from the mirror ledger: {error}");
+        }
     }
 
     pub(crate) fn list_workspace_sources(
@@ -761,6 +1093,8 @@ impl SourceManager {
         let credential_material = credential_storage
             .map(|storage| credential_guard.snapshot_material_with_state_lock_held(storage))
             .transpose()?;
+        let (previous_manifest, previous_materialization) =
+            self.load_source_artifact_rows(workspace_name, source_name)?;
         let previous = SourceRollbackState {
             source: stored,
             manifest_yaml: match removed.origin {
@@ -770,48 +1104,34 @@ impl SourceManager {
                 )?),
             },
             credential_material,
+            previous_manifest,
+            previous_materialization,
         };
         let source_dir_backup = fs::DirectoryBackup::move_for_delete(&source_dir, source_name)?;
-        if let Some(credential_storage) = credential_storage
-            && let Err(error) =
+        // The credential material goes first because it is the one part with no
+        // inverse, then the transaction that makes the deletion authoritative,
+        // then the mirror the ledger records once it has landed.
+        let deletion = credential_storage
+            .map(|credential_storage| {
                 credential_guard.remove_material_with_state_lock_held(credential_storage)
-        {
-            let restore_dir_result = source_dir_backup.restore();
-            self.restore_source_rollback_state_with_state_lock_held(
+            })
+            .transpose()
+            .map(|_removed| ())
+            .and_then(|()| self.remove_source_with_state_lock_held(workspace_name, source_name))
+            .and_then(|()| {
+                self.mirror_source_removal_with_state_lock_held(workspace_name, source_name)
+            });
+        if let Err(error) = deletion {
+            return Err(self.abort_source_deletion_with_state_lock_held(
                 workspace_name,
                 source_name,
-                Some(previous),
-                None,
+                previous,
+                &source_dir_backup,
                 &credential_guard,
-            );
-            if let Err(restore_error) = restore_dir_result {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source credentials for '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.backup_path().display()
-                )));
-            }
-            return Err(error);
+                error,
+            ));
         }
-        if let Err(error) = self
-            .config_store
-            .remove_source_unlocked(workspace_name, source_name)
-        {
-            let restore_dir_result = source_dir_backup.restore();
-            self.restore_source_rollback_state_with_state_lock_held(
-                workspace_name,
-                source_name,
-                Some(previous),
-                None,
-                &credential_guard,
-            );
-            if let Err(restore_error) = restore_dir_result {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
-                    source_dir_backup.backup_path().display()
-                )));
-            }
-            return Err(error);
-        }
+        self.forget_source_in_ledger(workspace_name, source_name);
         self.pool_registry
             .remove_catalog(workspace_name, source_name.as_str());
         source_dir_backup.commit()?;
@@ -1004,10 +1324,30 @@ impl SourceManager {
             },
             origin: request.origin,
         };
-        if let Err(error) = self
-            .config_store
-            .upsert_source_unlocked(workspace_name, stored.clone())
-        {
+        // The commit point. The files are staged, so the transaction is what
+        // decides whether this installation happened; the config mirror below
+        // follows it, and the ledger records the mirror once it has landed.
+        let commit = self
+            .read_v4_materialization_record(workspace_name, &source_name)
+            .and_then(|materialization| {
+                self.upsert_source_with_state_lock_held(
+                    workspace_name,
+                    &stored,
+                    request.manifest_yaml,
+                    materialization.as_ref(),
+                )
+            })
+            .and_then(|()| {
+                self.mirror_persisted_source_with_state_lock_held(workspace_name, stored.clone())
+                    .inspect_err(|_mirror_failure| {
+                        self.compensate_source_rows_with_state_lock_held(
+                            workspace_name,
+                            &source_name,
+                            previous.as_ref(),
+                        );
+                    })
+            });
+        if let Err(error) = commit {
             let restore_result = restore_materialization_backup(
                 &self.layout,
                 workspace_name,
@@ -1028,6 +1368,7 @@ impl SourceManager {
             }
             return Err(error);
         }
+        self.record_source_mirror_in_ledger(workspace_name, &stored, request.manifest_yaml);
         cleanup_materialization_backup(materialization_backup);
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
@@ -1436,6 +1777,8 @@ impl SourceManager {
                 credential_material.snapshot_material_with_state_lock_held(credential_storage)
             })
             .transpose()?;
+        let (previous_manifest, previous_materialization) =
+            self.load_source_artifact_rows(workspace_name, source_name)?;
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
                 SourceOrigin::Bundled => None,
@@ -1445,7 +1788,47 @@ impl SourceManager {
             },
             source,
             credential_material,
+            previous_manifest,
+            previous_materialization,
         }))
+    }
+
+    /// Undoes a deletion that could not be completed, and reports why.
+    ///
+    /// Every failed step leaves the same three things to put back — the staged
+    /// directory, the database rows, and the config entry with its credential
+    /// material — so one recovery serves all of them. Restoring rows a step
+    /// never got as far as removing rewrites them unchanged, which is cheaper
+    /// than tracking how far the deletion got and cannot get that wrong.
+    fn abort_source_deletion_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        previous: SourceRollbackState,
+        source_dir_backup: &fs::DirectoryBackup,
+        credential_material: &CredentialMaterialGuard<'_>,
+        error: AppError,
+    ) -> AppError {
+        let restore_dir_result = source_dir_backup.restore();
+        self.compensate_source_rows_with_state_lock_held(
+            workspace_name,
+            source_name,
+            Some(&previous),
+        );
+        self.restore_source_rollback_state_with_state_lock_held(
+            workspace_name,
+            source_name,
+            Some(previous),
+            None,
+            credential_material,
+        );
+        match restore_dir_result {
+            Ok(()) => error,
+            Err(restore_error) => AppError::FailedPrecondition(format!(
+                "failed to delete source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
+                source_dir_backup.backup_path().display()
+            )),
+        }
     }
 
     fn restore_source_rollback_state_with_state_lock_held(
@@ -1889,6 +2272,7 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::net::TcpListener as StdTcpListener;
     use std::path::Path;
+    use std::sync::Arc;
     use std::sync::mpsc as std_mpsc;
     use std::thread;
     use std::time::Duration;
@@ -1904,8 +2288,9 @@ mod tests {
         ImportSourceCommand, ImportSourceEventSender, ImportSourceWithCredentialsCommand,
         ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent,
         PersistSourceRequest, SourceBinding, SourceBindings, SourceManager,
-        SourceOAuthCredentialRetrieval, ValidatedBindings, materialization_inputs_from_bindings,
-        normalize_binding_key, source_needs_stored_material_for_validation,
+        SourceOAuthCredentialRetrieval, ValidatedBindings, block_on_runtime_aware,
+        materialization_inputs_from_bindings, normalize_binding_key,
+        source_needs_stored_material_for_validation,
     };
     use crate::bootstrap::AppError;
     use crate::credentials::{
@@ -1919,6 +2304,8 @@ mod tests {
         FINGERPRINT_FILENAME, MaterializationInputs, PROJECTIONS_FILENAME,
     };
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+    use crate::state::db::{DbRepos as _, MaterializationRecord, SourceManifestRecord};
+    use crate::state::mirror_ledger::MirrorLedger;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
     use coral_spec::{
@@ -3007,6 +3394,335 @@ surface:
             .get_source_info(&default_workspace(), &source_name)
             .expect("installed v4 source should be usable");
         assert_eq!(info.name.as_str(), "github_v4_test");
+    }
+
+    /// One v4 source installed under its own layout, with the descriptor file
+    /// the test can rewrite to drive an update.
+    struct DualWriteFixture {
+        _temp: TempDir,
+        _descriptor_temp: TempDir,
+        layout: AppStateLayout,
+        manager: SourceManager,
+        openapi_file: std::path::PathBuf,
+        updated_openapi_file: std::path::PathBuf,
+        updated: std::cell::Cell<bool>,
+    }
+
+    impl DualWriteFixture {
+        fn new() -> Self {
+            let temp = TempDir::new().expect("temp dir");
+            let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+            layout.ensure().expect("ensure layout");
+            let openapi_file = descriptor_temp.path().join("github-openapi.yaml");
+            std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write fixture");
+            let manager = SourceManager::new_for_tests(
+                ConfigStore::new(layout.clone()),
+                CredentialManager::new(CredentialStore::new(layout.clone())),
+                layout.clone(),
+            );
+            Self {
+                _temp: temp,
+                updated_openapi_file: descriptor_temp.path().join("github-openapi-updated.yaml"),
+                _descriptor_temp: descriptor_temp,
+                layout,
+                manager,
+                openapi_file,
+                updated: std::cell::Cell::new(false),
+            }
+        }
+
+        fn source_name() -> SourceName {
+            SourceName::parse("github_v4_test").expect("source name")
+        }
+
+        fn import_with(&self, manager: &SourceManager) -> Result<InstalledSource, AppError> {
+            let descriptor = if self.updated.get() {
+                &self.updated_openapi_file
+            } else {
+                &self.openapi_file
+            };
+            manager.import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_v4_with_file_descriptor(descriptor),
+                    bindings: SourceBindings::default(),
+                },
+            )
+        }
+
+        fn import(&self) -> InstalledSource {
+            self.import_with(&self.manager).expect("import v4 source")
+        }
+
+        /// Points the fixture at a second descriptor, so the next import of the
+        /// same source name produces both a different manifest — the descriptor
+        /// path is part of it — and a different materialization.
+        fn change_descriptor(&self) {
+            std::fs::write(
+                &self.updated_openapi_file,
+                v4_openapi_fixture_with_metadata(),
+            )
+            .expect("write updated fixture");
+            self.updated.set(true);
+        }
+
+        fn config_entry(&self) -> Option<InstalledSource> {
+            match self
+                .manager
+                .config_store
+                .get_source(&default_workspace(), &Self::source_name())
+            {
+                Ok(source) => Some(source),
+                Err(AppError::SourceNotFound(_)) => None,
+                Err(error) => panic!("read config entry: {error}"),
+            }
+        }
+
+        fn db_state(&self) -> DbSourceState {
+            let db = Arc::clone(self.manager.database().expect("database"));
+            let workspace_name = default_workspace();
+            let source_name = Self::source_name();
+            block_on_runtime_aware(async move {
+                let mut session = db.as_ref();
+                DbSourceState {
+                    source: session
+                        .sources()
+                        .get_source(&workspace_name, &source_name)
+                        .await
+                        .expect("read source row"),
+                    manifest: session
+                        .source_manifests()
+                        .get(&workspace_name, &source_name)
+                        .await
+                        .expect("read manifest row"),
+                    materialization: session
+                        .materializations()
+                        .get(&workspace_name, &source_name)
+                        .await
+                        .expect("read materialization row"),
+                    tombstoned: session
+                        .sources()
+                        .is_tombstoned(&workspace_name, &source_name)
+                        .await
+                        .expect("read tombstone"),
+                }
+            })
+        }
+
+        fn ledger(&self) -> MirrorLedger {
+            MirrorLedger::load(self.layout.config_file())
+        }
+
+        fn manifest_file_yaml(&self) -> String {
+            std::fs::read_to_string(
+                self.layout
+                    .manifest_file(&default_workspace(), &Self::source_name()),
+            )
+            .expect("read manifest file")
+        }
+    }
+
+    struct DbSourceState {
+        source: Option<InstalledSource>,
+        manifest: Option<SourceManifestRecord>,
+        materialization: Option<MaterializationRecord>,
+        tombstoned: bool,
+    }
+
+    #[test]
+    fn source_install_and_update_dual_write_the_database_and_the_config_mirror() {
+        let fixture = DualWriteFixture::new();
+
+        let installed = fixture.import();
+
+        let state = fixture.db_state();
+        let row = state.source.as_ref().expect("source row after install");
+        assert_eq!(row, &fixture.config_entry().expect("config entry"));
+        assert_eq!(row.name, installed.name);
+        let manifest = state.manifest.as_ref().expect("manifest row after install");
+        assert_eq!(manifest.manifest_yaml, fixture.manifest_file_yaml());
+        let materialization = state
+            .materialization
+            .as_ref()
+            .expect("materialization row after install");
+        assert_eq!(materialization.materialization_version, "v4");
+        assert_eq!(
+            materialization.projections_yaml,
+            std::fs::read_to_string(
+                fixture
+                    .layout
+                    .v4_materialized_dir(&default_workspace(), &DualWriteFixture::source_name())
+                    .join(PROJECTIONS_FILENAME)
+            )
+            .expect("read projections file")
+        );
+        let ledger = fixture.ledger();
+        assert!(ledger.matches_entry(&default_workspace(), &installed.name, row));
+        assert!(ledger.matches_manifest(
+            &default_workspace(),
+            &installed.name,
+            &super::sha256_hex(manifest.manifest_yaml.as_bytes())
+        ));
+
+        fixture.change_descriptor();
+        fixture.import();
+
+        let updated = fixture.db_state();
+        assert_eq!(
+            updated.source.as_ref().expect("source row after update"),
+            &fixture.config_entry().expect("config entry after update")
+        );
+        let updated_manifest = updated.manifest.expect("manifest row after update");
+        assert_eq!(updated_manifest.manifest_yaml, fixture.manifest_file_yaml());
+        assert_ne!(updated_manifest.manifest_yaml, manifest.manifest_yaml);
+        assert_ne!(
+            &updated
+                .materialization
+                .expect("materialization row after update"),
+            materialization,
+            "an update must replace the stored artifacts, not keep the first install's"
+        );
+    }
+
+    #[test]
+    fn deleting_a_source_tombstones_it_and_a_re_add_clears_the_tombstone() {
+        let fixture = DualWriteFixture::new();
+        let installed = fixture.import();
+
+        fixture
+            .manager
+            .delete_source(&default_workspace(), &installed.name)
+            .expect("delete source");
+
+        let deleted = fixture.db_state();
+        assert!(deleted.source.is_none(), "the catalog row must be gone");
+        assert!(deleted.manifest.is_none(), "the manifest row must cascade");
+        assert!(
+            deleted.materialization.is_none(),
+            "the materialization row must cascade"
+        );
+        assert!(deleted.tombstoned, "the deletion must be recorded");
+        assert!(fixture.config_entry().is_none());
+        assert!(
+            !fixture
+                .ledger()
+                .entry_recorded(&default_workspace(), &installed.name),
+            "a deleted source must leave no ledger record behind"
+        );
+
+        fixture.import();
+
+        let readded = fixture.db_state();
+        assert!(readded.source.is_some());
+        assert!(
+            !readded.tombstoned,
+            "re-adding a source must revoke the earlier deletion"
+        );
+        assert!(
+            fixture
+                .ledger()
+                .entry_recorded(&default_workspace(), &installed.name)
+        );
+    }
+
+    #[test]
+    fn a_failed_source_transaction_leaves_neither_files_nor_config_behind() {
+        let fixture = DualWriteFixture::new();
+        let failing = fixture.manager.clone().with_failing_database_write();
+
+        let error = fixture
+            .import_with(&failing)
+            .expect_err("a failed transaction must fail the install");
+
+        assert!(
+            error.to_string().contains("source database write failed"),
+            "unexpected error: {error}"
+        );
+        assert!(fixture.db_state().source.is_none());
+        assert!(fixture.config_entry().is_none());
+        assert!(
+            !fixture
+                .layout
+                .source_dir(&default_workspace(), &DualWriteFixture::source_name())
+                .exists(),
+            "a failed install must not leave its files behind"
+        );
+    }
+
+    #[test]
+    fn a_failed_transaction_on_an_update_leaves_the_installed_source_untouched() {
+        let fixture = DualWriteFixture::new();
+        fixture.import();
+        let before = fixture.db_state();
+        let manifest_before = fixture.manifest_file_yaml();
+        let failing = fixture.manager.clone().with_failing_database_write();
+
+        fixture.change_descriptor();
+        fixture
+            .import_with(&failing)
+            .expect_err("a failed transaction must fail the update");
+
+        let after = fixture.db_state();
+        assert_eq!(after.source, before.source);
+        assert_eq!(after.manifest, before.manifest);
+        assert_eq!(after.materialization, before.materialization);
+        assert_eq!(fixture.manifest_file_yaml(), manifest_before);
+        assert_eq!(fixture.config_entry(), before.source);
+    }
+
+    #[test]
+    fn a_failed_mirror_write_on_a_fresh_install_removes_the_new_rows() {
+        let fixture = DualWriteFixture::new();
+        let failing = fixture.manager.clone().with_failing_config_mirror();
+
+        fixture
+            .import_with(&failing)
+            .expect_err("a failed mirror write must fail the install");
+
+        let state = fixture.db_state();
+        assert!(
+            state.source.is_none(),
+            "the row the failed install inserted must be removed"
+        );
+        assert!(state.manifest.is_none());
+        assert!(state.materialization.is_none());
+        assert!(fixture.config_entry().is_none());
+    }
+
+    #[test]
+    fn a_failed_mirror_write_on_an_update_restores_the_previous_row_set() {
+        let fixture = DualWriteFixture::new();
+        fixture.import();
+        let before = fixture.db_state();
+        let failing = fixture.manager.clone().with_failing_config_mirror();
+
+        fixture.change_descriptor();
+        fixture
+            .import_with(&failing)
+            .expect_err("a failed mirror write must fail the update");
+
+        let after = fixture.db_state();
+        let restored = after.source.expect("an update must never remove the row");
+        assert_eq!(&restored, before.source.as_ref().expect("source row"));
+        assert!(
+            !after.tombstoned,
+            "compensating an update must not tombstone a working source"
+        );
+        let (restored_manifest, previous_manifest) = (
+            after.manifest.expect("manifest row"),
+            before.manifest.expect("manifest row"),
+        );
+        assert_eq!(
+            restored_manifest.manifest_yaml,
+            previous_manifest.manifest_yaml
+        );
+        assert_eq!(
+            restored_manifest.manifest_hash,
+            previous_manifest.manifest_hash
+        );
+        assert_eq!(after.materialization, before.materialization);
     }
 
     #[test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -23,12 +23,10 @@ use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
 use crate::sources::materialization::{
-    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, MaterializationBuild, MaterializationInputs,
-    OPERATION_METADATA_FILENAME, PROJECTIONS_FILENAME, SEMANTIC_IR_FILENAME,
-    SOURCE_DOCUMENT_RAW_FILENAME, SOURCE_DOCUMENT_YAML_FILENAME, SourceDiagnosticReporter,
+    MaterializationBuild, MaterializationInputs, SourceDiagnosticReporter,
     build_v4_materialization_tmp, canonicalize_file_descriptor, cleanup_materialization_backup,
-    cleanup_materialization_tmp, new_materialization_suffix, replace_or_retire_v4_materialization,
-    restore_materialization_backup,
+    cleanup_materialization_tmp, new_materialization_suffix, read_v4_materialization_record,
+    replace_or_retire_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
@@ -48,10 +46,6 @@ use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 use uuid::Uuid;
-
-/// The only materialization shape this manager stores; v4 is single-surface
-/// with a flat file layout, so one installed directory is one row.
-const V4_MATERIALIZATION_VERSION: &str = "v4";
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
@@ -571,47 +565,6 @@ impl SourceManager {
         if let Err(error) = restored {
             warn!("rollback: failed to restore the source's database rows: {error}");
         }
-    }
-
-    /// Reads the installed `materialized/v4` file set back as the row that
-    /// reproduces it.
-    ///
-    /// Reads the materialized directory rather than the layout's accessors,
-    /// which prefer an operator's override file: the row records what Coral
-    /// materialized, and an override is host-local by design.
-    fn read_v4_materialization_record(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<Option<MaterializationRecord>, AppError> {
-        let materialized_dir = self.layout.v4_materialized_dir(workspace_name, source_name);
-        if !materialized_dir.exists() {
-            return Ok(None);
-        }
-        let optional_artifact = |file: &str| -> Result<Option<String>, AppError> {
-            let path = materialized_dir.join(file);
-            if path.exists() {
-                Ok(Some(std::fs::read_to_string(path)?))
-            } else {
-                Ok(None)
-            }
-        };
-        Ok(Some(MaterializationRecord {
-            materialization_version: V4_MATERIALIZATION_VERSION.to_string(),
-            fingerprint_yaml: optional_artifact(FINGERPRINT_FILENAME)?,
-            projections_yaml: std::fs::read_to_string(materialized_dir.join(PROJECTIONS_FILENAME))?,
-            diagnostics_yaml: optional_artifact(DIAGNOSTICS_FILENAME)?,
-            source_document_raw: std::fs::read(
-                materialized_dir.join(SOURCE_DOCUMENT_RAW_FILENAME),
-            )?,
-            source_document_yaml: std::fs::read_to_string(
-                materialized_dir.join(SOURCE_DOCUMENT_YAML_FILENAME),
-            )?,
-            semantic_ir_yaml: std::fs::read_to_string(materialized_dir.join(SEMANTIC_IR_FILENAME))?,
-            operation_metadata_yaml: std::fs::read_to_string(
-                materialized_dir.join(OPERATION_METADATA_FILENAME),
-            )?,
-        }))
     }
 
     /// Writes the `config.toml` mirror of one persisted source.
@@ -1327,8 +1280,10 @@ impl SourceManager {
         // The commit point. The files are staged, so the transaction is what
         // decides whether this installation happened; the config mirror below
         // follows it, and the ledger records the mirror once it has landed.
-        let commit = self
-            .read_v4_materialization_record(workspace_name, &source_name)
+        let materialized_dir = self
+            .layout
+            .v4_materialized_dir(workspace_name, &source_name);
+        let commit = read_v4_materialization_record(&materialized_dir)
             .and_then(|materialization| {
                 self.upsert_source_with_state_lock_held(
                     workspace_name,
@@ -3723,6 +3678,58 @@ surface:
             previous_manifest.manifest_hash
         );
         assert_eq!(after.materialization, before.materialization);
+    }
+
+    #[test]
+    fn a_failed_mirror_write_on_a_delete_restores_the_source_untombstoned() {
+        let fixture = DualWriteFixture::new();
+        let installed = fixture.import();
+        let before = fixture.db_state();
+        let failing = fixture.manager.clone().with_failing_config_mirror();
+
+        failing
+            .delete_source(&default_workspace(), &installed.name)
+            .expect_err("a failed mirror write must fail the delete");
+
+        let after = fixture.db_state();
+        assert_eq!(
+            after.source.as_ref(),
+            before.source.as_ref(),
+            "compensating a delete must put the catalog row back"
+        );
+        let (restored_manifest, previous_manifest) = (
+            after.manifest.expect("manifest row"),
+            before.manifest.expect("manifest row"),
+        );
+        assert_eq!(
+            restored_manifest.manifest_yaml,
+            previous_manifest.manifest_yaml
+        );
+        assert_eq!(
+            restored_manifest.manifest_hash,
+            previous_manifest.manifest_hash
+        );
+        assert_eq!(after.materialization, before.materialization);
+        assert!(
+            !after.tombstoned,
+            "a delete that never landed must leave no tombstone behind"
+        );
+        assert_eq!(
+            fixture.config_entry().as_ref(),
+            before.source.as_ref(),
+            "the config entry must survive a delete that failed"
+        );
+        assert!(
+            fixture.ledger().matches_entry(
+                &default_workspace(),
+                &installed.name,
+                before
+                    .source
+                    .as_ref()
+                    .expect("source row before the delete")
+            ),
+            "a delete that never landed must keep this host's mirror record"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -29,6 +29,7 @@ use crate::sources::materialization::{
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
+use crate::state::db::CoralDb;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{
@@ -50,6 +51,7 @@ pub(crate) struct SourceManager {
     diagnostic_reporter: SourceDiagnosticReporter,
     search_observations: Option<SearchObservationHandle>,
     pool_registry: Arc<WorkspacePoolRegistry>,
+    db: Option<Arc<CoralDb>>,
     database_sources_enabled: bool,
 }
 
@@ -240,6 +242,7 @@ impl SourceManager {
             diagnostic_reporter,
             search_observations: None,
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
+            db: None,
             database_sources_enabled: false,
         }
     }
@@ -254,12 +257,30 @@ impl SourceManager {
         self
     }
 
+    pub(crate) fn with_database(mut self, db: Arc<CoralDb>) -> Self {
+        self.db = Some(db);
+        self
+    }
+
     pub(crate) fn with_search_observation_handle(
         mut self,
         search_observations: SearchObservationHandle,
     ) -> Self {
         self.search_observations = Some(search_observations);
         self
+    }
+
+    /// The database every DB-backed source path reads and writes through.
+    ///
+    /// The server always attaches one, so an absent database means a test
+    /// constructed the manager without one and then reached a DB-backed path.
+    /// That is a wiring defect, not a deployment shape: reporting it keeps the
+    /// gap loud instead of silently degrading to file-only behavior.
+    #[expect(dead_code, reason = "the source manager reads through this next")]
+    fn database(&self) -> Result<&Arc<CoralDb>, AppError> {
+        self.db.as_ref().ok_or_else(|| {
+            AppError::Internal("source manager was constructed without a database".to_string())
+        })
     }
 
     pub(crate) fn list_workspace_sources(

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 use crate::bootstrap::AppError;
 use crate::hash::sha256_hex;
 use crate::sources::SourceName;
+use crate::state::db::MaterializationRecord;
 use crate::state::{
     AppStateLayout, V4OperationMetadataFile, V4OperationMetadataOrigin, V4ProjectionCatalogFile,
     V4ProjectionCatalogOrigin,
@@ -45,6 +46,9 @@ pub(crate) const OPERATION_METADATA_FILENAME: &str = "operation-metadata.yaml";
 pub(crate) const SOURCE_DOCUMENT_RAW_FILENAME: &str = "source-document.raw";
 pub(crate) const SOURCE_DOCUMENT_YAML_FILENAME: &str = "source-document.yaml";
 pub(crate) const SEMANTIC_IR_FILENAME: &str = "semantic-ir.yaml";
+/// The only materialization shape Coral stores; v4 is single-surface with a
+/// flat file layout, so one installed directory is one row.
+pub(crate) const V4_MATERIALIZATION_VERSION: &str = "v4";
 
 type ReportedDiagnosticStateKey = (String, String, String);
 type ReportedDiagnostics = BTreeMap<ReportedDiagnosticStateKey, BTreeSet<String>>;
@@ -975,6 +979,44 @@ fn write_surface_artifacts(
         materialized_surface.plan.operation_metadata(),
     )?;
     Ok(())
+}
+
+/// Reads an installed `materialized/v4` directory back as the record that
+/// reproduces it, or `None` when the source has no materialized directory.
+///
+/// Reads the materialized directory rather than the layout's accessors, which
+/// prefer an operator's override file: the record stores what Coral
+/// materialized, and an override is host-local by design. A directory missing a
+/// required artifact is an error rather than a partial record, leaving each
+/// caller to decide whether that fails its write or is warned about and skipped.
+pub(crate) fn read_v4_materialization_record(
+    materialized_dir: &Path,
+) -> Result<Option<MaterializationRecord>, AppError> {
+    if !materialized_dir.exists() {
+        return Ok(None);
+    }
+    let optional_artifact = |file: &str| -> Result<Option<String>, AppError> {
+        let path = materialized_dir.join(file);
+        if path.exists() {
+            Ok(Some(std::fs::read_to_string(path)?))
+        } else {
+            Ok(None)
+        }
+    };
+    Ok(Some(MaterializationRecord {
+        materialization_version: V4_MATERIALIZATION_VERSION.to_string(),
+        fingerprint_yaml: optional_artifact(FINGERPRINT_FILENAME)?,
+        projections_yaml: std::fs::read_to_string(materialized_dir.join(PROJECTIONS_FILENAME))?,
+        diagnostics_yaml: optional_artifact(DIAGNOSTICS_FILENAME)?,
+        source_document_raw: std::fs::read(materialized_dir.join(SOURCE_DOCUMENT_RAW_FILENAME))?,
+        source_document_yaml: std::fs::read_to_string(
+            materialized_dir.join(SOURCE_DOCUMENT_YAML_FILENAME),
+        )?,
+        semantic_ir_yaml: std::fs::read_to_string(materialized_dir.join(SEMANTIC_IR_FILENAME))?,
+        operation_metadata_yaml: std::fs::read_to_string(
+            materialized_dir.join(OPERATION_METADATA_FILENAME),
+        )?,
+    }))
 }
 
 fn materialize_surface(

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1019,6 +1019,79 @@ pub(crate) fn read_v4_materialization_record(
     }))
 }
 
+/// Writes the `materialized/v4` directory one stored record describes.
+///
+/// The inverse of [`read_v4_materialization_record`], and deliberately its
+/// mirror image: the same flat file set, with every optional artifact written
+/// only when the record carries it, and the fingerprint written verbatim. The
+/// verbatim part is load-bearing — the boot pass decides a cache's freshness by
+/// comparing the on-disk fingerprint's bytes against the row's, which is only
+/// well defined while hydration reproduces them exactly.
+///
+/// Installed through the same tmp-dir-and-swap as a freshly materialized
+/// directory, so a crash mid-swap leaves the cache old, new, or absent, never
+/// torn — and an absent one is hydrated again by the next boot.
+pub(crate) fn hydrate_v4_materialization_cache(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    record: &MaterializationRecord,
+) -> Result<(), AppError> {
+    let temp_dir = layout.v4_materialized_tmp_dir(
+        workspace_name,
+        source_name,
+        &new_materialization_suffix("hydrate"),
+    );
+    if let Err(error) = write_materialization_record(&temp_dir, record) {
+        cleanup_materialization_tmp(Some(&temp_dir));
+        return Err(error);
+    }
+    match replace_or_retire_v4_materialization(layout, workspace_name, source_name, Some(&temp_dir))
+    {
+        Ok(backup) => {
+            cleanup_materialization_backup(backup);
+            Ok(())
+        }
+        Err(error) => {
+            cleanup_materialization_tmp(Some(&temp_dir));
+            Err(error)
+        }
+    }
+}
+
+fn write_materialization_record(
+    temp_dir: &Path,
+    record: &MaterializationRecord,
+) -> Result<(), AppError> {
+    if temp_dir.exists() {
+        std::fs::remove_dir_all(temp_dir)?;
+    }
+    fs::ensure_private_dir(temp_dir)?;
+    for (file, contents) in [
+        (FINGERPRINT_FILENAME, record.fingerprint_yaml.as_deref()),
+        (PROJECTIONS_FILENAME, Some(record.projections_yaml.as_str())),
+        (DIAGNOSTICS_FILENAME, record.diagnostics_yaml.as_deref()),
+        (
+            OPERATION_METADATA_FILENAME,
+            Some(record.operation_metadata_yaml.as_str()),
+        ),
+        (
+            SOURCE_DOCUMENT_YAML_FILENAME,
+            Some(record.source_document_yaml.as_str()),
+        ),
+        (SEMANTIC_IR_FILENAME, Some(record.semantic_ir_yaml.as_str())),
+    ] {
+        if let Some(contents) = contents {
+            std::fs::write(temp_dir.join(file), contents)?;
+        }
+    }
+    std::fs::write(
+        temp_dir.join(SOURCE_DOCUMENT_RAW_FILENAME),
+        &record.source_document_raw,
+    )?;
+    Ok(())
+}
+
 fn materialize_surface(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -42,6 +42,9 @@ pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
 pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";
 pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
 pub(crate) const OPERATION_METADATA_FILENAME: &str = "operation-metadata.yaml";
+pub(crate) const SOURCE_DOCUMENT_RAW_FILENAME: &str = "source-document.raw";
+pub(crate) const SOURCE_DOCUMENT_YAML_FILENAME: &str = "source-document.yaml";
+pub(crate) const SEMANTIC_IR_FILENAME: &str = "semantic-ir.yaml";
 
 type ReportedDiagnosticStateKey = (String, String, String);
 type ReportedDiagnostics = BTreeMap<ReportedDiagnosticStateKey, BTreeSet<String>>;
@@ -402,9 +405,9 @@ pub(crate) fn load_v4_materialization_with_reporter(
     )?;
     let mut diagnostics = load_optional_diagnostics(&diagnostics_path, &mut load_diagnostics);
     let materialized_dir = layout.v4_materialized_dir(workspace_name, source_name);
-    let raw_source_document_path = materialized_dir.join("source-document.raw");
-    let normalized_source_document_path = materialized_dir.join("source-document.yaml");
-    let semantic_ir_path = materialized_dir.join("semantic-ir.yaml");
+    let raw_source_document_path = materialized_dir.join(SOURCE_DOCUMENT_RAW_FILENAME);
+    let normalized_source_document_path = materialized_dir.join(SOURCE_DOCUMENT_YAML_FILENAME);
+    let semantic_ir_path = materialized_dir.join(SEMANTIC_IR_FILENAME);
     let semantic_ir = read_validated_semantic_ir_with_reporter(
         manifest,
         workspace_name,
@@ -927,8 +930,8 @@ fn write_materialization(
         surface: MaterializedSurface {
             plan: materialized_surface.plan,
             source_document_sha256: Some(materialized_surface.observed_sha256),
-            normalized_source_document_path: temp_dir.join("source-document.yaml"),
-            raw_source_document_path: temp_dir.join("source-document.raw"),
+            normalized_source_document_path: temp_dir.join(SOURCE_DOCUMENT_YAML_FILENAME),
+            raw_source_document_path: temp_dir.join(SOURCE_DOCUMENT_RAW_FILENAME),
         },
         projections: projections.clone(),
         diagnostics: diagnostics.clone(),
@@ -956,15 +959,15 @@ fn write_surface_artifacts(
 ) -> Result<(), AppError> {
     fs::ensure_private_dir(materialized_dir)?;
     std::fs::write(
-        materialized_dir.join("source-document.raw"),
+        materialized_dir.join(SOURCE_DOCUMENT_RAW_FILENAME),
         &materialized_surface.raw_document,
     )?;
     std::fs::write(
-        materialized_dir.join("source-document.yaml"),
+        materialized_dir.join(SOURCE_DOCUMENT_YAML_FILENAME),
         &materialized_surface.normalized_document,
     )?;
     write_yaml(
-        &materialized_dir.join("semantic-ir.yaml"),
+        &materialized_dir.join(SEMANTIC_IR_FILENAME),
         materialized_surface.plan.semantic_ir(),
     )?;
     write_yaml(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -100,7 +100,8 @@ impl SourceServiceApi for SourceService {
             authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let sources = sources
-                .discover_sources(&workspace_name)
+                .discover_sources_async(&workspace_name)
+                .await
                 .map_err(app_status)?
                 .into_iter()
                 .map(candidate_source_to_proto)
@@ -125,7 +126,8 @@ impl SourceServiceApi for SourceService {
             authorize_source_access(&authorizer, &workspace_name, &request_context).await?;
             require_workspace(&workspaces, &workspace_name).await?;
             let sources: Vec<_> = sources
-                .list_workspace_sources(&workspace_name)
+                .list_workspace_sources_async(&workspace_name)
+                .await
                 .map_err(app_status)?
                 .into_iter()
                 .map(|source| installed_source_to_proto(&workspace_name, source))
@@ -151,7 +153,8 @@ impl SourceServiceApi for SourceService {
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let source = sources
-                .get_source(&workspace_name, &source_name)
+                .get_source_async(&workspace_name, &source_name)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(GetSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, source)),
@@ -176,7 +179,8 @@ impl SourceServiceApi for SourceService {
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             let source = sources
-                .get_source_info(&workspace_name, &source_name)
+                .get_source_info_async(&workspace_name, &source_name)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(GetSourceInfoResponse {
                 source_info: Some(candidate_source_to_proto(source)),
@@ -398,6 +402,7 @@ impl SourceServiceApi for SourceService {
             require_workspace(&workspaces, &workspace_name).await?;
             let candidate = sources
                 .describe_source_manifest(&workspace_name, &request.manifest_yaml)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(DescribeSourceManifestResponse {
                 source_info: Some(candidate_source_to_proto(candidate)),
@@ -980,6 +985,16 @@ mod tests {
         })
     }
 
+    /// The status an RPC refused with, or an `Ok` status when it answered.
+    ///
+    /// The two whole-workspace listings read the catalog from the database,
+    /// which the poisoned config file cannot break, so an authorized caller is
+    /// answered rather than stopped by the state. What they still prove is the
+    /// gate: a refused caller never reaches that read.
+    fn outcome<T>(result: Result<T, Status>) -> Status {
+        result.err().unwrap_or_else(|| Status::ok(""))
+    }
+
     /// Calls every source RPC as `principal` and returns what each answered,
     /// in the order the authorization matrix lists them.
     ///
@@ -999,7 +1014,7 @@ mod tests {
     /// source is or would be configured with.
     async fn source_lookup_rpcs(service: &SourceService, principal: &Principal) -> Vec<Status> {
         vec![
-            status(
+            outcome(
                 service
                     .discover_sources(request(
                         DiscoverSourcesRequest {
@@ -1008,7 +1023,6 @@ mod tests {
                         principal,
                     ))
                     .await,
-                "DiscoverSources",
             ),
             status(
                 service
@@ -1022,7 +1036,7 @@ mod tests {
                     .await,
                 "DescribeSourceManifest",
             ),
-            status(
+            outcome(
                 service
                     .list_sources(request(
                         ListSourcesRequest {
@@ -1031,7 +1045,6 @@ mod tests {
                         principal,
                     ))
                     .await,
-                "ListSources",
             ),
             status(
                 service
@@ -1147,14 +1160,15 @@ mod tests {
     /// handed a redacted view, and a non-member is told nothing.
     ///
     /// The refusals are proved to be absences rather than error codes. The
-    /// config file on disk is unparseable, so any read of installed state
-    /// chokes on it, and the owner does choke on it: the four discovery and
-    /// lookup calls that read installed state, the delete, and the validate
-    /// all answer `Internal` from that read, while the manifest description
-    /// and the three install paths answer `InvalidArgument` from the empty
-    /// manifest, the bundled catalog, and the OAuth conversion they reach
-    /// first. Every refused caller answers `PermissionDenied` or `NotFound`
-    /// instead, and leaves the file with the bytes it started with.
+    /// config file on disk is unparseable, so the state a caller must be let
+    /// through to reach is unreadable, and the owner is let through to it: the
+    /// delete and the validate answer `Internal` from that read, the manifest
+    /// description and the three install paths answer `InvalidArgument` from
+    /// the empty manifest, the bundled catalog, and the OAuth conversion they
+    /// reach first, and the four catalog reads — which come from the database,
+    /// not the file — answer with the workspace's sources or with the absence
+    /// of the one named. Every refused caller answers `PermissionDenied` or
+    /// `NotFound` instead, and leaves the file with the bytes it started with.
     #[tokio::test]
     async fn source_configuration_reaches_only_workspace_owners() {
         let fixture = fixture().await;
@@ -1195,18 +1209,15 @@ mod tests {
             );
         }
 
+        let owner_outcomes = every_source_rpc(&fixture.service, &owner).await;
         assert_eq!(
-            every_source_rpc(&fixture.service, &owner)
-                .await
-                .iter()
-                .map(Status::code)
-                .collect::<Vec<_>>(),
+            owner_outcomes.iter().map(Status::code).collect::<Vec<_>>(),
             vec![
-                Code::Internal,
+                Code::Ok,
                 Code::InvalidArgument,
-                Code::Internal,
-                Code::Internal,
-                Code::Internal,
+                Code::Ok,
+                Code::NotFound,
+                Code::NotFound,
                 Code::InvalidArgument,
                 Code::InvalidArgument,
                 Code::InvalidArgument,
@@ -1215,6 +1226,16 @@ mod tests {
             ],
             "the owner must be stopped by the state or the request, never by the gate"
         );
+        // The owner's two `NotFound`s name the source the catalog does not
+        // hold, which is what separates them from the non-member's, who is
+        // told only that the workspace is not there.
+        for lookup in &owner_outcomes[3..=4] {
+            assert!(
+                lookup.message().contains(ABSENT_SOURCE),
+                "the owner must be answered about the source, not about the workspace: {}",
+                lookup.message()
+            );
+        }
         assert_eq!(
             std::fs::read_to_string(&fixture.config_file).expect("config file"),
             UNPARSEABLE_CONFIG,

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -583,7 +583,14 @@ impl ConfigStore {
         self.load_config_unlocked()
     }
 
-    /// Loads the source catalog without taking the app state lock.
+    /// Loads the mirrored source catalog without taking the app state lock.
+    ///
+    /// The mirror, not the authoritative catalog: production reads installed
+    /// sources from the database. What this returns is what the file world
+    /// claims, which is the input the boot import reconciles and the baseline
+    /// mirror reconciliation diffs against — plus the delete path's fallback
+    /// for a source an older binary added that no boot has imported yet. A
+    /// reader that wants the installed catalog wants `SourcesRepo`.
     ///
     /// Callers must already hold the state lock in shared or exclusive mode
     /// while using any filesystem-backed source artifacts derived from the
@@ -726,7 +733,10 @@ impl ConfigStore {
         Ok(config.workspace_sources(workspace_name))
     }
 
-    /// Loads one installed source without taking the app state lock.
+    /// Loads one mirrored source entry without taking the app state lock.
+    ///
+    /// The mirror, not the authoritative catalog — see
+    /// [`Self::load_catalog_unlocked`] for which readers legitimately want it.
     ///
     /// Callers must already hold the state lock while using source artifacts
     /// associated with the returned config entry.
@@ -755,7 +765,14 @@ impl ConfigStore {
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
-    /// Upserts one installed source without taking the app state lock.
+    /// Writes one source into the legacy config mirror without taking the app
+    /// state lock.
+    ///
+    /// This is a mirror write, not the commit: the database transaction is what
+    /// makes an install durable, and callers run this *after* it so a
+    /// downgraded binary reads a current catalog. A failure here therefore
+    /// compensates the committed rows rather than being ignored, and the mirror
+    /// ledger is stamped only once this write has returned.
     ///
     /// Callers must already hold the state lock in exclusive mode.
     pub(crate) fn upsert_source_unlocked(
@@ -778,7 +795,13 @@ impl ConfigStore {
         })
     }
 
-    /// Removes one installed source without taking the app state lock.
+    /// Drops one source from the legacy config mirror without taking the app
+    /// state lock.
+    ///
+    /// The counterpart of [`Self::upsert_source_unlocked`], with the same
+    /// after-the-commit ordering. What makes the deletion stick is the
+    /// tombstone row written in the removing transaction; this write only stops
+    /// a downgraded binary from still listing the source.
     ///
     /// Callers must already hold the state lock in exclusive mode.
     pub(crate) fn remove_source_unlocked(

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
-use tracing::{info_span, warn};
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
@@ -48,6 +48,10 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "config mirror reader the mirror's tests pin")
+    )]
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -302,16 +306,6 @@ impl SourceCatalog {
             .get(workspace_name)
             .and_then(|sources| sources.get(source_name))
             .cloned()
-    }
-
-    pub(crate) fn contains(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> bool {
-        self.0
-            .get(workspace_name)
-            .is_some_and(|sources| sources.contains_key(source_name))
     }
 
     pub(crate) fn upsert_source(
@@ -598,13 +592,6 @@ impl ConfigStore {
         self.load_config_unlocked().map(|config| config.catalog)
     }
 
-    pub(crate) fn load_catalog(&self) -> Result<SourceCatalog, AppError> {
-        let span = info_span!("coral.app.config.load_catalog");
-        let _guard = span.enter();
-        let _lock = self.state_lock_shared()?;
-        self.load_catalog_unlocked()
-    }
-
     fn update_config_unlocked<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
@@ -722,6 +709,15 @@ impl ConfigStore {
         })
     }
 
+    /// Lists one workspace's mirrored source entries.
+    ///
+    /// The mirror, not the catalog: production reads the installed catalog from
+    /// the database, so what is left here is the test coverage that pins what
+    /// the mirror was written to hold.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "config mirror assertions in tests")
+    )]
     pub(crate) fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
@@ -744,6 +740,10 @@ impl ConfigStore {
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "config mirror reader the mirror's tests pin")
+    )]
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1,6 +1,7 @@
 //! Persists the installed source catalog in top-level `config.toml`.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
 use serde::{Deserialize, Serialize};
@@ -557,6 +558,15 @@ impl ConfigStore {
         Ok(())
     }
 
+    /// The `config.toml` this store reads and writes.
+    ///
+    /// Host-local siblings of that file — the mirror ledger — are addressed by
+    /// its path, so a caller that maintains one needs the path this store
+    /// resolved rather than a second guess at where the config directory is.
+    pub(crate) fn config_file(&self) -> &Path {
+        self.layout.config_file()
+    }
+
     pub(crate) fn state_lock_shared(&self) -> Result<FileLock, AppError> {
         FileLock::shared(self.layout.state_lock()).map_err(Into::into)
     }
@@ -605,6 +615,11 @@ impl ConfigStore {
         Ok(result)
     }
 
+    /// Updates the config under the state lock, for the test helpers that take
+    /// no lock of their own. Every production writer takes the lock across the
+    /// wider operation its config write belongs to and calls
+    /// [`Self::update_config_unlocked`] under it.
+    #[cfg(test)]
     fn update_config<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
@@ -640,13 +655,18 @@ impl ConfigStore {
     ///
     /// What comes back carries everything the removal took away, so a caller
     /// whose next step fails can hand it to
-    /// [`Self::restore_workspace_config_entries`] rather than leave the file
-    /// disagreeing with the catalog it accompanies.
-    pub(crate) fn remove_workspace_config_entries(
+    /// [`Self::restore_workspace_config_entries_unlocked`] rather than leave
+    /// the file disagreeing with the catalog it accompanies.
+    ///
+    /// Callers must already hold the state lock exclusive. Taking it here
+    /// instead would let a workspace deletion wait for the lock with its
+    /// database transaction already open, inverting the lock-then-transaction
+    /// order every source lifecycle write takes.
+    pub(crate) fn remove_workspace_config_entries_unlocked(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Option<RemovedWorkspaceConfig>, AppError> {
-        self.update_config(|config| {
+        self.update_config_unlocked(|config| {
             let removed = config.workspaces.remove(workspace_name);
             if removed {
                 let sources = config
@@ -675,17 +695,21 @@ impl ConfigStore {
         })
     }
 
-    /// Puts back everything [`Self::remove_workspace_config_entries`] removed.
+    /// Puts back everything
+    /// [`Self::remove_workspace_config_entries_unlocked`] removed.
     ///
     /// The removal is durable the moment it returns while the database
     /// transaction it accompanies is not, so a deletion that fails to commit
     /// needs a genuine inverse here — without one the workspace stays in the
     /// catalog with its sources and functions gone from the file.
-    pub(crate) fn restore_workspace_config_entries(
+    ///
+    /// Callers must already hold the state lock exclusive: this runs on the
+    /// abort path of the removal above, under the same held lock.
+    pub(crate) fn restore_workspace_config_entries_unlocked(
         &self,
         removed: RemovedWorkspaceConfig,
     ) -> Result<(), AppError> {
-        self.update_config(|config| {
+        self.update_config_unlocked(|config| {
             let workspace_name = &removed.deleted.workspace.name;
             config.workspaces.insert(workspace_name.clone());
             for source in removed.deleted.sources {
@@ -1647,7 +1671,7 @@ origin = "bundled"
             .expect("upsert function");
 
         let removed = store
-            .remove_workspace_config_entries(&workspace_name)
+            .remove_workspace_config_entries_unlocked(&workspace_name)
             .expect("remove workspace config entries")
             .expect("workspace config should be removed");
         let deleted = removed.into_deleted_workspace();
@@ -1692,12 +1716,12 @@ origin = "bundled"
             .upsert_function(&workspace_name, installed_function("review_queue"))
             .expect("upsert function");
         let removed = store
-            .remove_workspace_config_entries(&workspace_name)
+            .remove_workspace_config_entries_unlocked(&workspace_name)
             .expect("remove workspace config entries")
             .expect("workspace config should be removed");
 
         store
-            .restore_workspace_config_entries(removed)
+            .restore_workspace_config_entries_unlocked(removed)
             .expect("restore workspace config entries");
 
         assert_eq!(
@@ -1750,7 +1774,7 @@ origin = "bundled"
                 .expect("create legacy workspace entry");
 
             let removed = store
-                .remove_workspace_config_entries(&workspace_name)
+                .remove_workspace_config_entries_unlocked(&workspace_name)
                 .expect("remove workspace config entries")
                 .unwrap_or_else(|| panic!("'{name}' should be removable"));
 
@@ -1760,7 +1784,7 @@ origin = "bundled"
             );
             assert!(
                 store
-                    .remove_workspace_config_entries(&workspace_name)
+                    .remove_workspace_config_entries_unlocked(&workspace_name)
                     .expect("remove an already removed workspace")
                     .is_none(),
                 "'{name}' must report nothing left to remove the second time"

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -48,18 +48,6 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "config mirror reader the mirror's tests pin")
-    )]
-    pub(crate) fn get_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Option<InstalledSource> {
-        self.catalog.get_source(workspace_name, source_name)
-    }
-
     pub(crate) fn dependent_join_config(
         &self,
         selected_source_names: &[String],
@@ -578,11 +566,6 @@ impl ConfigStore {
         self.load_unlocked()
     }
 
-    pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
-        let _lock = self.state_lock_shared()?;
-        self.load_config_unlocked()
-    }
-
     /// Loads the mirrored source catalog without taking the app state lock.
     ///
     /// The mirror, not the authoritative catalog: production reads installed
@@ -716,23 +699,6 @@ impl ConfigStore {
         })
     }
 
-    /// Lists one workspace's mirrored source entries.
-    ///
-    /// The mirror, not the catalog: production reads the installed catalog from
-    /// the database, so what is left here is the test coverage that pins what
-    /// the mirror was written to hold.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "config mirror assertions in tests")
-    )]
-    pub(crate) fn list_workspace_sources(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledSource>, AppError> {
-        let config = self.load_config()?;
-        Ok(config.workspace_sources(workspace_name))
-    }
-
     /// Loads one mirrored source entry without taking the app state lock.
     ///
     /// The mirror, not the authoritative catalog — see
@@ -746,21 +712,6 @@ impl ConfigStore {
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
         self.load_catalog_unlocked()?
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
-    }
-
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "config mirror reader the mirror's tests pin")
-    )]
-    pub(crate) fn get_source(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<InstalledSource, AppError> {
-        let config = self.load_config()?;
-        config
             .get_source(workspace_name, source_name)
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
@@ -1623,12 +1574,13 @@ origin = "bundled"
 
         assert!(
             store
-                .list_workspace_sources(&missing_workspace)
-                .expect("list source definitions")
+                .load_catalog_unlocked()
+                .expect("load catalog")
+                .workspace_sources(&missing_workspace)
                 .is_empty()
         );
         assert!(matches!(
-            store.get_source(&missing_workspace, &source_name),
+            store.get_source_unlocked(&missing_workspace, &source_name),
             Err(AppError::SourceNotFound(_))
         ));
         store
@@ -1636,7 +1588,7 @@ origin = "bundled"
             .expect("upsert source definition");
         assert_eq!(
             store
-                .get_source(&missing_workspace, &source_name)
+                .get_source_unlocked(&missing_workspace, &source_name)
                 .expect("get source definition")
                 .name,
             source_name
@@ -1645,7 +1597,7 @@ origin = "bundled"
             .remove_source(&missing_workspace, &source_name)
             .expect("remove source definition");
         assert!(matches!(
-            store.get_source(&missing_workspace, &source_name),
+            store.get_source_unlocked(&missing_workspace, &source_name),
             Err(AppError::SourceNotFound(_))
         ));
         assert!(
@@ -1704,8 +1656,9 @@ origin = "bundled"
         assert_eq!(deleted.sources[0].name.as_str(), "github");
         assert!(
             store
-                .list_workspace_sources(&deleted.workspace.name)
-                .expect("list source definitions")
+                .load_catalog_unlocked()
+                .expect("load catalog")
+                .workspace_sources(&deleted.workspace.name)
                 .is_empty()
         );
         assert!(
@@ -1749,7 +1702,7 @@ origin = "bundled"
 
         assert_eq!(
             store
-                .load_config()
+                .load_config_unlocked()
                 .expect("load config")
                 .legacy_workspace_records()
                 .into_iter()
@@ -1759,8 +1712,9 @@ origin = "bundled"
         );
         assert_eq!(
             store
-                .list_workspace_sources(&workspace_name)
-                .expect("list source definitions")
+                .load_catalog_unlocked()
+                .expect("load catalog")
+                .workspace_sources(&workspace_name)
                 .into_iter()
                 .map(|source| source.name)
                 .collect::<Vec<_>>(),

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,17 +1,23 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 
+use chrono::Utc;
 use tracing::{info, warn};
 
 use super::session::DbRepos;
-use super::{CoralDb, MaterializationRecord, now_unix_nanos_i64};
+use super::{CoralDb, MaterializationRecord, SourceManifestRecord, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
 use crate::hash::sha256_hex;
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
-use crate::sources::materialization::read_v4_materialization_record;
+use crate::sources::materialization::{
+    hydrate_v4_materialization_cache, read_v4_materialization_record,
+};
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::mirror_ledger::MirrorLedger;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
+use crate::storage::fs as storage_fs;
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
@@ -28,15 +34,16 @@ pub(crate) async fn run_state_migrations(
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store, layout).await?;
-    import_legacy_source_state(db, config_store, layout)
+    reconcile_source_state(db, config_store, layout)
         .await?
         .log();
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
 }
 
-/// What one boot's source import did, one counter per branch of the
-/// discrimination rule.
+/// What one boot's reconciliation did: one counter per branch of the
+/// discrimination rule, then what the mirror and hydration passes rebuilt from
+/// the rows.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct SourceImportReport {
     pub(crate) imported: usize,
@@ -61,12 +68,12 @@ pub(crate) struct SourceImportReport {
     /// Config-only workspaces the ledger proves were deleted through the
     /// database, skipped together with their sources.
     pub(crate) workspaces_skipped_deleted: usize,
-    /// Reserved for the artifact-cache hydration pass.
+    /// Manifest and materialization caches rebuilt from their rows.
     pub(crate) hydrated_caches: usize,
-    /// Reserved for mirror reconciliation: database rows added to the config.
+    /// Mirror reconciliation: database rows added to the config.
     pub(crate) mirrored_entries: usize,
-    /// Reserved for mirror reconciliation: ledger-proven stale config entries
-    /// rewritten from the database.
+    /// Mirror reconciliation: ledger-proven stale config entries rewritten
+    /// from the database.
     pub(crate) mirror_entries_refreshed: usize,
 }
 
@@ -90,16 +97,23 @@ impl SourceImportReport {
     }
 }
 
-/// Imports the config file's source catalog into the database.
+/// Reconciles this host's file world with the database, in three passes.
+///
+/// The import carries the config file's source catalog into the database, the
+/// mirror pass carries the database's rows back into `config.toml` where this
+/// host's copy is provably behind, and hydration rebuilds the artifact caches
+/// the rows are the record for. All three run under one hold of the state lock
+/// and over one ledger, because each pass rules on what the previous one
+/// recorded.
 ///
 /// Runs on every boot and carries no marker: a source — or a whole workspace —
 /// an older binary added to `config.toml` after the last boot has to be picked
 /// up at the next one, and a marker is exactly what would stop that.
 ///
-/// Additive by construction. It never edits `config.toml` and never removes a
-/// database row; unreadable legacy data is warned about and skipped, so only a
-/// broken database fails startup.
-async fn import_legacy_source_state(
+/// Additive by construction. It never removes a database row and never removes
+/// a config entry; unreadable legacy data is warned about and skipped, so only
+/// a broken database fails startup.
+async fn reconcile_source_state(
     db: &CoralDb,
     config_store: &ConfigStore,
     layout: &AppStateLayout,
@@ -121,12 +135,19 @@ async fn import_legacy_source_state(
         }
     };
 
-    for workspace in import.reconcilable_workspaces(&config).await? {
-        import.import_workspace_sources(&config, &workspace).await?;
+    let workspaces = import.reconcilable_workspaces(&config).await?;
+    for workspace in &workspaces {
+        import.import_workspace_sources(&config, workspace).await?;
+    }
+    for workspace in &workspaces {
+        import
+            .reconcile_source_mirror(config_store, &config, workspace)
+            .await?;
+        import.hydrate_missing_artifact_caches(workspace).await?;
     }
 
     if let Err(error) = import.ledger.save(config_path) {
-        warn!("legacy source import finished, but the mirror ledger could not be saved: {error}");
+        warn!("source reconciliation finished, but the mirror ledger could not be saved: {error}");
     }
     Ok(import.report)
 }
@@ -418,6 +439,223 @@ impl SourceImport<'_> {
             }
         }
     }
+
+    /// Brings the config mirror back up to the rows it mirrors.
+    ///
+    /// A row with no entry is the mirror write a crash separated from its
+    /// commit — or another host's addition — and is written out. An entry that
+    /// disagrees with its row while still matching this host's ledger is
+    /// provably Coral's own stale copy of a row another host has since updated,
+    /// and is rewritten; that is what keeps a downgraded binary's catalog
+    /// current for updates rather than only for additions. Anything else
+    /// disagrees with the ledger too, so it is an operator's entry and is left
+    /// byte-for-byte alone — the import pass has already warned about it, and
+    /// the served catalog is the database either way.
+    ///
+    /// Entries are never removed: a stale entry of a source deleted through
+    /// another host stays visible to a downgraded binary and inert to this one.
+    async fn reconcile_source_mirror(
+        &mut self,
+        config_store: &ConfigStore,
+        config: &AppConfig,
+        workspace: &WorkspaceName,
+    ) -> Result<(), AppError> {
+        let entries = config
+            .workspace_sources(workspace)
+            .into_iter()
+            .map(|entry| (entry.name.clone(), entry))
+            .collect::<BTreeMap<_, _>>();
+        let mut session = self.db;
+        for row in session.sources().list_workspace_sources(workspace).await? {
+            match entries.get(&row.name) {
+                None => {
+                    if self.write_mirror_entry(config_store, workspace, &row) {
+                        self.report.mirrored_entries += 1;
+                    }
+                }
+                Some(entry)
+                    if *entry != row && self.ledger.matches_entry(workspace, &row.name, entry) =>
+                {
+                    if self.write_mirror_entry(config_store, workspace, &row) {
+                        self.report.mirror_entries_refreshed += 1;
+                    }
+                }
+                Some(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Writes one row into the config mirror and records it, reporting whether
+    /// it landed.
+    ///
+    /// A mirror this host cannot write is warned about rather than fatal: the
+    /// database is what this binary serves, and the next boot tries again.
+    fn write_mirror_entry(
+        &mut self,
+        config_store: &ConfigStore,
+        workspace: &WorkspaceName,
+        row: &InstalledSource,
+    ) -> bool {
+        if let Err(error) = config_store.upsert_source_unlocked(workspace, row.clone()) {
+            warn!(
+                "the config mirror for source '{}' in workspace '{workspace}' could not be brought up to its database row: {error}",
+                row.name
+            );
+            return false;
+        }
+        self.ledger.record_entry(workspace, &row.name, row);
+        true
+    }
+
+    /// Rebuilds the artifact caches whose rows this host is missing or behind.
+    ///
+    /// Best-effort throughout: a cache that cannot be restored is warned about
+    /// and left as it is, because the row it came from is still the record.
+    async fn hydrate_missing_artifact_caches(
+        &mut self,
+        workspace: &WorkspaceName,
+    ) -> Result<(), AppError> {
+        let mut session = self.db;
+        let rows = session.sources().list_workspace_sources(workspace).await?;
+        for row in rows {
+            let mut session = self.db;
+            let manifest = session.source_manifests().get(workspace, &row.name).await?;
+            if let Some(manifest) = manifest {
+                self.hydrate_manifest_cache(workspace, &row.name, &manifest);
+            }
+            let mut session = self.db;
+            let materialization = session.materializations().get(workspace, &row.name).await?;
+            if let Some(materialization) = materialization {
+                self.hydrate_materialization_cache(workspace, &row.name, &materialization);
+            }
+        }
+        Ok(())
+    }
+
+    /// Restores one `manifest.yaml` from the row that is its record.
+    ///
+    /// An absent file is written outright. A file that disagrees with the row
+    /// is overwritten in place only when the ledger proves the bytes are
+    /// Coral's own stale cache — the routine cross-host update, which stays
+    /// silent and leaves no litter. Anything else has no provable owner, so it
+    /// is preserved under a timestamped sibling name before the row's copy
+    /// lands: hydration never silently destroys an edit.
+    fn hydrate_manifest_cache(
+        &mut self,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        record: &SourceManifestRecord,
+    ) {
+        let path = self.layout.manifest_file(workspace, source_name);
+        let on_disk = match std::fs::read(&path) {
+            Ok(bytes) => Some(sha256_hex(&bytes)),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => {
+                warn!(
+                    "leaving the manifest cache for source '{source_name}' in workspace '{workspace}' alone: it could not be read: {error}"
+                );
+                return;
+            }
+        };
+        if on_disk.as_deref() == Some(record.manifest_hash.as_str()) {
+            self.ledger
+                .record_manifest(workspace, source_name, &record.manifest_hash);
+            return;
+        }
+        if on_disk.is_some_and(|on_disk| {
+            !self
+                .ledger
+                .matches_manifest(workspace, source_name, &on_disk)
+        }) {
+            match set_aside_diverged_file(&path) {
+                Ok(kept) => warn!(
+                    "the manifest at '{}' for source '{source_name}' in workspace '{workspace}' is not the one the database holds and this host cannot prove Coral wrote it; keeping it as '{}' and restoring the database copy",
+                    path.display(),
+                    kept.display()
+                ),
+                Err(error) => {
+                    warn!(
+                        "leaving the manifest at '{}' for source '{source_name}' in workspace '{workspace}' alone: it could not be set aside: {error}",
+                        path.display()
+                    );
+                    return;
+                }
+            }
+        }
+        if let Err(error) = write_manifest_cache(&path, &record.manifest_yaml) {
+            warn!(
+                "the manifest cache for source '{source_name}' in workspace '{workspace}' could not be restored from the database: {error}"
+            );
+            return;
+        }
+        self.ledger
+            .record_manifest(workspace, source_name, &record.manifest_hash);
+        self.report.hydrated_caches += 1;
+    }
+
+    /// Restores one `materialized/v4` directory from the row that is its
+    /// record, when it is absent or the row's fingerprint is not the one on
+    /// disk.
+    ///
+    /// Freshness is a byte comparison of the fingerprint rather than of the
+    /// manifest hash: a re-materialization at unchanged manifest bytes still
+    /// moves the fingerprint's descriptor hash and generator versions, and
+    /// byte-identical fingerprints mean identical inputs and generators, so
+    /// there is nothing to refresh. A row without a fingerprint can prove
+    /// nothing either way, so it hydrates on absence only and never loops.
+    fn hydrate_materialization_cache(
+        &mut self,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        record: &MaterializationRecord,
+    ) {
+        let materialized_dir = self.layout.v4_materialized_dir(workspace, source_name);
+        let fingerprint_file = self.layout.v4_fingerprint_file(workspace, source_name);
+        let stale = match std::fs::read_to_string(fingerprint_file) {
+            Ok(on_disk) => record
+                .fingerprint_yaml
+                .as_ref()
+                .is_some_and(|row| *row != on_disk),
+            Err(_) => record.fingerprint_yaml.is_some(),
+        };
+        if materialized_dir.exists() && !stale {
+            return;
+        }
+        if let Err(error) =
+            hydrate_v4_materialization_cache(self.layout, workspace, source_name, record)
+        {
+            warn!(
+                "the materialized cache for source '{source_name}' in workspace '{workspace}' could not be restored from the database: {error}"
+            );
+            return;
+        }
+        self.report.hydrated_caches += 1;
+    }
+}
+
+/// Moves a file this host cannot prove Coral wrote out of the way, preserved
+/// under a timestamped sibling name, and reports where it went.
+///
+/// The timestamp carries sub-second precision so that a second set-aside can
+/// never land on — and destroy — the first.
+fn set_aside_diverged_file(path: &Path) -> Result<PathBuf, AppError> {
+    let mut kept_name = path.file_name().unwrap_or_default().to_os_string();
+    kept_name.push(format!(
+        ".diverged-{}",
+        Utc::now().format("%Y%m%dT%H%M%S%.9fZ")
+    ));
+    let kept = path.with_file_name(kept_name);
+    std::fs::rename(path, &kept)?;
+    Ok(kept)
+}
+
+fn write_manifest_cache(path: &Path, manifest_yaml: &str) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        storage_fs::ensure_dir(parent)?;
+    }
+    storage_fs::write_atomic(path, manifest_yaml.as_bytes())?;
+    Ok(())
 }
 
 fn remove_legacy_task_jsonl(
@@ -591,6 +829,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::path::PathBuf;
 
     use tempfile::tempdir;
 
@@ -598,7 +837,10 @@ mod tests {
         InstalledSource, MirrorLedger, SourceImportReport, SourceName, SourceOrigin,
         WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
-        import_legacy_source_state, run_state_migrations,
+        reconcile_source_state, resolve_installed_manifest, run_state_migrations,
+    };
+    use crate::credentials::{
+        CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStore,
     };
     use crate::sources::materialization::{
         FINGERPRINT_FILENAME, OPERATION_METADATA_FILENAME, PROJECTIONS_FILENAME,
@@ -955,11 +1197,42 @@ mod tests {
 
     impl ImportFixture {
         async fn new() -> Self {
+            Self::open(None).await
+        }
+
+        /// A second config directory reconciling against this one's database.
+        ///
+        /// One file-backed `SQLite` file stands in for the shared server
+        /// database: what makes a host a host in every rule here is its own
+        /// config file, ledger, and source tree, not how it reaches the rows.
+        async fn peer_host(&self) -> Self {
+            Self::open(Some(self.layout.database_file())).await
+        }
+
+        /// A peer host that has already reconciled the same install once: it
+        /// holds the same files and a ledger that records them, which is what
+        /// later makes its disagreements with the database provable.
+        async fn reconciled_peer_host(
+            &self,
+            workspace: &WorkspaceName,
+            source: &InstalledSource,
+        ) -> Self {
+            let peer = self.peer_host().await;
+            peer.declare_workspace(workspace);
+            peer.install(workspace, source);
+            peer.import().await;
+            peer
+        }
+
+        async fn open(shared_database: Option<PathBuf>) -> Self {
             let temp = tempdir().expect("temp dir");
             let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
             layout.ensure().expect("ensure layout");
             let config_store = ConfigStore::new(layout.clone());
-            let db = open_sqlite(&layout).await;
+            let db = match shared_database {
+                Some(path) => open_sqlite_at(path).await,
+                None => open_sqlite(&layout).await,
+            };
             Self {
                 _temp: temp,
                 layout,
@@ -1062,7 +1335,7 @@ mod tests {
         }
 
         async fn import(&self) -> SourceImportReport {
-            import_legacy_source_state(&self.db, &self.config_store, &self.layout)
+            reconcile_source_state(&self.db, &self.config_store, &self.layout)
                 .await
                 .expect("import legacy source state")
         }
@@ -1122,6 +1395,89 @@ mod tests {
 
         fn config_bytes(&self) -> Vec<u8> {
             std::fs::read(self.layout.config_file()).expect("read config file")
+        }
+
+        fn entry(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<InstalledSource> {
+            self.config_store.get_source(workspace, name).ok()
+        }
+
+        fn manifest_bytes(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<Vec<u8>> {
+            std::fs::read(self.layout.manifest_file(workspace, name)).ok()
+        }
+
+        /// Every file in the source's directory tree, keyed by its path
+        /// relative to that directory — what "restored byte-for-byte" means.
+        fn source_files(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+        ) -> BTreeMap<PathBuf, Vec<u8>> {
+            let root = self.layout.source_dir(workspace, name);
+            let mut files = BTreeMap::new();
+            let mut pending = vec![root.clone()];
+            while let Some(dir) = pending.pop() {
+                for entry in std::fs::read_dir(&dir).expect("read source dir") {
+                    let path = entry.expect("dir entry").path();
+                    if path.is_dir() {
+                        pending.push(path);
+                    } else {
+                        let relative = path.strip_prefix(&root).expect("relative path").to_owned();
+                        files.insert(relative, std::fs::read(&path).expect("read artifact"));
+                    }
+                }
+            }
+            files
+        }
+
+        /// The manifests hydration preserved rather than overwrote.
+        fn set_aside_manifests(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+        ) -> Vec<std::path::PathBuf> {
+            let mut kept = self
+                .source_files(workspace, name)
+                .into_keys()
+                .filter(|path| path.to_string_lossy().contains(".diverged-"))
+                .collect::<Vec<_>>();
+            kept.sort();
+            kept
+        }
+
+        fn fingerprint(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<String> {
+            std::fs::read_to_string(self.layout.v4_fingerprint_file(workspace, name)).ok()
+        }
+
+        /// Replays another host's re-materialization of an unchanged manifest:
+        /// only the fingerprint the row carries moves.
+        async fn rematerialize_elsewhere(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+            fingerprint_yaml: &str,
+        ) {
+            let mut record = self
+                .materialization_row(workspace, name)
+                .await
+                .expect("materialization row");
+            record.fingerprint_yaml = Some(fingerprint_yaml.to_string());
+            let mut tx = self.db.begin().await.expect("begin rematerialize tx");
+            tx.materializations()
+                .upsert(workspace, name, &record, 13)
+                .await
+                .expect("rewrite materialization row");
+            tx.commit().await.expect("commit rematerialize tx");
+        }
+
+        /// Removes a workspace the way another host sharing this database
+        /// would: the row and everything it cascades go, this host's files stay.
+        async fn delete_workspace_elsewhere(&self, workspace: &WorkspaceName) {
+            let mut tx = self.db.begin().await.expect("begin workspace delete tx");
+            tx.workspaces()
+                .delete(workspace.as_str())
+                .await
+                .expect("delete workspace row");
+            tx.commit().await.expect("commit workspace delete tx");
         }
     }
 
@@ -1542,11 +1898,319 @@ tables:
         assert_eq!(materialization.projections_yaml, "projections: []");
     }
 
+    /// The rows are the record; the files are a cache. Losing the cache costs
+    /// a boot, not the source — and what comes back is the same bytes the
+    /// manifest and materialization readers were serving before.
+    #[tokio::test]
+    async fn a_deleted_artifact_cache_is_restored_from_its_rows() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.import().await;
+        let installed = fixture.source_files(&workspace, &source.name);
+
+        std::fs::remove_file(fixture.layout.manifest_file(&workspace, &source.name))
+            .expect("delete manifest");
+        std::fs::remove_dir_all(fixture.layout.v4_materialized_dir(&workspace, &source.name))
+            .expect("delete materialization");
+        let report = fixture.import().await;
+
+        assert_eq!(report.hydrated_caches, 2);
+        assert_eq!(
+            fixture.source_files(&workspace, &source.name),
+            installed,
+            "hydration must restore the artifact files byte-for-byte"
+        );
+    }
+
+    /// The routine cross-host update: one host updates a source, the other
+    /// boots. Its stale mirror entry and its stale cache are both provably
+    /// Coral's own, so both are brought forward silently — no set-aside file,
+    /// and a downgrade catalog that is current rather than frozen.
+    #[tokio::test]
+    async fn an_update_on_one_host_refreshes_the_other_hosts_mirror_and_cache() {
+        let first = ImportFixture::new().await;
+        let workspace = analytics();
+        first.cut_over_workspace(&workspace).await;
+        let mut source = imported_source("reports");
+        first.install(&workspace, &source);
+        first.import().await;
+        let second = first.reconciled_peer_host(&workspace, &source).await;
+
+        source
+            .variables
+            .insert("region".to_string(), "eu".to_string());
+        first.write_entry(&workspace, &source);
+        let updated_manifest = manifest_yaml("reports").replace("version: 0.1.0", "version: 0.2.0");
+        first.write_manifest(&workspace, &source.name, &updated_manifest);
+        assert_eq!(first.import().await.updated_from_files, 1);
+
+        let report = second.import().await;
+
+        assert_eq!(report.mirror_entries_refreshed, 1);
+        assert_eq!(report.mirrored_entries, 0);
+        assert_eq!(second.entry(&workspace, &source.name), Some(source.clone()));
+        assert_eq!(
+            second.manifest_bytes(&workspace, &source.name),
+            Some(updated_manifest.into_bytes())
+        );
+        assert!(
+            second
+                .set_aside_manifests(&workspace, &source.name)
+                .is_empty(),
+            "a provably stale cache must be refreshed in place, not set aside"
+        );
+    }
+
+    /// A mirror entry that agrees with neither the row nor the ledger has no
+    /// provable owner, so the mirror pass leaves it exactly as the operator
+    /// wrote it — the database is what this binary serves either way.
+    #[tokio::test]
+    async fn an_entry_differing_from_both_its_row_and_the_ledger_is_left_alone() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let entry = imported_source("reports");
+        fixture.install(&workspace, &entry);
+        let mut row = entry.clone();
+        row.version = Some("9.9.9".to_string());
+        fixture.seed_rows(&workspace, &row).await;
+        let config_before = fixture.config_bytes();
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.mirror_entries_refreshed, 0);
+        assert_eq!(report.mirrored_entries, 0);
+        assert_eq!(fixture.config_bytes(), config_before);
+    }
+
+    /// A manifest this host cannot prove Coral wrote is never overwritten in
+    /// place: the edit is preserved beside the file, and the artifact of record
+    /// is restored over it.
+    #[tokio::test]
+    async fn a_hand_edited_manifest_is_set_aside_and_the_row_restored() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.import().await;
+        let edited = manifest_yaml("reports").replace("Rows", "Hand-edited rows");
+        fixture.write_manifest(&workspace, &source.name, &edited);
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.hydrated_caches, 1);
+        assert_eq!(
+            fixture.manifest_bytes(&workspace, &source.name),
+            Some(manifest_yaml("reports").into_bytes())
+        );
+        let kept = fixture.set_aside_manifests(&workspace, &source.name);
+        let [kept] = kept.as_slice() else {
+            panic!("the edit must be preserved beside the file, exactly once: {kept:?}");
+        };
+        let kept_bytes = std::fs::read(
+            fixture
+                .layout
+                .source_dir(&workspace, &source.name)
+                .join(kept),
+        )
+        .expect("read the set-aside manifest");
+        assert_eq!(kept_bytes, edited.into_bytes());
+    }
+
+    /// A host's first reconciled boot has no ledger, so the import seeds
+    /// records for caches that already match their rows. Without that, every
+    /// first boot would litter the install with set-aside files.
+    #[tokio::test]
+    async fn a_first_reconciled_boot_leaves_a_matching_cache_alone() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.seed_rows(&workspace, &source).await;
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.already_present, 1);
+        assert_eq!(report.hydrated_caches, 0);
+        assert!(
+            fixture
+                .set_aside_manifests(&workspace, &source.name)
+                .is_empty(),
+            "a cache byte-identical to its row is never set aside"
+        );
+    }
+
+    /// The disclosed first-boot residual: a cache that genuinely differs from
+    /// its row on a host that has never reconciled it is set aside once, and
+    /// the boot after that is quiet.
+    #[tokio::test]
+    async fn a_first_reconciled_boot_sets_a_differing_cache_aside_exactly_once() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.seed_rows(&workspace, &source).await;
+        fixture.write_manifest(&workspace, &source.name, "name: stale\n");
+
+        assert_eq!(fixture.import().await.hydrated_caches, 1);
+        assert_eq!(fixture.import().await.hydrated_caches, 0);
+
+        assert_eq!(
+            fixture.set_aside_manifests(&workspace, &source.name).len(),
+            1,
+            "the second boot must find the cache provably Coral's own"
+        );
+        assert_eq!(
+            fixture.manifest_bytes(&workspace, &source.name),
+            Some(manifest_yaml("reports").into_bytes())
+        );
+    }
+
+    /// Re-materializing an unchanged manifest moves the fingerprint's
+    /// generator versions and descriptor hash while its manifest hash stands
+    /// still, which is why freshness is decided on the fingerprint's bytes.
+    #[tokio::test]
+    async fn a_rematerialization_at_unchanged_manifest_bytes_refreshes_the_other_host() {
+        // Same length, one generator version apart: only a byte comparison
+        // separates these, which is the comparison the rule is built on.
+        const MATERIALIZED: &str = "projection_generator_version: 1\ndescriptor_sha256: aa\n";
+        const REMATERIALIZED: &str = "projection_generator_version: 2\ndescriptor_sha256: aa\n";
+
+        let first = ImportFixture::new().await;
+        let workspace = analytics();
+        first.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        first.install(&workspace, &source);
+        first.write_materialization(&workspace, &source.name, Some(MATERIALIZED));
+        first.import().await;
+        let second = first.peer_host().await;
+        second.declare_workspace(&workspace);
+        second.install(&workspace, &source);
+        second.write_materialization(&workspace, &source.name, Some(MATERIALIZED));
+        second.import().await;
+
+        first
+            .rematerialize_elsewhere(&workspace, &source.name, REMATERIALIZED)
+            .await;
+        let report = second.import().await;
+
+        assert_eq!(report.hydrated_caches, 1);
+        assert_eq!(
+            second.fingerprint(&workspace, &source.name),
+            Some(REMATERIALIZED.to_string())
+        );
+        assert!(
+            second
+                .set_aside_manifests(&workspace, &source.name)
+                .is_empty(),
+            "the manifest never moved, so nothing about it is divergent"
+        );
+    }
+
+    /// Deletions have to stick across hosts, and neither pass may undo one: the
+    /// import skips the stale mirror entry, and the mirror pass adds only rows,
+    /// of which the deleted source has none.
+    #[tokio::test]
+    async fn a_source_deleted_on_one_host_does_not_resurrect_from_the_other() {
+        let first = ImportFixture::new().await;
+        let workspace = analytics();
+        first.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        first.install(&workspace, &source);
+        first.import().await;
+        let second = first.reconciled_peer_host(&workspace, &source).await;
+
+        first.delete_rows_elsewhere(&workspace, &source.name).await;
+        let report = second.import().await;
+
+        assert_eq!(report.skipped_tombstoned, 1);
+        assert_eq!(report.imported, 0);
+        assert!(second.row(&workspace, &source.name).await.is_none());
+    }
+
+    /// Workspace deletions cascade their sources without tombstones, so the
+    /// workspace ledger is the only proof the other host has that its config
+    /// entry is a stale mirror rather than a new workspace.
+    #[tokio::test]
+    async fn a_workspace_deleted_on_one_host_does_not_resurrect_from_the_other() {
+        let first = ImportFixture::new().await;
+        let workspace = analytics();
+        first.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        first.install(&workspace, &source);
+        first.import().await;
+        let second = first.reconciled_peer_host(&workspace, &source).await;
+
+        first.delete_workspace_elsewhere(&workspace).await;
+        let report = second.import().await;
+
+        assert_eq!(report.workspaces_skipped_deleted, 1);
+        assert_eq!(report.workspaces_created, 0);
+        assert!(workspace_ids(&second.db).await.is_empty());
+    }
+
+    /// What a second host gets for free, and what it does not. The catalog row
+    /// and both artifact caches arrive from the database — enough to list,
+    /// inspect, and load the source. Credential material does not: it is
+    /// host-local by design, which is what a query against it surfaces as the
+    /// missing-secret diagnostic `load_query_source` raises.
+    #[tokio::test]
+    async fn a_second_host_hydrates_an_imported_source_but_never_its_credentials() {
+        let first = ImportFixture::new().await;
+        let workspace = analytics();
+        first.cut_over_workspace(&workspace).await;
+        let mut source = imported_source("reports");
+        source.secrets = vec!["token".to_string()];
+        source.credential_storage = Some(CredentialStorageKind::File);
+        first.install(&workspace, &source);
+        let credential_set = CredentialSetId::for_source(&source.name);
+        CredentialManager::new(CredentialStore::new(first.layout.clone()))
+            .replace_material(
+                &workspace,
+                &credential_set,
+                CredentialStorageKind::File,
+                &BTreeMap::from([("token".to_string(), "first-host-secret".to_string())]),
+            )
+            .expect("store credential material");
+        first.import().await;
+
+        let second = first.peer_host().await;
+        let report = second.import().await;
+
+        assert_eq!(report.mirrored_entries, 1);
+        assert_eq!(report.hydrated_caches, 2);
+        assert_eq!(
+            second.row(&workspace, &source.name).await,
+            Some(source.clone()),
+            "the second host lists the source from the rows of record"
+        );
+        assert_eq!(second.entry(&workspace, &source.name), Some(source.clone()));
+        resolve_installed_manifest(&workspace, &source, &second.layout)
+            .expect("the second host resolves the hydrated manifest");
+        assert_eq!(
+            CredentialManager::new(CredentialStore::new(second.layout.clone()))
+                .read_material(&workspace, &credential_set, CredentialStorageKind::File)
+                .expect("read credential material"),
+            BTreeMap::new(),
+            "credential material is per host and never travels with the row"
+        );
+    }
+
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
         let config = DatabaseConfig::load(layout).expect("db config");
         let DatabaseConfig::Sqlite { path } = config else {
             panic!("default test config should be sqlite");
         };
+        open_sqlite_at(path).await
+    }
+
+    async fn open_sqlite_at(path: PathBuf) -> CoralDb {
         let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
             .await
             .expect("open sqlite");

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,9 +1,17 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+
+use tracing::{info, warn};
 
 use super::session::DbRepos;
-use super::{CoralDb, now_unix_nanos_i64};
+use super::{CoralDb, MaterializationRecord, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
-use crate::state::{AppStateLayout, ConfigStore};
+use crate::hash::sha256_hex;
+use crate::sources::SourceName;
+use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::materialization::read_v4_materialization_record;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::state::mirror_ledger::MirrorLedger;
+use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
@@ -20,8 +28,396 @@ pub(crate) async fn run_state_migrations(
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store, layout).await?;
+    import_legacy_source_state(db, config_store, layout)
+        .await?
+        .log();
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
+}
+
+/// What one boot's source import did, one counter per branch of the
+/// discrimination rule.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct SourceImportReport {
+    pub(crate) imported: usize,
+    /// Present row the ledger proves the entry still matches.
+    pub(crate) already_present: usize,
+    /// Present row whose entry the ledger proves was rewritten locally, so the
+    /// file content won and was imported as an update.
+    pub(crate) updated_from_files: usize,
+    /// No ledger record and an entry that disagrees with the row: warned,
+    /// preserved on both sides, never stamped as reconciled.
+    pub(crate) divergent_unreconciled: usize,
+    /// Warn-and-skip for legacy data that could not be read, never a startup
+    /// failure.
+    pub(crate) skipped_invalid: usize,
+    /// A stale mirror of a source another host deleted through the database.
+    pub(crate) skipped_tombstoned: usize,
+    /// A tombstoned name whose entry changed since this host reconciled it —
+    /// a genuine re-add, which clears the tombstone.
+    pub(crate) readded_after_tombstone: usize,
+    /// Config-only workspaces given a row so their sources stay visible.
+    pub(crate) workspaces_created: usize,
+    /// Config-only workspaces the ledger proves were deleted through the
+    /// database, skipped together with their sources.
+    pub(crate) workspaces_skipped_deleted: usize,
+    /// Reserved for the artifact-cache hydration pass.
+    pub(crate) hydrated_caches: usize,
+    /// Reserved for mirror reconciliation: database rows added to the config.
+    pub(crate) mirrored_entries: usize,
+    /// Reserved for mirror reconciliation: ledger-proven stale config entries
+    /// rewritten from the database.
+    pub(crate) mirror_entries_refreshed: usize,
+}
+
+impl SourceImportReport {
+    fn log(&self) {
+        info!(
+            imported = self.imported,
+            already_present = self.already_present,
+            updated_from_files = self.updated_from_files,
+            divergent_unreconciled = self.divergent_unreconciled,
+            skipped_invalid = self.skipped_invalid,
+            skipped_tombstoned = self.skipped_tombstoned,
+            readded_after_tombstone = self.readded_after_tombstone,
+            workspaces_created = self.workspaces_created,
+            workspaces_skipped_deleted = self.workspaces_skipped_deleted,
+            hydrated_caches = self.hydrated_caches,
+            mirrored_entries = self.mirrored_entries,
+            mirror_entries_refreshed = self.mirror_entries_refreshed,
+            "reconciled the legacy source catalog with the database"
+        );
+    }
+}
+
+/// Imports the config file's source catalog into the database.
+///
+/// Runs on every boot and carries no marker: a source — or a whole workspace —
+/// an older binary added to `config.toml` after the last boot has to be picked
+/// up at the next one, and a marker is exactly what would stop that.
+///
+/// Additive by construction. It never edits `config.toml` and never removes a
+/// database row; unreadable legacy data is warned about and skipped, so only a
+/// broken database fails startup.
+async fn import_legacy_source_state(
+    db: &CoralDb,
+    config_store: &ConfigStore,
+    layout: &AppStateLayout,
+) -> Result<SourceImportReport, AppError> {
+    let _state_lock = config_store.state_lock_exclusive()?;
+    let config_path = layout.config_file();
+    let mut import = SourceImport {
+        db,
+        layout,
+        ledger: MirrorLedger::load(config_path),
+        report: SourceImportReport::default(),
+        now_unix_nanos: now_unix_nanos_i64()?,
+    };
+    let config = match config_store.load_config_unlocked() {
+        Ok(config) => config,
+        Err(error) => {
+            warn!("skipping the legacy source import: config.toml could not be read: {error}");
+            return Ok(import.report);
+        }
+    };
+
+    for workspace in import.reconcilable_workspaces(&config).await? {
+        import.import_workspace_sources(&config, &workspace).await?;
+    }
+
+    if let Err(error) = import.ledger.save(config_path) {
+        warn!("legacy source import finished, but the mirror ledger could not be saved: {error}");
+    }
+    Ok(import.report)
+}
+
+/// One boot's import, carrying the state every branch of the discrimination
+/// rule reads and writes.
+struct SourceImport<'a> {
+    db: &'a CoralDb,
+    layout: &'a AppStateLayout,
+    ledger: MirrorLedger,
+    report: SourceImportReport,
+    now_unix_nanos: i64,
+}
+
+impl SourceImport<'_> {
+    /// The workspaces whose sources this boot imports: the database's rows,
+    /// plus the config-only workspaces the ledger does not prove were deleted.
+    ///
+    /// The union is what carries a workspace an older binary created across —
+    /// the workspace cutover is one-shot, so nothing else would — and the
+    /// ledger gate is what stops it from resurrecting a workspace another host
+    /// deleted through the database, boot after boot.
+    async fn reconcilable_workspaces(
+        &mut self,
+        config: &AppConfig,
+    ) -> Result<Vec<WorkspaceName>, AppError> {
+        let mut session = self.db;
+        let rows = session.workspaces().list().await?;
+        let mut workspaces = Vec::with_capacity(rows.len());
+        for row in rows {
+            let Ok(name) = WorkspaceName::parse(&row.id) else {
+                continue;
+            };
+            self.ledger.record_workspace(&name);
+            workspaces.push(name);
+        }
+
+        let known = workspaces.iter().cloned().collect::<BTreeSet<_>>();
+        for record in config.legacy_workspace_records() {
+            if known.contains(&record.name) {
+                continue;
+            }
+            if self.ledger.has_workspace(&record.name) {
+                warn!(
+                    "skipping workspace '{}' and its sources: this host reconciled it and the database no longer holds it, so it was deleted through the database",
+                    record.name
+                );
+                self.report.workspaces_skipped_deleted += 1;
+                continue;
+            }
+            let mut tx = self.db.begin().await?;
+            tx.workspaces()
+                .ensure(record.name.as_str(), self.now_unix_nanos)
+                .await?;
+            tx.commit().await?;
+            self.ledger.record_workspace(&record.name);
+            self.report.workspaces_created += 1;
+            workspaces.push(record.name);
+        }
+        Ok(workspaces)
+    }
+
+    async fn import_workspace_sources(
+        &mut self,
+        config: &AppConfig,
+        workspace: &WorkspaceName,
+    ) -> Result<(), AppError> {
+        let entries = config.workspace_sources(workspace);
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let mut session = self.db;
+        let rows = session
+            .sources()
+            .list_workspace_sources(workspace)
+            .await?
+            .into_iter()
+            .map(|source| (source.name.clone(), source))
+            .collect::<BTreeMap<_, _>>();
+        for entry in entries {
+            match rows.get(&entry.name) {
+                Some(row) => {
+                    self.reconcile_present_source(workspace, &entry, row)
+                        .await?;
+                }
+                None => self.import_absent_source(workspace, &entry).await?,
+            }
+        }
+        Ok(())
+    }
+
+    /// The three-way rule for an entry that already has a row.
+    ///
+    /// A ledger match is provably this host's own mirror of the row and needs
+    /// nothing. A ledger record the entry no longer matches means the entry was
+    /// rewritten here since — by a downgraded binary or by an operator — and
+    /// the file content wins. Without a record, agreement seeds the ledger and
+    /// disagreement is unprovable, so neither side is touched.
+    async fn reconcile_present_source(
+        &mut self,
+        workspace: &WorkspaceName,
+        entry: &InstalledSource,
+        row: &InstalledSource,
+    ) -> Result<(), AppError> {
+        if self.ledger.matches_entry(workspace, &entry.name, entry) {
+            self.report.already_present += 1;
+            return self.seed_manifest_record(workspace, entry).await;
+        }
+        if self.ledger.entry_recorded(workspace, &entry.name) {
+            if self.import_source(workspace, entry).await? {
+                self.report.updated_from_files += 1;
+            } else {
+                self.report.skipped_invalid += 1;
+            }
+            return Ok(());
+        }
+        if entry == row {
+            self.report.already_present += 1;
+            self.ledger.record_entry(workspace, &entry.name, entry);
+            return self.seed_manifest_record(workspace, entry).await;
+        }
+
+        self.report.divergent_unreconciled += 1;
+        if !self
+            .ledger
+            .matches_divergence_warning(workspace, &entry.name, entry)
+        {
+            warn!(
+                "the config entry for source '{}' in workspace '{}' disagrees with its database row and this host has never reconciled it; leaving both untouched — re-import the source to make the file win, or fix the entry",
+                entry.name, workspace
+            );
+            self.ledger
+                .record_divergence_warned(workspace, &entry.name, entry);
+        }
+        Ok(())
+    }
+
+    /// The rule for an entry with no row: a tombstone the ledger still matches
+    /// is another host's deletion reaching this host's stale mirror, and
+    /// anything else is content to import — a re-add if the name was deleted.
+    async fn import_absent_source(
+        &mut self,
+        workspace: &WorkspaceName,
+        entry: &InstalledSource,
+    ) -> Result<(), AppError> {
+        let mut session = self.db;
+        let tombstoned = session
+            .sources()
+            .is_tombstoned(workspace, &entry.name)
+            .await?;
+        if tombstoned && self.ledger.matches_entry(workspace, &entry.name, entry) {
+            warn!(
+                "skipping source '{}' in workspace '{}': its config entry is this host's stale mirror of a source deleted through the database",
+                entry.name, workspace
+            );
+            self.report.skipped_tombstoned += 1;
+            return Ok(());
+        }
+        if !self.import_source(workspace, entry).await? {
+            self.report.skipped_invalid += 1;
+        } else if tombstoned {
+            self.report.readded_after_tombstone += 1;
+        } else {
+            self.report.imported += 1;
+        }
+        Ok(())
+    }
+
+    /// Writes one source and its artifacts in a transaction of their own, so
+    /// one unreadable source never blocks the rest, and records what landed.
+    ///
+    /// Reports whether the source was imported; `false` means it was warned
+    /// about and skipped.
+    async fn import_source(
+        &mut self,
+        workspace: &WorkspaceName,
+        entry: &InstalledSource,
+    ) -> Result<bool, AppError> {
+        let materialization = self.read_v4_materialization(workspace, &entry.name);
+        let mut tx = self.db.begin().await?;
+        tx.sources()
+            .upsert_source(workspace, entry, self.now_unix_nanos)
+            .await?;
+        let manifest_yaml = match entry.origin {
+            // A bundled source's manifest ships with the binary, so there is
+            // nothing on disk that is worth storing.
+            SourceOrigin::Bundled => None,
+            SourceOrigin::Imported => {
+                match resolve_installed_manifest(workspace, entry, self.layout) {
+                    Ok(manifest) => Some(manifest.manifest_yaml),
+                    Err(error) => {
+                        tx.rollback().await?;
+                        warn!(
+                            "skipping source '{}' in workspace '{}': its manifest could not be read: {error}",
+                            entry.name, workspace
+                        );
+                        return Ok(false);
+                    }
+                }
+            }
+        };
+        match manifest_yaml.as_deref() {
+            Some(manifest_yaml) => {
+                tx.source_manifests()
+                    .upsert(workspace, &entry.name, manifest_yaml, self.now_unix_nanos)
+                    .await?;
+            }
+            None => {
+                tx.source_manifests().remove(workspace, &entry.name).await?;
+            }
+        }
+        match materialization.as_ref() {
+            Some(materialization) => {
+                tx.materializations()
+                    .upsert(workspace, &entry.name, materialization, self.now_unix_nanos)
+                    .await?;
+            }
+            None => {
+                tx.materializations().remove(workspace, &entry.name).await?;
+            }
+        }
+        tx.commit().await?;
+
+        self.ledger.record_entry(workspace, &entry.name, entry);
+        if let Some(manifest_yaml) = manifest_yaml {
+            self.ledger.record_manifest(
+                workspace,
+                &entry.name,
+                &sha256_hex(manifest_yaml.as_bytes()),
+            );
+        }
+        Ok(true)
+    }
+
+    /// Records an on-disk manifest the row proves is Coral's own.
+    ///
+    /// Without this, a host's first reconciled boot would leave every cache
+    /// unproven, and the hydration pass would set aside caches that are in fact
+    /// byte-identical to the artifact of record.
+    async fn seed_manifest_record(
+        &mut self,
+        workspace: &WorkspaceName,
+        entry: &InstalledSource,
+    ) -> Result<(), AppError> {
+        if entry.origin != SourceOrigin::Imported {
+            return Ok(());
+        }
+        let Ok(bytes) = std::fs::read(self.layout.manifest_file(workspace, &entry.name)) else {
+            return Ok(());
+        };
+        let sha256 = sha256_hex(&bytes);
+        if self
+            .ledger
+            .matches_manifest(workspace, &entry.name, &sha256)
+        {
+            return Ok(());
+        }
+        let mut session = self.db;
+        if session
+            .source_manifests()
+            .get(workspace, &entry.name)
+            .await?
+            .is_some_and(|record| record.manifest_hash == sha256)
+        {
+            self.ledger.record_manifest(workspace, &entry.name, &sha256);
+        }
+        Ok(())
+    }
+
+    /// Reads an installed `materialized/v4` directory back as the row that
+    /// reproduces it, or nothing if it is absent or incomplete.
+    ///
+    /// A directory that is missing a required artifact is warned about and left
+    /// out, exactly as a partially written one is today — the next install
+    /// rebuilds it. Legacy state never fails a boot.
+    fn read_v4_materialization(
+        &self,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<MaterializationRecord> {
+        let materialized_dir = self.layout.v4_materialized_dir(workspace, source_name);
+        match read_v4_materialization_record(&materialized_dir) {
+            Ok(record) => record,
+            Err(error) => {
+                warn!(
+                    "importing source '{source_name}' in workspace '{workspace}' without its materialization: {error}"
+                );
+                None
+            }
+        }
+    }
 }
 
 fn remove_legacy_task_jsonl(
@@ -194,12 +590,19 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempfile::tempdir;
 
     use super::{
+        InstalledSource, MirrorLedger, SourceImportReport, SourceName, SourceOrigin,
         WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
         cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
-        run_state_migrations,
+        import_legacy_source_state, run_state_migrations,
+    };
+    use crate::sources::materialization::{
+        FINGERPRINT_FILENAME, OPERATION_METADATA_FILENAME, PROJECTIONS_FILENAME,
+        SEMANTIC_IR_FILENAME, SOURCE_DOCUMENT_RAW_FILENAME, SOURCE_DOCUMENT_YAML_FILENAME,
     };
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
@@ -539,6 +942,604 @@ mod tests {
 
         assert!(!first_legacy_file.exists());
         assert!(!second_legacy_file.exists());
+    }
+
+    /// One legacy file-based install: a config file, its source tree, and the
+    /// database a boot would reconcile it with.
+    struct ImportFixture {
+        _temp: tempfile::TempDir,
+        layout: AppStateLayout,
+        config_store: ConfigStore,
+        db: CoralDb,
+    }
+
+    impl ImportFixture {
+        async fn new() -> Self {
+            let temp = tempdir().expect("temp dir");
+            let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+            layout.ensure().expect("ensure layout");
+            let config_store = ConfigStore::new(layout.clone());
+            let db = open_sqlite(&layout).await;
+            Self {
+                _temp: temp,
+                layout,
+                config_store,
+                db,
+            }
+        }
+
+        /// Declares a workspace in `config.toml` and gives it a database row,
+        /// the shape an install that has already cut over is in.
+        async fn cut_over_workspace(&self, workspace: &WorkspaceName) {
+            self.declare_workspace(workspace);
+            cutover_legacy_workspace_catalog(&self.db, &self.config_store, &self.layout)
+                .await
+                .expect("cut over the legacy workspace catalog");
+        }
+
+        fn declare_workspace(&self, workspace: &WorkspaceName) {
+            self.config_store
+                .create_legacy_workspace_entry_for_tests(workspace)
+                .expect("declare legacy workspace");
+        }
+
+        fn write_entry(&self, workspace: &WorkspaceName, source: &InstalledSource) {
+            self.config_store
+                .upsert_source(workspace, source.clone())
+                .expect("write config entry");
+        }
+
+        fn write_manifest(&self, workspace: &WorkspaceName, name: &SourceName, yaml: &str) {
+            let path = self.layout.manifest_file(workspace, name);
+            std::fs::create_dir_all(path.parent().expect("source dir")).expect("create source dir");
+            std::fs::write(path, yaml).expect("write manifest");
+        }
+
+        fn write_materialization(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+            fingerprint: Option<&str>,
+        ) {
+            let dir = self.layout.v4_materialized_dir(workspace, name);
+            std::fs::create_dir_all(&dir).expect("create materialized dir");
+            for (file, contents) in [
+                (PROJECTIONS_FILENAME, "projections: []"),
+                (SOURCE_DOCUMENT_RAW_FILENAME, "raw"),
+                (SOURCE_DOCUMENT_YAML_FILENAME, "document: {}"),
+                (SEMANTIC_IR_FILENAME, "ir: {}"),
+                (OPERATION_METADATA_FILENAME, "operations: {}"),
+            ] {
+                std::fs::write(dir.join(file), contents).expect("write artifact");
+            }
+            if let Some(fingerprint) = fingerprint {
+                std::fs::write(dir.join(FINGERPRINT_FILENAME), fingerprint)
+                    .expect("write fingerprint");
+            }
+        }
+
+        /// Installs one source the way a previous boot would have left it:
+        /// config entry, manifest file, and a materialized directory.
+        fn install(&self, workspace: &WorkspaceName, source: &InstalledSource) {
+            self.write_entry(workspace, source);
+            self.write_manifest(
+                workspace,
+                &source.name,
+                &manifest_yaml(source.name.as_str()),
+            );
+            self.write_materialization(workspace, &source.name, Some("fingerprint: {}"));
+        }
+
+        /// Writes rows another host would have written, leaving this host's
+        /// ledger with no record of them.
+        async fn seed_rows(&self, workspace: &WorkspaceName, source: &InstalledSource) {
+            let mut tx = self.db.begin().await.expect("begin seed tx");
+            tx.sources()
+                .upsert_source(workspace, source, 7)
+                .await
+                .expect("seed source row");
+            tx.source_manifests()
+                .upsert(
+                    workspace,
+                    &source.name,
+                    &manifest_yaml(source.name.as_str()),
+                    7,
+                )
+                .await
+                .expect("seed manifest row");
+            tx.commit().await.expect("commit seed tx");
+        }
+
+        /// Removes one source the way another host sharing this database would:
+        /// the row goes, the tombstone lands, and this host's files stay.
+        async fn delete_rows_elsewhere(&self, workspace: &WorkspaceName, name: &SourceName) {
+            let mut tx = self.db.begin().await.expect("begin delete tx");
+            tx.sources()
+                .remove_source(workspace, name, 9)
+                .await
+                .expect("remove source row");
+            tx.commit().await.expect("commit delete tx");
+        }
+
+        async fn import(&self) -> SourceImportReport {
+            import_legacy_source_state(&self.db, &self.config_store, &self.layout)
+                .await
+                .expect("import legacy source state")
+        }
+
+        async fn row(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+        ) -> Option<InstalledSource> {
+            let mut session = &self.db;
+            session
+                .sources()
+                .get_source(workspace, name)
+                .await
+                .expect("read source row")
+        }
+
+        async fn manifest_row(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+        ) -> Option<String> {
+            let mut session = &self.db;
+            session
+                .source_manifests()
+                .get(workspace, name)
+                .await
+                .expect("read manifest row")
+                .map(|record| record.manifest_yaml)
+        }
+
+        async fn materialization_row(
+            &self,
+            workspace: &WorkspaceName,
+            name: &SourceName,
+        ) -> Option<crate::state::db::MaterializationRecord> {
+            let mut session = &self.db;
+            session
+                .materializations()
+                .get(workspace, name)
+                .await
+                .expect("read materialization row")
+        }
+
+        async fn tombstoned(&self, workspace: &WorkspaceName, name: &SourceName) -> bool {
+            let mut session = &self.db;
+            session
+                .sources()
+                .is_tombstoned(workspace, name)
+                .await
+                .expect("read tombstone")
+        }
+
+        fn ledger(&self) -> MirrorLedger {
+            MirrorLedger::load(self.layout.config_file())
+        }
+
+        fn config_bytes(&self) -> Vec<u8> {
+            std::fs::read(self.layout.config_file()).expect("read config file")
+        }
+    }
+
+    fn analytics() -> WorkspaceName {
+        WorkspaceName::parse("analytics").expect("workspace name")
+    }
+
+    fn imported_source(name: &str) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source name"),
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: uuid::Uuid::nil(),
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    fn manifest_yaml(name: &str) -> String {
+        format!(
+            r"
+name: {name}
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: rows
+    description: Rows
+    request:
+      method: GET
+      path: /rows
+    response: {{}}
+    columns:
+      - name: id
+        type: Utf8
+"
+        )
+    }
+
+    #[tokio::test]
+    async fn a_fresh_install_imports_nothing() {
+        let fixture = ImportFixture::new().await;
+
+        assert_eq!(fixture.import().await, SourceImportReport::default());
+    }
+
+    #[tokio::test]
+    async fn a_populated_config_imports_once_and_then_reports_it_present() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        let config_before = fixture.config_bytes();
+
+        let first = fixture.import().await;
+
+        assert_eq!(first.imported, 1);
+        assert_eq!(
+            fixture.row(&workspace, &source.name).await,
+            Some(source.clone())
+        );
+        assert_eq!(
+            fixture.manifest_row(&workspace, &source.name).await,
+            Some(manifest_yaml("reports"))
+        );
+        assert!(
+            fixture
+                .materialization_row(&workspace, &source.name)
+                .await
+                .is_some()
+        );
+        assert!(
+            fixture
+                .ledger()
+                .matches_entry(&workspace, &source.name, &source)
+        );
+
+        let second = fixture.import().await;
+
+        assert_eq!(second.imported, 0);
+        assert_eq!(second.already_present, 1);
+        assert_eq!(
+            fixture.config_bytes(),
+            config_before,
+            "the import must never edit config.toml"
+        );
+    }
+
+    /// There is no marker, so a source an older binary wrote to `config.toml`
+    /// after the first boot has to come across at the next one.
+    #[tokio::test]
+    async fn a_source_added_after_the_first_boot_imports_on_the_next_boot() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        fixture.import().await;
+
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+
+        assert_eq!(fixture.import().await.imported, 1);
+        assert_eq!(fixture.row(&workspace, &source.name).await, Some(source));
+    }
+
+    /// A ledger record the entry no longer matches proves the entry was
+    /// rewritten on this host since Coral reconciled it, so the files win.
+    #[tokio::test]
+    async fn an_entry_rewritten_since_reconciliation_imports_as_an_update() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let mut source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.import().await;
+
+        source
+            .variables
+            .insert("region".to_string(), "eu".to_string());
+        fixture.write_entry(&workspace, &source);
+        let updated_manifest = manifest_yaml("reports").replace("version: 0.1.0", "version: 0.2.0");
+        fixture.write_manifest(&workspace, &source.name, &updated_manifest);
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.updated_from_files, 1);
+        assert_eq!(
+            fixture.row(&workspace, &source.name).await,
+            Some(source.clone())
+        );
+        assert_eq!(
+            fixture.manifest_row(&workspace, &source.name).await,
+            Some(updated_manifest.clone())
+        );
+        let ledger = fixture.ledger();
+        assert!(ledger.matches_entry(&workspace, &source.name, &source));
+        assert!(ledger.matches_manifest(
+            &workspace,
+            &source.name,
+            &crate::hash::sha256_hex(updated_manifest.as_bytes())
+        ));
+    }
+
+    /// A host's first reconciled boot has no ledger. An entry that agrees with
+    /// its row is provably in sync, so the record is seeded — including the
+    /// manifest record, which is what keeps the hydration pass from setting
+    /// aside a cache that is byte-identical to the row.
+    #[tokio::test]
+    async fn an_unrecorded_entry_that_agrees_with_its_row_seeds_the_ledger() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.seed_rows(&workspace, &source).await;
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.already_present, 1);
+        assert_eq!(report.imported, 0);
+        let ledger = fixture.ledger();
+        assert!(ledger.matches_entry(&workspace, &source.name, &source));
+        assert!(ledger.matches_manifest(
+            &workspace,
+            &source.name,
+            &crate::hash::sha256_hex(manifest_yaml("reports").as_bytes())
+        ));
+    }
+
+    /// An unrecorded entry that disagrees with its row has no provable owner,
+    /// so neither side moves and the warning is recorded once per content.
+    #[tokio::test]
+    async fn an_unrecorded_entry_that_differs_from_its_row_is_warned_about_and_preserved() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let entry = imported_source("reports");
+        fixture.install(&workspace, &entry);
+        let mut row = entry.clone();
+        row.version = Some("9.9.9".to_string());
+        fixture.seed_rows(&workspace, &row).await;
+        let config_before = fixture.config_bytes();
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.divergent_unreconciled, 1);
+        assert_eq!(fixture.row(&workspace, &entry.name).await, Some(row));
+        assert_eq!(fixture.config_bytes(), config_before);
+        let ledger = fixture.ledger();
+        assert!(
+            !ledger.entry_recorded(&workspace, &entry.name),
+            "an unprovable entry must never be stamped as reconciled"
+        );
+        assert!(
+            ledger.matches_divergence_warning(&workspace, &entry.name, &entry),
+            "the warning must be recorded so the next boot stays quiet"
+        );
+
+        let second = fixture.import().await;
+
+        assert_eq!(second.divergent_unreconciled, 1);
+        assert!(!fixture.ledger().entry_recorded(&workspace, &entry.name));
+    }
+
+    /// The workspace cutover is one-shot, so a workspace an older binary added
+    /// to `config.toml` afterwards has no row. Without one, its sources would
+    /// be invisible once reads move to the database.
+    #[tokio::test]
+    async fn a_config_only_workspace_is_created_and_its_sources_imported() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.declare_workspace(&workspace);
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.workspaces_created, 1);
+        assert_eq!(report.imported, 1);
+        assert_eq!(
+            workspace_ids(&fixture.db).await,
+            vec!["analytics".to_string()]
+        );
+        assert_eq!(fixture.row(&workspace, &source.name).await, Some(source));
+    }
+
+    /// A workspace this host reconciled and the database no longer holds was
+    /// deleted through the database. Resurrecting it from this host's stale
+    /// config would undo that deletion at every boot.
+    #[tokio::test]
+    async fn a_config_only_workspace_the_ledger_recorded_is_skipped_with_its_sources() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.declare_workspace(&workspace);
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        let mut ledger = MirrorLedger::default();
+        ledger.record_workspace(&workspace);
+        ledger
+            .save(fixture.layout.config_file())
+            .expect("save ledger");
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.workspaces_skipped_deleted, 1);
+        assert_eq!(report.imported, 0);
+        assert!(workspace_ids(&fixture.db).await.is_empty());
+        assert!(fixture.row(&workspace, &source.name).await.is_none());
+    }
+
+    /// A tombstone plus a ledger-matching entry is another host's deletion
+    /// reaching this host's stale mirror; re-adding it would undo the deletion.
+    #[tokio::test]
+    async fn a_tombstoned_entry_the_ledger_still_matches_is_skipped() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.import().await;
+        fixture
+            .delete_rows_elsewhere(&workspace, &source.name)
+            .await;
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.skipped_tombstoned, 1);
+        assert!(fixture.row(&workspace, &source.name).await.is_none());
+        assert!(fixture.tombstoned(&workspace, &source.name).await);
+    }
+
+    /// A tombstoned name whose entry changed since Coral reconciled it is a
+    /// genuine re-add — a downgraded binary's, or an operator's.
+    #[tokio::test]
+    async fn a_tombstoned_entry_rewritten_since_reconciliation_is_readded() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let mut source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        fixture.import().await;
+        fixture
+            .delete_rows_elsewhere(&workspace, &source.name)
+            .await;
+
+        source
+            .variables
+            .insert("region".to_string(), "eu".to_string());
+        fixture.write_entry(&workspace, &source);
+        let report = fixture.import().await;
+
+        assert_eq!(report.readded_after_tombstone, 1);
+        assert_eq!(
+            fixture.row(&workspace, &source.name).await,
+            Some(source.clone())
+        );
+        assert!(
+            !fixture.tombstoned(&workspace, &source.name).await,
+            "a re-add must revoke the earlier deletion"
+        );
+    }
+
+    /// A tombstone this host never reconciled is not a deletion reaching a
+    /// stale mirror: compensating a failed fresh install on another host writes
+    /// one, and the config entry it would otherwise suppress here is a live
+    /// config-only source. Only a ledger record makes the entry a mirror.
+    #[tokio::test]
+    async fn a_tombstoned_entry_the_ledger_never_recorded_is_readded() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        // Another host installed and compensated the same name, leaving a
+        // tombstone; this host only ever had the source in its own files.
+        fixture.seed_rows(&workspace, &source).await;
+        fixture
+            .delete_rows_elsewhere(&workspace, &source.name)
+            .await;
+        fixture.install(&workspace, &source);
+        assert!(
+            fixture.tombstoned(&workspace, &source.name).await,
+            "the fixture must leave a tombstone for the import to rule on"
+        );
+        assert!(
+            !fixture.ledger().entry_recorded(&workspace, &source.name),
+            "this host must never have reconciled the entry"
+        );
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.readded_after_tombstone, 1);
+        assert_eq!(report.skipped_tombstoned, 0);
+        assert_eq!(
+            fixture.row(&workspace, &source.name).await,
+            Some(source.clone())
+        );
+        assert!(
+            !fixture.tombstoned(&workspace, &source.name).await,
+            "importing the entry must revoke the unreconciled deletion"
+        );
+    }
+
+    /// One unreadable source must not cost the install its other sources, nor
+    /// its startup.
+    #[tokio::test]
+    async fn a_source_whose_manifest_cannot_be_read_is_skipped_and_the_rest_import() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let healthy = imported_source("reports");
+        fixture.install(&workspace, &healthy);
+        let broken = imported_source("broken");
+        fixture.write_entry(&workspace, &broken);
+        fixture.write_manifest(&workspace, &broken.name, "this is not a manifest");
+
+        let report = fixture.import().await;
+
+        assert_eq!(report.imported, 1);
+        assert_eq!(report.skipped_invalid, 1);
+        assert_eq!(fixture.row(&workspace, &healthy.name).await, Some(healthy));
+        assert!(
+            fixture.row(&workspace, &broken.name).await.is_none(),
+            "the rolled-back transaction must leave no half-imported source"
+        );
+        assert!(!fixture.ledger().entry_recorded(&workspace, &broken.name));
+    }
+
+    /// Legacy data Coral cannot parse is never a reason to refuse to start.
+    #[tokio::test]
+    async fn an_unreadable_config_file_does_not_fail_startup() {
+        let fixture = ImportFixture::new().await;
+        std::fs::write(fixture.layout.config_file(), "[[workspaces]\n").expect("corrupt config");
+
+        assert_eq!(fixture.import().await, SourceImportReport::default());
+    }
+
+    /// The ledger is proof, not state of record: losing it costs a re-import,
+    /// never a boot.
+    #[tokio::test]
+    async fn a_corrupt_ledger_is_ignored_and_the_import_still_runs() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.install(&workspace, &source);
+        let ledger_path = fixture.layout.config_file().with_extension("toml.ledger");
+        std::fs::write(&ledger_path, b"{ not json at all").expect("corrupt ledger");
+
+        assert_eq!(fixture.import().await.imported, 1);
+        assert!(
+            fixture
+                .ledger()
+                .matches_entry(&workspace, &source.name, &source)
+        );
+    }
+
+    /// The fingerprint is optional to the v4 loader, so a materialization
+    /// written without one imports with a null fingerprint rather than being
+    /// dropped.
+    #[tokio::test]
+    async fn a_materialization_without_a_fingerprint_imports_with_a_null_one() {
+        let fixture = ImportFixture::new().await;
+        let workspace = analytics();
+        fixture.cut_over_workspace(&workspace).await;
+        let source = imported_source("reports");
+        fixture.write_entry(&workspace, &source);
+        fixture.write_manifest(&workspace, &source.name, &manifest_yaml("reports"));
+        fixture.write_materialization(&workspace, &source.name, None);
+
+        assert_eq!(fixture.import().await.imported, 1);
+        let materialization = fixture
+            .materialization_row(&workspace, &source.name)
+            .await
+            .expect("materialization row");
+        assert_eq!(materialization.fingerprint_yaml, None);
+        assert_eq!(materialization.projections_yaml, "projections: []");
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1398,7 +1398,7 @@ mod tests {
         }
 
         fn entry(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<InstalledSource> {
-            self.config_store.get_source(workspace, name).ok()
+            self.config_store.get_source_unlocked(workspace, name).ok()
         }
 
         fn manifest_bytes(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<Vec<u8>> {

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -69,7 +69,14 @@ fn rows_match_current_migrations(rows: &[(i64, Vec<u8>, bool)]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{MIGRATOR, rows_match_current_migrations};
+    use sqlx::error::{DatabaseError, ErrorKind};
+    use sqlx::{AssertSqlSafe, Column, Executor, SqlSafeStr};
+
+    use super::{
+        MIGRATOR, postgres_migrations_are_current, rows_match_current_migrations,
+        sqlite_migrations_are_current,
+    };
+    use crate::bootstrap;
 
     #[test]
     fn current_migration_rows_must_match_versions_checksums_and_success() {
@@ -126,6 +133,720 @@ mod tests {
         .execute(pool)
         .await
         .expect("insert user");
+    }
+
+    async fn migrated_postgres_pool() -> Option<sqlx::PgPool> {
+        let url = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())?;
+        let pool = sqlx::PgPool::connect(&url).await.expect("postgres pool");
+        MIGRATOR.run(&pool).await.expect("run migrations");
+        Some(pool)
+    }
+
+    /// A migrated pool for one backend, so a schema contract can be asserted
+    /// unchanged against both. Statements embed their literals rather than
+    /// binding them because the two backends spell placeholders differently;
+    /// every embedded value is generated here, never read from outside.
+    enum ContractPool<'a> {
+        Sqlite(&'a sqlx::SqlitePool),
+        Postgres(&'a sqlx::PgPool),
+    }
+
+    impl ContractPool<'_> {
+        /// Backend spelling of a one-byte binary literal.
+        fn blob_literal(&self) -> &'static str {
+            match self {
+                ContractPool::Sqlite(_) => "X'00'",
+                ContractPool::Postgres(_) => "'\\x00'::bytea",
+            }
+        }
+
+        async fn try_execute(&self, sql: &str) -> Result<(), sqlx::Error> {
+            match self {
+                ContractPool::Sqlite(pool) => sqlx::query(AssertSqlSafe(sql))
+                    .execute(*pool)
+                    .await
+                    .map(|_| ()),
+                ContractPool::Postgres(pool) => sqlx::query(AssertSqlSafe(sql))
+                    .execute(*pool)
+                    .await
+                    .map(|_| ()),
+            }
+        }
+
+        async fn execute(&self, sql: &str) {
+            if let Err(error) = self.try_execute(sql).await {
+                panic!("statement must be accepted: {sql}: {error}");
+            }
+        }
+
+        async fn expect_rejected(&self, sql: &str) -> sqlx::Error {
+            match self.try_execute(sql).await {
+                Ok(()) => panic!("statement must be rejected: {sql}"),
+                Err(error) => error,
+            }
+        }
+
+        async fn count(&self, sql: &str) -> i64 {
+            match self {
+                ContractPool::Sqlite(pool) => {
+                    sqlx::query_scalar(AssertSqlSafe(sql))
+                        .fetch_one(*pool)
+                        .await
+                }
+                ContractPool::Postgres(pool) => {
+                    sqlx::query_scalar(AssertSqlSafe(sql))
+                        .fetch_one(*pool)
+                        .await
+                }
+            }
+            .unwrap_or_else(|error| panic!("{sql}: {error}"))
+        }
+
+        async fn text(&self, sql: &str) -> String {
+            match self {
+                ContractPool::Sqlite(pool) => {
+                    sqlx::query_scalar(AssertSqlSafe(sql))
+                        .fetch_one(*pool)
+                        .await
+                }
+                ContractPool::Postgres(pool) => {
+                    sqlx::query_scalar(AssertSqlSafe(sql))
+                        .fetch_one(*pool)
+                        .await
+                }
+            }
+            .unwrap_or_else(|error| panic!("{sql}: {error}"))
+        }
+
+        async fn versions(&self, sql: &str) -> Vec<i64> {
+            match self {
+                ContractPool::Sqlite(pool) => {
+                    sqlx::query_scalar(AssertSqlSafe(sql))
+                        .fetch_all(*pool)
+                        .await
+                }
+                ContractPool::Postgres(pool) => {
+                    sqlx::query_scalar(AssertSqlSafe(sql))
+                        .fetch_all(*pool)
+                        .await
+                }
+            }
+            .unwrap_or_else(|error| panic!("{sql}: {error}"))
+        }
+
+        async fn column_names(&self, table: &str) -> Vec<String> {
+            let sql = AssertSqlSafe(format!("SELECT * FROM {table}")).into_sql_str();
+            match self {
+                ContractPool::Sqlite(pool) => (*pool)
+                    .describe(sql.clone())
+                    .await
+                    .map(|described| column_names(described.columns())),
+                ContractPool::Postgres(pool) => (*pool)
+                    .describe(sql.clone())
+                    .await
+                    .map(|described| column_names(described.columns())),
+            }
+            .unwrap_or_else(|error| panic!("describe {table}: {error}"))
+        }
+    }
+
+    fn column_names<C: Column>(columns: &[C]) -> Vec<String> {
+        columns
+            .iter()
+            .map(|column| column.name().to_owned())
+            .collect()
+    }
+
+    /// The constraint a rejected statement violated, as classified by whichever
+    /// backend rejected it.
+    fn violated(error: &sqlx::Error) -> Option<ErrorKind> {
+        error.as_database_error().map(DatabaseError::kind)
+    }
+
+    /// One column of a new-series table: a literal that is valid for it, and
+    /// whether the schema must reject `NULL` there. Literals may use the
+    /// `{workspace}`, `{source}`, and `{blob}` placeholders.
+    struct ColumnContract {
+        name: &'static str,
+        value: &'static str,
+        required: bool,
+    }
+
+    const fn required(name: &'static str, value: &'static str) -> ColumnContract {
+        ColumnContract {
+            name,
+            value,
+            required: true,
+        }
+    }
+
+    const fn nullable(name: &'static str, value: &'static str) -> ColumnContract {
+        ColumnContract {
+            name,
+            value,
+            required: false,
+        }
+    }
+
+    /// The shape one new-series table must have on every backend.
+    struct TableContract {
+        table: &'static str,
+        primary_key: &'static [&'static str],
+        columns: &'static [ColumnContract],
+    }
+
+    impl TableContract {
+        /// A complete `INSERT` for this table, with `overrides` replacing the
+        /// literal of the columns they name.
+        fn insert_sql(&self, workspace: &str, blob: &str, overrides: &[(&str, &str)]) -> String {
+            let names: Vec<&str> = self.columns.iter().map(|column| column.name).collect();
+            let values: Vec<String> = self
+                .columns
+                .iter()
+                .map(|column| {
+                    overrides
+                        .iter()
+                        .find(|(name, _)| *name == column.name)
+                        .map_or_else(
+                            || resolve_literal(column, workspace, blob),
+                            |(_, value)| (*value).to_owned(),
+                        )
+                })
+                .collect();
+            format!(
+                "INSERT INTO {} ({}) VALUES ({})",
+                self.table,
+                names.join(", "),
+                values.join(", ")
+            )
+        }
+
+        /// A `WHERE` clause selecting exactly the row `insert_sql` writes.
+        fn primary_key_predicate(&self, workspace: &str, blob: &str) -> String {
+            let terms: Vec<String> = self
+                .primary_key
+                .iter()
+                .map(|key| {
+                    let column = self
+                        .columns
+                        .iter()
+                        .find(|column| column.name == *key)
+                        .unwrap_or_else(|| panic!("{}.{key} is not a declared column", self.table));
+                    format!("{key} = {}", resolve_literal(column, workspace, blob))
+                })
+                .collect();
+            terms.join(" AND ")
+        }
+    }
+
+    /// A column's literal with its placeholders filled in.
+    fn resolve_literal(column: &ColumnContract, workspace: &str, blob: &str) -> String {
+        column
+            .value
+            .replace("{workspace}", workspace)
+            .replace("{source}", SEEDED_SOURCE)
+            .replace("{blob}", blob)
+    }
+
+    /// The source row every child-table contract row hangs off.
+    const SEEDED_SOURCE: &str = "seeded-source";
+
+    /// Every table the 0020/0021 series introduces, parents before children.
+    const SOURCE_CONTRACTS: [TableContract; 6] = [
+        TableContract {
+            table: "sources",
+            primary_key: &["workspace_id", "name"],
+            columns: &[
+                required("workspace_id", "'{workspace}'"),
+                required("name", "'contract-source'"),
+                nullable("version", "'1.2.3'"),
+                required("origin_kind", "'imported'"),
+                nullable("credential_storage", "'file'"),
+                required(
+                    "credential_revision",
+                    "'11111111-1111-1111-1111-111111111111'",
+                ),
+                required("created_at_unix_nanos", "1"),
+                required("updated_at_unix_nanos", "2"),
+            ],
+        },
+        TableContract {
+            table: "source_variables",
+            primary_key: &["workspace_id", "source_name", "key"],
+            columns: &[
+                required("workspace_id", "'{workspace}'"),
+                required("source_name", "'{source}'"),
+                required("key", "'region'"),
+                required("value", "'us-east-1'"),
+            ],
+        },
+        TableContract {
+            table: "source_secret_keys",
+            primary_key: &["workspace_id", "source_name", "key"],
+            columns: &[
+                required("workspace_id", "'{workspace}'"),
+                required("source_name", "'{source}'"),
+                required("key", "'api_token'"),
+            ],
+        },
+        // The source name below deliberately names no row in `sources`: a
+        // tombstone is written after its source is gone, so this table must
+        // carry the workspace foreign key and no other.
+        TableContract {
+            table: "source_tombstones",
+            primary_key: &["workspace_id", "source_name"],
+            columns: &[
+                required("workspace_id", "'{workspace}'"),
+                required("source_name", "'already-deleted-source'"),
+                required("deleted_at_unix_nanos", "7"),
+            ],
+        },
+        TableContract {
+            table: "source_manifests",
+            primary_key: &["workspace_id", "source_name"],
+            columns: &[
+                required("workspace_id", "'{workspace}'"),
+                required("source_name", "'{source}'"),
+                required("manifest_yaml", "'name: {source}'"),
+                required("manifest_hash", "'sha256:abc'"),
+                required("created_at_unix_nanos", "3"),
+            ],
+        },
+        TableContract {
+            table: "materializations",
+            primary_key: &["workspace_id", "source_name"],
+            columns: &[
+                required("workspace_id", "'{workspace}'"),
+                required("source_name", "'{source}'"),
+                required("materialization_version", "'v4'"),
+                nullable("fingerprint_yaml", "'fingerprint: v1'"),
+                required("projections_yaml", "'projections: []'"),
+                nullable("diagnostics_yaml", "'diagnostics: []'"),
+                required("source_document_raw", "{blob}"),
+                required("source_document_yaml", "'name: {source}'"),
+                required("semantic_ir_yaml", "'ir: none'"),
+                required("operation_metadata_yaml", "'op: none'"),
+                required("created_at_unix_nanos", "4"),
+            ],
+        },
+    ];
+
+    /// Rows the 0020/0021 series owns, counted within one workspace so the
+    /// assertions hold on a Postgres database shared with sibling tests.
+    #[derive(Debug, PartialEq, Eq)]
+    struct SourceRowCounts {
+        sources: i64,
+        variables: i64,
+        secret_keys: i64,
+        manifests: i64,
+        materializations: i64,
+        tombstones: i64,
+    }
+
+    async fn row_counts(pool: &ContractPool<'_>, workspace: &str) -> SourceRowCounts {
+        let mut counts = [0_i64; SOURCE_CONTRACTS.len()];
+        for (slot, contract) in counts.iter_mut().zip(&SOURCE_CONTRACTS) {
+            *slot = pool
+                .count(&format!(
+                    "SELECT COUNT(*) FROM {} WHERE workspace_id = '{workspace}'",
+                    contract.table
+                ))
+                .await;
+        }
+        let [
+            sources,
+            variables,
+            secret_keys,
+            tombstones,
+            manifests,
+            materializations,
+        ] = counts;
+        SourceRowCounts {
+            sources,
+            variables,
+            secret_keys,
+            manifests,
+            materializations,
+            tombstones,
+        }
+    }
+
+    fn unique_workspace_id() -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        format!("workspace_{}_{nanos}", std::process::id())
+    }
+
+    async fn seed_workspace(pool: &ContractPool<'_>, workspace: &str) {
+        pool.execute(&format!(
+            "INSERT INTO workspaces (id, created_at_unix_nanos) VALUES ('{workspace}', 0)"
+        ))
+        .await;
+    }
+
+    async fn seed_source(pool: &ContractPool<'_>, workspace: &str, source: &str) {
+        pool.execute(&format!(
+            "INSERT INTO sources \
+                (workspace_id, name, origin_kind, created_at_unix_nanos, updated_at_unix_nanos) \
+             VALUES ('{workspace}', '{source}', 'imported', 0, 0)"
+        ))
+        .await;
+    }
+
+    /// A source plus one row in each of its four child tables.
+    async fn seed_source_with_children(pool: &ContractPool<'_>, workspace: &str, source: &str) {
+        seed_source(pool, workspace, source).await;
+        let blob = pool.blob_literal();
+        for sql in [
+            format!(
+                "INSERT INTO source_variables (workspace_id, source_name, key, value) \
+                 VALUES ('{workspace}', '{source}', 'region', 'us-east-1')"
+            ),
+            format!(
+                "INSERT INTO source_secret_keys (workspace_id, source_name, key) \
+                 VALUES ('{workspace}', '{source}', 'api_token')"
+            ),
+            format!(
+                "INSERT INTO source_manifests \
+                    (workspace_id, source_name, manifest_yaml, manifest_hash, \
+                     created_at_unix_nanos) \
+                 VALUES ('{workspace}', '{source}', 'name: {source}', 'sha256:abc', 0)"
+            ),
+            format!(
+                "INSERT INTO materializations \
+                    (workspace_id, source_name, materialization_version, projections_yaml, \
+                     source_document_raw, source_document_yaml, semantic_ir_yaml, \
+                     created_at_unix_nanos) \
+                 VALUES ('{workspace}', '{source}', 'v4', 'projections: []', {blob}, '', '', 0)"
+            ),
+        ] {
+            pool.execute(&sql).await;
+        }
+    }
+
+    async fn seed_tombstone(pool: &ContractPool<'_>, workspace: &str, source: &str) {
+        pool.execute(&format!(
+            "INSERT INTO source_tombstones (workspace_id, source_name, deleted_at_unix_nanos) \
+             VALUES ('{workspace}', '{source}', 7)"
+        ))
+        .await;
+    }
+
+    /// Deleting the workspace takes every row this suite wrote with it.
+    async fn drop_workspace(pool: &ContractPool<'_>, workspace: &str) {
+        pool.execute(&format!("DELETE FROM workspaces WHERE id = '{workspace}'"))
+            .await;
+    }
+
+    /// One table's columns, `NOT NULL` columns, nullable columns, and primary
+    /// key, asserted in that order against a live migrated database.
+    async fn assert_table_contract(
+        pool: &ContractPool<'_>,
+        contract: &TableContract,
+        workspace: &str,
+    ) {
+        let table = contract.table;
+        let blob = pool.blob_literal();
+        let expected = column_contract_names(contract);
+        assert_eq!(pool.column_names(table).await, expected, "{table} columns");
+        for key in contract.primary_key {
+            assert!(
+                expected.iter().any(|name| name == key),
+                "{table} primary key names an absent column: {key}"
+            );
+        }
+
+        for column in contract.columns.iter().filter(|column| column.required) {
+            let sql = contract.insert_sql(workspace, blob, &[(column.name, "NULL")]);
+            let error = pool.expect_rejected(&sql).await;
+            assert_eq!(
+                violated(&error),
+                Some(ErrorKind::NotNullViolation),
+                "{table}.{} must reject NULL: {error}",
+                column.name
+            );
+        }
+
+        // Writing the row with every optional column NULL proves they are
+        // optional; writing it a second time proves the primary key.
+        let optional_nulls: Vec<(&str, &str)> = contract
+            .columns
+            .iter()
+            .filter(|column| !column.required)
+            .map(|column| (column.name, "NULL"))
+            .collect();
+        let sparse_row = contract.insert_sql(workspace, blob, &optional_nulls);
+        pool.execute(&sparse_row).await;
+        let error = pool.expect_rejected(&sparse_row).await;
+        assert_eq!(
+            violated(&error),
+            Some(ErrorKind::UniqueViolation),
+            "{table} must reject a duplicate primary key: {error}"
+        );
+
+        pool.execute(&format!(
+            "DELETE FROM {table} WHERE {}",
+            contract.primary_key_predicate(workspace, blob)
+        ))
+        .await;
+        pool.execute(&contract.insert_sql(workspace, blob, &[]))
+            .await;
+    }
+
+    fn column_contract_names(contract: &TableContract) -> Vec<String> {
+        contract
+            .columns
+            .iter()
+            .map(|column| column.name.to_owned())
+            .collect()
+    }
+
+    /// Every new table is anchored to its workspace, and the four child tables
+    /// additionally to their source row.
+    async fn assert_source_foreign_keys(pool: &ContractPool<'_>, workspace: &str) {
+        let blob = pool.blob_literal();
+        let absent_workspace = format!("'{workspace}-absent'");
+        for contract in &SOURCE_CONTRACTS {
+            let sql = contract.insert_sql(workspace, blob, &[("workspace_id", &absent_workspace)]);
+            let error = pool.expect_rejected(&sql).await;
+            assert_eq!(
+                violated(&error),
+                Some(ErrorKind::ForeignKeyViolation),
+                "{} must require its workspace: {error}",
+                contract.table
+            );
+        }
+
+        for contract in SOURCE_CONTRACTS
+            .iter()
+            .filter(|contract| contract.table != "sources")
+            .filter(|contract| contract.table != "source_tombstones")
+        {
+            let sql = contract.insert_sql(workspace, blob, &[("source_name", "'absent-source'")]);
+            let error = pool.expect_rejected(&sql).await;
+            assert_eq!(
+                violated(&error),
+                Some(ErrorKind::ForeignKeyViolation),
+                "{} must require its source: {error}",
+                contract.table
+            );
+        }
+    }
+
+    /// Columns the schema fills in for a writer that omits them.
+    async fn assert_column_defaults(pool: &ContractPool<'_>, workspace: &str) {
+        let blob = pool.blob_literal();
+        pool.execute(&format!(
+            "INSERT INTO sources \
+                (workspace_id, name, origin_kind, created_at_unix_nanos, updated_at_unix_nanos) \
+             VALUES ('{workspace}', 'defaulted-source', 'bundled', 0, 0)"
+        ))
+        .await;
+        pool.execute(&format!(
+            "INSERT INTO materializations \
+                (workspace_id, source_name, materialization_version, projections_yaml, \
+                 source_document_raw, source_document_yaml, semantic_ir_yaml, \
+                 created_at_unix_nanos) \
+             VALUES ('{workspace}', 'defaulted-source', 'v4', 'projections: []', {blob}, '', '', 0)"
+        ))
+        .await;
+
+        assert_eq!(
+            pool.text(&format!(
+                "SELECT credential_revision FROM sources \
+                 WHERE workspace_id = '{workspace}' AND name = 'defaulted-source'"
+            ))
+            .await,
+            "00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            pool.text(&format!(
+                "SELECT operation_metadata_yaml FROM materializations \
+                 WHERE workspace_id = '{workspace}' AND source_name = 'defaulted-source'"
+            ))
+            .await,
+            String::new()
+        );
+    }
+
+    async fn assert_source_schema_contract(pool: &ContractPool<'_>) {
+        let workspace = unique_workspace_id();
+        seed_workspace(pool, &workspace).await;
+        seed_source(pool, &workspace, SEEDED_SOURCE).await;
+
+        for contract in &SOURCE_CONTRACTS {
+            assert_table_contract(pool, contract, &workspace).await;
+        }
+        assert_source_foreign_keys(pool, &workspace).await;
+        assert_column_defaults(pool, &workspace).await;
+
+        drop_workspace(pool, &workspace).await;
+    }
+
+    /// Deleting one source takes its catalog and artifact rows with it in a
+    /// single statement, and leaves its sibling and its tombstone standing.
+    async fn assert_source_delete_cascade(pool: &ContractPool<'_>) {
+        let workspace = unique_workspace_id();
+        seed_workspace(pool, &workspace).await;
+        seed_source_with_children(pool, &workspace, "source-1").await;
+        seed_source_with_children(pool, &workspace, "source-2").await;
+        seed_tombstone(pool, &workspace, "source-1").await;
+
+        pool.execute(&format!(
+            "DELETE FROM sources WHERE workspace_id = '{workspace}' AND name = 'source-1'"
+        ))
+        .await;
+
+        assert_eq!(
+            row_counts(pool, &workspace).await,
+            SourceRowCounts {
+                sources: 1,
+                variables: 1,
+                secret_keys: 1,
+                manifests: 1,
+                materializations: 1,
+                tombstones: 1,
+            }
+        );
+
+        drop_workspace(pool, &workspace).await;
+    }
+
+    /// Deleting a workspace cascades through its sources to every catalog,
+    /// artifact, and tombstone row in a single statement.
+    async fn assert_workspace_delete_cascade(pool: &ContractPool<'_>) {
+        let workspace = unique_workspace_id();
+        seed_workspace(pool, &workspace).await;
+        seed_source_with_children(pool, &workspace, "source-1").await;
+        seed_source_with_children(pool, &workspace, "source-2").await;
+        seed_tombstone(pool, &workspace, "already-deleted-source").await;
+
+        assert_eq!(
+            row_counts(pool, &workspace).await,
+            SourceRowCounts {
+                sources: 2,
+                variables: 2,
+                secret_keys: 2,
+                manifests: 2,
+                materializations: 2,
+                tombstones: 1,
+            }
+        );
+
+        drop_workspace(pool, &workspace).await;
+
+        assert_eq!(
+            row_counts(pool, &workspace).await,
+            SourceRowCounts {
+                sources: 0,
+                variables: 0,
+                secret_keys: 0,
+                manifests: 0,
+                materializations: 0,
+                tombstones: 0,
+            }
+        );
+    }
+
+    /// A migrated database records every embedded migration, the 0020/0021
+    /// source series included.
+    async fn assert_source_series_recorded(pool: &ContractPool<'_>) {
+        let recorded = pool
+            .versions("SELECT version FROM _sqlx_migrations ORDER BY version")
+            .await;
+        let embedded: Vec<i64> = MIGRATOR
+            .migrations
+            .iter()
+            .map(|migration| migration.version)
+            .collect();
+
+        assert_eq!(recorded, embedded);
+        assert!(
+            recorded.contains(&20) && recorded.contains(&21),
+            "source series is not recorded: {recorded:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_source_schema_contract() {
+        let pool = migrated_sqlite_pool().await;
+
+        assert_source_schema_contract(&ContractPool::Sqlite(&pool)).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the schema contract against Postgres"]
+    async fn source_schema_contract_on_postgres() {
+        let Some(pool) = migrated_postgres_pool().await else {
+            return;
+        };
+
+        assert_source_schema_contract(&ContractPool::Postgres(&pool)).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_source_delete_cascade() {
+        let pool = migrated_sqlite_pool().await;
+
+        assert_source_delete_cascade(&ContractPool::Sqlite(&pool)).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the source cascade contract against Postgres"]
+    async fn source_delete_cascade_contract_on_postgres() {
+        let Some(pool) = migrated_postgres_pool().await else {
+            return;
+        };
+
+        assert_source_delete_cascade(&ContractPool::Postgres(&pool)).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_workspace_delete_cascade() {
+        let pool = migrated_sqlite_pool().await;
+
+        assert_workspace_delete_cascade(&ContractPool::Sqlite(&pool)).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the workspace cascade contract against Postgres"]
+    async fn workspace_delete_cascade_contract_on_postgres() {
+        let Some(pool) = migrated_postgres_pool().await else {
+            return;
+        };
+
+        assert_workspace_delete_cascade(&ContractPool::Postgres(&pool)).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_source_series_is_current_after_migrating() {
+        let pool = migrated_sqlite_pool().await;
+
+        assert!(
+            sqlite_migrations_are_current(&pool)
+                .await
+                .expect("sqlite currency check")
+        );
+        assert_source_series_recorded(&ContractPool::Sqlite(&pool)).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the currency contract against Postgres"]
+    async fn source_series_currency_contract_on_postgres() {
+        let Some(pool) = migrated_postgres_pool().await else {
+            return;
+        };
+
+        assert!(
+            postgres_migrations_are_current(&pool)
+                .await
+                .expect("postgres currency check")
+        );
+        assert_source_series_recorded(&ContractPool::Postgres(&pool)).await;
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -28,6 +28,8 @@ pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
     IdentitySpecScope,
 };
+pub(crate) use repositories::materializations::MaterializationRecord;
+pub(crate) use repositories::source_manifests::SourceManifestRecord;
 #[cfg(test)]
 pub(crate) use repositories::state_migrations::LOCAL_WORKSPACE_OWNERSHIP_MIGRATION_ID;
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};

--- a/crates/coral-app/src/state/db/repositories/materializations.rs
+++ b/crates/coral-app/src/state/db/repositories/materializations.rs
@@ -78,10 +78,6 @@ where
         Self { session }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the hydration pass reads through this next")
-    )]
     pub(crate) async fn get(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -114,10 +110,6 @@ where
     /// `created_at_unix_nanos` is restated on every write, unlike the catalog
     /// row's: a materialization is replaced wholesale rather than amended, so
     /// the timestamp dates the artifacts that are there.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager writes through this next")
-    )]
     pub(crate) async fn upsert(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -173,10 +165,6 @@ where
     }
 
     /// Drops one source's materialization, reporting whether one was there.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager writes through this next")
-    )]
     pub(crate) async fn remove(
         &mut self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/db/repositories/materializations.rs
+++ b/crates/coral-app/src/state/db/repositories/materializations.rs
@@ -1,0 +1,479 @@
+//! Materialized-source artifact persistence.
+//!
+//! One row reproduces one `materialized/v4` directory. It is singular by
+//! construction: v4 is single-surface with a flat file layout, so there is no
+//! child table and no surface id to key one by.
+//!
+//! Requiredness mirrors the v4 loader rather than the file system: the
+//! projections, the source document (raw and parsed), the semantic IR and the
+//! operation metadata are always present, while the fingerprint and the
+//! diagnostics are optional there and so nullable here.
+
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::sources::SourceName;
+use crate::state::db::DbError;
+use crate::state::db::schema::Materializations;
+use crate::state::db::session::DbSession;
+use crate::workspaces::WorkspaceName;
+
+/// One stored materialization, as the hydration pass reads it back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaterializationRecord {
+    pub(crate) materialization_version: String,
+    pub(crate) fingerprint_yaml: Option<String>,
+    pub(crate) projections_yaml: String,
+    pub(crate) diagnostics_yaml: Option<String>,
+    pub(crate) source_document_raw: Vec<u8>,
+    pub(crate) source_document_yaml: String,
+    pub(crate) semantic_ir_yaml: String,
+    pub(crate) operation_metadata_yaml: String,
+}
+
+#[derive(sqlx::FromRow)]
+struct MaterializationRow {
+    materialization_version: String,
+    fingerprint_yaml: Option<String>,
+    projections_yaml: String,
+    diagnostics_yaml: Option<String>,
+    source_document_raw: Vec<u8>,
+    source_document_yaml: String,
+    semantic_ir_yaml: String,
+    operation_metadata_yaml: String,
+}
+
+impl From<MaterializationRow> for MaterializationRecord {
+    fn from(row: MaterializationRow) -> Self {
+        Self {
+            materialization_version: row.materialization_version,
+            fingerprint_yaml: optional_artifact(row.fingerprint_yaml),
+            projections_yaml: row.projections_yaml,
+            diagnostics_yaml: optional_artifact(row.diagnostics_yaml),
+            source_document_raw: row.source_document_raw,
+            source_document_yaml: row.source_document_yaml,
+            semantic_ir_yaml: row.semantic_ir_yaml,
+            operation_metadata_yaml: row.operation_metadata_yaml,
+        }
+    }
+}
+
+/// Reads an optional artifact column as the loader would read the file.
+///
+/// A stored empty string is folded into `None` alongside SQL `NULL`: an absent
+/// fingerprint and a zero-byte one mean the same thing to the v4 loader, and a
+/// writer that has neither must not produce a record that claims to have one.
+fn optional_artifact(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
+pub(crate) struct MaterializationsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> MaterializationsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the hydration pass reads through this next")
+    )]
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<MaterializationRecord>, DbError> {
+        let statement = Query::select()
+            .columns([
+                Materializations::MaterializationVersion,
+                Materializations::FingerprintYaml,
+                Materializations::ProjectionsYaml,
+                Materializations::DiagnosticsYaml,
+                Materializations::SourceDocumentRaw,
+                Materializations::SourceDocumentYaml,
+                Materializations::SemanticIrYaml,
+                Materializations::OperationMetadataYaml,
+            ])
+            .from(Materializations::Table)
+            .and_where(Expr::col(Materializations::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Materializations::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        let row: Option<MaterializationRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(Into::into))
+    }
+
+    /// Stores one source's materialization, replacing any already held.
+    ///
+    /// The optional artifacts are normalized to `NULL` on the way in, so an
+    /// absent fingerprint is stored the one way the reader will report it back.
+    ///
+    /// `created_at_unix_nanos` is restated on every write, unlike the catalog
+    /// row's: a materialization is replaced wholesale rather than amended, so
+    /// the timestamp dates the artifacts that are there.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager writes through this next")
+    )]
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        record: &MaterializationRecord,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Materializations::Table)
+            .columns([
+                Materializations::WorkspaceId,
+                Materializations::SourceName,
+                Materializations::MaterializationVersion,
+                Materializations::FingerprintYaml,
+                Materializations::ProjectionsYaml,
+                Materializations::DiagnosticsYaml,
+                Materializations::SourceDocumentRaw,
+                Materializations::SourceDocumentYaml,
+                Materializations::SemanticIrYaml,
+                Materializations::OperationMetadataYaml,
+                Materializations::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_owned()),
+                Expr::val(source_name.as_str().to_owned()),
+                Expr::val(record.materialization_version.clone()),
+                Expr::val(optional_artifact(record.fingerprint_yaml.clone())),
+                Expr::val(record.projections_yaml.clone()),
+                Expr::val(optional_artifact(record.diagnostics_yaml.clone())),
+                Expr::val(record.source_document_raw.clone()),
+                Expr::val(record.source_document_yaml.clone()),
+                Expr::val(record.semantic_ir_yaml.clone()),
+                Expr::val(record.operation_metadata_yaml.clone()),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([Materializations::WorkspaceId, Materializations::SourceName])
+                    .update_columns([
+                        Materializations::MaterializationVersion,
+                        Materializations::FingerprintYaml,
+                        Materializations::ProjectionsYaml,
+                        Materializations::DiagnosticsYaml,
+                        Materializations::SourceDocumentRaw,
+                        Materializations::SourceDocumentYaml,
+                        Materializations::SemanticIrYaml,
+                        Materializations::OperationMetadataYaml,
+                        Materializations::CreatedAtUnixNanos,
+                    ])
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    /// Drops one source's materialization, reporting whether one was there.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager writes through this next")
+    )]
+    pub(crate) async fn remove(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<bool, DbError> {
+        let statement = Query::delete()
+            .from_table(Materializations::Table)
+            .and_where(Expr::col(Materializations::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Materializations::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        Ok(self.session.execute_rows_affected(statement).await? == 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use sea_query::{Alias, Expr, ExprTrait, Query};
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    use super::MaterializationRecord;
+    use crate::bootstrap;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::{DbRepos, DbSession};
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    /// Bytes chosen to break anything that round-trips through a string: an
+    /// embedded NUL, a lone 0xFF that is not valid UTF-8, and a trailing NUL
+    /// that a C-style truncation would eat.
+    const RAW_DOCUMENT: &[u8] = &[0x00, 0x01, 0xFF, 0xFE, b'y', b'a', b'm', b'l', 0x00];
+
+    #[tokio::test]
+    async fn materialization_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let config = DatabaseConfig::load(&layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_materialization_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn materialization_repository_contract_on_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_materialization_round_trip(&db).await;
+    }
+
+    /// Exercises the whole surface against one backend: store, read back with
+    /// the raw document intact, replace in place, and drop.
+    async fn assert_materialization_round_trip(db: &CoralDb) {
+        let (workspace, source_name) = seed_source(db, "materialized-source").await;
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .materializations()
+                .get(&workspace, &source_name)
+                .await
+                .expect("read absent materialization"),
+            None
+        );
+
+        let stored = materialization();
+        let mut tx = db.begin().await.expect("begin store tx");
+        tx.materializations()
+            .upsert(&workspace, &source_name, &stored, 10)
+            .await
+            .expect("store materialization");
+        tx.commit().await.expect("commit store tx");
+
+        let read_back = session
+            .materializations()
+            .get(&workspace, &source_name)
+            .await
+            .expect("read stored materialization")
+            .expect("a stored materialization reads back");
+        assert_eq!(read_back, stored);
+        assert_eq!(
+            read_back.source_document_raw, RAW_DOCUMENT,
+            "the raw source document must survive the round trip byte for byte"
+        );
+
+        assert_optional_artifacts_map_to_none(db, &workspace, &source_name).await;
+        assert_remove_reports_what_it_dropped(db, &workspace, &source_name).await;
+    }
+
+    /// A materialization without a fingerprint or diagnostics stores SQL NULL
+    /// and reads back as `None`, and so does one that carries empty strings —
+    /// and the second write replaces the first rather than adding a row.
+    async fn assert_optional_artifacts_map_to_none(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let without_optionals = MaterializationRecord {
+            fingerprint_yaml: None,
+            diagnostics_yaml: None,
+            ..materialization()
+        };
+        let mut tx = db.begin().await.expect("begin replace tx");
+        tx.materializations()
+            .upsert(workspace, source_name, &without_optionals, 20)
+            .await
+            .expect("replace materialization");
+        tx.commit().await.expect("commit replace tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .materializations()
+                .get(workspace, source_name)
+                .await
+                .expect("read materialization without optionals"),
+            Some(without_optionals.clone())
+        );
+        assert_eq!(
+            null_optional_counts(db, workspace, source_name).await,
+            (1, 1),
+            "an absent artifact must be stored as NULL, not as an empty string"
+        );
+
+        let with_empty_optionals = MaterializationRecord {
+            fingerprint_yaml: Some(String::new()),
+            diagnostics_yaml: Some(String::new()),
+            ..materialization()
+        };
+        let mut tx = db.begin().await.expect("begin empty-optionals tx");
+        tx.materializations()
+            .upsert(workspace, source_name, &with_empty_optionals, 21)
+            .await
+            .expect("store empty optionals");
+        tx.commit().await.expect("commit empty-optionals tx");
+
+        assert_eq!(
+            session
+                .materializations()
+                .get(workspace, source_name)
+                .await
+                .expect("read materialization with empty optionals"),
+            Some(without_optionals),
+            "an empty artifact must read back the same as an absent one"
+        );
+        assert_eq!(
+            null_optional_counts(db, workspace, source_name).await,
+            (1, 1),
+            "an empty artifact must be normalized to NULL on the way in"
+        );
+        assert_eq!(
+            count_where(db, workspace, source_name, None).await,
+            1,
+            "a source has one materialization, however many times it is written"
+        );
+    }
+
+    /// The first drop reports the materialization it removed; a second reports
+    /// none.
+    async fn assert_remove_reports_what_it_dropped(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let mut tx = db.begin().await.expect("begin drop tx");
+        assert!(
+            tx.materializations()
+                .remove(workspace, source_name)
+                .await
+                .expect("drop materialization")
+        );
+        assert!(
+            !tx.materializations()
+                .remove(workspace, source_name)
+                .await
+                .expect("drop absent materialization")
+        );
+        tx.commit().await.expect("commit drop tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .materializations()
+                .get(workspace, source_name)
+                .await
+                .expect("read dropped materialization"),
+            None
+        );
+    }
+
+    /// Counts the `(fingerprint, diagnostics)` columns that are physically
+    /// NULL, so the storage form is proven rather than inferred from a read
+    /// that folds empty strings into `None` anyway.
+    async fn null_optional_counts(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> (i64, i64) {
+        let mut counts = [0_i64; 2];
+        for (slot, column) in counts
+            .iter_mut()
+            .zip(["fingerprint_yaml", "diagnostics_yaml"])
+        {
+            *slot = count_where(db, workspace, source_name, Some(column)).await;
+        }
+        (counts[0], counts[1])
+    }
+
+    /// Counts one source's materialization rows straight from the physical
+    /// table, optionally narrowed to rows whose `null_column` is NULL.
+    async fn count_where(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        null_column: Option<&str>,
+    ) -> i64 {
+        let mut statement = Query::select()
+            .expr(Expr::col(Alias::new("workspace_id")).count())
+            .from(Alias::new("materializations"))
+            .and_where(Expr::col(Alias::new("workspace_id")).eq(workspace.as_str()))
+            .and_where(Expr::col(Alias::new("source_name")).eq(source_name.as_str()))
+            .to_owned();
+        if let Some(column) = null_column {
+            statement = statement
+                .and_where(Expr::col(Alias::new(column)).is_null())
+                .to_owned();
+        }
+
+        let mut session = db;
+        let counted: Option<(i64,)> = session
+            .fetch_optional(statement)
+            .await
+            .expect("count materialization rows");
+        counted.expect("a count always returns a row").0
+    }
+
+    fn materialization() -> MaterializationRecord {
+        MaterializationRecord {
+            materialization_version: "v4".to_owned(),
+            fingerprint_yaml: Some("inputs:\n  - orders.sql\n".to_owned()),
+            projections_yaml: "projections:\n  - name: orders\n".to_owned(),
+            diagnostics_yaml: Some("warnings: []\n".to_owned()),
+            source_document_raw: RAW_DOCUMENT.to_vec(),
+            source_document_yaml: "document:\n  kind: source\n".to_owned(),
+            semantic_ir_yaml: "ir:\n  version: 4\n".to_owned(),
+            operation_metadata_yaml: "operations: []\n".to_owned(),
+        }
+    }
+
+    /// Installs a workspace and one catalog row for the materialization to hang
+    /// off: `materializations` is foreign-keyed to `sources`, so there is no
+    /// such thing as a materialization for a source this database does not
+    /// have.
+    async fn seed_source(db: &CoralDb, name: &str) -> (WorkspaceName, SourceName) {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let workspace =
+            WorkspaceName::parse(&format!("workspace-{suffix}")).expect("parse workspace name");
+        let source = InstalledSource {
+            name: SourceName::parse(name).expect("parse source name"),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::nil(),
+            origin: SourceOrigin::Imported,
+        };
+
+        let mut tx = db.begin().await.expect("begin seed tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 1)
+            .await
+            .expect("install source");
+        tx.commit().await.expect("commit seed tx");
+
+        (workspace, source.name)
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod gui_onboarding;
 pub(crate) mod identity_specs;
+pub(crate) mod sources;
 pub(crate) mod state_migrations;
 pub(crate) mod task_queries;
 pub(crate) mod tasks;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod gui_onboarding;
 pub(crate) mod identity_specs;
+pub(crate) mod materializations;
+pub(crate) mod source_manifests;
 pub(crate) mod sources;
 pub(crate) mod state_migrations;
 pub(crate) mod task_queries;

--- a/crates/coral-app/src/state/db/repositories/source_manifests.rs
+++ b/crates/coral-app/src/state/db/repositories/source_manifests.rs
@@ -35,10 +35,6 @@ where
         Self { session }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the hydration pass reads through this next")
-    )]
     pub(crate) async fn get(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -62,10 +58,6 @@ where
     /// `created_at_unix_nanos` is restated on every write, unlike the catalog
     /// row's: a manifest is replaced wholesale rather than amended, so the
     /// timestamp dates the manifest that is there, not the first one ever was.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager writes through this next")
-    )]
     pub(crate) async fn upsert(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -103,10 +95,6 @@ where
     }
 
     /// Drops one source's manifest, reporting whether one was there to drop.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager writes through this next")
-    )]
     pub(crate) async fn remove(
         &mut self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/db/repositories/source_manifests.rs
+++ b/crates/coral-app/src/state/db/repositories/source_manifests.rs
@@ -1,0 +1,308 @@
+//! Imported-source manifest persistence.
+//!
+//! An imported source's `manifest.yaml` lives here as the artifact of record;
+//! the copy on a host's disk is a cache of this row. `manifest_hash` is what
+//! that cache's freshness is decided against, so it is computed here rather
+//! than taken from the caller: one hash function, applied to the one string
+//! that was actually stored.
+
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::hash::sha256_hex;
+use crate::sources::SourceName;
+use crate::state::db::DbError;
+use crate::state::db::schema::SourceManifests;
+use crate::state::db::session::DbSession;
+use crate::workspaces::WorkspaceName;
+
+/// One stored manifest, as the hydration pass reads it back.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct SourceManifestRecord {
+    pub(crate) manifest_yaml: String,
+    pub(crate) manifest_hash: String,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+pub(crate) struct SourceManifestsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> SourceManifestsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the hydration pass reads through this next")
+    )]
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<SourceManifestRecord>, DbError> {
+        let statement = Query::select()
+            .columns([
+                SourceManifests::ManifestYaml,
+                SourceManifests::ManifestHash,
+                SourceManifests::CreatedAtUnixNanos,
+            ])
+            .from(SourceManifests::Table)
+            .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceManifests::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+
+    /// Stores one source's manifest, replacing any manifest already held.
+    ///
+    /// `created_at_unix_nanos` is restated on every write, unlike the catalog
+    /// row's: a manifest is replaced wholesale rather than amended, so the
+    /// timestamp dates the manifest that is there, not the first one ever was.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager writes through this next")
+    )]
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        manifest_yaml: &str,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(SourceManifests::Table)
+            .columns([
+                SourceManifests::WorkspaceId,
+                SourceManifests::SourceName,
+                SourceManifests::ManifestYaml,
+                SourceManifests::ManifestHash,
+                SourceManifests::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_owned()),
+                Expr::val(source_name.as_str().to_owned()),
+                Expr::val(manifest_yaml.to_owned()),
+                Expr::val(sha256_hex(manifest_yaml.as_bytes())),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([SourceManifests::WorkspaceId, SourceManifests::SourceName])
+                    .update_columns([
+                        SourceManifests::ManifestYaml,
+                        SourceManifests::ManifestHash,
+                        SourceManifests::CreatedAtUnixNanos,
+                    ])
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    /// Drops one source's manifest, reporting whether one was there to drop.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager writes through this next")
+    )]
+    pub(crate) async fn remove(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<bool, DbError> {
+        let statement = Query::delete()
+            .from_table(SourceManifests::Table)
+            .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceManifests::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        Ok(self.session.execute_rows_affected(statement).await? == 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    use super::SourceManifestRecord;
+    use crate::bootstrap;
+    use crate::hash::sha256_hex;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    const MANIFEST: &str = "dsl_version: 4\nname: orders\n";
+    const REPLACEMENT: &str = "dsl_version: 4\nname: shipments\n";
+
+    #[tokio::test]
+    async fn source_manifest_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let config = DatabaseConfig::load(&layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_source_manifest_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn source_manifest_repository_contract_on_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_manifest_round_trip(&db).await;
+    }
+
+    /// Exercises the whole surface against one backend: store, read back,
+    /// replace in place, and drop.
+    async fn assert_source_manifest_round_trip(db: &CoralDb) {
+        let (workspace, source_name) = seed_source(db, "manifest-source").await;
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source_name)
+                .await
+                .expect("read absent manifest"),
+            None
+        );
+
+        let mut tx = db.begin().await.expect("begin store tx");
+        tx.source_manifests()
+            .upsert(&workspace, &source_name, MANIFEST, 10)
+            .await
+            .expect("store manifest");
+        tx.commit().await.expect("commit store tx");
+
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source_name)
+                .await
+                .expect("read stored manifest"),
+            Some(SourceManifestRecord {
+                manifest_yaml: MANIFEST.to_owned(),
+                manifest_hash: sha256_hex(MANIFEST.as_bytes()),
+                created_at_unix_nanos: 10,
+            }),
+            "the stored hash must be the hash of the stored manifest"
+        );
+
+        assert_replacement_is_singular(db, &workspace, &source_name).await;
+        assert_remove_reports_what_it_dropped(db, &workspace, &source_name).await;
+    }
+
+    /// A second write replaces the manifest rather than adding a second row,
+    /// and restates both the hash and the timestamp with it.
+    async fn assert_replacement_is_singular(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let mut tx = db.begin().await.expect("begin replace tx");
+        tx.source_manifests()
+            .upsert(workspace, source_name, REPLACEMENT, 20)
+            .await
+            .expect("replace manifest");
+        tx.commit().await.expect("commit replace tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(workspace, source_name)
+                .await
+                .expect("read replaced manifest"),
+            Some(SourceManifestRecord {
+                manifest_yaml: REPLACEMENT.to_owned(),
+                manifest_hash: sha256_hex(REPLACEMENT.as_bytes()),
+                created_at_unix_nanos: 20,
+            })
+        );
+    }
+
+    /// The first drop reports the manifest it removed; a second reports none.
+    async fn assert_remove_reports_what_it_dropped(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let mut tx = db.begin().await.expect("begin drop tx");
+        assert!(
+            tx.source_manifests()
+                .remove(workspace, source_name)
+                .await
+                .expect("drop manifest")
+        );
+        assert!(
+            !tx.source_manifests()
+                .remove(workspace, source_name)
+                .await
+                .expect("drop absent manifest")
+        );
+        tx.commit().await.expect("commit drop tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(workspace, source_name)
+                .await
+                .expect("read dropped manifest"),
+            None
+        );
+    }
+
+    /// Installs a workspace and one catalog row for the manifest to hang off:
+    /// `source_manifests` is foreign-keyed to `sources`, so there is no such
+    /// thing as a manifest for a source this database does not have.
+    async fn seed_source(db: &CoralDb, name: &str) -> (WorkspaceName, SourceName) {
+        let suffix = Uuid::new_v4().simple().to_string();
+        let workspace =
+            WorkspaceName::parse(&format!("workspace-{suffix}")).expect("parse workspace name");
+        let source = InstalledSource {
+            name: SourceName::parse(name).expect("parse source name"),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            credential_revision: Uuid::nil(),
+            origin: SourceOrigin::Imported,
+        };
+
+        let mut tx = db.begin().await.expect("begin seed tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 1)
+            .await
+            .expect("install source");
+        tx.commit().await.expect("commit seed tx");
+
+        (workspace, source.name)
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -53,10 +53,6 @@ where
     /// Postgres's locale-aware default disagree on names that differ only by
     /// case or punctuation. One listing must not depend on which backend a
     /// deployment happens to run.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager reads through this next")
-    )]
     pub(crate) async fn list_workspace_sources(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -197,10 +193,6 @@ where
     }
 
     /// Reports whether this database records a deletion for `(workspace, name)`.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the boot import consults this next")
-    )]
     pub(crate) async fn is_tombstoned(
         &mut self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -87,10 +87,6 @@ where
     /// source is exactly the operator action that revokes an earlier deletion,
     /// and leaving the record standing would have a peer's boot import skip the
     /// re-added entry.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager writes through this next")
-    )]
     pub(crate) async fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -161,10 +157,6 @@ where
     /// database never learned about can still exist in a host's config mirror —
     /// written there by an older binary — and deleting it has to stick for the
     /// same reason deleting a known one does.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager writes through this next")
-    )]
     pub(crate) async fn remove_source(
         &mut self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -60,10 +60,8 @@ where
         self.load(workspace_name, None).await
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager reads through this next")
-    )]
+    /// Reads one workspace's installed source, or `None` when it has no such
+    /// row.
     pub(crate) async fn get_source(
         &mut self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -1,0 +1,791 @@
+//! Installed-source catalog persistence.
+//!
+//! One [`InstalledSource`] spans three tables — `sources` plus the
+//! `source_variables` and `source_secret_keys` child sets — so every read here
+//! reassembles it and every write replaces the child sets wholesale inside the
+//! caller's transaction.
+//!
+//! Deletions additionally write a row to `source_tombstones`. The tombstone is
+//! what makes a deletion stick when several hosts share one database: the
+//! deleting binary records the removal, and a peer's boot import consults the
+//! record instead of re-adding the entry from its own stale config mirror.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use sea_query::{Expr, ExprTrait, OnConflict, Query, SelectStatement};
+use uuid::Uuid;
+
+use crate::credentials::CredentialStorageKind;
+use crate::sources::SourceName;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::state::db::DbError;
+use crate::state::db::schema::{SourceSecretKeys, SourceTombstones, SourceVariables, Sources};
+use crate::state::db::session::DbSession;
+use crate::workspaces::WorkspaceName;
+
+/// One `sources` row, before its child sets are folded back in.
+#[derive(sqlx::FromRow)]
+struct SourceRow {
+    name: String,
+    version: Option<String>,
+    origin_kind: String,
+    credential_storage: Option<String>,
+    credential_revision: String,
+}
+
+pub(crate) struct SourcesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> SourcesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    /// Lists one workspace's installed sources, ordered by source name.
+    ///
+    /// The ordering is applied in Rust rather than in SQL because a source name
+    /// is a name its installer chose: ordering it in the database would order it
+    /// under the backend's collation, and `SQLite`'s binary comparison and
+    /// Postgres's locale-aware default disagree on names that differ only by
+    /// case or punctuation. One listing must not depend on which backend a
+    /// deployment happens to run.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager reads through this next")
+    )]
+    pub(crate) async fn list_workspace_sources(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, DbError> {
+        self.load(workspace_name, None).await
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager reads through this next")
+    )]
+    pub(crate) async fn get_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, DbError> {
+        Ok(self.load(workspace_name, Some(source_name)).await?.pop())
+    }
+
+    /// Writes one source and replaces its child sets.
+    ///
+    /// The child sets are deleted and reinserted rather than merged: they are
+    /// sets, so a stale key left behind by a merge would be indistinguishable
+    /// from a configured one. Everything runs on the caller's session, so a
+    /// caller in a transaction gets the whole replacement atomically.
+    ///
+    /// Any tombstone for this `(workspace, name)` is cleared first — re-adding a
+    /// source is exactly the operator action that revokes an earlier deletion,
+    /// and leaving the record standing would have a peer's boot import skip the
+    /// re-added entry.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager writes through this next")
+    )]
+    pub(crate) async fn upsert_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let workspace_id = workspace_name.as_str();
+        let name = source.name.as_str();
+
+        self.clear_tombstone(workspace_id, name).await?;
+
+        let statement = Query::insert()
+            .into_table(Sources::Table)
+            .columns([
+                Sources::WorkspaceId,
+                Sources::Name,
+                Sources::Version,
+                Sources::OriginKind,
+                Sources::CredentialStorage,
+                Sources::CredentialRevision,
+                Sources::CreatedAtUnixNanos,
+                Sources::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_owned()),
+                Expr::val(name.to_owned()),
+                Expr::val(source.version.clone()),
+                Expr::val(source.origin.as_config_value().to_owned()),
+                Expr::val(
+                    source
+                        .credential_storage
+                        .map(|kind| kind.as_config_value().to_owned()),
+                ),
+                Expr::val(source.credential_revision.to_string()),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                // `created_at_unix_nanos` is deliberately absent: an update
+                // must not restate when the source was first installed.
+                OnConflict::columns([Sources::WorkspaceId, Sources::Name])
+                    .update_columns([
+                        Sources::Version,
+                        Sources::OriginKind,
+                        Sources::CredentialStorage,
+                        Sources::CredentialRevision,
+                        Sources::UpdatedAtUnixNanos,
+                    ])
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await?;
+
+        self.replace_variables(workspace_id, name, &source.variables)
+            .await?;
+        self.replace_secret_keys(workspace_id, name, &source.secrets)
+            .await
+    }
+
+    /// Removes one source and records the deletion, reporting whether a row was
+    /// there to remove.
+    ///
+    /// The child and artifact rows go with it through the schema's cascade, and
+    /// the tombstone is written on the same session, so a caller in a
+    /// transaction cannot commit a removal without its record.
+    ///
+    /// The tombstone is written whether or not a row was removed. A source this
+    /// database never learned about can still exist in a host's config mirror —
+    /// written there by an older binary — and deleting it has to stick for the
+    /// same reason deleting a known one does.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager writes through this next")
+    )]
+    pub(crate) async fn remove_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        now_unix_nanos: i64,
+    ) -> Result<bool, DbError> {
+        let workspace_id = workspace_name.as_str();
+        let name = source_name.as_str();
+
+        let delete = Query::delete()
+            .from_table(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Sources::Name).eq(name))
+            .to_owned();
+        let removed = self.session.execute_rows_affected(delete).await? == 1;
+
+        let tombstone = Query::insert()
+            .into_table(SourceTombstones::Table)
+            .columns([
+                SourceTombstones::WorkspaceId,
+                SourceTombstones::SourceName,
+                SourceTombstones::DeletedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_owned()),
+                Expr::val(name.to_owned()),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([SourceTombstones::WorkspaceId, SourceTombstones::SourceName])
+                    .update_column(SourceTombstones::DeletedAtUnixNanos)
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(tombstone).await?;
+
+        Ok(removed)
+    }
+
+    /// Reports whether this database records a deletion for `(workspace, name)`.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the boot import consults this next")
+    )]
+    pub(crate) async fn is_tombstoned(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<bool, DbError> {
+        let statement = Query::select()
+            .column(SourceTombstones::SourceName)
+            .from(SourceTombstones::Table)
+            .and_where(Expr::col(SourceTombstones::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceTombstones::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        let found: Option<(String,)> = self.session.fetch_optional(statement).await?;
+        Ok(found.is_some())
+    }
+
+    /// Reads one workspace's sources, optionally narrowed to a single name.
+    ///
+    /// Both reads take the same three statements — parent rows plus the two
+    /// child sets — so a single source and a whole workspace are assembled by
+    /// one piece of code rather than two that can drift apart.
+    async fn load(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: Option<&SourceName>,
+    ) -> Result<Vec<InstalledSource>, DbError> {
+        let workspace_id = workspace_name.as_str();
+        let name = source_name.map(SourceName::as_str);
+
+        let mut parents = Query::select()
+            .columns([
+                Sources::Name,
+                Sources::Version,
+                Sources::OriginKind,
+                Sources::CredentialStorage,
+                Sources::CredentialRevision,
+            ])
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_id))
+            .to_owned();
+        if let Some(name) = name {
+            parents = parents
+                .and_where(Expr::col(Sources::Name).eq(name))
+                .to_owned();
+        }
+        let rows: Vec<SourceRow> = self.session.fetch_all(parents).await?;
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let variables_query = Query::select()
+            .columns([
+                SourceVariables::SourceName,
+                SourceVariables::Key,
+                SourceVariables::Value,
+            ])
+            .from(SourceVariables::Table)
+            .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_id))
+            .to_owned();
+        let variables: Vec<(String, String, String)> = self
+            .session
+            .fetch_all(narrow_to_source(
+                variables_query,
+                SourceVariables::SourceName,
+                name,
+            ))
+            .await?;
+
+        let secrets_query = Query::select()
+            .columns([SourceSecretKeys::SourceName, SourceSecretKeys::Key])
+            .from(SourceSecretKeys::Table)
+            .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_id))
+            .to_owned();
+        let secrets: Vec<(String, String)> = self
+            .session
+            .fetch_all(narrow_to_source(
+                secrets_query,
+                SourceSecretKeys::SourceName,
+                name,
+            ))
+            .await?;
+
+        build_sources(rows, variables, secrets)
+    }
+
+    async fn clear_tombstone(
+        &mut self,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(SourceTombstones::Table)
+            .and_where(Expr::col(SourceTombstones::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(SourceTombstones::SourceName).eq(source_name))
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    async fn replace_variables(
+        &mut self,
+        workspace_id: &str,
+        source_name: &str,
+        variables: &BTreeMap<String, String>,
+    ) -> Result<(), DbError> {
+        let delete = Query::delete()
+            .from_table(SourceVariables::Table)
+            .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(SourceVariables::SourceName).eq(source_name))
+            .to_owned();
+        self.session.execute(delete).await?;
+        if variables.is_empty() {
+            return Ok(());
+        }
+
+        let mut insert = Query::insert()
+            .into_table(SourceVariables::Table)
+            .columns([
+                SourceVariables::WorkspaceId,
+                SourceVariables::SourceName,
+                SourceVariables::Key,
+                SourceVariables::Value,
+            ])
+            .to_owned();
+        for (key, value) in variables {
+            insert.values_panic([
+                Expr::val(workspace_id.to_owned()),
+                Expr::val(source_name.to_owned()),
+                Expr::val(key.clone()),
+                Expr::val(value.clone()),
+            ]);
+        }
+        self.session.execute(insert).await
+    }
+
+    async fn replace_secret_keys(
+        &mut self,
+        workspace_id: &str,
+        source_name: &str,
+        secrets: &[String],
+    ) -> Result<(), DbError> {
+        let delete = Query::delete()
+            .from_table(SourceSecretKeys::Table)
+            .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name))
+            .to_owned();
+        self.session.execute(delete).await?;
+
+        // Deduplicated because the table is keyed on the key: a caller that
+        // names the same secret twice is asking for one row, not a conflict.
+        let keys: BTreeSet<&String> = secrets.iter().collect();
+        if keys.is_empty() {
+            return Ok(());
+        }
+
+        let mut insert = Query::insert()
+            .into_table(SourceSecretKeys::Table)
+            .columns([
+                SourceSecretKeys::WorkspaceId,
+                SourceSecretKeys::SourceName,
+                SourceSecretKeys::Key,
+            ])
+            .to_owned();
+        for key in keys {
+            insert.values_panic([
+                Expr::val(workspace_id.to_owned()),
+                Expr::val(source_name.to_owned()),
+                Expr::val(key.clone()),
+            ]);
+        }
+        self.session.execute(insert).await
+    }
+}
+
+/// Narrows a workspace-wide child-set read to one source, when one is named.
+fn narrow_to_source<C>(
+    mut statement: SelectStatement,
+    column: C,
+    source_name: Option<&str>,
+) -> SelectStatement
+where
+    C: sea_query::IntoColumnRef,
+{
+    let Some(source_name) = source_name else {
+        return statement;
+    };
+    statement
+        .and_where(Expr::col(column).eq(source_name))
+        .to_owned()
+}
+
+/// Folds the child sets back into their parent rows.
+///
+/// Both sets are rebuilt through ordered Rust collections rather than an
+/// `ORDER BY`, for the collation reason spelled out on
+/// [`SourcesRepo::list_workspace_sources`].
+fn build_sources(
+    rows: Vec<SourceRow>,
+    variables: Vec<(String, String, String)>,
+    secrets: Vec<(String, String)>,
+) -> Result<Vec<InstalledSource>, DbError> {
+    let mut grouped_variables: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    for (source_name, key, value) in variables {
+        grouped_variables
+            .entry(source_name)
+            .or_default()
+            .insert(key, value);
+    }
+    let mut grouped_secrets: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (source_name, key) in secrets {
+        grouped_secrets.entry(source_name).or_default().insert(key);
+    }
+
+    let mut sources = rows
+        .into_iter()
+        .map(|row| {
+            let name = decode_source_name(&row.name)?;
+            let variables = grouped_variables.remove(&row.name).unwrap_or_default();
+            let secrets = grouped_secrets.remove(&row.name).unwrap_or_default();
+            let credential_storage = row
+                .credential_storage
+                .as_deref()
+                .map(decode_credential_storage)
+                .transpose()?;
+            Ok(InstalledSource {
+                name,
+                version: row.version,
+                variables,
+                secrets: secrets.into_iter().collect(),
+                credential_storage,
+                credential_revision: decode_credential_revision(&row.credential_revision)?,
+                origin: decode_origin(&row.origin_kind)?,
+            })
+        })
+        .collect::<Result<Vec<InstalledSource>, DbError>>()?;
+    sources.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(sources)
+}
+
+fn decode_source_name(value: &str) -> Result<SourceName, DbError> {
+    SourceName::parse(value)
+        .map_err(|error| corrupt(&format!("source row name '{value}' is unusable: {error}")))
+}
+
+fn decode_origin(value: &str) -> Result<SourceOrigin, DbError> {
+    match value {
+        "bundled" => Ok(SourceOrigin::Bundled),
+        "imported" => Ok(SourceOrigin::Imported),
+        other => Err(corrupt(&format!(
+            "source row has an unrecognized origin '{other}'"
+        ))),
+    }
+}
+
+fn decode_credential_storage(value: &str) -> Result<CredentialStorageKind, DbError> {
+    match value {
+        "file" => Ok(CredentialStorageKind::File),
+        "keychain" => Ok(CredentialStorageKind::Keychain),
+        other => Err(corrupt(&format!(
+            "source row has an unrecognized credential storage '{other}'"
+        ))),
+    }
+}
+
+fn decode_credential_revision(value: &str) -> Result<Uuid, DbError> {
+    Uuid::parse_str(value).map_err(|error| {
+        corrupt(&format!(
+            "source row credential revision '{value}' is not a uuid: {error}"
+        ))
+    })
+}
+
+fn corrupt(detail: &str) -> DbError {
+    DbError::CorruptData(detail.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use sea_query::{Alias, Expr, ExprTrait, Func, Query};
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    use super::{decode_credential_storage, decode_origin};
+    use crate::bootstrap;
+    use crate::credentials::CredentialStorageKind;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::{DbRepos, DbSession};
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn source_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_source_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn source_repository_contract_on_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_repository_round_trip(&db).await;
+    }
+
+    #[test]
+    fn unrecognized_enum_columns_decode_as_corrupt_data() {
+        assert_eq!(
+            decode_origin("imported").expect("imported decodes"),
+            SourceOrigin::Imported
+        );
+        assert_eq!(
+            decode_credential_storage("keychain").expect("keychain decodes"),
+            CredentialStorageKind::Keychain
+        );
+        assert!(
+            decode_origin("user").is_err(),
+            "a legacy origin value must not decode"
+        );
+        assert!(
+            decode_credential_storage("vault").is_err(),
+            "an unknown credential store must not decode"
+        );
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    /// Exercises the whole surface against one backend: install, read back,
+    /// update, delete with its tombstone, and re-add.
+    async fn assert_source_repository_round_trip(db: &CoralDb) {
+        let workspace = unique_workspace_name();
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit workspace tx");
+
+        let installed = installed_source("beta-source", SourceOrigin::Imported);
+        let sibling = installed_source("alpha-source", SourceOrigin::Bundled);
+        let mut tx = db.begin().await.expect("begin install tx");
+        tx.sources()
+            .upsert_source(&workspace, &installed, 10)
+            .await
+            .expect("install source");
+        tx.sources()
+            .upsert_source(&workspace, &sibling, 11)
+            .await
+            .expect("install sibling");
+        tx.commit().await.expect("commit install tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &installed.name)
+                .await
+                .expect("read installed source"),
+            Some(installed.clone())
+        );
+        assert_eq!(
+            session
+                .sources()
+                .list_workspace_sources(&workspace)
+                .await
+                .expect("list sources"),
+            vec![sibling.clone(), installed.clone()],
+            "sources must come back ordered by name"
+        );
+
+        assert_update_replaces_child_sets(db, &workspace, &installed).await;
+        assert_delete_tombstones_and_readd_clears(db, &workspace, &installed, &sibling).await;
+    }
+
+    /// An update rewrites the child sets rather than merging into them, and
+    /// leaves the sibling source untouched.
+    async fn assert_update_replaces_child_sets(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        installed: &InstalledSource,
+    ) {
+        let mut updated = installed.clone();
+        updated.version = None;
+        updated.variables = BTreeMap::from([("region".to_owned(), "eu-west-1".to_owned())]);
+        updated.secrets = vec!["rotated_token".to_owned()];
+        updated.credential_storage = Some(CredentialStorageKind::Keychain);
+        updated.credential_revision = Uuid::from_u128(0x5eed);
+
+        let mut tx = db.begin().await.expect("begin update tx");
+        tx.sources()
+            .upsert_source(workspace, &updated, 20)
+            .await
+            .expect("update source");
+        tx.commit().await.expect("commit update tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(workspace, &updated.name)
+                .await
+                .expect("read updated source"),
+            Some(updated)
+        );
+    }
+
+    /// A delete takes the child rows with it and records the removal in the
+    /// same transaction; re-adding the source revokes the record.
+    async fn assert_delete_tombstones_and_readd_clears(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        installed: &InstalledSource,
+        sibling: &InstalledSource,
+    ) {
+        let mut session = db;
+        assert!(
+            !session
+                .sources()
+                .is_tombstoned(workspace, &installed.name)
+                .await
+                .expect("read tombstone before delete")
+        );
+        assert_eq!(
+            child_row_counts(db, workspace, &installed.name).await,
+            (1, 1),
+            "the update should have left one variable and one secret key behind"
+        );
+
+        let mut tx = db.begin().await.expect("begin delete tx");
+        assert!(
+            tx.sources()
+                .remove_source(workspace, &installed.name, 30)
+                .await
+                .expect("remove source")
+        );
+        tx.commit().await.expect("commit delete tx");
+
+        assert_eq!(
+            session
+                .sources()
+                .get_source(workspace, &installed.name)
+                .await
+                .expect("read deleted source"),
+            None
+        );
+        assert!(
+            session
+                .sources()
+                .is_tombstoned(workspace, &installed.name)
+                .await
+                .expect("read tombstone after delete")
+        );
+        assert_eq!(
+            child_row_counts(db, workspace, &installed.name).await,
+            (0, 0),
+            "the delete must take the child rows with the source row"
+        );
+        assert_eq!(
+            session
+                .sources()
+                .list_workspace_sources(workspace)
+                .await
+                .expect("list after delete"),
+            vec![sibling.clone()],
+            "the sibling source and its child rows must survive the delete"
+        );
+
+        // Deleting again still records the removal but reports nothing removed.
+        let mut tx = db.begin().await.expect("begin second delete tx");
+        assert!(
+            !tx.sources()
+                .remove_source(workspace, &installed.name, 31)
+                .await
+                .expect("remove missing source")
+        );
+        tx.commit().await.expect("commit second delete tx");
+
+        // Re-adding the source is what revokes the deletion record, and the
+        // child rows the cascade took must come back with it.
+        let mut tx = db.begin().await.expect("begin re-add tx");
+        tx.sources()
+            .upsert_source(workspace, installed, 40)
+            .await
+            .expect("re-add source");
+        tx.commit().await.expect("commit re-add tx");
+
+        assert!(
+            !session
+                .sources()
+                .is_tombstoned(workspace, &installed.name)
+                .await
+                .expect("read tombstone after re-add")
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(workspace, &installed.name)
+                .await
+                .expect("read re-added source"),
+            Some(installed.clone())
+        );
+    }
+
+    /// Counts one source's `(variables, secret keys)` rows straight from the
+    /// physical tables, so the cascade is proven rather than inferred from a
+    /// reassembled read. Both tables name their key columns identically, which
+    /// is what lets one loop read them.
+    async fn child_row_counts(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> (i64, i64) {
+        let mut session = db;
+        let mut counts = [0_i64; 2];
+        for (slot, table) in counts
+            .iter_mut()
+            .zip(["source_variables", "source_secret_keys"])
+        {
+            let statement = Query::select()
+                .expr(Func::count(Expr::val(1)))
+                .from(Alias::new(table))
+                .and_where(Expr::col(Alias::new("workspace_id")).eq(workspace.as_str()))
+                .and_where(Expr::col(Alias::new("source_name")).eq(source_name.as_str()))
+                .to_owned();
+            let counted: Option<(i64,)> = session
+                .fetch_optional(statement)
+                .await
+                .expect("count child rows");
+            *slot = counted.expect("a count always returns a row").0;
+        }
+        (counts[0], counts[1])
+    }
+
+    fn installed_source(name: &str, origin: SourceOrigin) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("parse source name"),
+            version: Some("1.2.3".to_owned()),
+            variables: BTreeMap::from([
+                ("account".to_owned(), "acme".to_owned()),
+                ("region".to_owned(), "us-east-1".to_owned()),
+            ]),
+            secrets: vec!["api_token".to_owned(), "refresh_token".to_owned()],
+            credential_storage: Some(CredentialStorageKind::File),
+            credential_revision: Uuid::from_u128(0x00c0_ffee),
+            origin,
+        }
+    }
+
+    fn unique_workspace_name() -> WorkspaceName {
+        let suffix = Uuid::new_v4().simple().to_string();
+        WorkspaceName::parse(&format!("workspace-{suffix}")).expect("parse workspace name")
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+    }
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -159,7 +159,6 @@ pub(in crate::state::db) enum SourceTombstones {
 }
 
 #[derive(Iden)]
-#[expect(dead_code, reason = "source repositories wire these next")]
 pub(in crate::state::db) enum SourceManifests {
     Table,
     WorkspaceId,
@@ -170,7 +169,6 @@ pub(in crate::state::db) enum SourceManifests {
 }
 
 #[derive(Iden)]
-#[expect(dead_code, reason = "source repositories wire these next")]
 pub(in crate::state::db) enum Materializations {
     Table,
     WorkspaceId,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -119,3 +119,73 @@ pub(in crate::state::db) enum GuiOnboardingCompletions {
     PrincipalId,
     CompletedAtUnixNanos,
 }
+
+#[derive(Iden)]
+#[expect(dead_code, reason = "source repositories wire these next")]
+pub(in crate::state::db) enum Sources {
+    Table,
+    WorkspaceId,
+    Name,
+    Version,
+    OriginKind,
+    CredentialStorage,
+    CredentialRevision,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+#[expect(dead_code, reason = "source repositories wire these next")]
+pub(in crate::state::db) enum SourceVariables {
+    Table,
+    WorkspaceId,
+    SourceName,
+    Key,
+    Value,
+}
+
+#[derive(Iden)]
+#[expect(dead_code, reason = "source repositories wire these next")]
+pub(in crate::state::db) enum SourceSecretKeys {
+    Table,
+    WorkspaceId,
+    SourceName,
+    Key,
+}
+
+#[derive(Iden)]
+#[expect(dead_code, reason = "source repositories wire these next")]
+pub(in crate::state::db) enum SourceTombstones {
+    Table,
+    WorkspaceId,
+    SourceName,
+    DeletedAtUnixNanos,
+}
+
+#[derive(Iden)]
+#[expect(dead_code, reason = "source repositories wire these next")]
+pub(in crate::state::db) enum SourceManifests {
+    Table,
+    WorkspaceId,
+    SourceName,
+    ManifestYaml,
+    ManifestHash,
+    CreatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+#[expect(dead_code, reason = "source repositories wire these next")]
+pub(in crate::state::db) enum Materializations {
+    Table,
+    WorkspaceId,
+    SourceName,
+    MaterializationVersion,
+    FingerprintYaml,
+    ProjectionsYaml,
+    DiagnosticsYaml,
+    SourceDocumentRaw,
+    SourceDocumentYaml,
+    SemanticIrYaml,
+    OperationMetadataYaml,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -121,7 +121,6 @@ pub(in crate::state::db) enum GuiOnboardingCompletions {
 }
 
 #[derive(Iden)]
-#[expect(dead_code, reason = "source repositories wire these next")]
 pub(in crate::state::db) enum Sources {
     Table,
     WorkspaceId,
@@ -135,7 +134,6 @@ pub(in crate::state::db) enum Sources {
 }
 
 #[derive(Iden)]
-#[expect(dead_code, reason = "source repositories wire these next")]
 pub(in crate::state::db) enum SourceVariables {
     Table,
     WorkspaceId,
@@ -145,7 +143,6 @@ pub(in crate::state::db) enum SourceVariables {
 }
 
 #[derive(Iden)]
-#[expect(dead_code, reason = "source repositories wire these next")]
 pub(in crate::state::db) enum SourceSecretKeys {
     Table,
     WorkspaceId,
@@ -154,7 +151,6 @@ pub(in crate::state::db) enum SourceSecretKeys {
 }
 
 #[derive(Iden)]
-#[expect(dead_code, reason = "source repositories wire these next")]
 pub(in crate::state::db) enum SourceTombstones {
     Table,
     WorkspaceId,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -80,26 +80,14 @@ pub(crate) trait DbRepos: DbSession + Sized {
         WorkspaceMembersRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager wires this next")
-    )]
     fn sources(&mut self) -> SourcesRepo<'_, Self> {
         SourcesRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager wires this next")
-    )]
     fn source_manifests(&mut self) -> SourceManifestsRepo<'_, Self> {
         SourceManifestsRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the source manager wires this next")
-    )]
     fn materializations(&mut self) -> MaterializationsRepo<'_, Self> {
         MaterializationsRepo::new(self)
     }

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -10,6 +10,8 @@ use crate::state::db::repositories::gui_onboarding::GuiOnboardingRepo;
 use crate::state::db::repositories::identity_specs::{
     IdentitySpecDocumentsRepo, IdentitySpecsRepo,
 };
+use crate::state::db::repositories::materializations::MaterializationsRepo;
+use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
 use crate::state::db::repositories::task_queries::TaskQueriesRepo;
@@ -84,6 +86,22 @@ pub(crate) trait DbRepos: DbSession + Sized {
     )]
     fn sources(&mut self) -> SourcesRepo<'_, Self> {
         SourcesRepo::new(self)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager wires this next")
+    )]
+    fn source_manifests(&mut self) -> SourceManifestsRepo<'_, Self> {
+        SourceManifestsRepo::new(self)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager wires this next")
+    )]
+    fn materializations(&mut self) -> MaterializationsRepo<'_, Self> {
+        MaterializationsRepo::new(self)
     }
 
     fn identity_specs(&mut self) -> IdentitySpecsRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -10,6 +10,7 @@ use crate::state::db::repositories::gui_onboarding::GuiOnboardingRepo;
 use crate::state::db::repositories::identity_specs::{
     IdentitySpecDocumentsRepo, IdentitySpecsRepo,
 };
+use crate::state::db::repositories::sources::SourcesRepo;
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
 use crate::state::db::repositories::task_queries::TaskQueriesRepo;
 use crate::state::db::repositories::tasks::TasksRepo;
@@ -75,6 +76,14 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn workspace_members(&mut self) -> WorkspaceMembersRepo<'_, Self> {
         WorkspaceMembersRepo::new(self)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the source manager wires this next")
+    )]
+    fn sources(&mut self) -> SourcesRepo<'_, Self> {
+        SourcesRepo::new(self)
     }
 
     fn identity_specs(&mut self) -> IdentitySpecsRepo<'_, Self> {

--- a/crates/coral-app/src/state/mirror_ledger.rs
+++ b/crates/coral-app/src/state/mirror_ledger.rs
@@ -9,10 +9,6 @@
 //! operator-authored, which means resurrect-and-import for tombstone and update
 //! decisions and set-aside-and-warn for manifest and divergence decisions —
 //! never a silent overwrite of content this host cannot vouch for.
-#![cfg_attr(
-    not(test),
-    expect(dead_code, reason = "the reconciliation passes wire this next")
-)]
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::ErrorKind;
@@ -146,14 +142,35 @@ impl MirrorLedger {
         self.entry_mut(workspace, name).manifest_sha256 = Some(sha256.to_string());
     }
 
-    /// Record that this host already warned about divergent content `sha256`.
+    /// Record that this host already warned about `source` as divergent.
     pub(crate) fn record_divergence_warned(
         &mut self,
         workspace: &WorkspaceName,
         name: &SourceName,
-        sha256: &str,
+        source: &InstalledSource,
     ) {
-        self.entry_mut(workspace, name).divergence_warned_sha256 = Some(sha256.to_string());
+        if let Some(sha256) = canonical_entry_sha256(source) {
+            self.entry_mut(workspace, name).divergence_warned_sha256 = Some(sha256);
+        }
+    }
+
+    /// Whether this host has already warned about exactly this content.
+    ///
+    /// Keyed on content rather than on the name, so an entry that diverges
+    /// again in a new way is warned about again.
+    pub(crate) fn matches_divergence_warning(
+        &self,
+        workspace: &WorkspaceName,
+        name: &SourceName,
+        source: &InstalledSource,
+    ) -> bool {
+        let Some(recorded) = self
+            .entry(workspace, name)
+            .and_then(|entry| entry.divergence_warned_sha256.as_deref())
+        else {
+            return false;
+        };
+        canonical_entry_sha256(source).is_some_and(|current| current == recorded)
     }
 
     /// Forget every record for `name`, on source delete.
@@ -271,6 +288,12 @@ fn ledger_path(config_path: &Path) -> PathBuf {
 ///
 /// `None` means the entry could not be canonicalized, which the callers treat
 /// as "not recorded" — never as a match.
+///
+/// The hash is coupled to [`InstalledSource`]'s serde shape: adding a field to
+/// it changes every hash, so the boot after such a release sees every recorded
+/// entry as locally rewritten and re-imports it from the file world once. That
+/// reclassification is benign — the entries and the rows agree at that point —
+/// and it is the expected cost of not versioning the hash.
 fn canonical_entry_sha256(source: &InstalledSource) -> Option<String> {
     match serde_json::to_vec(source) {
         Ok(canonical) => Some(sha256_hex(&canonical)),
@@ -415,7 +438,7 @@ mod tests {
         ledger.record_workspace(&team);
         ledger.record_entry(&team, &github, &source);
         ledger.record_manifest(&team, &github, "manifest-hash");
-        ledger.record_divergence_warned(&team, &github, "warned-hash");
+        ledger.record_divergence_warned(&team, &github, &installed("linear"));
         ledger.save(&config).expect("save ledger");
 
         let loaded = MirrorLedger::load(&config);
@@ -424,12 +447,7 @@ mod tests {
         assert!(loaded.entry_recorded(&team, &github));
         assert!(loaded.matches_entry(&team, &github, &source));
         assert!(loaded.matches_manifest(&team, &github, "manifest-hash"));
-        assert_eq!(
-            loaded
-                .entry(&team, &github)
-                .and_then(|entry| entry.divergence_warned_sha256.as_deref()),
-            Some("warned-hash")
-        );
+        assert!(loaded.matches_divergence_warning(&team, &github, &installed("linear")));
     }
 
     /// `write_atomic` renames a temp file into place, so a completed save
@@ -459,11 +477,26 @@ mod tests {
         let source = installed("github");
 
         let mut ledger = MirrorLedger::default();
-        ledger.record_divergence_warned(&team, &github, "warned-hash");
+        ledger.record_divergence_warned(&team, &github, &source);
 
+        assert!(ledger.matches_divergence_warning(&team, &github, &source));
         assert!(!ledger.entry_recorded(&team, &github));
         assert!(!ledger.matches_entry(&team, &github, &source));
-        assert!(!ledger.matches_manifest(&team, &github, "warned-hash"));
+    }
+
+    /// The warning is keyed on content, so an entry that diverges again in a
+    /// new way is reported again rather than swallowed by the old note.
+    #[test]
+    fn a_divergence_warning_covers_only_the_content_it_recorded() {
+        let team = workspace("team");
+        let github = source_name("github");
+        let mut source = installed("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_divergence_warned(&team, &github, &source);
+        source.version = Some("9.9.9".to_string());
+
+        assert!(!ledger.matches_divergence_warning(&team, &github, &source));
     }
 
     #[test]

--- a/crates/coral-app/src/state/mirror_ledger.rs
+++ b/crates/coral-app/src/state/mirror_ledger.rs
@@ -1,0 +1,553 @@
+//! Host-local record of what this host has reconciled into its config mirror.
+//!
+//! The ledger lives next to `config.toml` as `config.toml.ledger` and is read
+//! and written only under the state lock, always *after* the write it records.
+//! Old binaries never read it: to them it is an unknown sibling file.
+//!
+//! A crash between a mirror write and its ledger update fails toward the safe
+//! direction by construction. An unrecorded or mismatched record looks
+//! operator-authored, which means resurrect-and-import for tombstone and update
+//! decisions and set-aside-and-warn for manifest and divergence decisions —
+//! never a silent overwrite of content this host cannot vouch for.
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "the reconciliation passes wire this next")
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::bootstrap::AppError;
+use crate::hash::sha256_hex;
+use crate::sources::SourceName;
+use crate::sources::model::InstalledSource;
+use crate::storage::fs as storage_fs;
+use crate::workspaces::WorkspaceName;
+
+/// Ledger schema version. A file written by any other version is discarded
+/// rather than interpreted: a wrong record claims a reconciliation this host
+/// never performed, and an empty ledger only costs a re-import.
+const LEDGER_VERSION: u32 = 1;
+
+/// What this host last reconciled for one source, per artifact.
+///
+/// Every field is independently optional because the three writes happen on
+/// different paths and at different times.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "each field names the artifact its hash covers"
+)]
+pub(crate) struct LedgerEntry {
+    /// Hash of the canonical serialization of the [`InstalledSource`] this host
+    /// last reconciled into its `config.toml`. `None` means this host has never
+    /// reconciled the entry.
+    pub(crate) entry_sha256: Option<String>,
+    /// Hash of the `manifest.yaml` bytes Coral last wrote to this host's file.
+    pub(crate) manifest_sha256: Option<String>,
+    /// Warn-once bookkeeping for an unproven divergent config entry: the hash
+    /// this host last warned about. Never treated as reconciled — it only
+    /// suppresses repeating one warning every boot.
+    pub(crate) divergence_warned_sha256: Option<String>,
+}
+
+/// The host-local ledger for one config directory.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MirrorLedger {
+    workspaces: BTreeSet<WorkspaceName>,
+    sources: BTreeMap<(WorkspaceName, SourceName), LedgerEntry>,
+}
+
+impl MirrorLedger {
+    /// Read the ledger beside `config_path`.
+    ///
+    /// A missing, unreadable, corrupt, or foreign-version file loads as empty.
+    /// This never fails: the ledger is an optimization over the safe default,
+    /// so losing it must never keep the server from booting.
+    pub(crate) fn load(config_path: &Path) -> Self {
+        let path = ledger_path(config_path);
+        let raw = match std::fs::read(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                if error.kind() != ErrorKind::NotFound {
+                    warn!(%error, path = %path.display(), "ignoring unreadable mirror ledger");
+                }
+                return Self::default();
+            }
+        };
+        match serde_json::from_slice::<PersistedLedger>(&raw) {
+            Ok(persisted) if persisted.version == LEDGER_VERSION => Self::from_persisted(persisted),
+            Ok(persisted) => {
+                warn!(
+                    version = persisted.version,
+                    path = %path.display(),
+                    "ignoring mirror ledger written by another schema version"
+                );
+                Self::default()
+            }
+            Err(error) => {
+                warn!(%error, path = %path.display(), "ignoring corrupt mirror ledger");
+                Self::default()
+            }
+        }
+    }
+
+    /// Write the ledger beside `config_path`, atomically.
+    pub(crate) fn save(&self, config_path: &Path) -> Result<(), AppError> {
+        let path = ledger_path(config_path);
+        if let Some(parent) = path.parent() {
+            storage_fs::ensure_dir(parent)?;
+        }
+        let raw = serde_json::to_vec_pretty(&self.to_persisted())?;
+        storage_fs::write_atomic(&path, &raw)?;
+        Ok(())
+    }
+
+    /// Record that this host has reconciled `workspace` with the database.
+    pub(crate) fn record_workspace(&mut self, workspace: &WorkspaceName) {
+        self.workspaces.insert(workspace.clone());
+    }
+
+    /// Whether this host has reconciled `workspace`.
+    pub(crate) fn has_workspace(&self, workspace: &WorkspaceName) -> bool {
+        self.workspaces.contains(workspace)
+    }
+
+    /// Forget `workspace` and every source record it owns, on workspace delete.
+    pub(crate) fn remove_workspace(&mut self, workspace: &WorkspaceName) {
+        self.workspaces.remove(workspace);
+        self.sources
+            .retain(|(entry_workspace, _), _| entry_workspace != workspace);
+    }
+
+    /// Record the config entry this host just mirrored for `name`.
+    pub(crate) fn record_entry(
+        &mut self,
+        workspace: &WorkspaceName,
+        name: &SourceName,
+        source: &InstalledSource,
+    ) {
+        if let Some(sha256) = canonical_entry_sha256(source) {
+            self.entry_mut(workspace, name).entry_sha256 = Some(sha256);
+        }
+    }
+
+    /// Record the `manifest.yaml` bytes this host just wrote for `name`.
+    pub(crate) fn record_manifest(
+        &mut self,
+        workspace: &WorkspaceName,
+        name: &SourceName,
+        sha256: &str,
+    ) {
+        self.entry_mut(workspace, name).manifest_sha256 = Some(sha256.to_string());
+    }
+
+    /// Record that this host already warned about divergent content `sha256`.
+    pub(crate) fn record_divergence_warned(
+        &mut self,
+        workspace: &WorkspaceName,
+        name: &SourceName,
+        sha256: &str,
+    ) {
+        self.entry_mut(workspace, name).divergence_warned_sha256 = Some(sha256.to_string());
+    }
+
+    /// Forget every record for `name`, on source delete.
+    pub(crate) fn remove(&mut self, workspace: &WorkspaceName, name: &SourceName) {
+        self.sources.remove(&(workspace.clone(), name.clone()));
+    }
+
+    /// Whether `source` is byte-for-byte the entry this host last mirrored.
+    pub(crate) fn matches_entry(
+        &self,
+        workspace: &WorkspaceName,
+        name: &SourceName,
+        source: &InstalledSource,
+    ) -> bool {
+        let Some(recorded) = self.entry_sha256(workspace, name) else {
+            return false;
+        };
+        canonical_entry_sha256(source).is_some_and(|current| current == recorded)
+    }
+
+    /// Whether this host has ever reconciled the config entry for `name`.
+    ///
+    /// Keyed on the entry hash alone, so a divergence warning — which records
+    /// content this host explicitly did *not* vouch for — can never answer yes.
+    pub(crate) fn entry_recorded(&self, workspace: &WorkspaceName, name: &SourceName) -> bool {
+        self.entry_sha256(workspace, name).is_some()
+    }
+
+    /// Whether `sha256` is the manifest content this host last wrote.
+    pub(crate) fn matches_manifest(
+        &self,
+        workspace: &WorkspaceName,
+        name: &SourceName,
+        sha256: &str,
+    ) -> bool {
+        self.entry(workspace, name)
+            .and_then(|entry| entry.manifest_sha256.as_deref())
+            == Some(sha256)
+    }
+
+    fn entry(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<&LedgerEntry> {
+        self.sources.get(&(workspace.clone(), name.clone()))
+    }
+
+    fn entry_sha256(&self, workspace: &WorkspaceName, name: &SourceName) -> Option<&str> {
+        self.entry(workspace, name)
+            .and_then(|entry| entry.entry_sha256.as_deref())
+    }
+
+    fn entry_mut(&mut self, workspace: &WorkspaceName, name: &SourceName) -> &mut LedgerEntry {
+        self.sources
+            .entry((workspace.clone(), name.clone()))
+            .or_default()
+    }
+
+    fn to_persisted(&self) -> PersistedLedger {
+        PersistedLedger {
+            version: LEDGER_VERSION,
+            workspaces: self
+                .workspaces
+                .iter()
+                .map(|workspace| workspace.as_str().to_string())
+                .collect(),
+            sources: self
+                .sources
+                .iter()
+                .map(|((workspace, name), entry)| PersistedEntry {
+                    workspace: workspace.as_str().to_string(),
+                    source: name.as_str().to_string(),
+                    entry_sha256: entry.entry_sha256.clone(),
+                    manifest_sha256: entry.manifest_sha256.clone(),
+                    divergence_warned_sha256: entry.divergence_warned_sha256.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    fn from_persisted(persisted: PersistedLedger) -> Self {
+        Self {
+            workspaces: persisted
+                .workspaces
+                .iter()
+                .filter_map(|workspace| WorkspaceName::parse(workspace).ok())
+                .collect(),
+            sources: persisted
+                .sources
+                .into_iter()
+                .filter_map(|entry| {
+                    let workspace = WorkspaceName::parse(&entry.workspace).ok()?;
+                    let name = SourceName::parse(&entry.source).ok()?;
+                    Some((
+                        (workspace, name),
+                        LedgerEntry {
+                            entry_sha256: entry.entry_sha256,
+                            manifest_sha256: entry.manifest_sha256,
+                            divergence_warned_sha256: entry.divergence_warned_sha256,
+                        },
+                    ))
+                })
+                .collect(),
+        }
+    }
+}
+
+/// `config.toml` -> `config.toml.ledger`.
+fn ledger_path(config_path: &Path) -> PathBuf {
+    let mut path = config_path.as_os_str().to_os_string();
+    path.push(".ledger");
+    PathBuf::from(path)
+}
+
+/// Hash the canonical serialization of `source` rather than its rendered
+/// `config.toml` bytes: the mirror re-renders the whole catalog, so formatting
+/// normalization must never make a Coral-written entry look operator-authored.
+///
+/// `None` means the entry could not be canonicalized, which the callers treat
+/// as "not recorded" — never as a match.
+fn canonical_entry_sha256(source: &InstalledSource) -> Option<String> {
+    match serde_json::to_vec(source) {
+        Ok(canonical) => Some(sha256_hex(&canonical)),
+        Err(error) => {
+            warn!(%error, source = %source.name, "could not canonicalize a source for the mirror ledger");
+            None
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedLedger {
+    version: u32,
+    #[serde(default)]
+    workspaces: Vec<String>,
+    #[serde(default)]
+    sources: Vec<PersistedEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedEntry {
+    workspace: String,
+    source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    entry_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manifest_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    divergence_warned_sha256: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use super::{LEDGER_VERSION, MirrorLedger, ledger_path};
+    use crate::credentials::CredentialStorageKind;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::workspaces::WorkspaceName;
+
+    fn config_path(dir: &TempDir) -> std::path::PathBuf {
+        dir.path().join("config.toml")
+    }
+
+    fn workspace(name: &str) -> WorkspaceName {
+        WorkspaceName::parse(name).expect("parse workspace name")
+    }
+
+    fn source_name(name: &str) -> SourceName {
+        SourceName::parse(name).expect("parse source name")
+    }
+
+    fn installed(name: &str) -> InstalledSource {
+        InstalledSource {
+            name: source_name(name),
+            version: Some("1.2.3".to_string()),
+            variables: BTreeMap::from([
+                ("owner".to_string(), "withcoral".to_string()),
+                ("repo".to_string(), "coral".to_string()),
+            ]),
+            secrets: vec!["token".to_string()],
+            credential_storage: Some(CredentialStorageKind::File),
+            credential_revision: Uuid::nil(),
+            origin: SourceOrigin::Imported,
+        }
+    }
+
+    #[test]
+    fn ledger_is_a_sibling_of_the_config_file() {
+        let dir = TempDir::new().expect("temp dir");
+        assert_eq!(
+            ledger_path(&config_path(&dir)),
+            dir.path().join("config.toml.ledger")
+        );
+    }
+
+    #[test]
+    fn a_missing_ledger_loads_as_empty() {
+        let dir = TempDir::new().expect("temp dir");
+        let ledger = MirrorLedger::load(&config_path(&dir));
+
+        assert!(!ledger.has_workspace(&workspace("team")));
+        assert!(!ledger.entry_recorded(&workspace("team"), &source_name("github")));
+    }
+
+    #[test]
+    fn a_corrupt_ledger_loads_as_empty() {
+        let dir = TempDir::new().expect("temp dir");
+        let config = config_path(&dir);
+        std::fs::write(ledger_path(&config), b"{ not json at all").expect("write corrupt ledger");
+
+        let ledger = MirrorLedger::load(&config);
+
+        assert!(!ledger.has_workspace(&workspace("team")));
+        assert!(!ledger.entry_recorded(&workspace("team"), &source_name("github")));
+    }
+
+    /// A ledger from another schema version is discarded rather than read:
+    /// a record we cannot interpret must never claim a reconciliation.
+    #[test]
+    fn a_foreign_version_ledger_loads_as_empty() {
+        let dir = TempDir::new().expect("temp dir");
+        let config = config_path(&dir);
+        let raw = format!(
+            r#"{{"version":{},"workspaces":["team"],"sources":[]}}"#,
+            LEDGER_VERSION + 1
+        );
+        std::fs::write(ledger_path(&config), raw).expect("write foreign ledger");
+
+        assert!(!MirrorLedger::load(&config).has_workspace(&workspace("team")));
+    }
+
+    /// Names that no longer parse are dropped instead of failing the load.
+    #[test]
+    fn unparsable_names_are_skipped_on_load() {
+        let dir = TempDir::new().expect("temp dir");
+        let config = config_path(&dir);
+        let raw = format!(
+            r#"{{"version":{LEDGER_VERSION},"workspaces":["../escape"],"sources":[{{"workspace":"team","source":"../escape","entry_sha256":"abc"}}]}}"#
+        );
+        std::fs::write(ledger_path(&config), raw).expect("write ledger");
+
+        let ledger = MirrorLedger::load(&config);
+
+        assert!(!ledger.has_workspace(&workspace("team")));
+        assert!(!ledger.entry_recorded(&workspace("team"), &source_name("github")));
+    }
+
+    #[test]
+    fn save_and_load_round_trip_workspaces_and_every_hash() {
+        let dir = TempDir::new().expect("temp dir");
+        let config = config_path(&dir);
+        let team = workspace("team");
+        let github = source_name("github");
+        let source = installed("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_workspace(&team);
+        ledger.record_entry(&team, &github, &source);
+        ledger.record_manifest(&team, &github, "manifest-hash");
+        ledger.record_divergence_warned(&team, &github, "warned-hash");
+        ledger.save(&config).expect("save ledger");
+
+        let loaded = MirrorLedger::load(&config);
+
+        assert!(loaded.has_workspace(&team));
+        assert!(loaded.entry_recorded(&team, &github));
+        assert!(loaded.matches_entry(&team, &github, &source));
+        assert!(loaded.matches_manifest(&team, &github, "manifest-hash"));
+        assert_eq!(
+            loaded
+                .entry(&team, &github)
+                .and_then(|entry| entry.divergence_warned_sha256.as_deref()),
+            Some("warned-hash")
+        );
+    }
+
+    /// `write_atomic` renames a temp file into place, so a completed save
+    /// leaves the ledger and nothing else behind.
+    #[test]
+    fn save_leaves_no_partial_file_behind() {
+        let dir = TempDir::new().expect("temp dir");
+        let config = config_path(&dir);
+        let mut ledger = MirrorLedger::default();
+        ledger.record_workspace(&workspace("team"));
+        ledger.save(&config).expect("save ledger");
+
+        let written: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read temp dir")
+            .map(|entry| entry.expect("dir entry").file_name())
+            .collect();
+
+        assert_eq!(written, vec!["config.toml.ledger"]);
+    }
+
+    /// The record means "this exact content was reconciled here"; a warn-once
+    /// note records content this host explicitly did not vouch for.
+    #[test]
+    fn a_divergence_warning_alone_never_reads_as_reconciled() {
+        let team = workspace("team");
+        let github = source_name("github");
+        let source = installed("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_divergence_warned(&team, &github, "warned-hash");
+
+        assert!(!ledger.entry_recorded(&team, &github));
+        assert!(!ledger.matches_entry(&team, &github, &source));
+        assert!(!ledger.matches_manifest(&team, &github, "warned-hash"));
+    }
+
+    #[test]
+    fn a_changed_entry_no_longer_matches_but_stays_recorded() {
+        let team = workspace("team");
+        let github = source_name("github");
+        let mut source = installed("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_entry(&team, &github, &source);
+        assert!(ledger.matches_entry(&team, &github, &source));
+
+        source.version = Some("9.9.9".to_string());
+
+        assert!(!ledger.matches_entry(&team, &github, &source));
+        assert!(ledger.entry_recorded(&team, &github));
+    }
+
+    /// The hash covers the canonical value, not rendered file bytes, so an
+    /// entry rebuilt in a different order still matches.
+    #[test]
+    fn entry_hashing_is_insensitive_to_construction_order() {
+        let team = workspace("team");
+        let github = source_name("github");
+        let mut source = installed("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_entry(&team, &github, &source);
+
+        source.variables = BTreeMap::from([
+            ("repo".to_string(), "coral".to_string()),
+            ("owner".to_string(), "withcoral".to_string()),
+        ]);
+
+        assert!(ledger.matches_entry(&team, &github, &source));
+    }
+
+    #[test]
+    fn matches_manifest_is_keyed_on_the_recorded_bytes() {
+        let team = workspace("team");
+        let github = source_name("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_manifest(&team, &github, "manifest-hash");
+
+        assert!(ledger.matches_manifest(&team, &github, "manifest-hash"));
+        assert!(!ledger.matches_manifest(&team, &github, "other-hash"));
+        assert!(!ledger.matches_manifest(&team, &source_name("linear"), "manifest-hash"));
+    }
+
+    #[test]
+    fn remove_drops_one_sources_records() {
+        let team = workspace("team");
+        let github = source_name("github");
+        let linear = source_name("linear");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_entry(&team, &github, &installed("github"));
+        ledger.record_entry(&team, &linear, &installed("linear"));
+        ledger.remove(&team, &github);
+
+        assert!(!ledger.entry_recorded(&team, &github));
+        assert!(ledger.entry_recorded(&team, &linear));
+    }
+
+    #[test]
+    fn remove_workspace_drops_the_workspace_and_its_source_entries() {
+        let team = workspace("team");
+        let other = workspace("other");
+        let github = source_name("github");
+
+        let mut ledger = MirrorLedger::default();
+        ledger.record_workspace(&team);
+        ledger.record_workspace(&other);
+        ledger.record_entry(&team, &github, &installed("github"));
+        ledger.record_manifest(&team, &github, "manifest-hash");
+        ledger.record_entry(&other, &github, &installed("github"));
+
+        ledger.remove_workspace(&team);
+
+        assert!(!ledger.has_workspace(&team));
+        assert!(!ledger.entry_recorded(&team, &github));
+        assert!(!ledger.matches_manifest(&team, &github, "manifest-hash"));
+        assert!(ledger.has_workspace(&other));
+        assert!(ledger.entry_recorded(&other, &github));
+    }
+}

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -3,6 +3,7 @@
 mod config;
 pub(crate) mod db;
 mod layout;
+pub(crate) mod mirror_ledger;
 
 pub(crate) use config::{AppConfig, ConfigStore, RemovedWorkspaceConfig};
 pub(crate) use config::{

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -947,8 +947,9 @@ mod tests {
         );
         assert_eq!(
             store
-                .list_workspace_sources(&workspace_name)
-                .expect("list workspace sources")
+                .load_catalog_unlocked()
+                .expect("load mirrored catalog")
+                .workspace_sources(&workspace_name)
                 .into_iter()
                 .map(|source| source.name)
                 .collect::<Vec<_>>(),
@@ -1362,8 +1363,9 @@ mod tests {
         assert_eq!(deleted.name, workspace_name);
         assert!(
             store
-                .list_workspace_sources(&workspace_name)
-                .expect("list source definitions")
+                .load_catalog_unlocked()
+                .expect("load mirrored catalog")
+                .workspace_sources(&workspace_name)
                 .is_empty()
         );
         assert!(

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -11,6 +11,7 @@ use crate::state::db::{
     AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbError, DbRepos, RemoveMemberOutcome,
     WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
 };
+use crate::state::mirror_ledger::MirrorLedger;
 use crate::state::{ConfigStore, RemovedWorkspaceConfig};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
@@ -170,6 +171,16 @@ impl WorkspaceManager {
             })?;
 
         let (deleted, workspace_dir_backup) = {
+            // The state lock comes before the transaction, which is the order
+            // every source lifecycle write takes: it locks state and then
+            // writes the database. Opening the transaction first and only then
+            // waiting for the lock — where the config removal below used to
+            // take it — inverts that order and closes a cycle. A source
+            // install in another workspace holds the state lock and blocks on
+            // SQLite's writer lock, which this transaction is holding, while
+            // this deletion blocks on the state lock the install is holding;
+            // neither moves until the busy timeout fails the install.
+            let state_lock = self.config_store.state_lock_exclusive()?;
             let Some(deletion) = self
                 .db
                 .begin_workspace_deletion(workspace_name.as_str())
@@ -179,7 +190,7 @@ impl WorkspaceManager {
             };
             let removed = match self
                 .config_store
-                .remove_workspace_config_entries(workspace_name)
+                .remove_workspace_config_entries_unlocked(workspace_name)
             {
                 Ok(removed) => removed,
                 Err(error) => {
@@ -192,7 +203,9 @@ impl WorkspaceManager {
                 // the catalog while its config entries are already gone. The
                 // removal is durable and carries everything it took away, so
                 // put it back rather than leave the two disagreeing.
-                if let Err(restore_error) = self.restore_workspace_config_entries(removed) {
+                if let Err(restore_error) =
+                    self.restore_workspace_config_entries_with_state_lock_held(removed)
+                {
                     // Both halves failed, which is the split this restore
                     // exists to prevent. Report it instead of the commit
                     // failure alone, so the caller knows the deployment needs
@@ -206,6 +219,14 @@ impl WorkspaceManager {
                 }
                 return Err(commit_error.into());
             }
+            // The transaction is over, so the lock has nothing left to order
+            // against it. The steps below take it again one at a time, the way
+            // they did before it was hoisted above the transaction.
+            drop(state_lock);
+            // The commit is durable and the config entries are gone with it, so
+            // this host's record of what it had mirrored is now describing a
+            // workspace that no longer exists.
+            self.forget_workspace_in_ledger(workspace_name);
             let deleted = removed.map_or_else(
                 || DeletedWorkspace {
                     workspace: WorkspaceRecord {
@@ -238,6 +259,41 @@ impl WorkspaceManager {
         self.prune_deleted_workspace_traces(&deleted_workspace_name)
             .await;
         Ok(deleted.workspace)
+    }
+
+    /// Drops this host's ledger records for a workspace it just deleted.
+    ///
+    /// Holds the state lock across the load-modify-save, because that is the
+    /// ledger's contract: a concurrent source install — in this process or in
+    /// another one sharing the config directory — records its own entry under
+    /// the same lock, and an unlocked read-modify-write here would drop that
+    /// record on the floor, leaving Coral's own mirror write looking
+    /// operator-authored at the next boot.
+    ///
+    /// Best effort, like every other recovery here: a ledger that keeps stale
+    /// records makes a later boot treat mirrored content as unproven, which
+    /// preserves it and warns rather than acting on it.
+    fn forget_workspace_in_ledger(&self, workspace_name: &WorkspaceName) {
+        let _state_lock = match self.config_store.state_lock_exclusive() {
+            Ok(lock) => lock,
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    "workspace deleted, but failed to lock app state to drop it from the mirror \
+                     ledger: {error}"
+                );
+                return;
+            }
+        };
+        let config_path = self.config_store.config_file();
+        let mut ledger = MirrorLedger::load(config_path);
+        ledger.remove_workspace(workspace_name);
+        if let Err(error) = ledger.save(config_path) {
+            warn!(
+                workspace = %workspace_name,
+                "workspace deleted, but failed to drop it from the mirror ledger: {error}"
+            );
+        }
     }
 
     /// Erases the credential material of a workspace that has just been deleted.
@@ -323,7 +379,10 @@ impl WorkspaceManager {
     /// the database holding a workspace whose sources and functions are gone
     /// from the file, and a caller that only hears about the step which
     /// triggered the abort would never learn the two now disagree.
-    fn restore_workspace_config_entries(
+    ///
+    /// Runs under the state lock the deletion already holds, alongside the
+    /// removal it undoes.
+    fn restore_workspace_config_entries_with_state_lock_held(
         &self,
         removed: Option<RemovedWorkspaceConfig>,
     ) -> Result<(), AppError> {
@@ -336,7 +395,8 @@ impl WorkspaceManager {
                 "workspace config restore failed for tests".to_string(),
             ));
         }
-        self.config_store.restore_workspace_config_entries(removed)
+        self.config_store
+            .restore_workspace_config_entries_unlocked(removed)
     }
 
     fn stage_deleted_workspace_dir(
@@ -621,6 +681,7 @@ mod tests {
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbRepos, LoginIdentity, LoginProvisioning, ResolvedDatabaseConfig,
     };
+    use crate::state::mirror_ledger::MirrorLedger;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{
         MemberRole, WorkspaceMember, WorkspaceMembership, WorkspaceName, WorkspacePoolRegistry,
@@ -1230,6 +1291,54 @@ mod tests {
             &pool_registry_before_delete,
             &pool_registry_after_delete
         ));
+    }
+
+    #[tokio::test]
+    async fn delete_workspace_drops_this_hosts_ledger_records() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let db = test_db(&layout).await;
+        let manager = WorkspaceManager::new(
+            store,
+            credential_manager,
+            layout.clone(),
+            None,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+            Arc::clone(&db),
+            SourceDiagnosticReporter::default(),
+        );
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+        let kept = WorkspaceName::parse("kept").expect("workspace");
+        let source = installed_source("github");
+        let owner = seed_user(&db, "owner").await;
+        manager
+            .create_workspace_for_user(&workspace_name, &owner)
+            .await
+            .expect("create workspace");
+        let mut ledger = MirrorLedger::load(layout.config_file());
+        ledger.record_workspace(&workspace_name);
+        ledger.record_entry(&workspace_name, &source.name, &source);
+        ledger.record_workspace(&kept);
+        ledger.record_entry(&kept, &source.name, &source);
+        ledger.save(layout.config_file()).expect("save ledger");
+
+        manager
+            .delete_workspace(&workspace_name)
+            .await
+            .expect("delete workspace");
+
+        let ledger = MirrorLedger::load(layout.config_file());
+        assert!(!ledger.has_workspace(&workspace_name));
+        assert!(
+            !ledger.entry_recorded(&workspace_name, &source.name),
+            "a deleted workspace must leave no source records behind"
+        );
+        assert!(
+            ledger.has_workspace(&kept) && ledger.entry_recorded(&kept, &source.name),
+            "deleting one workspace must not disturb another's records"
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -7,6 +7,7 @@ use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::identity::Principal;
 use crate::sources::materialization::SourceDiagnosticReporter;
+use crate::sources::model::InstalledSource;
 use crate::state::db::{
     AddMemberOutcome, CoralDb, CreateWorkspaceOutcome, DbError, DbRepos, RemoveMemberOutcome,
     WorkspaceDeletion, WorkspaceMemberRecord, now_unix_nanos_i64,
@@ -92,7 +93,6 @@ impl WorkspaceManager {
     /// Lends the workspace database to sibling app code that needs the same
     /// handle, so callers share this manager's database rather than opening or
     /// threading a second one.
-    #[expect(dead_code, reason = "the query manager reads through this next")]
     pub(crate) fn database(&self) -> &Arc<CoralDb> {
         &self.db
     }
@@ -181,6 +181,16 @@ impl WorkspaceManager {
             // this deletion blocks on the state lock the install is holding;
             // neither moves until the busy timeout fails the install.
             let state_lock = self.config_store.state_lock_exclusive()?;
+            // Read the catalog before the deletion cascades its rows away:
+            // they are what the credential and artifact cleanup below works
+            // from.
+            let catalog_sources = {
+                let mut session = self.db.as_ref();
+                session
+                    .sources()
+                    .list_workspace_sources(workspace_name)
+                    .await?
+            };
             let Some(deletion) = self
                 .db
                 .begin_workspace_deletion(workspace_name.as_str())
@@ -227,7 +237,7 @@ impl WorkspaceManager {
             // this host's record of what it had mirrored is now describing a
             // workspace that no longer exists.
             self.forget_workspace_in_ledger(workspace_name);
-            let deleted = removed.map_or_else(
+            let mut deleted = removed.map_or_else(
                 || DeletedWorkspace {
                     workspace: WorkspaceRecord {
                         name: workspace_name.clone(),
@@ -236,6 +246,7 @@ impl WorkspaceManager {
                 },
                 RemovedWorkspaceConfig::into_deleted_workspace,
             );
+            deleted.sources = deleted_workspace_sources(catalog_sources, deleted.sources);
             self.pool_registry.remove(workspace_name);
             self.remove_deleted_workspace_credentials(&deleted);
             // Staging comes last, and failing to move the directory only
@@ -454,6 +465,25 @@ impl WorkspaceManager {
             );
         }
     }
+}
+
+/// The sources a deleted workspace's cleanup has to cover.
+///
+/// The catalog rows are authoritative, but a source an older binary added has
+/// a config entry and no row of its own until the next boot imports it. Its
+/// credentials and artifacts still have to be erased, so the config entries
+/// fill in whatever the catalog does not name.
+fn deleted_workspace_sources(
+    catalog_sources: Vec<InstalledSource>,
+    config_entries: Vec<InstalledSource>,
+) -> Vec<InstalledSource> {
+    let mut sources = catalog_sources;
+    for entry in config_entries {
+        if !sources.iter().any(|source| source.name == entry.name) {
+            sources.push(entry);
+        }
+    }
+    sources
 }
 
 /// The creator-owned workspace and membership seam.
@@ -1195,6 +1225,77 @@ mod tests {
                 .expect("read the directory row")
                 .is_some(),
             "deleting a workspace must not delete its members' directory rows"
+        );
+    }
+
+    /// A source the catalog holds and the config mirror does not still has to
+    /// lose its credentials when its workspace goes, and its rows have to go
+    /// with the workspace.
+    #[tokio::test]
+    async fn delete_workspace_cleans_credentials_of_a_catalog_only_source() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let db = test_db(&layout).await;
+        let manager = WorkspaceManager::new(
+            store,
+            credential_manager.clone(),
+            layout,
+            None,
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+            Arc::clone(&db),
+            SourceDiagnosticReporter::default(),
+        );
+        let workspace_name = WorkspaceName::parse("work").expect("workspace");
+        let owner = seed_user(&db, "owner").await;
+        manager
+            .create_workspace_for_user(&workspace_name, &owner)
+            .await
+            .expect("create workspace");
+        let mut source = installed_source("github");
+        source.credential_storage = Some(crate::credentials::CredentialStorageKind::File);
+        let credential_set_id = CredentialSetId::for_source(&source.name);
+        let mut tx = db.begin().await.expect("begin source seed");
+        tx.sources()
+            .upsert_source(&workspace_name, &source, 1)
+            .await
+            .expect("seed catalog row");
+        tx.commit().await.expect("commit source seed");
+        credential_manager
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                crate::credentials::CredentialStorageKind::File,
+                &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+            )
+            .expect("write credential material");
+
+        manager
+            .delete_workspace(&workspace_name)
+            .await
+            .expect("delete workspace");
+
+        let material = credential_manager
+            .read_material(
+                &workspace_name,
+                &credential_set_id,
+                crate::credentials::CredentialStorageKind::File,
+            )
+            .expect("read credential material");
+        assert!(
+            material.is_empty(),
+            "a catalog-only source must still have its credentials erased"
+        );
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .sources()
+                .list_workspace_sources(&workspace_name)
+                .await
+                .expect("list catalog rows")
+                .is_empty(),
+            "deleting the workspace must cascade its source rows"
         );
     }
 

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -88,6 +88,14 @@ impl WorkspaceManager {
         self
     }
 
+    /// Lends the workspace database to sibling app code that needs the same
+    /// handle, so callers share this manager's database rather than opening or
+    /// threading a second one.
+    #[expect(dead_code, reason = "the query manager reads through this next")]
+    pub(crate) fn database(&self) -> &Arc<CoralDb> {
+        &self.db
+    }
+
     #[cfg(test)]
     pub(crate) const fn with_failing_deletion_commit(mut self) -> Self {
         self.deletion_commit_fails = true;

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -270,6 +270,140 @@ impl GrpcHarness {
         )
         .expect("query rows")
     }
+
+    /// Everything the source catalog holds for one source of the default
+    /// workspace, or `None` when it holds no row for that name.
+    pub(crate) async fn catalog_entry(&self, source_name: &str) -> Option<CatalogEntry> {
+        let workspace = default_workspace().name;
+        let pool = open_app_database(&self.config_dir).await;
+        let source = sqlx::query_as::<_, (Option<String>, String, Option<String>)>(
+            "SELECT version, origin_kind, credential_storage FROM sources \
+             WHERE workspace_id = ? AND name = ?",
+        )
+        .bind(&workspace)
+        .bind(source_name)
+        .fetch_optional(&pool)
+        .await
+        .expect("read the catalog row");
+        let entry = match source {
+            Some((version, origin_kind, credential_storage)) => Some(CatalogEntry {
+                version,
+                origin_kind,
+                credential_storage,
+                variables: sqlx::query_as::<_, (String, String)>(
+                    "SELECT key, value FROM source_variables \
+                     WHERE workspace_id = ? AND source_name = ? ORDER BY key",
+                )
+                .bind(&workspace)
+                .bind(source_name)
+                .fetch_all(&pool)
+                .await
+                .expect("read the catalog variables"),
+                secret_keys: sqlx::query_scalar::<_, String>(
+                    "SELECT key FROM source_secret_keys \
+                     WHERE workspace_id = ? AND source_name = ? ORDER BY key",
+                )
+                .bind(&workspace)
+                .bind(source_name)
+                .fetch_all(&pool)
+                .await
+                .expect("read the catalog secret keys"),
+                manifest_yaml: sqlx::query_scalar::<_, String>(
+                    "SELECT manifest_yaml FROM source_manifests \
+                     WHERE workspace_id = ? AND source_name = ?",
+                )
+                .bind(&workspace)
+                .bind(source_name)
+                .fetch_optional(&pool)
+                .await
+                .expect("read the stored manifest"),
+            }),
+            None => None,
+        };
+        pool.close().await;
+        entry
+    }
+
+    /// The source names the artifact tables still hold rows for, whether or not
+    /// the catalog still lists those sources. A deletion that leaves a name
+    /// here left an artifact orphaned.
+    pub(crate) async fn artifact_source_names(&self) -> Vec<String> {
+        let pool = open_app_database(&self.config_dir).await;
+        let names = sqlx::query_scalar::<_, String>(
+            "SELECT source_name FROM source_manifests \
+             UNION SELECT source_name FROM materializations ORDER BY source_name",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("read the artifact rows");
+        pool.close().await;
+        names
+    }
+
+    /// The sources this deployment recorded a deletion for.
+    pub(crate) async fn tombstoned_sources(&self) -> Vec<String> {
+        let pool = open_app_database(&self.config_dir).await;
+        let names = sqlx::query_scalar::<_, String>(
+            "SELECT source_name FROM source_tombstones ORDER BY source_name",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("read the deletion records");
+        pool.close().await;
+        names
+    }
+
+    /// Rewrites one configured variable in the catalog behind the running
+    /// server's back, leaving `config.toml` and the installed files alone.
+    ///
+    /// Nothing an operator does produces this state; it is how a test tells a
+    /// database-backed read apart from one still served by the config mirror,
+    /// which would keep reporting the value the import wrote. The version is
+    /// not usable for this: listings repopulate it from the manifest file.
+    pub(crate) async fn rewrite_catalog_variable(&self, source_name: &str, key: &str, value: &str) {
+        let pool = open_app_database(&self.config_dir).await;
+        let updated = sqlx::query(
+            "UPDATE source_variables SET value = ? \
+             WHERE workspace_id = ? AND source_name = ? AND key = ?",
+        )
+        .bind(value)
+        .bind(default_workspace().name)
+        .bind(source_name)
+        .bind(key)
+        .execute(&pool)
+        .await
+        .expect("rewrite the catalog variable")
+        .rows_affected();
+        pool.close().await;
+        assert_eq!(updated, 1, "{source_name} should configure {key} once");
+    }
+
+    /// Drops one catalog row behind the running server's back, the way a peer
+    /// host's deletion reaches a database this server never re-read.
+    pub(crate) async fn forget_catalog_row(&self, source_name: &str) {
+        let pool = open_app_database(&self.config_dir).await;
+        let removed = sqlx::query("DELETE FROM sources WHERE workspace_id = ? AND name = ?")
+            .bind(default_workspace().name)
+            .bind(source_name)
+            .execute(&pool)
+            .await
+            .expect("drop the catalog row")
+            .rows_affected();
+        pool.close().await;
+        assert_eq!(removed, 1, "{source_name} should have one catalog row");
+    }
+}
+
+/// What the source catalog holds for one installed source, across the parent
+/// row, its two child sets, and its stored manifest.
+#[derive(Debug)]
+pub(crate) struct CatalogEntry {
+    pub(crate) version: Option<String>,
+    pub(crate) origin_kind: String,
+    pub(crate) credential_storage: Option<String>,
+    pub(crate) variables: Vec<(String, String)>,
+    pub(crate) secret_keys: Vec<String>,
+    pub(crate) manifest_yaml: Option<String>,
 }
 
 /// The configuration an unauthenticated deployment reads: no `[auth]` at all,
@@ -808,13 +942,19 @@ impl SharedDeployment {
     }
 
     async fn app_database(&self) -> sqlx::SqlitePool {
-        SqlitePoolOptions::new()
-            .connect_with(
-                SqliteConnectOptions::new().filename(self.install.config_dir().join("coral.db")),
-            )
-            .await
-            .expect("open the app database")
+        open_app_database(self.install.config_dir()).await
     }
+}
+
+/// Opens the `SQLite` database an install persists its app state in.
+///
+/// Tests read it to see what a deployment actually recorded, rather than only
+/// what an RPC chose to report back.
+async fn open_app_database(config_dir: &Path) -> sqlx::SqlitePool {
+    SqlitePoolOptions::new()
+        .connect_with(SqliteConnectOptions::new().filename(config_dir.join("coral.db")))
+        .await
+        .expect("open the app database")
 }
 
 fn span_names_workspace(line: &str, workspace_name: &str) -> bool {

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -599,6 +599,106 @@ SECOND_TOKEN=expired-secondary-token
     );
 }
 
+#[tokio::test]
+async fn refresh_persists_against_the_catalog_row_the_source_was_reimported_into() {
+    let fixture = RefreshingHttpFixture::new().await;
+    let harness = GrpcHarness::with_workspace().await;
+    let manifest_yaml = oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url);
+    let variables = vec![SourceVariable {
+        key: "API_BASE".to_string(),
+        value: fixture.base_url.clone(),
+    }];
+    let secrets = vec![SourceSecret {
+        key: "API_TOKEN".to_string(),
+        value: "expired-token".to_string(),
+    }];
+    harness
+        .import_source(manifest_yaml.clone(), variables.clone(), secrets.clone())
+        .await;
+    harness
+        .import_source(manifest_yaml.replace("0.1.0", "0.2.0"), variables, secrets)
+        .await;
+    assert_eq!(
+        harness
+            .catalog_entry("refreshed_messages")
+            .await
+            .expect("the re-import should leave a catalog row")
+            .version
+            .as_deref(),
+        Some("0.2.0"),
+        "the re-import should have rewritten the row the refresh matches itself against"
+    );
+
+    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
+    seed_expired_api_token_material(
+        &secret_path,
+        &fixture.token_url,
+        Some("stored-refresh-token"),
+    );
+
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(fixture.token_forms().len(), 1);
+    // Persisting is what proves the check read the current row: a refresh whose
+    // snapshot no longer matches the catalog refreshes in memory and keeps its
+    // rotated token to itself.
+    let material = fs::read_to_string(secret_path).expect("read refreshed material");
+    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    assert!(
+        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
+        "{material}"
+    );
+}
+
+#[tokio::test]
+async fn a_source_the_catalog_forgot_never_reaches_its_token_endpoint() {
+    let fixture = RefreshingHttpFixture::new().await;
+    let harness = GrpcHarness::with_workspace().await;
+    harness
+        .import_source(
+            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: fixture.base_url.clone(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "expired-token".to_string(),
+            }],
+        )
+        .await;
+    seed_expired_api_token_material(
+        &source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env"),
+        &fixture.token_url,
+        Some("stored-refresh-token"),
+    );
+
+    harness.forget_catalog_row("refreshed_messages").await;
+
+    let status = harness
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT id FROM refreshed_messages.messages".to_string(),
+            guide_read_context: None,
+            task_attribution: None,
+        }))
+        .await
+        .expect_err("a source the catalog does not hold has no tables to query");
+    assert_eq!(status.code(), Code::NotFound);
+    assert!(
+        status.message().contains("refreshed_messages"),
+        "{status:?}"
+    );
+    assert!(
+        fixture.token_forms().is_empty(),
+        "credential refresh follows the catalog, not the files a deletion left behind"
+    );
+}
+
 fn seed_expired_api_token_material(
     secret_path: &Path,
     token_url: &str,

--- a/crates/coral-app/tests/grpc/ownership_migration_tests.rs
+++ b/crates/coral-app/tests/grpc/ownership_migration_tests.rs
@@ -13,11 +13,12 @@ use std::path::Path;
 
 use coral_api::v1::{ListSourcesRequest, WorkspaceRole};
 use coral_client::AppClient;
+use serde_json::json;
 use tonic::{Code, Request};
 
 use crate::harness::{
-    Admission, Install, concealed_refusal, create_workspace, execute_sql, membership_rows,
-    named_workspace,
+    Admission, Install, concealed_refusal, create_workspace, execute_sql, manifest_yaml,
+    membership_rows, named_workspace,
 };
 
 /// The user id the upgrade writes its ownership under.
@@ -49,6 +50,41 @@ version = "0.1.0"
 fn write_legacy_config(config_dir: &Path, config: &str) {
     std::fs::create_dir_all(config_dir).expect("create config dir");
     std::fs::write(config_dir.join("config.toml"), config).expect("write legacy config");
+}
+
+/// Writes the installed manifest that goes with a legacy config entry.
+///
+/// An imported source is a directory of files, not a catalog entry alone: the
+/// boot import reads the manifest to bring the source across, and deliberately
+/// skips one it cannot read rather than importing it half-formed. A fixture
+/// that wrote only the entry would describe an install that never existed.
+fn write_legacy_source(config_dir: &Path, workspace: &str, source: &str) {
+    let source_dir = config_dir
+        .join("workspaces")
+        .join(workspace)
+        .join("sources")
+        .join(source);
+    std::fs::create_dir_all(&source_dir).expect("create legacy source dir");
+    let manifest = manifest_yaml(&json!({
+        "name": source,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": "https://legacy.example.com",
+        "tables": [{
+            "name": "messages",
+            "description": "Legacy messages",
+            "request": {
+                "method": "GET",
+                "path": "/messages",
+            },
+            "response": {},
+            "columns": [
+                {"name": "id", "type": "Utf8"},
+            ],
+        }],
+    }));
+    std::fs::write(source_dir.join("manifest.yaml"), manifest).expect("write legacy manifest");
 }
 
 fn legacy_config_naming(workspaces: &[&str]) -> String {
@@ -114,6 +150,7 @@ async fn listed_memberships(client: &AppClient) -> Vec<(String, WorkspaceRole)> 
 async fn a_single_user_upgrade_adopts_every_legacy_workspace_once_and_keeps_its_name_and_data() {
     let install = Install::new();
     write_legacy_config(install.config_dir(), LEGACY_CONFIG_WITH_DATA);
+    write_legacy_source(install.config_dir(), "analytics", "legacy_messages");
 
     let deployment = install
         .start(Admission::LocalPrincipal)

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -1569,3 +1569,201 @@ origin = "imported"
         "newly added source should be in config"
     );
 }
+
+#[tokio::test]
+async fn import_source_writes_its_catalog_row_and_manifest() {
+    let harness = GrpcHarness::with_workspace().await;
+    let manifest_yaml = fixture_manifest_with_inputs_yaml();
+
+    harness
+        .import_source(
+            manifest_yaml.clone(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+
+    let entry = harness
+        .catalog_entry("secured_messages")
+        .await
+        .expect("the import should leave a catalog row");
+    assert_eq!(entry.version.as_deref(), Some("0.1.0"));
+    assert_eq!(entry.origin_kind, "imported");
+    assert_eq!(entry.credential_storage.as_deref(), Some("file"));
+    assert_eq!(
+        entry.variables,
+        vec![("API_BASE".to_string(), "https://example.com".to_string())]
+    );
+    // Only the key: the secret's value belongs to the credential store the
+    // `credential_storage` route names, never to the catalog.
+    assert_eq!(entry.secret_keys, vec!["API_TOKEN".to_string()]);
+    assert_eq!(entry.manifest_yaml.as_deref(), Some(manifest_yaml.as_str()));
+    assert!(harness.tombstoned_sources().await.is_empty());
+}
+
+#[tokio::test]
+async fn installed_sources_are_listed_from_their_catalog_row() {
+    let harness = GrpcHarness::with_workspace().await;
+    harness
+        .import_source(
+            fixture_manifest_with_inputs_yaml(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+
+    harness
+        .rewrite_catalog_variable("secured_messages", "API_BASE", "https://rewritten.example")
+        .await;
+
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].variables[0].value, "https://rewritten.example");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get source")
+        .into_inner()
+        .source
+        .expect("get source response");
+    assert_eq!(fetched.variables[0].value, "https://rewritten.example");
+
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(
+        config_raw.contains("https://example.com"),
+        "the config mirror still holds the imported value: {config_raw}"
+    );
+}
+
+#[tokio::test]
+async fn a_source_the_catalog_no_longer_holds_is_not_installed() {
+    let harness = GrpcHarness::with_workspace().await;
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    harness.forget_catalog_row("local_messages").await;
+
+    assert!(harness.list_sources().await.is_empty());
+    for error in [
+        harness
+            .source_client()
+            .get_source(Request::new(GetSourceRequest {
+                workspace: Some(default_workspace()),
+                name: "local_messages".to_string(),
+            }))
+            .await
+            .expect_err("get should not answer for a forgotten source"),
+        harness
+            .source_client()
+            .get_source_info(Request::new(GetSourceInfoRequest {
+                workspace: Some(default_workspace()),
+                name: "local_messages".to_string(),
+            }))
+            .await
+            .expect_err("info should not answer for a forgotten source"),
+    ] {
+        assert_eq!(error.code(), tonic::Code::NotFound);
+    }
+
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(
+        config_raw.contains("[workspaces.default.sources.local_messages]"),
+        "the config mirror is untouched, so the listing came from the catalog: {config_raw}"
+    );
+}
+
+#[tokio::test]
+async fn delete_source_clears_its_catalog_rows_and_records_a_tombstone() {
+    let harness = GrpcHarness::with_workspace().await;
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(
+        harness.artifact_source_names().await,
+        vec!["local_messages".to_string()]
+    );
+
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect("delete source");
+
+    assert!(harness.catalog_entry("local_messages").await.is_none());
+    assert!(
+        harness.artifact_source_names().await.is_empty(),
+        "deleting a source should take its artifact rows with it"
+    );
+    assert_eq!(
+        harness.tombstoned_sources().await,
+        vec!["local_messages".to_string()],
+        "the deletion is recorded so a peer host does not re-add it"
+    );
+}
+
+#[tokio::test]
+async fn reimporting_a_deleted_source_clears_its_tombstone() {
+    let harness = GrpcHarness::with_workspace().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml.clone(), Vec::new(), Vec::new())
+        .await;
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect("delete source");
+    assert_eq!(harness.tombstoned_sources().await.len(), 1);
+
+    harness
+        .import_source(
+            manifest_yaml.replace("0.1.0", "0.2.0"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let entry = harness
+        .catalog_entry("local_messages")
+        .await
+        .expect("the re-import should leave a catalog row");
+    assert_eq!(entry.version.as_deref(), Some("0.2.0"));
+    assert!(
+        harness.tombstoned_sources().await.is_empty(),
+        "re-adding a source revokes the earlier deletion"
+    );
+}

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -249,6 +249,217 @@ async fn assert_workspace_deletion_cascades_tombstones(pool: &PgPool) {
     );
 }
 
+/// Pins the source artifact tables against the schema a real Postgres-configured
+/// boot leaves behind.
+///
+/// `SourceManifestsRepo` and `MaterializationsRepo` are covered in-crate against
+/// both backends over a pool the harness migrates itself. What is asserted here
+/// is what only Postgres can answer: that `source_document_raw` is a real
+/// `bytea` and returns the bytes it was given rather than a text round trip,
+/// that the two optional artifact columns are the only nullable ones, and that
+/// removing a source — or the workspace above it — takes its artifacts with it.
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the source artifact write contract"]
+async fn source_artifacts_hold_their_write_contract_after_a_postgres_boot() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let server = ServerBuilder::new()
+        .with_config_dir(postgres_config_dir(&temp))
+        .start()
+        .await
+        .expect("start server with Postgres config");
+    let pool = PgPoolOptions::new()
+        .connect(&database_url)
+        .await
+        .expect("open Postgres database");
+
+    assert_manifest_round_trips_and_replaces_in_place(&pool).await;
+    assert_materialization_keeps_the_raw_document_byte_for_byte(&pool).await;
+    assert_optional_artifacts_are_the_only_nullable_columns(&pool).await;
+    assert_artifacts_cascade_from_the_source_and_the_workspace(&pool).await;
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+/// A manifest reads back as what was written, a second write replaces it in
+/// place, and a manifest for a source this database does not have is refused.
+async fn assert_manifest_round_trips_and_replaces_in_place(pool: &PgPool) {
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+
+    upsert_manifest(
+        pool,
+        &workspace_id,
+        &source_name,
+        MANIFEST_YAML,
+        MANIFEST_HASH,
+        10,
+    )
+    .await
+    .expect("store manifest");
+    assert_eq!(
+        manifest_row(pool, &workspace_id, &source_name).await,
+        Some((MANIFEST_YAML.to_owned(), MANIFEST_HASH.to_owned(), 10))
+    );
+
+    upsert_manifest(
+        pool,
+        &workspace_id,
+        &source_name,
+        REPLACEMENT_MANIFEST_YAML,
+        REPLACEMENT_MANIFEST_HASH,
+        20,
+    )
+    .await
+    .expect("replace manifest");
+    assert_eq!(
+        manifest_row(pool, &workspace_id, &source_name).await,
+        Some((
+            REPLACEMENT_MANIFEST_YAML.to_owned(),
+            REPLACEMENT_MANIFEST_HASH.to_owned(),
+            20,
+        )),
+        "a manifest is replaced wholesale, so the write restates its timestamp"
+    );
+    assert_eq!(
+        artifact_counts(pool, &workspace_id).await,
+        (1, 0),
+        "a source has one manifest, however many times it is written"
+    );
+
+    assert!(
+        upsert_manifest(
+            pool,
+            &workspace_id,
+            "source_this_database_never_installed",
+            MANIFEST_YAML,
+            MANIFEST_HASH,
+            10,
+        )
+        .await
+        .is_err(),
+        "a manifest hangs off a catalog row, so one without a source must be refused"
+    );
+}
+
+/// The raw source document survives Postgres as the bytes it went in as, out of
+/// a column that is genuinely `bytea` rather than text that happened to hold
+/// them, and a replacement restates those bytes rather than appending a row.
+async fn assert_materialization_keeps_the_raw_document_byte_for_byte(pool: &PgPool) {
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+
+    let stored = MaterializationArtifacts {
+        fingerprint_yaml: Some("inputs:\n  - orders.sql\n".to_owned()),
+        diagnostics_yaml: Some("warnings: []\n".to_owned()),
+        source_document_raw: RAW_DOCUMENT.to_vec(),
+    };
+    upsert_materialization(pool, &workspace_id, &source_name, &stored, 10)
+        .await
+        .expect("store materialization");
+
+    let read_back = materialization_row(pool, &workspace_id, &source_name)
+        .await
+        .expect("a stored materialization reads back");
+    assert_eq!(
+        read_back.source_document_raw, RAW_DOCUMENT,
+        "the raw source document must survive Postgres byte for byte"
+    );
+    assert_eq!(
+        read_back,
+        MaterializationRow {
+            materialization_version: MATERIALIZATION_VERSION.to_owned(),
+            fingerprint_yaml: stored.fingerprint_yaml.clone(),
+            diagnostics_yaml: stored.diagnostics_yaml.clone(),
+            source_document_raw: RAW_DOCUMENT.to_vec(),
+            created_at_unix_nanos: 10,
+        }
+    );
+    assert_eq!(
+        artifact_column_type(pool, "source_document_raw").await,
+        "bytea",
+        "the raw document must be stored as bytes, not as a lossy text column"
+    );
+
+    let replacement = MaterializationArtifacts {
+        source_document_raw: REPLACEMENT_RAW_DOCUMENT.to_vec(),
+        ..stored
+    };
+    upsert_materialization(pool, &workspace_id, &source_name, &replacement, 20)
+        .await
+        .expect("replace materialization");
+    let replaced = materialization_row(pool, &workspace_id, &source_name)
+        .await
+        .expect("a replaced materialization reads back");
+    assert_eq!(replaced.source_document_raw, REPLACEMENT_RAW_DOCUMENT);
+    assert_eq!(replaced.created_at_unix_nanos, 20);
+    assert_eq!(
+        artifact_counts(pool, &workspace_id).await,
+        (0, 1),
+        "a source has one materialization, however many times it is written"
+    );
+}
+
+/// The fingerprint and the diagnostics are the only artifacts the v4 loader
+/// treats as optional, so they are the only columns the schema lets go missing —
+/// and a write without them stores SQL NULL rather than an empty string.
+async fn assert_optional_artifacts_are_the_only_nullable_columns(pool: &PgPool) {
+    assert_eq!(
+        nullable_columns(pool, "source_manifests").await,
+        Vec::<String>::new(),
+        "every part of a stored manifest is required"
+    );
+    assert_eq!(
+        nullable_columns(pool, "materializations").await,
+        ["diagnostics_yaml", "fingerprint_yaml"]
+    );
+
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+    let without_optionals = MaterializationArtifacts {
+        fingerprint_yaml: None,
+        diagnostics_yaml: None,
+        source_document_raw: RAW_DOCUMENT.to_vec(),
+    };
+    upsert_materialization(pool, &workspace_id, &source_name, &without_optionals, 10)
+        .await
+        .expect("store materialization without optionals");
+
+    let read_back = materialization_row(pool, &workspace_id, &source_name)
+        .await
+        .expect("a stored materialization reads back");
+    assert_eq!(read_back.fingerprint_yaml, None);
+    assert_eq!(read_back.diagnostics_yaml, None);
+}
+
+/// Removing a source takes its artifacts with it, and so does removing the
+/// workspace above it: the cascade runs the whole chain, not just one link.
+async fn assert_artifacts_cascade_from_the_source_and_the_workspace(pool: &PgPool) {
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+    write_both_artifacts(pool, &workspace_id, &source_name).await;
+    assert_eq!(artifact_counts(pool, &workspace_id).await, (1, 1));
+
+    delete_source(pool, &workspace_id, &source_name).await;
+    assert_eq!(
+        artifact_counts(pool, &workspace_id).await,
+        (0, 0),
+        "artifacts must not outlive the source row they describe"
+    );
+
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+    write_both_artifacts(pool, &workspace_id, &source_name).await;
+    sqlx::query("DELETE FROM workspaces WHERE id = $1")
+        .bind(&workspace_id)
+        .execute(pool)
+        .await
+        .expect("delete workspace");
+    assert_eq!(
+        artifact_counts(pool, &workspace_id).await,
+        (0, 0),
+        "artifacts must not outlive the workspace that scoped them"
+    );
+    assert_eq!(source_count(pool, &workspace_id).await, 0);
+}
+
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run Postgres source inventory coverage"]
 async fn postgres_source_inventory_reads_information_schema_domain_columns_as_utf8() {
@@ -607,6 +818,225 @@ async fn tombstone_deleted_at(pool: &PgPool, workspace_id: &str, source_name: &s
     .fetch_optional(pool)
     .await
     .expect("read the deletion record")
+}
+
+/// Bytes chosen to break anything that round-trips a `bytea` through text: an
+/// embedded NUL, a lone `0xFF` that is not valid UTF-8, and a trailing NUL a
+/// C-style truncation would eat.
+const RAW_DOCUMENT: &[u8] = &[0x00, 0x01, 0xFF, 0xFE, b'y', b'a', b'm', b'l', 0x00];
+const REPLACEMENT_RAW_DOCUMENT: &[u8] = &[0xFF, 0x00, b'v', b'2'];
+
+const MANIFEST_YAML: &str = "dsl_version: 4\nname: orders\n";
+const REPLACEMENT_MANIFEST_YAML: &str = "dsl_version: 4\nname: shipments\n";
+
+/// The hash column holds opaque text here on purpose: which digest a manifest
+/// gets is the repository's business and is pinned in-crate, while what this
+/// file asserts is that the column carries whatever it was handed.
+const MANIFEST_HASH: &str = "0f4d1c3a";
+const REPLACEMENT_MANIFEST_HASH: &str = "9b27ae60";
+
+const MATERIALIZATION_VERSION: &str = "v4";
+
+/// The artifacts one materialization write varies. The rest of the row is the
+/// same fixed YAML every time, because what is under test is the columns rather
+/// than the artifact contents.
+struct MaterializationArtifacts {
+    fingerprint_yaml: Option<String>,
+    diagnostics_yaml: Option<String>,
+    source_document_raw: Vec<u8>,
+}
+
+/// One materialization row as Postgres hands it back.
+#[derive(Debug, PartialEq, Eq, sqlx::FromRow)]
+struct MaterializationRow {
+    materialization_version: String,
+    fingerprint_yaml: Option<String>,
+    diagnostics_yaml: Option<String>,
+    source_document_raw: Vec<u8>,
+    created_at_unix_nanos: i64,
+}
+
+/// Stores one manifest, replacing any manifest already held for the source.
+async fn upsert_manifest(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+    manifest_yaml: &str,
+    manifest_hash: &str,
+    now_unix_nanos: i64,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO source_manifests (
+             workspace_id, source_name, manifest_yaml, manifest_hash, created_at_unix_nanos
+         )
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (workspace_id, source_name) DO UPDATE SET
+             manifest_yaml = EXCLUDED.manifest_yaml,
+             manifest_hash = EXCLUDED.manifest_hash,
+             created_at_unix_nanos = EXCLUDED.created_at_unix_nanos",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .bind(manifest_yaml)
+    .bind(manifest_hash)
+    .bind(now_unix_nanos)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+async fn manifest_row(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+) -> Option<(String, String, i64)> {
+    sqlx::query_as(
+        "SELECT manifest_yaml, manifest_hash, created_at_unix_nanos
+         FROM source_manifests
+         WHERE workspace_id = $1 AND source_name = $2",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .fetch_optional(pool)
+    .await
+    .expect("read the stored manifest")
+}
+
+/// Stores one materialization, replacing any row already held for the source.
+///
+/// The conflict clause restates only the columns these tests vary rather than
+/// transcribing the repository's, so the statement carries no copy of the
+/// repository's write that could drift out from under it. What is exercised
+/// here is the migrated table: its keys, its nullability, and its `bytea`.
+async fn upsert_materialization(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+    artifacts: &MaterializationArtifacts,
+    now_unix_nanos: i64,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO materializations (
+             workspace_id,
+             source_name,
+             materialization_version,
+             fingerprint_yaml,
+             projections_yaml,
+             diagnostics_yaml,
+             source_document_raw,
+             source_document_yaml,
+             semantic_ir_yaml,
+             operation_metadata_yaml,
+             created_at_unix_nanos
+         )
+         VALUES (
+             $1, $2, $3, $4, 'projections:\n  - name: orders\n', $5, $6,
+             'document:\n  kind: source\n', 'ir:\n  version: 4\n', 'operations: []\n', $7
+         )
+         ON CONFLICT (workspace_id, source_name) DO UPDATE SET
+             fingerprint_yaml = EXCLUDED.fingerprint_yaml,
+             diagnostics_yaml = EXCLUDED.diagnostics_yaml,
+             source_document_raw = EXCLUDED.source_document_raw,
+             created_at_unix_nanos = EXCLUDED.created_at_unix_nanos",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .bind(MATERIALIZATION_VERSION)
+    .bind(artifacts.fingerprint_yaml.as_deref())
+    .bind(artifacts.diagnostics_yaml.as_deref())
+    .bind(artifacts.source_document_raw.as_slice())
+    .bind(now_unix_nanos)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+async fn materialization_row(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+) -> Option<MaterializationRow> {
+    sqlx::query_as(
+        "SELECT materialization_version, fingerprint_yaml, diagnostics_yaml,
+                source_document_raw, created_at_unix_nanos
+         FROM materializations
+         WHERE workspace_id = $1 AND source_name = $2",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .fetch_optional(pool)
+    .await
+    .expect("read the stored materialization")
+}
+
+/// Writes one manifest and one materialization for a source, so a cascade has
+/// both artifact kinds to take with it.
+async fn write_both_artifacts(pool: &PgPool, workspace_id: &str, source_name: &str) {
+    upsert_manifest(
+        pool,
+        workspace_id,
+        source_name,
+        MANIFEST_YAML,
+        MANIFEST_HASH,
+        10,
+    )
+    .await
+    .expect("store manifest");
+    upsert_materialization(
+        pool,
+        workspace_id,
+        source_name,
+        &MaterializationArtifacts {
+            fingerprint_yaml: None,
+            diagnostics_yaml: None,
+            source_document_raw: RAW_DOCUMENT.to_vec(),
+        },
+        10,
+    )
+    .await
+    .expect("store materialization");
+}
+
+/// Counts a workspace's `(manifest, materialization)` rows.
+async fn artifact_counts(pool: &PgPool, workspace_id: &str) -> (i64, i64) {
+    let mut counts = [0_i64; 2];
+    for (slot, statement) in counts.iter_mut().zip([
+        "SELECT COUNT(*) FROM source_manifests WHERE workspace_id = $1",
+        "SELECT COUNT(*) FROM materializations WHERE workspace_id = $1",
+    ]) {
+        *slot = sqlx::query_scalar(statement)
+            .bind(workspace_id)
+            .fetch_one(pool)
+            .await
+            .expect("count artifact rows");
+    }
+    (counts[0], counts[1])
+}
+
+/// Reports the physical Postgres type of one `materializations` column.
+async fn artifact_column_type(pool: &PgPool, column: &str) -> String {
+    sqlx::query_scalar(
+        "SELECT data_type FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = 'materializations'
+           AND column_name = $1",
+    )
+    .bind(column)
+    .fetch_one(pool)
+    .await
+    .expect("read the migrated column type")
+}
+
+/// Names the columns of one migrated table that accept SQL NULL.
+async fn nullable_columns(pool: &PgPool, table: &str) -> Vec<String> {
+    sqlx::query_scalar(
+        "SELECT column_name FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = $1 AND is_nullable = 'YES'
+         ORDER BY column_name",
+    )
+    .bind(table)
+    .fetch_all(pool)
+    .await
+    .expect("read the migrated column nullability")
 }
 
 #[expect(

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::path::PathBuf;
 
 use coral_client::local::ServerBuilder;
 use coral_engine::{
@@ -16,6 +17,7 @@ use coral_spec::{
     DatabaseConnectionSpec, DatabaseSourceManifest, ParsedTemplate, PostgresConnectionSpec,
     SourceManifestCommon,
 };
+use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
 
@@ -26,13 +28,7 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         return;
     };
     let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(
-        config_dir.join("config.toml"),
-        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
-    )
-    .expect("write config");
+    let config_dir = postgres_config_dir(&temp);
 
     // `make postgres-tests` points every Postgres test at one database, where
     // the legacy default name is now an ordinary one somebody may legitimately
@@ -56,6 +52,201 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
     );
 
     server.shutdown().await.expect("shutdown server");
+}
+
+/// Pins the source catalog's write contract against the schema a real
+/// Postgres-configured boot leaves behind.
+///
+/// `SourcesRepo`'s own behavior is covered in-crate against both backends over
+/// a pool that harness migrates itself. What is asserted here is the other
+/// half: that the catalog a booted server actually provisions holds the writes
+/// that repository makes — the same install, update, remove, and tombstone
+/// sequence, issued straight at the tables so a drift between the migrated
+/// schema and the statements the repository builds fails a statement rather
+/// than passing a self-provisioned harness.
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run the source catalog write contract"]
+async fn source_catalog_holds_its_write_contract_after_a_postgres_boot() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let server = ServerBuilder::new()
+        .with_config_dir(postgres_config_dir(&temp))
+        .start()
+        .await
+        .expect("start server with Postgres config");
+    let pool = PgPoolOptions::new()
+        .connect(&database_url)
+        .await
+        .expect("open Postgres database");
+
+    assert_installed_source_round_trips(&pool).await;
+    assert_update_keeps_the_install_time_and_rekeys_the_child_sets(&pool).await;
+    assert_removal_cascades_children_and_leaves_the_tombstone(&pool).await;
+    assert_workspace_deletion_cascades_tombstones(&pool).await;
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+/// An install writes one parent row and its two child sets, and reads back as
+/// what was written.
+async fn assert_installed_source_round_trips(pool: &PgPool) {
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+
+    let installed: (Option<String>, String, Option<String>, String, i64, i64) = sqlx::query_as(
+        "SELECT version, origin_kind, credential_storage, credential_revision,
+                created_at_unix_nanos, updated_at_unix_nanos
+         FROM sources
+         WHERE workspace_id = $1 AND name = $2",
+    )
+    .bind(&workspace_id)
+    .bind(&source_name)
+    .fetch_one(pool)
+    .await
+    .expect("read the installed source row");
+    assert_eq!(
+        installed,
+        (
+            Some("1.2.3".to_owned()),
+            "imported".to_owned(),
+            Some("file".to_owned()),
+            INSTALL_REVISION.to_owned(),
+            10,
+            10,
+        )
+    );
+    assert_eq!(
+        variables(pool, &workspace_id, &source_name).await,
+        [("region".to_owned(), "us-east-1".to_owned())]
+    );
+    assert_eq!(
+        secret_keys(pool, &workspace_id, &source_name).await,
+        ["api_token"]
+    );
+}
+
+/// An update restates everything but when the source was installed, and the
+/// child sets are keyed — rewriting one is a conflict, not a second row, which
+/// is why the repository replaces those sets wholesale instead of merging.
+async fn assert_update_keeps_the_install_time_and_rekeys_the_child_sets(pool: &PgPool) {
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+
+    upsert_source(pool, &workspace_id, &source_name, None, 20)
+        .await
+        .expect("update source");
+    let updated: (Option<String>, i64, i64) = sqlx::query_as(
+        "SELECT version, created_at_unix_nanos, updated_at_unix_nanos
+         FROM sources
+         WHERE workspace_id = $1 AND name = $2",
+    )
+    .bind(&workspace_id)
+    .bind(&source_name)
+    .fetch_one(pool)
+    .await
+    .expect("read the updated source row");
+    assert_eq!(
+        updated,
+        (None, 10, 20),
+        "an update must not restate when the source was installed"
+    );
+
+    assert!(
+        insert_variable(pool, &workspace_id, &source_name, "region", "eu-west-1")
+            .await
+            .is_err(),
+        "a variable key is an identity, so rewriting it in place must conflict"
+    );
+    assert!(
+        insert_secret_key(pool, &workspace_id, &source_name, "api_token")
+            .await
+            .is_err(),
+        "a secret key names a set member, so naming it twice must conflict"
+    );
+
+    delete_child_rows(pool, &workspace_id, &source_name).await;
+    insert_variable(pool, &workspace_id, &source_name, "region", "eu-west-1")
+        .await
+        .expect("replace variable");
+    insert_secret_key(pool, &workspace_id, &source_name, "rotated_token")
+        .await
+        .expect("replace secret key");
+    assert_eq!(
+        variables(pool, &workspace_id, &source_name).await,
+        [("region".to_owned(), "eu-west-1".to_owned())],
+        "the replaced set must carry the new value"
+    );
+    assert_eq!(
+        secret_keys(pool, &workspace_id, &source_name).await,
+        ["rotated_token"],
+        "the replaced set must not keep the key it replaced"
+    );
+}
+
+/// Removing a source takes its child rows with it and leaves the deletion
+/// record standing: the tombstone carries no foreign key to the row it records.
+async fn assert_removal_cascades_children_and_leaves_the_tombstone(pool: &PgPool) {
+    let (workspace_id, source_name) = install_source_with_children(pool).await;
+
+    upsert_tombstone(pool, &workspace_id, &source_name, 30).await;
+    delete_source(pool, &workspace_id, &source_name).await;
+
+    assert_eq!(source_count(pool, &workspace_id).await, 0);
+    assert!(
+        variables(pool, &workspace_id, &source_name)
+            .await
+            .is_empty()
+    );
+    assert!(
+        secret_keys(pool, &workspace_id, &source_name)
+            .await
+            .is_empty()
+    );
+    assert_eq!(
+        tombstone_deleted_at(pool, &workspace_id, &source_name).await,
+        Some(30),
+        "the deletion record must outlive the row it records"
+    );
+
+    // Deleting again records the later removal over the earlier one.
+    upsert_tombstone(pool, &workspace_id, &source_name, 31).await;
+    assert_eq!(
+        tombstone_deleted_at(pool, &workspace_id, &source_name).await,
+        Some(31)
+    );
+
+    // Re-adding the source is what revokes the record.
+    delete_tombstone(pool, &workspace_id, &source_name).await;
+    upsert_source(pool, &workspace_id, &source_name, Some("1.2.3"), 40)
+        .await
+        .expect("re-add source");
+    assert_eq!(
+        tombstone_deleted_at(pool, &workspace_id, &source_name).await,
+        None
+    );
+    assert_eq!(source_count(pool, &workspace_id).await, 1);
+}
+
+/// A deleted workspace takes its deletion records with it: a tombstone outlives
+/// its source but not the workspace that scoped it, so a re-created workspace
+/// does not inherit an old host's removals.
+async fn assert_workspace_deletion_cascades_tombstones(pool: &PgPool) {
+    let (workspace_id, source_name) = fresh_catalog_ids();
+    insert_workspace(pool, &workspace_id).await;
+    // Recorded without a source row on purpose: a removal this database never
+    // saw installed is still written, and must still be scoped to a workspace.
+    upsert_tombstone(pool, &workspace_id, &source_name, 30).await;
+
+    sqlx::query("DELETE FROM workspaces WHERE id = $1")
+        .bind(&workspace_id)
+        .execute(pool)
+        .await
+        .expect("delete workspace");
+
+    assert_eq!(
+        tombstone_deleted_at(pool, &workspace_id, &source_name).await,
+        None
+    );
 }
 
 #[tokio::test]
@@ -195,6 +386,227 @@ async fn count_legacy_default_workspaces(database_url: &str) -> Option<i64> {
         .await
         .expect("count the workspace rows holding the legacy default name");
     Some(count)
+}
+
+/// Writes a config directory that points a server at the test database.
+fn postgres_config_dir(temp: &TempDir) -> PathBuf {
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
+    )
+    .expect("write config");
+    config_dir
+}
+
+/// The credential revision an install writes; the column holds it as text.
+const INSTALL_REVISION: &str = "6dcf7b1e-4a10-4c8c-9f6f-2f1a0d2b7c31";
+
+/// A workspace and source name no other test shares, because `make
+/// postgres-tests` points every Postgres test at one database.
+fn fresh_catalog_ids() -> (String, String) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    (format!("workspace_{suffix}"), format!("source_{suffix}"))
+}
+
+/// Installs one source with one variable and one secret key under a workspace
+/// of its own, and reports the ids it generated.
+async fn install_source_with_children(pool: &PgPool) -> (String, String) {
+    let (workspace_id, source_name) = fresh_catalog_ids();
+    insert_workspace(pool, &workspace_id).await;
+    upsert_source(pool, &workspace_id, &source_name, Some("1.2.3"), 10)
+        .await
+        .expect("install source");
+    insert_variable(pool, &workspace_id, &source_name, "region", "us-east-1")
+        .await
+        .expect("install variable");
+    insert_secret_key(pool, &workspace_id, &source_name, "api_token")
+        .await
+        .expect("install secret key");
+    (workspace_id, source_name)
+}
+
+async fn insert_workspace(pool: &PgPool, workspace_id: &str) {
+    sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES ($1, 1)")
+        .bind(workspace_id)
+        .execute(pool)
+        .await
+        .expect("insert workspace");
+}
+
+/// Installs or updates one source through the repository's conflict clause,
+/// which deliberately leaves `created_at_unix_nanos` alone on an update.
+async fn upsert_source(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+    version: Option<&str>,
+    now_unix_nanos: i64,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO sources (
+             workspace_id,
+             name,
+             version,
+             origin_kind,
+             credential_storage,
+             credential_revision,
+             created_at_unix_nanos,
+             updated_at_unix_nanos
+         )
+         VALUES ($1, $2, $3, 'imported', 'file', $4, $5, $5)
+         ON CONFLICT (workspace_id, name) DO UPDATE SET
+             version = EXCLUDED.version,
+             origin_kind = EXCLUDED.origin_kind,
+             credential_storage = EXCLUDED.credential_storage,
+             credential_revision = EXCLUDED.credential_revision,
+             updated_at_unix_nanos = EXCLUDED.updated_at_unix_nanos",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .bind(version)
+    .bind(INSTALL_REVISION)
+    .bind(now_unix_nanos)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+async fn insert_variable(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+    key: &str,
+    value: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO source_variables (workspace_id, source_name, key, value)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .bind(key)
+    .bind(value)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+async fn insert_secret_key(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+    key: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO source_secret_keys (workspace_id, source_name, key)
+         VALUES ($1, $2, $3)",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .bind(key)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+async fn upsert_tombstone(
+    pool: &PgPool,
+    workspace_id: &str,
+    source_name: &str,
+    deleted_at_unix_nanos: i64,
+) {
+    sqlx::query(
+        "INSERT INTO source_tombstones (workspace_id, source_name, deleted_at_unix_nanos)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (workspace_id, source_name) DO UPDATE SET
+             deleted_at_unix_nanos = EXCLUDED.deleted_at_unix_nanos",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .bind(deleted_at_unix_nanos)
+    .execute(pool)
+    .await
+    .expect("record the deletion");
+}
+
+async fn delete_tombstone(pool: &PgPool, workspace_id: &str, source_name: &str) {
+    sqlx::query("DELETE FROM source_tombstones WHERE workspace_id = $1 AND source_name = $2")
+        .bind(workspace_id)
+        .bind(source_name)
+        .execute(pool)
+        .await
+        .expect("revoke the deletion record");
+}
+
+async fn delete_source(pool: &PgPool, workspace_id: &str, source_name: &str) {
+    sqlx::query("DELETE FROM sources WHERE workspace_id = $1 AND name = $2")
+        .bind(workspace_id)
+        .bind(source_name)
+        .execute(pool)
+        .await
+        .expect("delete source");
+}
+
+async fn delete_child_rows(pool: &PgPool, workspace_id: &str, source_name: &str) {
+    for statement in [
+        "DELETE FROM source_variables WHERE workspace_id = $1 AND source_name = $2",
+        "DELETE FROM source_secret_keys WHERE workspace_id = $1 AND source_name = $2",
+    ] {
+        sqlx::query(statement)
+            .bind(workspace_id)
+            .bind(source_name)
+            .execute(pool)
+            .await
+            .expect("delete child rows");
+    }
+}
+
+async fn source_count(pool: &PgPool, workspace_id: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM sources WHERE workspace_id = $1")
+        .bind(workspace_id)
+        .fetch_one(pool)
+        .await
+        .expect("count sources")
+}
+
+async fn variables(pool: &PgPool, workspace_id: &str, source_name: &str) -> Vec<(String, String)> {
+    sqlx::query_as(
+        "SELECT key, value FROM source_variables
+         WHERE workspace_id = $1 AND source_name = $2
+         ORDER BY key",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .fetch_all(pool)
+    .await
+    .expect("read source variables")
+}
+
+async fn secret_keys(pool: &PgPool, workspace_id: &str, source_name: &str) -> Vec<String> {
+    sqlx::query_scalar(
+        "SELECT key FROM source_secret_keys
+         WHERE workspace_id = $1 AND source_name = $2
+         ORDER BY key",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .fetch_all(pool)
+    .await
+    .expect("read source secret keys")
+}
+
+async fn tombstone_deleted_at(pool: &PgPool, workspace_id: &str, source_name: &str) -> Option<i64> {
+    sqlx::query_scalar(
+        "SELECT deleted_at_unix_nanos FROM source_tombstones
+         WHERE workspace_id = $1 AND source_name = $2",
+    )
+    .bind(workspace_id)
+    .bind(source_name)
+    .fetch_optional(pool)
+    .await
+    .expect("read the deletion record")
 }
 
 #[expect(


### PR DESCRIPTION
## Intent

Since 0.15.0, *who* can access a workspace lives in Coral's database — consistent across every host that shares one Postgres, exactly as the deployment docs describe. But *what is in* the workspace — the installed sources, their imported manifests, and the artifacts Coral has materialized for them — still lives in files on each host. Point two servers at the same database today and they agree on membership while disagreeing on content: the same workspace can show different sources, or none at all, depending on which host answers the request.

There is also a durability and buildability cost that applies to every install, shared or not. Everything the team wants to layer on top of source state — the workspace UI, server APIs, multi-user features — needs a durable, queryable record of what sources exist and what Coral has derived from them. A per-host `config.toml` plus scattered per-source files is not that record.

This change moves the source catalog, imported manifests, and v4 materialization state into the database, and keeps the config file as a maintained mirror rather than the source of truth. Scope is deliberately narrow: sources only. Credential material is untouched and stays per-host by design.

## What it enables

**One catalog from every host.** A server backed by Postgres serves the same sources, the same imported manifests, and the same materialized artifacts from every host reading that database (single-writer topology, as today). Refreshes converge too, including a re-import whose manifest text is unchanged but whose derived artifacts differ — the case a manifest hash provably cannot see, so freshness is decided by a fingerprint byte-compare.

**A zero-step upgrade.** On first boot of the new version, every previously installed source is present and usable — listed, inspectable, queryable — with no manual steps. The boot import is additive and never fails startup: bad legacy data, a corrupt manifest, a corrupt `config.toml`, or a missing ledger all result in Coral starting anyway and reporting what it skipped.

**Nothing silently lost, in either direction.** A source added or updated by an older binary — including across a downgrade-then-upgrade sequence, and including sources in workspaces the database has not seen yet — is imported on the next boot; the file content wins. The deliberate flip side is that a deletion made by an older binary is resurrected rather than lost (typically reporting missing credentials, since the old binary removed its secrets). Resurrect-rather-than-lose is the chosen failure direction, and three narrow corners are disclosed rather than papered over:

1. A host *first upgraded after* another host's deletion has no reconciliation record and cannot tell that host's stale config entry from a genuine addition, so it resurrects the source once.
2. A downgraded re-add whose config entry is indistinguishable from the stale mirrored copy already in that host's config file defers to the deletion. The config entry itself is never touched — the downgraded binary keeps working with it — and re-importing with the current binary makes the source visible again.
3. The same first-boot window exists for whole workspaces: deleting a workspace through the current binary removes its row and its sources' rows, but a host first upgraded after that deletion still carries the workspace in its config file and resurrects it, with its sources, once.

One further honesty rule: on a host's very first reconciled boot, a config entry or manifest cache that *differs* from the database cannot be proven to be Coral's own stale copy, so Coral never guesses. The database copy is served; the file is preserved — a divergent config entry stays in place with a warning, a divergent manifest cache is set aside once. From that boot on, routine cross-host updates refresh silently with no residue files.

**Deletions stick.** Deletes by the current binary write a tombstone in the same transaction as the row removal, so they survive reboots and hold across hosts sharing one database. A host-local mirror ledger records what Coral last wrote to that host's files, which is what lets the boot import distinguish "this is Coral's own stale copy, refresh it" from "a person or an older binary changed this, import it" — and therefore lets a re-add clear a tombstone without the tombstone ever swallowing a genuine addition.

**Older binaries keep working.** There is no new refusal-to-start gate. Existing config files remain valid inputs, and the per-host config mirror is kept current — including rewriting entries Coral can prove are its own stale copies after another host's update — so a downgraded binary reads a current catalog rather than a frozen one.

## Usage examples

**Day-to-day source management is unchanged.** `coral source add`, `list`, `info`, `remove`, source discovery, and querying behave exactly as before, on both SQLite and Postgres deployments:

```
coral source add --file ./my-source/manifest.yaml
coral source list
coral source info my-source
coral source remove my-source
```

**Two hosts, one Postgres.** Host A and host B point at the same database and each keeps its own config directory:

```
# on host A
coral source add --file ./analytics/manifest.yaml
coral source list          # analytics

# on host B, no manual step
coral source list          # analytics
coral source info analytics
```

Host B lists and inspects the source immediately, and hydrates its own `manifest.yaml` and `materialized/v4` cache from the database on boot. Queries against a credential-bearing source on host B require its credential material to be provisioned locally first — credentials remain per-host and out of scope here — and until then the query fails with a clear missing-credentials diagnostic rather than a confusing empty result. A `coral source remove analytics` on host A stays removed when host B reboots.

**What an operator sees on upgrade.** Start the new binary against an existing install; sources appear exactly as before. The logs report the boot import — how many sources were imported, how many were already present, and anything skipped — and startup proceeds regardless. Nothing needs to be run by hand, and the config file is left byte-for-byte intact by the import itself.

**Docs.** The contract is written up in `apps/docs/reference/configuration.mdx` under "Source persistence": what the boot import does, how Coral tells its own files apart, manifest ownership and the set-aside behavior, the downgrade story with the corners above, per-host credentials, and what stays file-based.

## Size and review shape

This PR adds roughly 8,400 lines across 29 files, well over half of them tests (migration-contract tests, Postgres contract tests, repository round-trip tests, the in-file test halves of the three repositories and the source manager, plus grpc end-to-end coverage). Saul explicitly waived the house LoC cap for this change, so it lands as one PR rather than a stack.

That size is far beyond a normal review unit, so the branch is built to be **reviewed commit by commit**. Each of the 14 commits is a coherent unit that compiles and passes `make rust-checks` (fmt, clippy `--all-features --locked -D warnings`, nextest `--all-features`, and rustdoc with `-D warnings`) standalone — verified by running the checks at each commit during assembly, not assumed. The tip is additionally green under `make postgres-tests`. The history bisects cleanly: no intermediate commit encodes a contradictory state (the delete path's row removal lands before the importer, so no commit accumulates rows with no deleter; the importer lands before the read flip, so no commit reads an unpopulated database; the ledger and the test harness both land below their first consumers).

1. `56732d12e` **feat(app): add source catalog and artifact schema** — migrations 0020 and 0021 (all six tables including tombstones), the schema Iden enums, and migration-contract and currency tests on both backends.
2. `2eb7b8e20` **feat(app): add sources repository with tombstone operations** — the catalog repository (list/get/upsert with tombstone clear, remove with tombstone write, tombstone query), its session accessor, SQLite round-trip and cascade tests, and Postgres contract tests.
3. `159732571` **feat(app): add manifest and materialization repositories** — the two artifact repositories with BYTEA fidelity tests and their Postgres contract tests.
4. `1e321c463` **feat(app): add the host-local mirror ledger** — the ledger store and its unit tests: tolerant load, atomic save, workspace records, entry and manifest hash records, warn-once divergence notes.
5. `29dcc1f14` **feat(app): thread the database into the source manager** — plumbing only: the database field and builder, internal accessors, server wiring. No behavior change.
6. `be1bd6b5a` **test(app): back source-manager tests with a migrated database** — the test constructors open and migrate a file-backed SQLite under the test's own layout and seed the workspace rows, through a runtime-aware blocking helper that works under both sync `#[test]` and `#[tokio::test]`. This lands *below* the first behavior change so no later commit is red.
7. `90af4a14c` **feat(app): dual-write the source lifecycle to the database** — the database bridge, lock-held upsert and remove, transactions inside `persist_source` and the delete path, pre-transaction capture for direction-aware compensation, and ledger updates after mirror and manifest writes. Reads are still config-backed here.
8. `c4058afc7` **feat(app): import legacy source state at startup** — the boot import and its report, the full three-way discrimination rule including update import, divergence warn, and the tombstone plus ledger re-add rule, with ledger and manifest-hash seeding.
9. `f102fd66a` **feat(app): read installed sources from the database** — flips every read site, adds the four async read variants used directly by the service handlers, and keeps the sync entry points on the bridge for the test harness.
10. `0fedb2e50` **test(app): extend end-to-end source coverage on the database path** — grpc harness plus source-lifecycle and OAuth-refresh coverage. No production code.
11. `861af8dcf` **feat(app): reconcile the mirror and hydrate artifact caches** — mirror reconciliation (add plus ledger-proven refresh), materialization cache hydration with fingerprint byte-compare freshness, and the two-config-dir tests covering silent refresh, set-aside, non-resurrection, and re-add.
12. `d94bf7117` **docs(app): document the source persistence contract** — the configuration reference section and the config writer doc-comments.
13. `77e71a0a8` **refactor(app): drop the test-only config mirror readers** — removes the config-backed read seams left with no callers after the flip.
14. `6fc0341d0` **docs(app): tighten the source persistence contract wording** — three accuracy fixes from the pre-publication text review (docs only).

## Lock-order change — concurrency review requested

The lock graph changed, and per the standing lesson that concurrency changes deserve review over the combined diff rather than per fix, please look at this as a whole:

- Workspace deletion now takes the **exclusive state flock before** opening the deletion transaction. The transaction nests inside the flock and the flock is dropped after commit.
- Mirror-ledger writes happen only under the state lock, including the workspace-forget path.
- The config removal and restore helpers were renamed to `*_unlocked` and now carry an explicit caller-holds-the-lock contract.

Please check this against the starvation fix in #2265 specifically — that is the interaction most worth a second pair of eyes. Two things are already pinned by tests: `state_lock_liveness` is green at every commit on this branch, and a standing guard test, `async_source_reads_never_cross_the_database_bridge`, asserts that no async read path crosses the blocking bridge, so a future async caller that reintroduces a bridged read fails the suite rather than passing silently.

## Pre-merge gate — table-name collision with the donor rdbms stack

**Do not merge before this is resolved.** The donor rdbms stack still has open PRs — the #1436 chain, #2275, and #2276 — whose migrations 0010 through 0016 create five of the same tables this PR creates in 0020 and 0021 — `sources`, `source_variables`, `source_secret_keys`, `source_manifests`, `materializations` — under materially different definitions (the donor's `materializations` schema differs column for column and adds a `materialization_surfaces` child table; this PR folds surfaces into one row and adds `source_tombstones`). Those PRs must be closed or their migrations renamed before this one merges. The migration numbers themselves do not collide, and every statement is `CREATE TABLE IF NOT EXISTS` — so if both sets ever run against one database, whichever runs first defines each table and the other's DDL silently no-ops: every migration reports success while the schema no longer matches what one side's code expects.

## CI

Drafts run no substantive CI in this repo — SKIPPED is not green. Flip this to ready to fire the full matrix. Note that the Postgres contract tests run only in CI's postgres job; they were verified green locally at the tip via `make postgres-tests`.