### PR TITLE
fix(coral-ui): drop the unused routePath import from onboarding

### DIFF
--- a/apps/coral-ui/app/routes/onboarding.tsx
+++ b/apps/coral-ui/app/routes/onboarding.tsx
@@ -14,7 +14,6 @@ import {
   listWorkspacesForRequest,
   pickImpliedWorkspace,
 } from '@/lib/workspaces.server'
-import { routePath } from '@/routing/routemap'
 import { OnboardingView } from '@/views/onboarding/onboarding'
 import { addToast } from '@/wax/components/toast'
 


### PR DESCRIPTION
`oxlint --deny-warnings` fails on `main`:

```
app/routes/onboarding.tsx:17:10: error eslint(no-unused-vars):
Identifier 'routePath' is imported but never used.
```

#2293 removed the last call to `routePath` in this file; #2290 landed on top without noticing. Main's Validate has been red since `2f853643f` (`ea969856e` before it was green).

Every open pull request is red too, not just main: `actions/checkout` resolves the merge ref on a `pull_request` event, so each PR lints main-merged-into-branch.

Deletes the import. Nothing else.

## Verification

Run with CI's pinned linter (`oxlint@1.71.0`, per `package-lock.json`), not the newer one a stale `node_modules` may give you:

| tree | `oxlint --deny-warnings` |
|---|---|
| `main` (`2f853643f`) | the error above |
| this branch | exit 0 |

`oxfmt --check` clean, `npm run typecheck` clean, 39 files / 411 tests pass.