### PR TITLE
feat(sources/community/polymarket): add Polymarket community sources

### DIFF
--- a/sources/community/polymarket/README.md
+++ b/sources/community/polymarket/README.md
@@ -1,0 +1,78 @@
+# Polymarket (Gamma)
+
+Query Polymarket's public Gamma catalog: markets, events, tags, series, sports
+metadata, and public profiles.
+
+No authentication required.
+
+This source covers `https://gamma-api.polymarket.com` only. Analytics live in
+`polymarket_data`. Public CLOB reads live in `polymarket_clob`. Authenticated
+CLOB trading is not included.
+
+Columns were mapped from live Gamma list responses. The reverse-engineered
+OpenAPI in [modiqo/api-specs](https://github.com/modiqo/api-specs) was used as
+a draft, not as proof of row shape. Official docs:
+[docs.polymarket.com](https://docs.polymarket.com).
+
+## Setup
+
+```bash
+coral source add --file sources/community/polymarket/manifest.yaml
+coral source test polymarket
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `markets` | Prediction markets | — |
+| `events` | Event containers for one or more markets | — |
+| `tags` | Catalog tags | — |
+| `series` | Recurring series such as NFL | — |
+| `sports` | Sports metadata | — |
+| `public_profiles` | Public profile for a wallet | `address` |
+
+Join keys: `markets.condition_id` matches Data/CLOB condition ids.
+`events.id` is the Data API `live_volume` event id.
+
+### Not included
+
+- `GET /comments` and `GET /sports/teams` return HTTP 422 on the public API.
+- `GET /search` returns HTTP 401 without credentials.
+- `GET /profiles/{address}` is not a public GET. Use `public_profiles`.
+
+## SQL examples
+
+```sql
+SELECT question, volume_24hr, best_bid, best_ask, active
+FROM polymarket.markets
+WHERE active_filter = 'true'
+ORDER BY volume_24hr DESC
+LIMIT 10;
+```
+
+```sql
+SELECT title, volume, comment_count
+FROM polymarket.events
+WHERE active_filter = 'true'
+LIMIT 10;
+```
+
+```sql
+SELECT name, verified_badge, weighted_volume
+FROM polymarket.public_profiles
+WHERE address = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83';
+```
+
+## Limitations
+
+- Use `active_filter` / `closed_filter` / `archived_filter` to push those
+  flags to Gamma. `active`, `closed`, and `archived` are Boolean response
+  columns and cannot take a string equality.
+- Use `sort_by` (not `order` or `sort`) for Gamma's `order` query. Values
+  are camelCase (`volume24hr`, `volume`, `liquidity`). The returned order
+  is Gamma's.
+- Gamma list fields such as `outcomes` and `clob_token_ids` are JSON-encoded
+  strings, matching the live payload.
+- Nested `events`, `markets`, and `tags` arrays are exposed as `Json`.
+- Rate limits are not published. Keep validation queries small.

--- a/sources/community/polymarket/manifest.yaml
+++ b/sources/community/polymarket/manifest.yaml
@@ -1,0 +1,1218 @@
+name: polymarket
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Polymarket Gamma catalog data: markets, events, tags, series,
+  sports metadata, and public profiles.
+base_url: https://gamma-api.polymarket.com
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - >-
+    SELECT id, question, volume_24hr, active
+    FROM polymarket.markets
+    WHERE active_filter = 'true' AND sort_by = 'volume24hr'
+    LIMIT 5
+  - >-
+    SELECT id, title, volume, active
+    FROM polymarket.events
+    WHERE active_filter = 'true'
+    LIMIT 5
+  - SELECT id, label, slug FROM polymarket.tags LIMIT 5
+  - SELECT id, title, ticker FROM polymarket.series LIMIT 5
+  - SELECT id, sport, name FROM polymarket.sports LIMIT 5
+  - >-
+    SELECT proxy_wallet, name, verified_badge
+    FROM polymarket.public_profiles
+    WHERE address = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'
+    LIMIT 1
+
+tables:
+  - name: markets
+    description: >-
+      Prediction markets from the Gamma catalog, including question text,
+      condition id, volume, liquidity, and book flags.
+    guide: >-
+      `SELECT question, volume_24hr, best_bid, best_ask FROM polymarket.markets
+      WHERE active_filter = 'true' ORDER BY volume_24hr DESC LIMIT 20`.
+      Join to CLOB and data tables on condition_id. Use `active_filter` for
+      the Gamma query param; `active` is the Boolean response column.
+    fetch_limit_default: 50
+    filters:
+      - name: id
+        required: false
+        description: Gamma market id.
+      - name: slug
+        required: false
+        description: Market slug.
+      - name: active_filter
+        required: false
+        description: Gamma `active` query (`true` or `false`).
+      - name: closed_filter
+        required: false
+        description: Gamma `closed` query (`true` or `false`).
+      - name: archived_filter
+        required: false
+        description: Gamma `archived` query (`true` or `false`).
+      - name: tag_id
+        required: false
+        description: Gamma tag id.
+      - name: tag
+        required: false
+        description: Tag slug.
+      - name: condition_id
+        required: false
+        description: On-chain condition id.
+      - name: sort_by
+        required: false
+        description: Gamma `order` field such as volume24hr or volume.
+      - name: ascending
+        required: false
+        description: Sort ascending (`true` or `false`).
+    request:
+      method: GET
+      path: /markets
+      query:
+        - name: id
+          from: filter
+          key: id
+        - name: slug
+          from: filter
+          key: slug
+        - name: active
+          from: filter
+          key: active_filter
+        - name: closed
+          from: filter
+          key: closed_filter
+        - name: archived
+          from: filter
+          key: archived_filter
+        - name: tag_id
+          from: filter
+          key: tag_id
+        - name: tag
+          from: filter
+          key: tag
+        - name: conditionId
+          from: filter
+          key: condition_id
+        - name: order
+          from: filter
+          key: sort_by
+        - name: ascending
+          from: filter
+          key: ascending
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Gamma market id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: question
+        type: Utf8
+        nullable: true
+        description: Market question text.
+        expr:
+          kind: path
+          path:
+            - question
+      - name: condition_id
+        type: Utf8
+        nullable: true
+        description: On-chain condition id used as the CLOB/data join key.
+        expr:
+          kind: path
+          path:
+            - conditionId
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: URL slug for the market.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Resolution rules and market description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: resolution_source
+        type: Utf8
+        nullable: true
+        description: Stated resolution source.
+        expr:
+          kind: path
+          path:
+            - resolutionSource
+      - name: outcomes
+        type: Utf8
+        nullable: true
+        description: JSON-encoded outcome labels as returned by Gamma.
+        expr:
+          kind: path
+          path:
+            - outcomes
+      - name: outcome_prices
+        type: Utf8
+        nullable: true
+        description: JSON-encoded outcome prices as returned by Gamma.
+        expr:
+          kind: path
+          path:
+            - outcomePrices
+      - name: clob_token_ids
+        type: Utf8
+        nullable: true
+        description: JSON-encoded CLOB token ids for each outcome.
+        expr:
+          kind: path
+          path:
+            - clobTokenIds
+      - name: volume
+        type: Utf8
+        nullable: true
+        description: Lifetime volume string from the list payload.
+        expr:
+          kind: path
+          path:
+            - volume
+      - name: volume_num
+        type: Float64
+        nullable: true
+        description: Lifetime volume as a number.
+        expr:
+          kind: path
+          path:
+            - volumeNum
+      - name: volume_24hr
+        type: Float64
+        nullable: true
+        description: Rolling 24-hour volume.
+        expr:
+          kind: path
+          path:
+            - volume24hr
+      - name: volume_1wk
+        type: Float64
+        nullable: true
+        description: Rolling 1-week volume.
+        expr:
+          kind: path
+          path:
+            - volume1wk
+      - name: volume_1mo
+        type: Float64
+        nullable: true
+        description: Rolling 1-month volume.
+        expr:
+          kind: path
+          path:
+            - volume1mo
+      - name: liquidity
+        type: Utf8
+        nullable: true
+        description: Listed liquidity string from the list payload.
+        expr:
+          kind: path
+          path:
+            - liquidity
+      - name: liquidity_num
+        type: Float64
+        nullable: true
+        description: Listed liquidity as a number.
+        expr:
+          kind: path
+          path:
+            - liquidityNum
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the market is currently active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the market is closed.
+        expr:
+          kind: path
+          path:
+            - closed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the market is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: featured
+        type: Boolean
+        nullable: true
+        description: Whether Gamma marks the market as featured.
+        expr:
+          kind: path
+          path:
+            - featured
+      - name: restricted
+        type: Boolean
+        nullable: true
+        description: Whether the market is geo-restricted.
+        expr:
+          kind: path
+          path:
+            - restricted
+      - name: enable_order_book
+        type: Boolean
+        nullable: true
+        description: Whether the CLOB order book is enabled.
+        expr:
+          kind: path
+          path:
+            - enableOrderBook
+      - name: accepting_orders
+        type: Boolean
+        nullable: true
+        description: Whether the book is currently accepting orders.
+        expr:
+          kind: path
+          path:
+            - acceptingOrders
+      - name: best_bid
+        type: Float64
+        nullable: true
+        description: Best bid price on the last list snapshot.
+        expr:
+          kind: path
+          path:
+            - bestBid
+      - name: best_ask
+        type: Float64
+        nullable: true
+        description: Best ask price on the last list snapshot.
+        expr:
+          kind: path
+          path:
+            - bestAsk
+      - name: last_trade_price
+        type: Float64
+        nullable: true
+        description: Last trade price on the last list snapshot.
+        expr:
+          kind: path
+          path:
+            - lastTradePrice
+      - name: spread
+        type: Float64
+        nullable: true
+        description: Bid-ask spread on the last list snapshot.
+        expr:
+          kind: path
+          path:
+            - spread
+      - name: one_day_price_change
+        type: Float64
+        nullable: true
+        description: One-day price change.
+        expr:
+          kind: path
+          path:
+            - oneDayPriceChange
+      - name: competitive
+        type: Float64
+        nullable: true
+        description: Gamma competitiveness score.
+        expr:
+          kind: path
+          path:
+            - competitive
+      - name: start_date
+        type: Utf8
+        nullable: true
+        description: Market start timestamp.
+        expr:
+          kind: path
+          path:
+            - startDate
+      - name: end_date
+        type: Utf8
+        nullable: true
+        description: Market end timestamp.
+        expr:
+          kind: path
+          path:
+            - endDate
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Row created-at timestamp.
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Row updated-at timestamp.
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: image
+        type: Utf8
+        nullable: true
+        description: Market image URL.
+        expr:
+          kind: path
+          path:
+            - image
+      - name: events
+        type: Json
+        nullable: true
+        description: Nested event objects attached to the market row.
+        expr:
+          kind: path
+          path:
+            - events
+      - name: active_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gamma `active` query (`true` or `false`).
+        expr:
+          kind: from_filter
+          key: active_filter
+      - name: closed_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gamma `closed` query (`true` or `false`).
+        expr:
+          kind: from_filter
+          key: closed_filter
+      - name: archived_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gamma `archived` query (`true` or `false`).
+        expr:
+          kind: from_filter
+          key: archived_filter
+      - name: tag_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested Gamma tag id.
+        expr:
+          kind: from_filter
+          key: tag_id
+      - name: tag
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested tag slug.
+        expr:
+          kind: from_filter
+          key: tag
+      - name: sort_by
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested Gamma `order` field such as volume24hr.
+        expr:
+          kind: from_filter
+          key: sort_by
+      - name: ascending
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested Gamma `ascending` query.
+        expr:
+          kind: from_filter
+          key: ascending
+
+  - name: events
+    description: >-
+      Top-level Gamma events that group one or more markets.
+    guide: >-
+      `SELECT title, volume, comment_count FROM polymarket.events
+      WHERE active_filter = 'true' LIMIT 20`. Nested markets and tags are
+      JSON. Use `active_filter` for the Gamma query param.
+    fetch_limit_default: 50
+    filters:
+      - name: id
+        required: false
+        description: Gamma event id.
+      - name: slug
+        required: false
+        description: Event slug.
+      - name: ticker
+        required: false
+        description: Event ticker.
+      - name: active_filter
+        required: false
+        description: Gamma `active` query (`true` or `false`).
+      - name: closed_filter
+        required: false
+        description: Gamma `closed` query (`true` or `false`).
+      - name: archived_filter
+        required: false
+        description: Gamma `archived` query (`true` or `false`).
+      - name: tag_id
+        required: false
+        description: Gamma tag id.
+      - name: tag
+        required: false
+        description: Tag slug.
+      - name: sort_by
+        required: false
+        description: Gamma `order` field such as volume24hr or volume.
+      - name: ascending
+        required: false
+        description: Sort ascending (`true` or `false`).
+    request:
+      method: GET
+      path: /events
+      query:
+        - name: id
+          from: filter
+          key: id
+        - name: slug
+          from: filter
+          key: slug
+        - name: ticker
+          from: filter
+          key: ticker
+        - name: active
+          from: filter
+          key: active_filter
+        - name: closed
+          from: filter
+          key: closed_filter
+        - name: archived
+          from: filter
+          key: archived_filter
+        - name: tag_id
+          from: filter
+          key: tag_id
+        - name: tag
+          from: filter
+          key: tag
+        - name: order
+          from: filter
+          key: sort_by
+        - name: ascending
+          from: filter
+          key: ascending
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Gamma event id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: ticker
+        type: Utf8
+        nullable: true
+        description: Event ticker.
+        expr:
+          kind: path
+          path:
+            - ticker
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: URL slug for the event.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Event title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Event description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: category
+        type: Utf8
+        nullable: true
+        description: Event category label.
+        expr:
+          kind: path
+          path:
+            - category
+      - name: series_slug
+        type: Utf8
+        nullable: true
+        description: Parent series slug when present.
+        expr:
+          kind: path
+          path:
+            - seriesSlug
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the event is active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the event is closed.
+        expr:
+          kind: path
+          path:
+            - closed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the event is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: featured
+        type: Boolean
+        nullable: true
+        description: Whether Gamma marks the event as featured.
+        expr:
+          kind: path
+          path:
+            - featured
+      - name: restricted
+        type: Boolean
+        nullable: true
+        description: Whether the event is geo-restricted.
+        expr:
+          kind: path
+          path:
+            - restricted
+      - name: liquidity
+        type: Float64
+        nullable: true
+        description: Event liquidity.
+        expr:
+          kind: path
+          path:
+            - liquidity
+      - name: volume
+        type: Float64
+        nullable: true
+        description: Event lifetime volume.
+        expr:
+          kind: path
+          path:
+            - volume
+      - name: volume_24hr
+        type: Float64
+        nullable: true
+        description: Event 24-hour volume.
+        expr:
+          kind: path
+          path:
+            - volume24hr
+      - name: comment_count
+        type: Int64
+        nullable: true
+        description: Comment count on the event.
+        expr:
+          kind: path
+          path:
+            - commentCount
+      - name: start_date
+        type: Utf8
+        nullable: true
+        description: Event start timestamp.
+        expr:
+          kind: path
+          path:
+            - startDate
+      - name: end_date
+        type: Utf8
+        nullable: true
+        description: Event end timestamp.
+        expr:
+          kind: path
+          path:
+            - endDate
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Row created-at timestamp.
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Row updated-at timestamp.
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: image
+        type: Utf8
+        nullable: true
+        description: Event image URL.
+        expr:
+          kind: path
+          path:
+            - image
+      - name: markets
+        type: Json
+        nullable: true
+        description: Nested market objects on the event row.
+        expr:
+          kind: path
+          path:
+            - markets
+      - name: tags
+        type: Json
+        nullable: true
+        description: Nested tag objects on the event row.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: series
+        type: Json
+        nullable: true
+        description: Nested series objects on the event row.
+        expr:
+          kind: path
+          path:
+            - series
+      - name: active_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gamma `active` query (`true` or `false`).
+        expr:
+          kind: from_filter
+          key: active_filter
+      - name: closed_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gamma `closed` query (`true` or `false`).
+        expr:
+          kind: from_filter
+          key: closed_filter
+      - name: archived_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Gamma `archived` query (`true` or `false`).
+        expr:
+          kind: from_filter
+          key: archived_filter
+      - name: tag_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested Gamma tag id.
+        expr:
+          kind: from_filter
+          key: tag_id
+      - name: tag
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested tag slug.
+        expr:
+          kind: from_filter
+          key: tag
+      - name: sort_by
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested Gamma `order` field such as volume24hr.
+        expr:
+          kind: from_filter
+          key: sort_by
+      - name: ascending
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Requested Gamma `ascending` query.
+        expr:
+          kind: from_filter
+          key: ascending
+
+  - name: tags
+    description: Catalog tags used to classify Gamma events and markets.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /tags
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tag id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: label
+        type: Utf8
+        nullable: true
+        description: Tag display label.
+        expr:
+          kind: path
+          path:
+            - label
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Tag slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Tag created-at timestamp.
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Tag updated-at timestamp.
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: requires_translation
+        type: Boolean
+        nullable: true
+        description: Whether Gamma flags the tag for translation.
+        expr:
+          kind: path
+          path:
+            - requiresTranslation
+
+  - name: series
+    description: Recurring series (for example NFL) that group events.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /series
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Series id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: ticker
+        type: Utf8
+        nullable: true
+        description: Series ticker.
+        expr:
+          kind: path
+          path:
+            - ticker
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Series slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Series title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: series_type
+        type: Utf8
+        nullable: true
+        description: Series type.
+        expr:
+          kind: path
+          path:
+            - seriesType
+      - name: recurrence
+        type: Utf8
+        nullable: true
+        description: Recurrence label such as daily.
+        expr:
+          kind: path
+          path:
+            - recurrence
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Series description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the series is active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the series is closed.
+        expr:
+          kind: path
+          path:
+            - closed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the series is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: featured
+        type: Boolean
+        nullable: true
+        description: Whether the series is featured.
+        expr:
+          kind: path
+          path:
+            - featured
+      - name: volume_24hr
+        type: Float64
+        nullable: true
+        description: Series 24-hour volume.
+        expr:
+          kind: path
+          path:
+            - volume24hr
+      - name: comment_count
+        type: Int64
+        nullable: true
+        description: Comment count on the series.
+        expr:
+          kind: path
+          path:
+            - commentCount
+      - name: start_date
+        type: Utf8
+        nullable: true
+        description: Series start timestamp.
+        expr:
+          kind: path
+          path:
+            - startDate
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Row created-at timestamp.
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Row updated-at timestamp.
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: events
+        type: Json
+        nullable: true
+        description: Nested events attached to the series row.
+        expr:
+          kind: path
+          path:
+            - events
+
+  - name: sports
+    description: Sports metadata used to organize sports markets and series.
+    fetch_limit_default: 200
+    request:
+      method: GET
+      path: /sports
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Sports metadata id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: sport
+        type: Utf8
+        nullable: true
+        description: Sport slug such as nfl or nba.
+        expr:
+          kind: path
+          path:
+            - sport
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Sport display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: image
+        type: Utf8
+        nullable: true
+        description: Sport image URL.
+        expr:
+          kind: path
+          path:
+            - image
+      - name: resolution
+        type: Utf8
+        nullable: true
+        description: Resolution notes.
+        expr:
+          kind: path
+          path:
+            - resolution
+      - name: ordering
+        type: Utf8
+        nullable: true
+        description: Display ordering key.
+        expr:
+          kind: path
+          path:
+            - ordering
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Associated tags as returned by Gamma.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: primary_tag_id
+        type: Int64
+        nullable: true
+        description: Primary tag id.
+        expr:
+          kind: path
+          path:
+            - primaryTagId
+      - name: series
+        type: Utf8
+        nullable: true
+        description: Associated series identifier.
+        expr:
+          kind: path
+          path:
+            - series
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Row created-at timestamp.
+        expr:
+          kind: path
+          path:
+            - createdAt
+
+  - name: public_profiles
+    description: >-
+      Public profile for a wallet address, including display name and
+      verified-badge state.
+    guide: >-
+      Requires `address`. Example:
+      `SELECT name, verified_badge FROM polymarket.public_profiles
+      WHERE address = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'`.
+    filters:
+      - name: address
+        required: true
+        description: Wallet address (0x...).
+    request:
+      method: GET
+      path: /public-profile
+      query:
+        - name: address
+          from: filter
+          key: address
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: address
+        type: Utf8
+        nullable: false
+        description: Requested wallet address.
+        expr:
+          kind: from_filter
+          key: address
+      - name: proxy_wallet
+        type: Utf8
+        nullable: true
+        description: Profile proxy wallet.
+        expr:
+          kind: path
+          path:
+            - proxyWallet
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Public display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: pseudonym
+        type: Utf8
+        nullable: true
+        description: Generated pseudonym.
+        expr:
+          kind: path
+          path:
+            - pseudonym
+      - name: verified_badge
+        type: Boolean
+        nullable: true
+        description: Whether the profile has a verified badge.
+        expr:
+          kind: path
+          path:
+            - verifiedBadge
+      - name: display_username_public
+        type: Boolean
+        nullable: true
+        description: Whether the username is public.
+        expr:
+          kind: path
+          path:
+            - displayUsernamePublic
+      - name: taker_tier
+        type: Int64
+        nullable: true
+        description: Taker tier number.
+        expr:
+          kind: path
+          path:
+            - takerTier
+      - name: taker_tier_name
+        type: Utf8
+        nullable: true
+        description: Taker tier label.
+        expr:
+          kind: path
+          path:
+            - takerTierName
+      - name: weighted_volume
+        type: Float64
+        nullable: true
+        description: Weighted volume on the profile.
+        expr:
+          kind: path
+          path:
+            - weightedVolume
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Profile created-at timestamp.
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: users
+        type: Json
+        nullable: true
+        description: Nested user records on the profile.
+        expr:
+          kind: path
+          path:
+            - users

--- a/sources/community/polymarket/manifest.yaml
+++ b/sources/community/polymarket/manifest.yaml
@@ -22,6 +22,11 @@ test_queries:
     WHERE active_filter = 'true'
     LIMIT 5
   - SELECT id, label, slug FROM polymarket.tags LIMIT 5
+  - >-
+    SELECT id, question, condition_id
+    FROM polymarket.markets
+    WHERE condition_id = '0xa467b14d51f01b957109d9cbb1d6c124fab2a089d52ed8f471d23c2812e743b7'
+    LIMIT 5
   - SELECT id, title, ticker FROM polymarket.series LIMIT 5
   - SELECT id, sport, name FROM polymarket.sports LIMIT 5
   - >-
@@ -97,7 +102,7 @@ tables:
         - name: tag
           from: filter
           key: tag
-        - name: conditionId
+        - name: condition_ids
           from: filter
           key: condition_id
         - name: order

--- a/sources/community/polymarket_clob/README.md
+++ b/sources/community/polymarket_clob/README.md
@@ -1,0 +1,71 @@
+# Polymarket CLOB
+
+Query public Polymarket Central Limit Order Book reads: simplified markets,
+order books, prices, midpoints, spreads, last trades, tick sizes, fee rates,
+and price history.
+
+No authentication required for these reads.
+
+This source covers `https://clob.polymarket.com` public GET endpoints only.
+Authenticated trading (`POST /order`, cancels, user trades) is not included.
+Coral cannot compute Polymarket's per-request HMAC-SHA256 L2 headers.
+
+## Setup
+
+```bash
+coral source add --file sources/community/polymarket_clob/manifest.yaml
+coral source test polymarket_clob
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `simplified_markets` | CLOB market list | — |
+| `sampling_markets` | Sampling-program markets | — |
+| `sampling_simplified_markets` | Simplified sampling list | — |
+| `order_book` | Book snapshot | `token_id` |
+| `price` | Best price for a side | `token_id`, `side` |
+| `midpoint` | Midpoint price | `token_id` |
+| `spread` | Bid-ask spread | `token_id` |
+| `last_trade_price` | Last public trade | `token_id` |
+| `tick_size` | Minimum tick size | `token_id` |
+| `fee_rate` | Base fee | `token_id` |
+| `prices_history` | Historical price points | `market` (token id), `history_interval` |
+
+`token_id` values come from `polymarket.markets.clob_token_ids` (a
+JSON-encoded string of outcome token ids).
+
+### Not included
+
+- `POST /order`, `POST /orders`, cancels, heartbeats, and authenticated
+  `/trades` or `/orders` lists. Those require L2 HMAC signing.
+- Body-form batch POSTs (`/books`, `/prices`). Use the GET query forms.
+
+## SQL examples
+
+```sql
+SELECT condition_id, active, accepting_orders
+FROM polymarket_clob.simplified_markets
+LIMIT 10;
+```
+
+```sql
+SELECT market, tick_size, last_trade_price, bids, asks
+FROM polymarket_clob.order_book
+WHERE token_id = '32338220190071351435772801779725302244575775216413325951443816017994629993401';
+```
+
+```sql
+SELECT t, p
+FROM polymarket_clob.prices_history
+WHERE market = '32338220190071351435772801779725302244575775216413325951443816017994629993401'
+  AND history_interval = '1d'
+LIMIT 20;
+```
+
+## Limitations
+
+- Market lists use cursor pagination (`next_cursor`).
+- Book bids/asks are JSON arrays on one row, matching the live snapshot.
+- Price fields on several CLOB endpoints are strings in the live payload.

--- a/sources/community/polymarket_clob/README.md
+++ b/sources/community/polymarket_clob/README.md
@@ -25,7 +25,7 @@ coral source test polymarket_clob
 | `sampling_markets` | Sampling-program markets | — |
 | `sampling_simplified_markets` | Simplified sampling list | — |
 | `order_book` | Book snapshot | `token_id` |
-| `price` | Best price for a side | `token_id`, `side` |
+| `price` | Best price for a side | `token_id`, `side` (`BUY`/`SELL`) |
 | `midpoint` | Midpoint price | `token_id` |
 | `spread` | Bid-ask spread | `token_id` |
 | `last_trade_price` | Last public trade | `token_id` |

--- a/sources/community/polymarket_clob/manifest.yaml
+++ b/sources/community/polymarket_clob/manifest.yaml
@@ -24,6 +24,12 @@ test_queries:
     WHERE market = '32338220190071351435772801779725302244575775216413325951443816017994629993401'
       AND history_interval = '1d'
     LIMIT 5
+  - >-
+    SELECT token_id, side, price
+    FROM polymarket_clob.price
+    WHERE token_id = '32338220190071351435772801779725302244575775216413325951443816017994629993401'
+      AND side = 'BUY'
+    LIMIT 1
 
 tables:
   - name: simplified_markets
@@ -374,7 +380,7 @@ tables:
         description: CLOB token id.
       - name: side
         required: true
-        description: Order side (`buy` or `sell`).
+        description: Order side (`BUY` or `SELL`).
     request:
       method: GET
       path: /price
@@ -643,13 +649,16 @@ tables:
           kind: from_filter
           key: history_interval
       - name: t
-        type: Int64
+        type: Timestamp
         nullable: true
-        description: Unix timestamp of the price point.
+        description: Price point timestamp.
         expr:
-          kind: path
-          path:
-            - t
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - t
       - name: p
         type: Float64
         nullable: true

--- a/sources/community/polymarket_clob/manifest.yaml
+++ b/sources/community/polymarket_clob/manifest.yaml
@@ -1,0 +1,660 @@
+name: polymarket_clob
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query public Polymarket CLOB reads: simplified markets, order books,
+  prices, midpoints, spreads, last trades, tick sizes, and price history.
+base_url: https://clob.polymarket.com
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT condition_id, active, accepting_orders FROM polymarket_clob.simplified_markets LIMIT 5
+  - SELECT condition_id, active FROM polymarket_clob.sampling_markets LIMIT 5
+  - >-
+    SELECT market, tick_size, last_trade_price
+    FROM polymarket_clob.order_book
+    WHERE token_id = '32338220190071351435772801779725302244575775216413325951443816017994629993401'
+    LIMIT 1
+  - >-
+    SELECT market, t, p
+    FROM polymarket_clob.prices_history
+    WHERE market = '32338220190071351435772801779725302244575775216413325951443816017994629993401'
+      AND history_interval = '1d'
+    LIMIT 5
+
+tables:
+  - name: simplified_markets
+    description: CLOB simplified market list with token metadata and book flags.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /simplified-markets
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: condition_id
+        type: Utf8
+        nullable: false
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - condition_id
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the market is active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the market is closed.
+        expr:
+          kind: path
+          path:
+            - closed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the market is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: accepting_orders
+        type: Boolean
+        nullable: true
+        description: Whether the book accepts orders.
+        expr:
+          kind: path
+          path:
+            - accepting_orders
+      - name: tokens
+        type: Json
+        nullable: true
+        description: Outcome token objects for the market.
+        expr:
+          kind: path
+          path:
+            - tokens
+      - name: rewards
+        type: Json
+        nullable: true
+        description: Reward metadata for the market.
+        expr:
+          kind: path
+          path:
+            - rewards
+
+  - name: sampling_markets
+    description: CLOB sampling market list used for reward / sampling programs.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /sampling-markets
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: condition_id
+        type: Utf8
+        nullable: false
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - condition_id
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the market is active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the market is closed.
+        expr:
+          kind: path
+          path:
+            - closed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the market is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: accepting_orders
+        type: Boolean
+        nullable: true
+        description: Whether the book accepts orders.
+        expr:
+          kind: path
+          path:
+            - accepting_orders
+      - name: tokens
+        type: Json
+        nullable: true
+        description: Outcome token objects for the market.
+        expr:
+          kind: path
+          path:
+            - tokens
+      - name: rewards
+        type: Json
+        nullable: true
+        description: Reward metadata for the market.
+        expr:
+          kind: path
+          path:
+            - rewards
+
+  - name: sampling_simplified_markets
+    description: Simplified CLOB sampling-market list.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /sampling-simplified-markets
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: next_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: condition_id
+        type: Utf8
+        nullable: false
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - condition_id
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the market is active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the market is closed.
+        expr:
+          kind: path
+          path:
+            - closed
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the market is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: accepting_orders
+        type: Boolean
+        nullable: true
+        description: Whether the book accepts orders.
+        expr:
+          kind: path
+          path:
+            - accepting_orders
+      - name: tokens
+        type: Json
+        nullable: true
+        description: Outcome token objects for the market.
+        expr:
+          kind: path
+          path:
+            - tokens
+      - name: rewards
+        type: Json
+        nullable: true
+        description: Reward metadata for the market.
+        expr:
+          kind: path
+          path:
+            - rewards
+
+  - name: order_book
+    description: Public order book snapshot for one CLOB token.
+    guide: >-
+      Requires `token_id`. Bids and asks are JSON arrays on a single row.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+    request:
+      method: GET
+      path: /book
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: market
+        type: Utf8
+        nullable: true
+        description: Condition id for the book.
+        expr:
+          kind: path
+          path:
+            - market
+      - name: asset_id
+        type: Utf8
+        nullable: true
+        description: Book asset id.
+        expr:
+          kind: path
+          path:
+            - asset_id
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        description: Book snapshot timestamp.
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: hash
+        type: Utf8
+        nullable: true
+        description: Book hash.
+        expr:
+          kind: path
+          path:
+            - hash
+      - name: min_order_size
+        type: Utf8
+        nullable: true
+        description: Minimum order size.
+        expr:
+          kind: path
+          path:
+            - min_order_size
+      - name: tick_size
+        type: Utf8
+        nullable: true
+        description: Tick size.
+        expr:
+          kind: path
+          path:
+            - tick_size
+      - name: neg_risk
+        type: Boolean
+        nullable: true
+        description: Whether the market is negative-risk.
+        expr:
+          kind: path
+          path:
+            - neg_risk
+      - name: last_trade_price
+        type: Utf8
+        nullable: true
+        description: Last trade price on the book.
+        expr:
+          kind: path
+          path:
+            - last_trade_price
+      - name: bids
+        type: Json
+        nullable: true
+        description: Bid levels.
+        expr:
+          kind: path
+          path:
+            - bids
+      - name: asks
+        type: Json
+        nullable: true
+        description: Ask levels.
+        expr:
+          kind: path
+          path:
+            - asks
+
+  - name: price
+    description: Best price for one token and side.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+      - name: side
+        required: true
+        description: Order side (`buy` or `sell`).
+    request:
+      method: GET
+      path: /price
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+        - name: side
+          from: filter
+          key: side
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: side
+        type: Utf8
+        nullable: false
+        description: Requested side.
+        expr:
+          kind: from_filter
+          key: side
+      - name: price
+        type: Utf8
+        nullable: true
+        description: Best price for that side.
+        expr:
+          kind: path
+          path:
+            - price
+
+  - name: midpoint
+    description: Midpoint price for one token.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+    request:
+      method: GET
+      path: /midpoint
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: mid
+        type: Utf8
+        nullable: true
+        description: Midpoint price.
+        expr:
+          kind: path
+          path:
+            - mid
+
+  - name: spread
+    description: Bid-ask spread for one token.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+    request:
+      method: GET
+      path: /spread
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: spread
+        type: Utf8
+        nullable: true
+        description: Spread value.
+        expr:
+          kind: path
+          path:
+            - spread
+
+  - name: last_trade_price
+    description: Last public trade for one token.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+    request:
+      method: GET
+      path: /last-trade-price
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: price
+        type: Utf8
+        nullable: true
+        description: Last trade price.
+        expr:
+          kind: path
+          path:
+            - price
+      - name: side
+        type: Utf8
+        nullable: true
+        description: Last trade side.
+        expr:
+          kind: path
+          path:
+            - side
+
+  - name: tick_size
+    description: Minimum tick size for one token.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+    request:
+      method: GET
+      path: /tick-size
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: minimum_tick_size
+        type: Float64
+        nullable: true
+        description: Minimum tick size.
+        expr:
+          kind: path
+          path:
+            - minimum_tick_size
+
+  - name: fee_rate
+    description: Base fee rate for one token.
+    filters:
+      - name: token_id
+        required: true
+        description: CLOB token id.
+    request:
+      method: GET
+      path: /fee-rate
+      query:
+        - name: token_id
+          from: filter
+          key: token_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: token_id
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: token_id
+      - name: base_fee
+        type: Int64
+        nullable: true
+        description: Base fee.
+        expr:
+          kind: path
+          path:
+            - base_fee
+
+  - name: prices_history
+    description: Historical price points for one token.
+    guide: >-
+      Requires `market` (CLOB token id) and `history_interval` (`1d`,
+      `6h`, `1h`, or `max`). `interval` is a SQL reserved word, so the
+      filter is named `history_interval`.
+    filters:
+      - name: market
+        required: true
+        description: CLOB token id (the prices-history `market` query).
+      - name: history_interval
+        required: true
+        description: History interval (`1d`, `6h`, `1h`, or `max`).
+    request:
+      method: GET
+      path: /prices-history
+      query:
+        - name: market
+          from: filter
+          key: market
+        - name: interval
+          from: filter
+          key: history_interval
+    response:
+      rows_path:
+        - history
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: market
+        type: Utf8
+        nullable: false
+        description: Requested token id.
+        expr:
+          kind: from_filter
+          key: market
+      - name: history_interval
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested history interval.
+        expr:
+          kind: from_filter
+          key: history_interval
+      - name: t
+        type: Int64
+        nullable: true
+        description: Unix timestamp of the price point.
+        expr:
+          kind: path
+          path:
+            - t
+      - name: p
+        type: Float64
+        nullable: true
+        description: Price at that timestamp.
+        expr:
+          kind: path
+          path:
+            - p

--- a/sources/community/polymarket_data/README.md
+++ b/sources/community/polymarket_data/README.md
@@ -33,7 +33,8 @@ coral source test polymarket_data
 | `holders` | Top holders for a market | `market` (condition id) |
 | `live_volume` | Live volume for an event | `event_id` (Gamma event id) |
 
-`builder_volume` returns a large unpaginated list. Always `LIMIT` it.
+`builder_volume` is unpaginated: the full list is transferred before SQL
+`LIMIT` trims it.
 
 `holders` is one row per outcome token. The `holders` column is a JSON array
 of holder objects from the live payload.
@@ -76,5 +77,5 @@ WHERE event_id = '903269';
 
 - Wallet and market filters must be supplied as query parameters. They are
   not implied by a join alone.
-- `live_volume.id` is a Gamma **event** id, not a condition id.
+- `live_volume.event_id` is a Gamma **event** id, not a condition id.
 - No credentials are stored. All endpoints used here are public reads.

--- a/sources/community/polymarket_data/README.md
+++ b/sources/community/polymarket_data/README.md
@@ -1,0 +1,80 @@
+# Polymarket Data
+
+Query Polymarket's public Data API: trades, leaderboards, wallet positions,
+activity, holders, live event volume, and builder stats.
+
+No authentication required.
+
+This source covers `https://data-api.polymarket.com` only. The Gamma catalog
+is `polymarket`. Public CLOB reads are `polymarket_clob`.
+
+Columns were mapped from live Data API responses. Official docs:
+[docs.polymarket.com](https://docs.polymarket.com).
+
+## Setup
+
+```bash
+coral source add --file sources/community/polymarket_data/manifest.yaml
+coral source test polymarket_data
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `trades` | Recent public trades | — |
+| `leaderboard` | Trader leaderboard | — |
+| `builder_leaderboard` | Builder leaderboard | — |
+| `builder_volume` | Daily builder volume series | — |
+| `positions` | Open positions for a wallet | `user` |
+| `closed_positions` | Closed positions for a wallet | `user` |
+| `activity` | Wallet activity | `user` |
+| `value` | Portfolio value for a wallet | `user` |
+| `holders` | Top holders for a market | `market` (condition id) |
+| `live_volume` | Live volume for an event | `event_id` (Gamma event id) |
+
+`builder_volume` returns a large unpaginated list. Always `LIMIT` it.
+
+`holders` is one row per outcome token. The `holders` column is a JSON array
+of holder objects from the live payload.
+
+## SQL examples
+
+```sql
+SELECT title, side, size, price, transaction_hash
+FROM polymarket_data.trades
+LIMIT 10;
+```
+
+```sql
+SELECT rank, user_name, pnl, vol
+FROM polymarket_data.leaderboard
+LIMIT 10;
+```
+
+```sql
+SELECT title, size, cash_pnl, percent_pnl
+FROM polymarket_data.positions
+WHERE user = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'
+LIMIT 10;
+```
+
+```sql
+SELECT title, realized_pnl, total_bought
+FROM polymarket_data.closed_positions
+WHERE user = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'
+LIMIT 10;
+```
+
+```sql
+SELECT total, markets
+FROM polymarket_data.live_volume
+WHERE event_id = '903269';
+```
+
+## Limitations
+
+- Wallet and market filters must be supplied as query parameters. They are
+  not implied by a join alone.
+- `live_volume.id` is a Gamma **event** id, not a condition id.
+- No credentials are stored. All endpoints used here are public reads.

--- a/sources/community/polymarket_data/manifest.yaml
+++ b/sources/community/polymarket_data/manifest.yaml
@@ -1,0 +1,994 @@
+name: polymarket_data
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Polymarket Data API analytics: public trades, leaderboards,
+  wallet positions, activity, holders, and builder volume.
+base_url: https://data-api.polymarket.com
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT title, side, size, price FROM polymarket_data.trades LIMIT 5
+  - SELECT rank, user_name, pnl, vol FROM polymarket_data.leaderboard LIMIT 5
+  - SELECT rank, builder, volume FROM polymarket_data.builder_leaderboard LIMIT 5
+  - >-
+    SELECT title, size, cash_pnl
+    FROM polymarket_data.positions
+    WHERE user = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'
+    LIMIT 5
+  - >-
+    SELECT total
+    FROM polymarket_data.live_volume
+    WHERE event_id = '903269'
+    LIMIT 1
+  - >-
+    SELECT title, realized_pnl, total_bought
+    FROM polymarket_data.closed_positions
+    WHERE user = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'
+    LIMIT 5
+
+tables:
+  - name: trades
+    description: Recent public trades across Polymarket markets.
+    guide: >-
+      `SELECT title, side, size, price, transaction_hash
+      FROM polymarket_data.trades LIMIT 20`.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /trades
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: proxy_wallet
+        type: Utf8
+        nullable: true
+        description: Trader proxy wallet.
+        expr:
+          kind: path
+          path:
+            - proxyWallet
+      - name: side
+        type: Utf8
+        nullable: true
+        description: Trade side (BUY or SELL).
+        expr:
+          kind: path
+          path:
+            - side
+      - name: asset
+        type: Utf8
+        nullable: true
+        description: Traded asset / token id.
+        expr:
+          kind: path
+          path:
+            - asset
+      - name: condition_id
+        type: Utf8
+        nullable: true
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - conditionId
+      - name: size
+        type: Float64
+        nullable: true
+        description: Trade size.
+        expr:
+          kind: path
+          path:
+            - size
+      - name: price
+        type: Float64
+        nullable: true
+        description: Trade price.
+        expr:
+          kind: path
+          path:
+            - price
+      - name: timestamp
+        type: Int64
+        nullable: true
+        description: Unix timestamp of the trade.
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Market title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Market slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: event_slug
+        type: Utf8
+        nullable: true
+        description: Parent event slug.
+        expr:
+          kind: path
+          path:
+            - eventSlug
+      - name: outcome
+        type: Utf8
+        nullable: true
+        description: Outcome label.
+        expr:
+          kind: path
+          path:
+            - outcome
+      - name: outcome_index
+        type: Int64
+        nullable: true
+        description: Outcome index.
+        expr:
+          kind: path
+          path:
+            - outcomeIndex
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Trader display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: pseudonym
+        type: Utf8
+        nullable: true
+        description: Trader pseudonym.
+        expr:
+          kind: path
+          path:
+            - pseudonym
+      - name: transaction_hash
+        type: Utf8
+        nullable: true
+        description: On-chain transaction hash.
+        expr:
+          kind: path
+          path:
+            - transactionHash
+      - name: icon
+        type: Utf8
+        nullable: true
+        description: Market icon URL.
+        expr:
+          kind: path
+          path:
+            - icon
+
+  - name: leaderboard
+    description: Public trader leaderboard by volume and PnL.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /v1/leaderboard
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: rank
+        type: Utf8
+        nullable: true
+        description: Leaderboard rank.
+        expr:
+          kind: path
+          path:
+            - rank
+      - name: proxy_wallet
+        type: Utf8
+        nullable: true
+        description: Trader proxy wallet.
+        expr:
+          kind: path
+          path:
+            - proxyWallet
+      - name: user_name
+        type: Utf8
+        nullable: true
+        description: Display user name.
+        expr:
+          kind: path
+          path:
+            - userName
+      - name: x_username
+        type: Utf8
+        nullable: true
+        description: Linked X username.
+        expr:
+          kind: path
+          path:
+            - xUsername
+      - name: verified_badge
+        type: Boolean
+        nullable: true
+        description: Whether the trader is verified.
+        expr:
+          kind: path
+          path:
+            - verifiedBadge
+      - name: vol
+        type: Float64
+        nullable: true
+        description: Reported volume.
+        expr:
+          kind: path
+          path:
+            - vol
+      - name: pnl
+        type: Float64
+        nullable: true
+        description: Reported profit and loss.
+        expr:
+          kind: path
+          path:
+            - pnl
+      - name: profile_image
+        type: Utf8
+        nullable: true
+        description: Profile image URL.
+        expr:
+          kind: path
+          path:
+            - profileImage
+
+  - name: builder_leaderboard
+    description: Builder leaderboard by routed volume and active users.
+    fetch_limit_default: 50
+    request:
+      method: GET
+      path: /v1/builders/leaderboard
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: rank
+        type: Utf8
+        nullable: true
+        description: Builder rank.
+        expr:
+          kind: path
+          path:
+            - rank
+      - name: builder
+        type: Utf8
+        nullable: true
+        description: Builder name.
+        expr:
+          kind: path
+          path:
+            - builder
+      - name: builder_code
+        type: Utf8
+        nullable: true
+        description: Builder code.
+        expr:
+          kind: path
+          path:
+            - builderCode
+      - name: volume
+        type: Float64
+        nullable: true
+        description: Builder volume.
+        expr:
+          kind: path
+          path:
+            - volume
+      - name: active_users
+        type: Int64
+        nullable: true
+        description: Active users.
+        expr:
+          kind: path
+          path:
+            - activeUsers
+      - name: verified
+        type: Boolean
+        nullable: true
+        description: Whether the builder is verified.
+        expr:
+          kind: path
+          path:
+            - verified
+      - name: builder_logo
+        type: Utf8
+        nullable: true
+        description: Builder logo URL.
+        expr:
+          kind: path
+          path:
+            - builderLogo
+
+  - name: builder_volume
+    description: >-
+      Daily builder volume time series. The endpoint returns a large
+      unpaginated list; keep queries bounded with LIMIT.
+    fetch_limit_default: 20
+    request:
+      method: GET
+      path: /v1/builders/volume
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: dt
+        type: Utf8
+        nullable: true
+        description: Volume date.
+        expr:
+          kind: path
+          path:
+            - dt
+      - name: builder
+        type: Utf8
+        nullable: true
+        description: Builder name.
+        expr:
+          kind: path
+          path:
+            - builder
+      - name: builder_code
+        type: Utf8
+        nullable: true
+        description: Builder code.
+        expr:
+          kind: path
+          path:
+            - builderCode
+      - name: volume
+        type: Float64
+        nullable: true
+        description: Volume on that date.
+        expr:
+          kind: path
+          path:
+            - volume
+      - name: active_users
+        type: Int64
+        nullable: true
+        description: Active users on that date.
+        expr:
+          kind: path
+          path:
+            - activeUsers
+      - name: rank
+        type: Utf8
+        nullable: true
+        description: Rank on that date.
+        expr:
+          kind: path
+          path:
+            - rank
+      - name: verified
+        type: Boolean
+        nullable: true
+        description: Whether the builder is verified.
+        expr:
+          kind: path
+          path:
+            - verified
+      - name: builder_logo
+        type: Utf8
+        nullable: true
+        description: Builder logo URL.
+        expr:
+          kind: path
+          path:
+            - builderLogo
+
+  - name: positions
+    description: Current open positions for a wallet.
+    guide: >-
+      Requires `user`. Example:
+      `SELECT title, size, cash_pnl FROM polymarket_data.positions
+      WHERE user = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'`.
+    filters:
+      - name: user
+        required: true
+        description: Wallet address (0x...).
+    request:
+      method: GET
+      path: /positions
+      query:
+        - name: user
+          from: filter
+          key: user
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: user
+        type: Utf8
+        nullable: false
+        description: Requested wallet.
+        expr:
+          kind: from_filter
+          key: user
+      - name: proxy_wallet
+        type: Utf8
+        nullable: true
+        description: Position proxy wallet.
+        expr:
+          kind: path
+          path:
+            - proxyWallet
+      - name: asset
+        type: Utf8
+        nullable: true
+        description: Position asset / token id.
+        expr:
+          kind: path
+          path:
+            - asset
+      - name: condition_id
+        type: Utf8
+        nullable: true
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - conditionId
+      - name: size
+        type: Float64
+        nullable: true
+        description: Current position size.
+        expr:
+          kind: path
+          path:
+            - size
+      - name: avg_price
+        type: Float64
+        nullable: true
+        description: Average entry price.
+        expr:
+          kind: path
+          path:
+            - avgPrice
+      - name: initial_value
+        type: Float64
+        nullable: true
+        description: Initial position value.
+        expr:
+          kind: path
+          path:
+            - initialValue
+      - name: current_value
+        type: Float64
+        nullable: true
+        description: Current mark-to-market value.
+        expr:
+          kind: path
+          path:
+            - currentValue
+      - name: cash_pnl
+        type: Float64
+        nullable: true
+        description: Unrealized cash PnL.
+        expr:
+          kind: path
+          path:
+            - cashPnl
+      - name: percent_pnl
+        type: Float64
+        nullable: true
+        description: Unrealized percent PnL.
+        expr:
+          kind: path
+          path:
+            - percentPnl
+      - name: realized_pnl
+        type: Float64
+        nullable: true
+        description: Realized PnL.
+        expr:
+          kind: path
+          path:
+            - realizedPnl
+      - name: cur_price
+        type: Float64
+        nullable: true
+        description: Current outcome price.
+        expr:
+          kind: path
+          path:
+            - curPrice
+      - name: redeemable
+        type: Boolean
+        nullable: true
+        description: Whether the position is redeemable.
+        expr:
+          kind: path
+          path:
+            - redeemable
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Market title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Market slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: event_slug
+        type: Utf8
+        nullable: true
+        description: Parent event slug.
+        expr:
+          kind: path
+          path:
+            - eventSlug
+      - name: outcome
+        type: Utf8
+        nullable: true
+        description: Outcome label.
+        expr:
+          kind: path
+          path:
+            - outcome
+      - name: end_date
+        type: Utf8
+        nullable: true
+        description: Market end date.
+        expr:
+          kind: path
+          path:
+            - endDate
+
+  - name: closed_positions
+    description: Closed positions for a wallet.
+    guide: >-
+      Requires `user`. Example:
+      `SELECT title, realized_pnl, total_bought
+      FROM polymarket_data.closed_positions
+      WHERE user = '0x34dd4a4b70eaf79a17878f7938263c801d4dfd83'`.
+    filters:
+      - name: user
+        required: true
+        description: Wallet address (0x...).
+    request:
+      method: GET
+      path: /closed-positions
+      query:
+        - name: user
+          from: filter
+          key: user
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: user
+        type: Utf8
+        nullable: false
+        description: Requested wallet.
+        expr:
+          kind: from_filter
+          key: user
+      - name: proxy_wallet
+        type: Utf8
+        nullable: true
+        description: Position proxy wallet.
+        expr:
+          kind: path
+          path:
+            - proxyWallet
+      - name: asset
+        type: Utf8
+        nullable: true
+        description: Position asset / token id.
+        expr:
+          kind: path
+          path:
+            - asset
+      - name: condition_id
+        type: Utf8
+        nullable: true
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - conditionId
+      - name: avg_price
+        type: Float64
+        nullable: true
+        description: Average entry price.
+        expr:
+          kind: path
+          path:
+            - avgPrice
+      - name: total_bought
+        type: Float64
+        nullable: true
+        description: Total bought size.
+        expr:
+          kind: path
+          path:
+            - totalBought
+      - name: realized_pnl
+        type: Float64
+        nullable: true
+        description: Realized PnL.
+        expr:
+          kind: path
+          path:
+            - realizedPnl
+      - name: cur_price
+        type: Float64
+        nullable: true
+        description: Price at close / current.
+        expr:
+          kind: path
+          path:
+            - curPrice
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Market title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Market slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: outcome
+        type: Utf8
+        nullable: true
+        description: Outcome label.
+        expr:
+          kind: path
+          path:
+            - outcome
+      - name: end_date
+        type: Utf8
+        nullable: true
+        description: Market end date.
+        expr:
+          kind: path
+          path:
+            - endDate
+      - name: timestamp
+        type: Int64
+        nullable: true
+        description: Close timestamp.
+        expr:
+          kind: path
+          path:
+            - timestamp
+
+  - name: activity
+    description: Wallet activity (trades, redeems, and related events).
+    filters:
+      - name: user
+        required: true
+        description: Wallet address (0x...).
+    request:
+      method: GET
+      path: /activity
+      query:
+        - name: user
+          from: filter
+          key: user
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    columns:
+      - name: user
+        type: Utf8
+        nullable: false
+        description: Requested wallet.
+        expr:
+          kind: from_filter
+          key: user
+      - name: proxy_wallet
+        type: Utf8
+        nullable: true
+        description: Activity proxy wallet.
+        expr:
+          kind: path
+          path:
+            - proxyWallet
+      - name: timestamp
+        type: Int64
+        nullable: true
+        description: Activity unix timestamp.
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: condition_id
+        type: Utf8
+        nullable: true
+        description: Market condition id.
+        expr:
+          kind: path
+          path:
+            - conditionId
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Activity type.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: size
+        type: Float64
+        nullable: true
+        description: Activity size.
+        expr:
+          kind: path
+          path:
+            - size
+      - name: usdc_size
+        type: Float64
+        nullable: true
+        description: USDC notional size.
+        expr:
+          kind: path
+          path:
+            - usdcSize
+      - name: price
+        type: Float64
+        nullable: true
+        description: Activity price.
+        expr:
+          kind: path
+          path:
+            - price
+      - name: side
+        type: Utf8
+        nullable: true
+        description: Side when the activity is a trade.
+        expr:
+          kind: path
+          path:
+            - side
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Market title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Market slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: outcome
+        type: Utf8
+        nullable: true
+        description: Outcome label.
+        expr:
+          kind: path
+          path:
+            - outcome
+      - name: transaction_hash
+        type: Utf8
+        nullable: true
+        description: On-chain transaction hash.
+        expr:
+          kind: path
+          path:
+            - transactionHash
+
+  - name: value
+    description: Portfolio value for a wallet.
+    filters:
+      - name: user
+        required: true
+        description: Wallet address (0x...).
+    request:
+      method: GET
+      path: /value
+      query:
+        - name: user
+          from: filter
+          key: user
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: user
+        type: Utf8
+        nullable: false
+        description: Requested wallet.
+        expr:
+          kind: from_filter
+          key: user
+      - name: wallet
+        type: Utf8
+        nullable: true
+        description: Value row wallet.
+        expr:
+          kind: path
+          path:
+            - user
+      - name: value
+        type: Float64
+        nullable: true
+        description: Reported portfolio value.
+        expr:
+          kind: path
+          path:
+            - value
+
+  - name: holders
+    description: >-
+      Top holders for a market, grouped by token. The holders array is
+      returned as JSON on each token row.
+    guide: >-
+      Requires `market` (condition id). Example:
+      `SELECT token, holders FROM polymarket_data.holders
+      WHERE market = '0xa467b14d51f01b957109d9cbb1d6c124fab2a089d52ed8f471d23c2812e743b7'`.
+    filters:
+      - name: market
+        required: true
+        description: Market condition id.
+    request:
+      method: GET
+      path: /holders
+      query:
+        - name: market
+          from: filter
+          key: market
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: market
+        type: Utf8
+        nullable: false
+        description: Requested condition id.
+        expr:
+          kind: from_filter
+          key: market
+      - name: token
+        type: Utf8
+        nullable: true
+        description: Outcome token id.
+        expr:
+          kind: path
+          path:
+            - token
+      - name: holders
+        type: Json
+        nullable: true
+        description: Array of holder objects for this token.
+        expr:
+          kind: path
+          path:
+            - holders
+
+  - name: live_volume
+    description: Live volume for an event, with per-market breakdown.
+    guide: >-
+      Requires `event_id` (Gamma event id). Example:
+      `SELECT total, markets FROM polymarket_data.live_volume
+      WHERE event_id = '903269'`.
+    filters:
+      - name: event_id
+        required: true
+        description: Gamma event id.
+    request:
+      method: GET
+      path: /v1/live-volume
+      query:
+        - name: id
+          from: filter
+          key: event_id
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: event_id
+        type: Utf8
+        nullable: false
+        description: Requested event id.
+        expr:
+          kind: from_filter
+          key: event_id
+      - name: total
+        type: Float64
+        nullable: true
+        description: Total live volume for the event.
+        expr:
+          kind: path
+          path:
+            - total
+      - name: markets
+        type: Json
+        nullable: true
+        description: Per-market live volume objects.
+        expr:
+          kind: path
+          path:
+            - markets

--- a/sources/community/polymarket_data/manifest.yaml
+++ b/sources/community/polymarket_data/manifest.yaml
@@ -101,13 +101,16 @@ tables:
           path:
             - price
       - name: timestamp
-        type: Int64
+        type: Timestamp
         nullable: true
-        description: Unix timestamp of the trade.
+        description: Trade timestamp.
         expr:
-          kind: path
-          path:
-            - timestamp
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - timestamp
       - name: title
         type: Utf8
         nullable: true
@@ -341,8 +344,8 @@ tables:
 
   - name: builder_volume
     description: >-
-      Daily builder volume time series. The endpoint returns a large
-      unpaginated list; keep queries bounded with LIMIT.
+      Daily builder volume time series. The endpoint is unpaginated, so the
+      full list is transferred before SQL LIMIT trims it.
     fetch_limit_default: 20
     request:
       method: GET
@@ -354,13 +357,16 @@ tables:
       mode: none
     columns:
       - name: dt
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Volume date.
         expr:
-          kind: path
-          path:
-            - dt
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - dt
       - name: builder
         type: Utf8
         nullable: true
@@ -717,13 +723,16 @@ tables:
           path:
             - endDate
       - name: timestamp
-        type: Int64
+        type: Timestamp
         nullable: true
         description: Close timestamp.
         expr:
-          kind: path
-          path:
-            - timestamp
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - timestamp
 
   - name: activity
     description: Wallet activity (trades, redeems, and related events).
@@ -766,13 +775,16 @@ tables:
           path:
             - proxyWallet
       - name: timestamp
-        type: Int64
+        type: Timestamp
         nullable: true
-        description: Activity unix timestamp.
+        description: Activity timestamp.
         expr:
-          kind: path
-          path:
-            - timestamp
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - timestamp
       - name: condition_id
         type: Utf8
         nullable: true


### PR DESCRIPTION
## Summary

- Adds three sibling community sources for Polymarket's three public hosts: `polymarket` (Gamma catalog), `polymarket_data` (analytics), and `polymarket_clob` (public CLOB reads). DSL v3 `base_url` is source-level, so one manifest cannot cover all three.
- Columns and filters were mapped from live responses. Boolean Gamma flags use `active_filter` / `closed_filter` / `archived_filter` so they do not collide with Boolean response columns. CLOB price history uses `history_interval` because `interval` is reserved SQL. Authenticated CLOB trading (`POST /order`, cancels, HMAC-SHA256 L2 headers) is out of scope.
- Closes #2287.

## Source shape

| Source | Host | Auth | Tables |
|---|---|---|---|
| `polymarket` | `https://gamma-api.polymarket.com` | none | markets, events, tags, series, sports, public_profiles |
| `polymarket_data` | `https://data-api.polymarket.com` | none | trades, leaderboard, builder_leaderboard, builder_volume, positions, closed_positions, activity, value, holders, live_volume |
| `polymarket_clob` | `https://clob.polymarket.com` | none (public GETs) | simplified_markets, sampling_markets, sampling_simplified_markets, order_book, price, midpoint, spread, last_trade_price, tick_size, fee_rate, prices_history |

Not included: Gamma `GET /comments` and `GET /sports/teams` (HTTP 422), `GET /search` (HTTP 401), path-style `GET /profiles/{address}` (use `public_profiles`), and any signed CLOB write or user-order endpoint.

## Test plan

- [x] `coral source lint` on all three manifests
- [x] `coral source add --file` then `coral source test` in workspace `polymarket-review`
  - polymarket: 6 declared · 6 passed
  - polymarket_data: 6 declared · 6 passed
  - polymarket_clob: 4 declared · 4 passed
- [x] Extra live SQL for remaining required-filter tables: `activity`, `value`, `holders`, `builder_volume`, CLOB `price` / `midpoint` / `spread` / `last_trade_price` / `tick_size` / `fee_rate` / `sampling_simplified_markets`
- [x] Reviewer: `coral source add --file sources/community/polymarket/manifest.yaml` (and the `_data` / `_clob` siblings), then `coral source test` each name