### PR TITLE
feat(coral-ui): prototype operation approval card states

### DIFF
--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1488,6 +1488,7 @@ function OperationApproval({
       {canReviewFuturePolicy && envelopeEvaluation ? (
         <PolicyUpdateProposalDialog
           evaluation={envelopeEvaluation}
+          key={`${envelopeEvaluation.envelopeId}-${envelopeEvaluation.envelopeMatch}`}
           onOpenChange={setPolicyProposalOpen}
           onUpdatePolicy={onUpdatePolicy}
           open={policyProposalOpen}
@@ -1862,6 +1863,7 @@ function PolicyUpdateProposalDialog({
           <Dialog.Close />
           <PolicySelectionBanner
             blockingCheck={unsafeChecks[0] ?? unselectedChecks[0]}
+            isCreatingPolicy={isCreatingPolicy}
             status={selectionStatus}
           />
           <section style={policyProposalListStyle}>
@@ -1917,16 +1919,20 @@ function PolicyUpdateProposalDialog({
 
 function PolicySelectionBanner({
   blockingCheck,
+  isCreatingPolicy,
   status,
 }: {
   blockingCheck?: AuthorityEnvelopeEvaluation['checks'][number]
+  isCreatingPolicy: boolean
   status: 'allows' | 'blocked' | 'incomplete'
 }) {
   const copy =
     status === 'allows'
       ? {
           detail: 'The exact Operation Invocation would be covered by the selected policy.',
-          title: 'Selected changes would allow this invocation',
+          title: isCreatingPolicy
+            ? 'Selected policy would allow this invocation'
+            : 'Selected changes would allow this invocation',
         }
       : status === 'blocked'
         ? {
@@ -1934,8 +1940,12 @@ function PolicySelectionBanner({
             title: 'Cannot create a safe automatic policy update',
           }
         : {
-            detail: `${blockingCheck?.label ?? 'A required check'} remains outside policy.`,
-            title: 'Selected changes still require approval',
+            detail: isCreatingPolicy
+              ? `${blockingCheck?.label ?? 'A required check'} is not included in the proposed policy.`
+              : `${blockingCheck?.label ?? 'A required check'} remains outside policy.`,
+            title: isCreatingPolicy
+              ? 'Selected policy would not cover this invocation'
+              : 'Selected changes still require approval',
           }
 
   return (
@@ -1986,6 +1996,9 @@ function PolicyUpdateProposalRow({
     } satisfies PolicyProposal)
   const isCreatingPolicy = candidatePolicy !== undefined
   const selectable = isCreatingPolicy ? status === 'pass' : resolvedProposal.kind === 'automatic'
+  const statusColor = isCreatingPolicy && selectable ? (checked ? 'green' : 'amber') : undefined
+  const statusLabel =
+    isCreatingPolicy && selectable ? (checked ? 'Included' : 'Not included') : null
 
   return (
     <div style={{ ...policyProposalRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
@@ -1996,7 +2009,9 @@ function PolicyUpdateProposalRow({
           label={label}
           onCheckedChange={onCheckedChange}
         />
-        <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
+        <Pill color={statusColor ?? envelopeStatusColors[status]}>
+          {statusLabel ?? envelopeStatusLabels[status]}
+        </Pill>
       </div>
       <Typography.BodySmall as="p" style={policyObservedStyle} variant="secondary">
         Observed: {observed}

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { type } from 'arktype'
 import { useId, useState } from 'react'
 import { fn } from 'storybook/test'
 
@@ -35,7 +36,7 @@ interface OperationApprovalStoryProps {
   showArguments?: boolean
   showApprovalAuthority?: boolean
   showExpiry?: boolean
-  showEnvelopeCheck?: boolean
+  showAuthorityEnvelopeMatch?: boolean
   showIdentity?: boolean
   showProgramBody?: boolean
   showProgramSnippet?: boolean
@@ -72,8 +73,9 @@ type EnvelopeCheckStatus = 'fail' | 'pass' | 'unknown'
 
 interface AuthorityEnvelopeEvaluation {
   checks: Array<{
-    detail: string
     label: string
+    observed: string
+    policy: string
     status: EnvelopeCheckStatus
   }>
   decision: 'allow' | 'requiresApproval'
@@ -82,9 +84,31 @@ interface AuthorityEnvelopeEvaluation {
   installedBy: string
 }
 
+interface AuthorityEnvelope {
+  envelopeId: string
+  facts: {
+    body: string
+    commentsToday?: number
+    evaluatedAt: string
+    issueState?: string
+    operationCallPath: string
+    repository: string
+  }
+  installedBy: string
+  policy: {
+    allowedOperationCallPath: string
+    allowedRepository: string
+    dailyCommentLimit: number
+    expiresAt: string
+    forbiddenMassMentions: string[]
+    maxBodyCharacters: number
+    requiredIssueState: string
+  }
+}
+
 interface OperationApprovalModel {
   approvalAuthority: string
-  authorityEnvelopeEvaluation?: AuthorityEnvelopeEvaluation
+  authorityEnvelope?: AuthorityEnvelope
   expiresAt: string
   identity: string
   invocationArguments: Array<{ label: string; value: ArgumentValue }>
@@ -110,9 +134,9 @@ const meta = {
       control: 'select',
       options: ['github', 'linear', 'loop', 'savedFunction', 'envelopeMatches', 'envelopeOutside'],
     },
-    showEnvelopeCheck: {
+    showAuthorityEnvelopeMatch: {
       control: 'boolean',
-      description: 'Show a Storybook-only deterministic Owner-policy envelope evaluation.',
+      description: 'Execute and show a Storybook-only deterministic Owner-policy envelope.',
     },
     showRequestContext: {
       control: 'boolean',
@@ -130,7 +154,7 @@ const meta = {
     onViewRun: fn(),
     showRequestContext: false,
     showProviderReference: false,
-    showEnvelopeCheck: false,
+    showAuthorityEnvelopeMatch: false,
   },
   component: OperationApprovalStory,
   decorators: [
@@ -152,7 +176,7 @@ Every Medium+ story keeps the same first-screen decision contract: Operation cal
 
 Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
-The envelope stories use Storybook-only mock evaluation data. They explore deterministic authorization from a Workspace Owner-installed policy; they do not model an agent approving another agent or introduce a production API contract. A passing envelope applies only to the exact Invocation shown.
+The envelope stories execute Storybook-only mock policy definitions against observed Invocation facts with ArkType. They explore deterministic authorization from a Workspace Owner-installed policy; ArkType is not proposed as Coral’s production authorization engine, and the stories do not model an agent approving another agent. A passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to run this experiment for a compatible dataset.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
@@ -185,17 +209,18 @@ type Story = StoryObj<typeof meta>
 
 function createEnvelopeDataset({
   body,
-  evaluation,
-  repo,
+  issueState,
+  repository,
 }: {
   body: string
-  evaluation: AuthorityEnvelopeEvaluation
-  repo: string
+  issueState?: string
+  repository: string
 }): OperationApprovalModel {
+  const [org, repo] = repository.split('/')
   const invocationArguments: OperationApprovalModel['invocationArguments'] = [
     {
       label: 'Argument 1',
-      value: { body, issue_number: 85, org: 'withcoral', repo },
+      value: { body, issue_number: 85, org, repo },
     },
     { label: 'Argument 2', value: { format: 'markdown' } },
     { label: 'Argument 3', value: 'notify-requester' },
@@ -203,7 +228,27 @@ function createEnvelopeDataset({
 
   return {
     approvalAuthority: 'Workspace owner',
-    authorityEnvelopeEvaluation: evaluation,
+    authorityEnvelope: {
+      envelopeId: 'env_01K4B6ZA',
+      facts: {
+        body,
+        commentsToday: 7,
+        evaluatedAt: '2026-09-02T12:00:00Z',
+        issueState,
+        operationCallPath: 'coral.providers.github.issues.createComment',
+        repository,
+      },
+      installedBy: 'Workspace Owner',
+      policy: {
+        allowedOperationCallPath: 'coral.providers.github.issues.createComment',
+        allowedRepository: 'withcoral/lagoon',
+        dailyCommentLimit: 20,
+        expiresAt: '2026-09-30T23:59:00Z',
+        forbiddenMassMentions: ['@channel', '@here'],
+        maxBodyCharacters: 2000,
+        requiredIssueState: 'open',
+      },
+    },
     expiresAt: '2026-09-02 16:00 UTC',
     identity: 'coral-bot',
     invocationArguments,
@@ -232,72 +277,99 @@ function createEnvelopeDataset({
   }
 }
 
+function evaluateAuthorityEnvelope(envelope: AuthorityEnvelope): AuthorityEnvelopeEvaluation {
+  const { facts, policy } = envelope
+  const operationPolicy = type('string').narrow(
+    (value) => value === policy.allowedOperationCallPath,
+  )
+  const repositoryPolicy = type('string').narrow((value) => value === policy.allowedRepository)
+  const bodyLengthPolicy = type('string').narrow(
+    (value) => value.length <= policy.maxBodyCharacters,
+  )
+  const mentionPolicy = type('string').narrow((value) =>
+    policy.forbiddenMassMentions.every((mention) => !value.includes(mention)),
+  )
+  const issueStatePolicy = type('string').narrow((value) => value === policy.requiredIssueState)
+  const quotaPolicy = type('number').narrow((value) => value < policy.dailyCommentLimit)
+  const expiryPolicy = type('Date').narrow(
+    (evaluatedAt) => evaluatedAt.getTime() < new Date(policy.expiresAt).getTime(),
+  )
+  const detectedMassMentions = policy.forbiddenMassMentions.filter((mention) =>
+    facts.body.includes(mention),
+  )
+  const checks: AuthorityEnvelopeEvaluation['checks'] = [
+    {
+      label: 'Operation',
+      observed: facts.operationCallPath,
+      policy: `Equals ${policy.allowedOperationCallPath}`,
+      status: arkStatus(operationPolicy(facts.operationCallPath)),
+    },
+    {
+      label: 'Repository',
+      observed: facts.repository,
+      policy: `Equals ${policy.allowedRepository}`,
+      status: arkStatus(repositoryPolicy(facts.repository)),
+    },
+    {
+      label: 'Issue state',
+      observed: facts.issueState ?? 'Unavailable',
+      policy: `Must be ${policy.requiredIssueState}`,
+      status:
+        facts.issueState === undefined ? 'unknown' : arkStatus(issueStatePolicy(facts.issueState)),
+    },
+    {
+      label: 'Body length',
+      observed: `${facts.body.length.toLocaleString()} characters`,
+      policy: `At most ${policy.maxBodyCharacters.toLocaleString()} characters`,
+      status: arkStatus(bodyLengthPolicy(facts.body)),
+    },
+    {
+      label: 'Mention policy',
+      observed:
+        detectedMassMentions.length > 0 ? detectedMassMentions.join(', ') : 'No mass mentions',
+      policy: `Excludes ${policy.forbiddenMassMentions.join(' and ')}`,
+      status: arkStatus(mentionPolicy(facts.body)),
+    },
+    {
+      label: 'Daily quota',
+      observed:
+        facts.commentsToday === undefined
+          ? 'Unavailable'
+          : `${facts.commentsToday} comments used today`,
+      policy: `Fewer than ${policy.dailyCommentLimit} comments used today`,
+      status:
+        facts.commentsToday === undefined ? 'unknown' : arkStatus(quotaPolicy(facts.commentsToday)),
+    },
+    {
+      label: 'Policy expiry',
+      observed: `Evaluated ${facts.evaluatedAt}`,
+      policy: `Expires ${policy.expiresAt}`,
+      status: arkStatus(expiryPolicy(new Date(facts.evaluatedAt))),
+    },
+  ]
+
+  return {
+    checks,
+    decision: checks.every(({ status }) => status === 'pass') ? 'allow' : 'requiresApproval',
+    envelopeId: envelope.envelopeId,
+    expiresAt: policy.expiresAt,
+    installedBy: envelope.installedBy,
+  }
+}
+
+function arkStatus(result: unknown): EnvelopeCheckStatus {
+  return result instanceof type.errors ? 'fail' : 'pass'
+}
+
 const datasets: Record<DatasetKey, OperationApprovalModel> = {
   envelopeMatches: createEnvelopeDataset({
     body: 'Approval envelope exploration is ready for review.',
-    evaluation: {
-      checks: [
-        {
-          detail: 'github.issues.createComment is allowed',
-          label: 'Operation',
-          status: 'pass',
-        },
-        {
-          detail: 'withcoral/lagoon matches the allowed repository',
-          label: 'Repository',
-          status: 'pass',
-        },
-        { detail: 'Issue #85 is open', label: 'Issue state', status: 'pass' },
-        { detail: '50 of 2,000 characters', label: 'Body length', status: 'pass' },
-        { detail: 'No mass mentions', label: 'Mention policy', status: 'pass' },
-        { detail: '7 of 20 comments used today', label: 'Daily quota', status: 'pass' },
-        {
-          detail: 'Expires 2026-09-30 23:59 UTC',
-          label: 'Policy expiry',
-          status: 'pass',
-        },
-      ],
-      decision: 'allow',
-      envelopeId: 'env_01K4B6ZA',
-      expiresAt: '2026-09-30 23:59 UTC',
-      installedBy: 'Workspace Owner',
-    },
-    repo: 'lagoon',
+    issueState: 'open',
+    repository: 'withcoral/lagoon',
   }),
   envelopeOutside: createEnvelopeDataset({
     body: '@channel Approval envelope exploration is ready for review.',
-    evaluation: {
-      checks: [
-        {
-          detail: 'github.issues.createComment is allowed',
-          label: 'Operation',
-          status: 'pass',
-        },
-        {
-          detail: 'withcoral/private-roadmap is outside the allowed repository',
-          label: 'Repository',
-          status: 'fail',
-        },
-        {
-          detail: 'Issue state was unavailable; this check did not pass',
-          label: 'Issue state',
-          status: 'unknown',
-        },
-        { detail: '59 of 2,000 characters', label: 'Body length', status: 'pass' },
-        { detail: 'Body contains @channel', label: 'Mention policy', status: 'fail' },
-        { detail: '7 of 20 comments used today', label: 'Daily quota', status: 'pass' },
-        {
-          detail: 'Expires 2026-09-30 23:59 UTC',
-          label: 'Policy expiry',
-          status: 'pass',
-        },
-      ],
-      decision: 'requiresApproval',
-      envelopeId: 'env_01K4B6ZA',
-      expiresAt: '2026-09-30 23:59 UTC',
-      installedBy: 'Workspace Owner',
-    },
-    repo: 'private-roadmap',
+    repository: 'withcoral/private-roadmap',
   }),
   github: {
     invocationArguments: [
@@ -838,7 +910,7 @@ export const EnvelopeMatches: Story = {
     argumentsInitiallyExpanded: true,
     dataset: 'envelopeMatches',
     showArguments: true,
-    showEnvelopeCheck: true,
+    showAuthorityEnvelopeMatch: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
     showRequester: true,
@@ -860,7 +932,7 @@ export const EnvelopeDoesNotMatch: Story = {
     dataset: 'envelopeOutside',
     showArguments: true,
     showApprovalAuthority: true,
-    showEnvelopeCheck: true,
+    showAuthorityEnvelopeMatch: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -962,7 +1034,7 @@ function OperationApproval({
   showArguments,
   showApprovalAuthority,
   showExpiry,
-  showEnvelopeCheck,
+  showAuthorityEnvelopeMatch,
   showIdentity,
   showProgramBody,
   showProgramSnippet,
@@ -974,10 +1046,14 @@ function OperationApproval({
   showTechnicalDetails,
 }: OperationApprovalProps) {
   const hasDecisionContext = Boolean(showApprovalAuthority)
+  const envelopeEvaluation =
+    showAuthorityEnvelopeMatch && approval.authorityEnvelope
+      ? evaluateAuthorityEnvelope(approval.authorityEnvelope)
+      : undefined
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
-    showEnvelopeCheck ||
+    showAuthorityEnvelopeMatch ||
     showIdentity ||
     hasDecisionContext ||
     showProgramBody ||
@@ -993,7 +1069,7 @@ function OperationApproval({
     <section style={{ ...cardStyle, ...(compact ? compactCardStyle : {}) }}>
       <ApprovalHeader
         approval={approval}
-        envelopeEvaluation={showEnvelopeCheck ? approval.authorityEnvelopeEvaluation : undefined}
+        envelopeEvaluation={envelopeEvaluation}
         hasContext={hasContext}
         showApprovalAuthority={showApprovalAuthority}
         showExpiry={showExpiry}
@@ -1010,9 +1086,7 @@ function OperationApproval({
         />
       ) : null}
 
-      {showEnvelopeCheck && approval.authorityEnvelopeEvaluation ? (
-        <EnvelopeCheckSection evaluation={approval.authorityEnvelopeEvaluation} />
-      ) : null}
+      {envelopeEvaluation ? <EnvelopeCheckSection evaluation={envelopeEvaluation} /> : null}
 
       {(showRequestContext && approval.requestContext) ||
       (showProgramSnippet && approval.programContext) ? (
@@ -1085,7 +1159,7 @@ function OperationApproval({
         </div>
       ) : null}
 
-      {showEnvelopeCheck && approval.authorityEnvelopeEvaluation?.decision === 'allow' ? null : (
+      {envelopeEvaluation?.decision === 'allow' ? null : (
         <ApprovalActions onApprove={onApprove} onDecline={onDecline} />
       )}
     </section>
@@ -1218,11 +1292,12 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
       <dl style={contextDetailsStyle}>
         <DetailRow label="Installed by" value={evaluation.installedBy} />
         <DetailRow label="Envelope expiry" value={evaluation.expiresAt} />
-        {evaluation.checks.map(({ detail, label, status }, index) => (
+        {evaluation.checks.map(({ label, observed, policy, status }, index) => (
           <EnvelopeCheckRow
             key={label}
-            detail={detail}
             label={label}
+            observed={observed}
+            policy={policy}
             showDivider={index < evaluation.checks.length - 1}
             status={status}
           />
@@ -1238,13 +1313,15 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
 }
 
 function EnvelopeCheckRow({
-  detail,
   label,
+  observed,
+  policy,
   showDivider,
   status,
 }: {
-  detail: string
   label: string
+  observed: string
+  policy: string
   showDivider: boolean
   status: EnvelopeCheckStatus
 }) {
@@ -1257,9 +1334,14 @@ function EnvelopeCheckRow({
         {label}
       </Typography.BodySmall>
       <div style={envelopeCheckValueStyle}>
-        <Typography.BodySmall as="dd" style={detailValueStyle} variant="primary">
-          {detail}
-        </Typography.BodySmall>
+        <div style={envelopeCheckCopyStyle}>
+          <Typography.BodySmall as="dd" style={detailValueStyle} variant="primary">
+            Policy: {policy}
+          </Typography.BodySmall>
+          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+            Observed: {observed}
+          </Typography.BodySmall>
+        </div>
         <Pill color={statusColor}>{statusLabel}</Pill>
       </div>
     </div>
@@ -1555,6 +1637,14 @@ const envelopeCheckValueStyle: CSSProperties = {
   display: 'flex',
   gap: '8px',
   justifyContent: 'space-between',
+  minWidth: 0,
+}
+
+const envelopeCheckCopyStyle: CSSProperties = {
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  gap: '2px',
   minWidth: 0,
 }
 

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1485,7 +1485,7 @@ function InvocationArgumentRow({
       style={{
         ...argumentGroupStyle,
         ...(argumentStatus && !isInterleavedObject
-          ? envelopeArgumentBackgrounds[argumentStatus]
+          ? envelopeArgumentStatusStyles[argumentStatus]
           : {}),
         ...(!showDivider ? lastDetailRowStyle : {}),
       }}
@@ -1546,7 +1546,7 @@ function InterleavedArgumentFields({
               key={field}
               style={{
                 ...interleavedFieldStyle,
-                ...(fieldStatus ? envelopeInterleavedBackgrounds[fieldStatus] : {}),
+                ...(fieldStatus ? envelopeArgumentStatusStyles[fieldStatus] : {}),
                 ...(index === fields.length - 1 ? lastDetailRowStyle : {}),
               }}
             >
@@ -1576,9 +1576,9 @@ function EnvelopeArgumentAnnotation({
 }) {
   return (
     <div style={argumentAnnotationStyle}>
-      <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+      <code style={policyExpressionStyle}>
         Policy: {label} {policy}
-      </Typography.BodySmall>
+      </code>
       <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
     </div>
   )
@@ -1611,7 +1611,9 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
             {matches ? 'Allowed by Owner policy' : 'Outside Owner policy'}
           </Typography.BodySmallStrong>
           <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
-            {matches ? 'Can continue without per-call approval' : 'Requires approval'}
+            {matches
+              ? 'Can continue without per-call approval'
+              : 'Requires owner approval for this Invocation'}
           </Typography.BodySmall>
         </div>
         <Pill color={matches ? 'green' : 'amber'}>{matches ? 'Allowed' : 'Review'}</Pill>
@@ -1659,12 +1661,10 @@ function EnvelopeCheckRow({
       </Typography.BodySmall>
       <div style={envelopeCheckValueStyle}>
         <div style={envelopeCheckCopyStyle}>
-          <Typography.BodySmall as="dd" style={detailValueStyle} variant="primary">
-            Policy: {policy}
-          </Typography.BodySmall>
-          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+          <Typography.BodySmall as="dd" style={detailValueStyle} variant="secondary">
             Observed: {observed}
           </Typography.BodySmall>
+          <code style={policyExpressionStyle}>Policy: {policy}</code>
         </div>
         <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
       </div>
@@ -1964,28 +1964,19 @@ const interleavedFieldValueStyle: CSSProperties = {
   gridTemplateColumns: '120px minmax(0, 1fr)',
 }
 
-const envelopeArgumentBackgrounds: Record<EnvelopeCheckStatus, CSSProperties> = {
+const envelopeArgumentStatusStyles: Record<EnvelopeCheckStatus, CSSProperties> = {
   fail: {
-    background: theme.content.errorBackground,
-    borderRadius: '6px',
-    padding: '0 8px 8px',
+    borderLeft: `1px solid ${theme.content.error}`,
+    paddingLeft: '8px',
   },
   pass: {
-    background: theme.content.successBackground,
-    borderRadius: '6px',
-    padding: '0 8px 8px',
+    borderLeft: `1px solid ${theme.content.success}`,
+    paddingLeft: '8px',
   },
   unknown: {
-    background: theme.content.warningBackground,
-    borderRadius: '6px',
-    padding: '0 8px 8px',
+    borderLeft: `1px solid ${theme.content.warning}`,
+    paddingLeft: '8px',
   },
-}
-
-const envelopeInterleavedBackgrounds: Record<EnvelopeCheckStatus, CSSProperties> = {
-  fail: { background: theme.content.errorBackground, borderRadius: '6px' },
-  pass: { background: theme.content.successBackground, borderRadius: '6px' },
-  unknown: { background: theme.content.warningBackground, borderRadius: '6px' },
 }
 
 const argumentAnnotationsStyle: CSSProperties = {
@@ -2001,6 +1992,14 @@ const argumentAnnotationStyle: CSSProperties = {
   gap: '8px',
   justifyContent: 'space-between',
   minWidth: 0,
+}
+
+const policyExpressionStyle: CSSProperties = {
+  color: theme.content.tertiary,
+  fontFamily: 'monospace',
+  fontSize: '11px',
+  lineHeight: 1.4,
+  overflowWrap: 'anywhere',
 }
 
 const lastDetailRowStyle: CSSProperties = { borderBottom: 0 }

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -210,7 +210,47 @@ const meta = {
     },
     showRequestContext: {
       control: 'boolean',
-      description: 'Show Task and exec intent as secondary request context.',
+      description: 'Show Task, Task intent, and exec intent as secondary request context.',
+    },
+    showProgramBody: {
+      control: 'boolean',
+      description: 'Show submitted Program body as supporting context.',
+    },
+    showProgramSnippet: {
+      control: 'boolean',
+      description: 'Show highlighted Program snippet as supporting context.',
+    },
+    showArguments: {
+      control: 'boolean',
+      description: 'Show exact positional Invocation arguments as primary evidence.',
+    },
+    showApprovalAuthority: {
+      control: 'boolean',
+      description: 'Show who can approve the pending Invocation.',
+    },
+    showExpiry: {
+      control: 'boolean',
+      description: 'Show the Approval Request expiry.',
+    },
+    showIdentity: {
+      control: 'boolean',
+      description: 'Show the selected provider identity when available.',
+    },
+    showRequester: {
+      control: 'boolean',
+      description: 'Show the invoking principal as Requested by.',
+    },
+    showRequestMetadataInHeader: {
+      control: 'boolean',
+      description: 'Place requester, approval authority, and expiry in the header.',
+    },
+    showRunContext: {
+      control: 'boolean',
+      description: 'Show secondary Program Run context and the View run action.',
+    },
+    showTechnicalDetails: {
+      control: 'boolean',
+      description: 'Show the collapsed technical details disclosure.',
     },
     showProviderReference: {
       control: 'boolean',
@@ -224,6 +264,8 @@ const meta = {
     onDecline: fn(),
     onUpdatePolicy: fn(),
     onViewRun: fn(),
+    showProgramBody: false,
+    showProgramSnippet: false,
     showRequestContext: false,
     showProviderReference: false,
     showAuthorityEnvelopeMatch: false,

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -21,6 +21,7 @@ type ArgumentValue =
 type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
 type EnvelopeMatch = 'inside' | 'none' | 'outside'
 type EnvelopeArgsDisplay = 'interleaved' | 'none' | 'summary'
+type SectionDisplay = 'collapsed' | 'expanded' | 'hidden' | 'visible'
 
 interface OperationApprovalStoryProps {
   argumentsCollapsible?: boolean
@@ -64,13 +65,13 @@ interface OperationApprovalDisplay {
     showRequester?: boolean
   }
   sections?: {
-    authorityEnvelope?: boolean
-    programBody?: boolean
-    programSnippet?: boolean
-    providerReference?: boolean
-    requestContext?: boolean
-    runContext?: boolean
-    technicalDetails?: boolean
+    authorityEnvelope?: SectionDisplay
+    programBody?: SectionDisplay
+    programSnippet?: SectionDisplay
+    providerReference?: SectionDisplay
+    requestContext?: SectionDisplay
+    runContext?: SectionDisplay
+    technicalDetails?: SectionDisplay
   }
 }
 
@@ -1388,6 +1389,25 @@ export const MaximalEvidence: Story = {
   },
 }
 
+function sectionDisplay(
+  show: boolean | undefined,
+  defaultWhenShown: SectionDisplay = 'visible',
+): SectionDisplay {
+  return show ? defaultWhenShown : 'hidden'
+}
+
+function shouldShowSection(display: SectionDisplay | undefined): boolean {
+  return display !== undefined && display !== 'hidden'
+}
+
+function sectionIsDisclosure(display: SectionDisplay | undefined): boolean {
+  return display === 'collapsed' || display === 'expanded'
+}
+
+function sectionInitiallyOpen(display: SectionDisplay | undefined): boolean {
+  return display === 'expanded'
+}
+
 function OperationApprovalStory({
   argumentsCollapsible,
   argumentsInitiallyExpanded,
@@ -1443,13 +1463,13 @@ function OperationApprovalStory({
           showRequester,
         },
         sections: {
-          authorityEnvelope: showAuthorityEnvelopeMatch,
-          programBody: showProgramBody,
-          programSnippet: showProgramSnippet,
-          providerReference: showProviderReference,
-          requestContext: showRequestContext,
-          runContext: showRunContext,
-          technicalDetails: showTechnicalDetails,
+          authorityEnvelope: sectionDisplay(showAuthorityEnvelopeMatch),
+          programBody: sectionDisplay(showProgramBody, 'collapsed'),
+          programSnippet: sectionDisplay(showProgramSnippet),
+          providerReference: sectionDisplay(showProviderReference, 'collapsed'),
+          requestContext: sectionDisplay(showRequestContext),
+          runContext: sectionDisplay(showRunContext),
+          technicalDetails: sectionDisplay(showTechnicalDetails, 'collapsed'),
         },
       }}
     />
@@ -1472,7 +1492,8 @@ function OperationApproval({
   const showIdentity = header.showIdentity
   const showRequester = header.showRequester
   const hasDecisionContext = Boolean(showApprovalAuthority)
-  const isEnvelopeVisible = sections.authorityEnvelope || envelopeArgsDisplay !== 'none'
+  const isEnvelopeVisible =
+    shouldShowSection(sections.authorityEnvelope) || envelopeArgsDisplay !== 'none'
   const envelopeArgumentChecks =
     envelopeArgsDisplay !== 'none' && envelopeEvaluation?.envelopeMatch !== 'none'
       ? envelopeEvaluation?.checks
@@ -1482,17 +1503,17 @@ function OperationApproval({
   const hasContext = Boolean(
     argumentsDisplay.visible ||
     showExpiry ||
-    sections.authorityEnvelope ||
+    shouldShowSection(sections.authorityEnvelope) ||
     envelopeArgsDisplay !== 'none' ||
     showIdentity ||
     hasDecisionContext ||
-    sections.programBody ||
-    sections.programSnippet ||
-    sections.providerReference ||
-    sections.requestContext ||
+    shouldShowSection(sections.programBody) ||
+    shouldShowSection(sections.programSnippet) ||
+    shouldShowSection(sections.providerReference) ||
+    shouldShowSection(sections.requestContext) ||
     showRequester ||
-    sections.runContext ||
-    sections.technicalDetails,
+    shouldShowSection(sections.runContext) ||
+    shouldShowSection(sections.technicalDetails),
   )
 
   return (
@@ -1508,11 +1529,17 @@ function OperationApproval({
         showRequester={showRequester}
       />
 
-      {(sections.requestContext && approval.requestContext) ||
-      (sections.programSnippet && approval.programContext) ? (
+      {(shouldShowSection(sections.requestContext) && approval.requestContext) ||
+      (shouldShowSection(sections.programSnippet) && approval.programContext) ? (
         <ContextSection
-          programSnippet={sections.programSnippet ? approval.programContext?.snippet : undefined}
-          requestContext={sections.requestContext ? approval.requestContext : undefined}
+          programSnippet={
+            shouldShowSection(sections.programSnippet)
+              ? approval.programContext?.snippet
+              : undefined
+          }
+          requestContext={
+            shouldShowSection(sections.requestContext) ? approval.requestContext : undefined
+          }
         />
       ) : null}
 
@@ -1526,12 +1553,15 @@ function OperationApproval({
         />
       ) : null}
 
-      {sections.authorityEnvelope && envelopeEvaluation ? (
+      {shouldShowSection(sections.authorityEnvelope) && envelopeEvaluation ? (
         <EnvelopeCheckSection evaluation={envelopeEvaluation} />
       ) : null}
 
-      {sections.programBody && approval.programContext ? (
-        <ProgramBodyDisclosure programBody={approval.programContext.body} />
+      {shouldShowSection(sections.programBody) && approval.programContext ? (
+        <ProgramBodySection
+          display={sections.programBody}
+          programBody={approval.programContext.body}
+        />
       ) : null}
 
       {(showRequester || showExpiry) && !hasDecisionContext && !showRequestMetadataInHeader ? (
@@ -1570,13 +1600,18 @@ function OperationApproval({
         </section>
       ) : null}
 
-      {sections.providerReference && approval.providerReference ? (
-        <ProviderReferenceSection providerReference={approval.providerReference} />
+      {shouldShowSection(sections.providerReference) && approval.providerReference ? (
+        <ProviderReferenceSection
+          display={sections.providerReference}
+          providerReference={approval.providerReference}
+        />
       ) : null}
 
-      {sections.technicalDetails ? <TechnicalDetailsSection approval={approval} /> : null}
+      {shouldShowSection(sections.technicalDetails) ? (
+        <TechnicalDetailsSection approval={approval} display={sections.technicalDetails} />
+      ) : null}
 
-      {sections.runContext ? (
+      {shouldShowSection(sections.runContext) ? (
         <div style={runContextStyle}>
           <div style={runCopyStyle}>
             <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
@@ -2300,56 +2335,102 @@ function RequestContextDetails({ requestContext }: { requestContext: RequestCont
   )
 }
 
-function ProgramBodyDisclosure({ programBody }: { programBody: ProgramEvidence }) {
-  return (
-    <details open={false} style={disclosureSectionStyle}>
+function ProgramBodySection({
+  display,
+  programBody,
+}: {
+  display?: SectionDisplay
+  programBody: ProgramEvidence
+}) {
+  const content = <ProgramEvidenceBlock evidence={programBody} />
+
+  return sectionIsDisclosure(display) ? (
+    <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
       <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
         Program body
       </Typography.BodySmallStrong>
-      <div style={disclosureContentStyle}>
-        <ProgramEvidenceBlock evidence={programBody} />
-      </div>
+      <div style={disclosureContentStyle}>{content}</div>
     </details>
+  ) : (
+    <section style={sectionStyle}>
+      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+        Program body
+      </Typography.BodySmallStrong>
+      {content}
+    </section>
   )
 }
 
-function ProviderReferenceSection({ providerReference }: { providerReference: string }) {
-  return (
-    <details style={disclosureSectionStyle}>
+function ProviderReferenceSection({
+  display,
+  providerReference,
+}: {
+  display?: SectionDisplay
+  providerReference: string
+}) {
+  const content = (
+    <>
+      <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+        Optional provider-authored text; it does not define this approval’s exact effect.
+      </Typography.BodySmall>
+      <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+        {providerReference}
+      </Typography.BodySmall>
+    </>
+  )
+
+  return sectionIsDisclosure(display) ? (
+    <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
       <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
         Reference
       </Typography.BodySmallStrong>
-      <div style={disclosureContentStyle}>
-        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
-          Optional provider-authored text; it does not define this approval’s exact effect.
-        </Typography.BodySmall>
-        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
-          {providerReference}
-        </Typography.BodySmall>
-      </div>
+      <div style={disclosureContentStyle}>{content}</div>
     </details>
+  ) : (
+    <section style={sectionStyle}>
+      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+        Reference
+      </Typography.BodySmallStrong>
+      {content}
+    </section>
   )
 }
 
-function TechnicalDetailsSection({ approval }: { approval: OperationApprovalModel }) {
+function TechnicalDetailsSection({
+  approval,
+  display,
+}: {
+  approval: OperationApprovalModel
+  display?: SectionDisplay
+}) {
   const technicalDetails = buildTechnicalDetails(approval)
+  const content = (
+    <dl style={technicalListStyle}>
+      {technicalDetails.map(({ label, value }, index) => (
+        <DetailRow
+          key={label}
+          label={label}
+          showDivider={index < technicalDetails.length - 1}
+          value={value}
+        />
+      ))}
+    </dl>
+  )
 
-  return (
-    <details style={disclosureSectionStyle}>
+  return sectionIsDisclosure(display) ? (
+    <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
       <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
         Technical details
       </Typography.BodySmallStrong>
-      <dl style={technicalListStyle}>
-        {technicalDetails.map(({ label, value }, index) => (
-          <DetailRow
-            key={label}
-            label={label}
-            showDivider={index < technicalDetails.length - 1}
-            value={value}
-          />
-        ))}
-      </dl>
+      {content}
     </details>
+  ) : (
+    <section style={sectionStyle}>
+      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+        Technical details
+      </Typography.BodySmallStrong>
+      {content}
+    </section>
   )
 }
 

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -17,17 +17,13 @@ type ArgumentValue =
   | null
   | ArgumentValue[]
   | { [key: string]: ArgumentValue }
-type DatasetKey =
-  | 'envelopeMatches'
-  | 'envelopeOutside'
-  | 'github'
-  | 'linear'
-  | 'loop'
-  | 'savedFunction'
+type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
+type EnvelopeMatch = 'inside' | 'outside'
 
 interface OperationApprovalStoryProps {
   argumentsCollapsible?: boolean
   argumentsInitiallyExpanded?: boolean
+  envelopeMatch: EnvelopeMatch
   compact?: boolean
   dataset: DatasetKey
   onApprove: () => void
@@ -48,8 +44,9 @@ interface OperationApprovalStoryProps {
   showTechnicalDetails?: boolean
 }
 
-type OperationApprovalProps = Omit<OperationApprovalStoryProps, 'dataset'> & {
+type OperationApprovalProps = Omit<OperationApprovalStoryProps, 'dataset' | 'envelopeMatch'> & {
   approval: OperationApprovalModel
+  authorityEnvelope: AuthorityEnvelope
 }
 
 interface ProgramEvidence {
@@ -86,29 +83,29 @@ interface AuthorityEnvelopeEvaluation {
 
 interface AuthorityEnvelope {
   envelopeId: string
-  facts: {
-    body: string
-    commentsToday?: number
-    evaluatedAt: string
-    issueState?: string
-    operationCallPath: string
-    repository: string
-  }
+  evaluatedAt: string
+  expiresAt: string
   installedBy: string
-  policy: {
-    allowedOperationCallPath: string
-    allowedRepository: string
-    dailyCommentLimit: number
-    expiresAt: string
-    forbiddenMassMentions: string[]
-    maxBodyCharacters: number
-    requiredIssueState: string
+  operationCallPath: string
+  rules: AuthorityEnvelopeRule[]
+}
+
+interface AuthorityEnvelopeRule {
+  evaluate: (approval: OperationApprovalModel) => {
+    observed: string
+    status: EnvelopeCheckStatus
   }
+  label: string
+  policy: string
+}
+
+interface OperationApprovalDataset {
+  approval: OperationApprovalModel
+  authorityEnvelopes: Record<EnvelopeMatch, AuthorityEnvelope>
 }
 
 interface OperationApprovalModel {
   approvalAuthority: string
-  authorityEnvelope?: AuthorityEnvelope
   expiresAt: string
   identity: string
   invocationArguments: Array<{ label: string; value: ArgumentValue }>
@@ -130,9 +127,15 @@ interface OperationApprovalModel {
 
 const meta = {
   argTypes: {
+    envelopeMatch: {
+      control: 'inline-radio',
+      description: 'Choose the Owner envelope evaluated against the selected dataset.',
+      name: 'Match envelope',
+      options: ['inside', 'outside'],
+    },
     dataset: {
       control: 'select',
-      options: ['github', 'linear', 'loop', 'savedFunction', 'envelopeMatches', 'envelopeOutside'],
+      options: ['github', 'linear', 'loop', 'savedFunction'],
     },
     showAuthorityEnvelopeMatch: {
       control: 'boolean',
@@ -148,6 +151,7 @@ const meta = {
     },
   },
   args: {
+    envelopeMatch: 'inside',
     dataset: 'github',
     onApprove: fn(),
     onDecline: fn(),
@@ -176,7 +180,7 @@ Every Medium+ story keeps the same first-screen decision contract: Operation cal
 
 Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
-The envelope stories execute Storybook-only mock policy definitions against observed Invocation facts with ArkType. They explore deterministic authorization from a Workspace Owner-installed policy; ArkType is not proposed as Coral’s production authorization engine, and the stories do not model an agent approving another agent. A passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to run this experiment for a compatible dataset.
+Every dataset supplies two Storybook-only Owner envelopes: \`inside\` matches its exact Invocation and \`outside\` fails explicit argument filters. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the evaluation.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
@@ -207,144 +211,31 @@ Use the least disclosure that still makes the concrete target clear. Program bod
 export default meta
 type Story = StoryObj<typeof meta>
 
-function createEnvelopeDataset({
-  body,
-  issueState,
-  repository,
-}: {
-  body: string
-  issueState?: string
-  repository: string
-}): OperationApprovalModel {
-  const [org, repo] = repository.split('/')
-  const invocationArguments: OperationApprovalModel['invocationArguments'] = [
-    {
-      label: 'Argument 1',
-      value: { body, issue_number: 85, org, repo },
-    },
-    { label: 'Argument 2', value: { format: 'markdown' } },
-    { label: 'Argument 3', value: 'notify-requester' },
-  ]
-
-  return {
-    approvalAuthority: 'Workspace owner',
-    authorityEnvelope: {
-      envelopeId: 'env_01K4B6ZA',
-      facts: {
-        body,
-        commentsToday: 7,
-        evaluatedAt: '2026-09-02T12:00:00Z',
-        issueState,
-        operationCallPath: 'coral.providers.github.issues.createComment',
-        repository,
-      },
-      installedBy: 'Workspace Owner',
-      policy: {
-        allowedOperationCallPath: 'coral.providers.github.issues.createComment',
-        allowedRepository: 'withcoral/lagoon',
-        dailyCommentLimit: 20,
-        expiresAt: '2026-09-30T23:59:00Z',
-        forbiddenMassMentions: ['@channel', '@here'],
-        maxBodyCharacters: 2000,
-        requiredIssueState: 'open',
-      },
-    },
-    expiresAt: '2026-09-02 16:00 UTC',
-    identity: 'coral-bot',
-    invocationArguments,
-    invokingPrincipal: 'triage-bot',
-    operationCallPath: 'coral.providers.github.issues.createComment',
-    policyText: 'Agents cannot approve their own operations.',
-    provider: 'GitHub',
-    providerReference:
-      'Creates a comment on an issue in the selected repository using the authenticated GitHub account.',
-    rawInvocation: invocationArguments.map(({ value }) => value),
-    requestContext: {
-      execIntent: 'Post the prepared triage note to the selected GitHub issue.',
-      taskId: 'task_01K4B7TP',
-      taskIntent: 'Triage the approval-policy follow-up for the Lagoon workspace.',
-    },
-    runContext: {
-      runId: 'run_01K4B7V2',
-      status: 'running',
-      workspace: 'Lagoon',
-    },
-    technicalDetails: [
-      { label: 'Operation invocation', value: 'inv_01K4B7X4 · pending' },
-      { label: 'Provider generation', value: 'github@gen_0198' },
-      { label: 'Credential route', value: 'route_github_coral_bot' },
-    ],
-  }
-}
-
-function evaluateAuthorityEnvelope(envelope: AuthorityEnvelope): AuthorityEnvelopeEvaluation {
-  const { facts, policy } = envelope
-  const operationPolicy = type('string').narrow(
-    (value) => value === policy.allowedOperationCallPath,
-  )
-  const repositoryPolicy = type('string').narrow((value) => value === policy.allowedRepository)
-  const bodyLengthPolicy = type('string').narrow(
-    (value) => value.length <= policy.maxBodyCharacters,
-  )
-  const mentionPolicy = type('string').narrow((value) =>
-    policy.forbiddenMassMentions.every((mention) => !value.includes(mention)),
-  )
-  const issueStatePolicy = type('string').narrow((value) => value === policy.requiredIssueState)
-  const quotaPolicy = type('number').narrow((value) => value < policy.dailyCommentLimit)
+function evaluateAuthorityEnvelope(
+  approval: OperationApprovalModel,
+  envelope: AuthorityEnvelope,
+): AuthorityEnvelopeEvaluation {
+  const operationPolicy = type('string').narrow((value) => value === envelope.operationCallPath)
   const expiryPolicy = type('Date').narrow(
-    (evaluatedAt) => evaluatedAt.getTime() < new Date(policy.expiresAt).getTime(),
-  )
-  const detectedMassMentions = policy.forbiddenMassMentions.filter((mention) =>
-    facts.body.includes(mention),
+    (evaluatedAt) => evaluatedAt.getTime() < new Date(envelope.expiresAt).getTime(),
   )
   const checks: AuthorityEnvelopeEvaluation['checks'] = [
     {
-      label: 'Operation',
-      observed: facts.operationCallPath,
-      policy: `Equals ${policy.allowedOperationCallPath}`,
-      status: arkStatus(operationPolicy(facts.operationCallPath)),
+      label: 'Operation call path',
+      observed: approval.operationCallPath,
+      policy: `== ${JSON.stringify(envelope.operationCallPath)}`,
+      status: arkStatus(operationPolicy(approval.operationCallPath)),
     },
-    {
-      label: 'Repository',
-      observed: facts.repository,
-      policy: `Equals ${policy.allowedRepository}`,
-      status: arkStatus(repositoryPolicy(facts.repository)),
-    },
-    {
-      label: 'Issue state',
-      observed: facts.issueState ?? 'Unavailable',
-      policy: `Must be ${policy.requiredIssueState}`,
-      status:
-        facts.issueState === undefined ? 'unknown' : arkStatus(issueStatePolicy(facts.issueState)),
-    },
-    {
-      label: 'Body length',
-      observed: `${facts.body.length.toLocaleString()} characters`,
-      policy: `At most ${policy.maxBodyCharacters.toLocaleString()} characters`,
-      status: arkStatus(bodyLengthPolicy(facts.body)),
-    },
-    {
-      label: 'Mention policy',
-      observed:
-        detectedMassMentions.length > 0 ? detectedMassMentions.join(', ') : 'No mass mentions',
-      policy: `Excludes ${policy.forbiddenMassMentions.join(' and ')}`,
-      status: arkStatus(mentionPolicy(facts.body)),
-    },
-    {
-      label: 'Daily quota',
-      observed:
-        facts.commentsToday === undefined
-          ? 'Unavailable'
-          : `${facts.commentsToday} comments used today`,
-      policy: `Fewer than ${policy.dailyCommentLimit} comments used today`,
-      status:
-        facts.commentsToday === undefined ? 'unknown' : arkStatus(quotaPolicy(facts.commentsToday)),
-    },
+    ...envelope.rules.map(({ evaluate, label, policy }) => ({
+      label,
+      policy,
+      ...evaluate(approval),
+    })),
     {
       label: 'Policy expiry',
-      observed: `Evaluated ${facts.evaluatedAt}`,
-      policy: `Expires ${policy.expiresAt}`,
-      status: arkStatus(expiryPolicy(new Date(facts.evaluatedAt))),
+      observed: `Evaluated ${envelope.evaluatedAt}`,
+      policy: `expires ${envelope.expiresAt}`,
+      status: arkStatus(expiryPolicy(new Date(envelope.evaluatedAt))),
     },
   ]
 
@@ -352,7 +243,7 @@ function evaluateAuthorityEnvelope(envelope: AuthorityEnvelope): AuthorityEnvelo
     checks,
     decision: checks.every(({ status }) => status === 'pass') ? 'allow' : 'requiresApproval',
     envelopeId: envelope.envelopeId,
-    expiresAt: policy.expiresAt,
+    expiresAt: envelope.expiresAt,
     installedBy: envelope.installedBy,
   }
 }
@@ -361,16 +252,7 @@ function arkStatus(result: unknown): EnvelopeCheckStatus {
   return result instanceof type.errors ? 'fail' : 'pass'
 }
 
-const datasets: Record<DatasetKey, OperationApprovalModel> = {
-  envelopeMatches: createEnvelopeDataset({
-    body: 'Approval envelope exploration is ready for review.',
-    issueState: 'open',
-    repository: 'withcoral/lagoon',
-  }),
-  envelopeOutside: createEnvelopeDataset({
-    body: '@channel Approval envelope exploration is ready for review.',
-    repository: 'withcoral/private-roadmap',
-  }),
+const approvalDatasets: Record<DatasetKey, OperationApprovalModel> = {
   github: {
     invocationArguments: [
       {
@@ -694,6 +576,265 @@ export default async function postApprovalFollowUp(input) {
   },
 }
 
+function createArgumentRule({
+  argumentIndex,
+  formatObserved = formatEnvelopeObserved,
+  label,
+  path,
+  policy,
+  validate,
+}: {
+  argumentIndex: number
+  formatObserved?: (value: ArgumentValue) => string
+  label: string
+  path: string[]
+  policy: string
+  validate: (value: ArgumentValue) => unknown
+}): AuthorityEnvelopeRule {
+  return {
+    evaluate: (approval) => {
+      const observed = readInvocationArgument(approval, argumentIndex, path)
+
+      return observed === undefined
+        ? { observed: 'Unavailable', status: 'unknown' }
+        : { observed: formatObserved(observed), status: arkStatus(validate(observed)) }
+    },
+    label,
+    policy,
+  }
+}
+
+function stringEqualsRule(label: string, argumentIndex: number, path: string[], expected: string) {
+  const schema = type('string').narrow((value) => value === expected)
+  return createArgumentRule({
+    argumentIndex,
+    label,
+    path,
+    policy: `== ${JSON.stringify(expected)}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function stringInRule(label: string, argumentIndex: number, path: string[], allowed: string[]) {
+  const schema = type('string').narrow((value) => allowed.includes(value))
+  return createArgumentRule({
+    argumentIndex,
+    label,
+    path,
+    policy: `in ${JSON.stringify(allowed)}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function numberInRule(label: string, argumentIndex: number, path: string[], allowed: number[]) {
+  const schema = type('number').narrow((value) => allowed.includes(value))
+  return createArgumentRule({
+    argumentIndex,
+    label,
+    path,
+    policy: `in ${JSON.stringify(allowed)}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function booleanEqualsRule(
+  label: string,
+  argumentIndex: number,
+  path: string[],
+  expected: boolean,
+) {
+  const schema = type('boolean').narrow((value) => value === expected)
+  return createArgumentRule({
+    argumentIndex,
+    label,
+    path,
+    policy: `== ${String(expected)}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function stringLengthRule(label: string, argumentIndex: number, path: string[], maximum: number) {
+  const schema = type('string').narrow((value) => value.length <= maximum)
+  return createArgumentRule({
+    argumentIndex,
+    formatObserved: (value) =>
+      typeof value === 'string'
+        ? `${value.length.toLocaleString()} characters`
+        : JSON.stringify(value),
+    label,
+    path,
+    policy: `length <= ${maximum.toLocaleString()}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function stringExcludesRule(
+  label: string,
+  argumentIndex: number,
+  path: string[],
+  excluded: string[],
+) {
+  const schema = type('string').narrow((value) =>
+    excluded.every((candidate) => !value.includes(candidate)),
+  )
+  return createArgumentRule({
+    argumentIndex,
+    formatObserved: (value) => {
+      if (typeof value !== 'string') return JSON.stringify(value)
+      const matches = excluded.filter((candidate) => value.includes(candidate))
+      return matches.length > 0 ? matches.join(', ') : 'No excluded values'
+    },
+    label,
+    path,
+    policy: `excludes ${JSON.stringify(excluded)}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function stringArrayIncludesRule(
+  label: string,
+  argumentIndex: number,
+  path: string[],
+  required: string,
+) {
+  const schema = type('string[]').narrow((value) => value.includes(required))
+  return createArgumentRule({
+    argumentIndex,
+    label,
+    path,
+    policy: `includes ${JSON.stringify(required)}`,
+    validate: (value) => schema(value),
+  })
+}
+
+function readInvocationArgument(
+  approval: OperationApprovalModel,
+  argumentIndex: number,
+  path: string[],
+): ArgumentValue | undefined {
+  let value = approval.invocationArguments[argumentIndex]?.value
+
+  for (const segment of path) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+    value = value[segment]
+  }
+
+  return value
+}
+
+function formatEnvelopeObserved(value: ArgumentValue) {
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
+function createAuthorityEnvelope(
+  envelopeId: string,
+  approval: OperationApprovalModel,
+  rules: AuthorityEnvelopeRule[],
+): AuthorityEnvelope {
+  return {
+    envelopeId,
+    evaluatedAt: '2026-09-02T12:00:00Z',
+    expiresAt: '2026-09-30T23:59:00Z',
+    installedBy: 'Workspace Owner',
+    operationCallPath: approval.operationCallPath,
+    rules,
+  }
+}
+
+function createDataset(
+  datasetKey: DatasetKey,
+  insideRules: AuthorityEnvelopeRule[],
+  outsideRules: AuthorityEnvelopeRule[],
+): OperationApprovalDataset {
+  const approval = approvalDatasets[datasetKey]
+  return {
+    approval,
+    authorityEnvelopes: {
+      inside: createAuthorityEnvelope(`env_${datasetKey}_inside`, approval, insideRules),
+      outside: createAuthorityEnvelope(`env_${datasetKey}_outside`, approval, outsideRules),
+    },
+  }
+}
+
+const githubSharedRules = [
+  stringEqualsRule('args[0].org', 0, ['org'], 'withcoral'),
+  stringLengthRule('args[0].body.length', 0, ['body'], 2000),
+  stringExcludesRule('args[0].body mentions', 0, ['body'], ['@channel', '@here']),
+]
+const linearSharedRules = [
+  stringArrayIncludesRule('args[0].labels', 0, ['labels'], 'run-status'),
+  booleanEqualsRule('args[1].notifyAssignee', 1, ['notifyAssignee'], true),
+]
+const loopSharedRules = [
+  stringEqualsRule('args[0].source.issue', 0, ['source', 'issue'], 'withcoral/lagoon#91'),
+  booleanEqualsRule('args[1].notifyAssignee', 1, ['notifyAssignee'], false),
+]
+const savedFunctionSharedRules = [
+  stringEqualsRule('args[0].org', 0, ['org'], 'withcoral'),
+  stringLengthRule('args[0].body.length', 0, ['body'], 2000),
+  stringEqualsRule(
+    'args[1].functionPath',
+    1,
+    ['functionPath'],
+    'coral.functions.postApprovalFollowUp',
+  ),
+]
+
+const datasets = {
+  github: createDataset(
+    'github',
+    [
+      ...githubSharedRules,
+      stringEqualsRule('args[0].repo', 0, ['repo'], 'lagoon'),
+      numberInRule('args[0].issue_number', 0, ['issue_number'], [85]),
+    ],
+    [
+      ...githubSharedRules,
+      stringEqualsRule('args[0].repo', 0, ['repo'], 'coral-internal'),
+      numberInRule('args[0].issue_number', 0, ['issue_number'], [99]),
+    ],
+  ),
+  linear: createDataset(
+    'linear',
+    [
+      ...linearSharedRules,
+      stringInRule('args[0].issue_id', 0, ['issue_id'], ['LIN-482']),
+      stringEqualsRule('args[0].state_id', 0, ['state_id'], 'in_review'),
+    ],
+    [
+      ...linearSharedRules,
+      stringInRule('args[0].issue_id', 0, ['issue_id'], ['LIN-999']),
+      stringEqualsRule('args[0].state_id', 0, ['state_id'], 'done'),
+    ],
+  ),
+  loop: createDataset(
+    'loop',
+    [
+      ...loopSharedRules,
+      stringInRule('args[0].issue_id', 0, ['issue_id'], ['LIN-491']),
+      stringEqualsRule('args[0].state_id', 0, ['state_id'], 'triaged'),
+    ],
+    [
+      ...loopSharedRules,
+      stringInRule('args[0].issue_id', 0, ['issue_id'], ['LIN-999']),
+      stringEqualsRule('args[0].state_id', 0, ['state_id'], 'done'),
+    ],
+  ),
+  savedFunction: createDataset(
+    'savedFunction',
+    [
+      ...savedFunctionSharedRules,
+      stringEqualsRule('args[0].repo', 0, ['repo'], 'lagoon'),
+      numberInRule('args[0].issue_number', 0, ['issue_number'], [85]),
+    ],
+    [
+      ...savedFunctionSharedRules,
+      stringEqualsRule('args[0].repo', 0, ['repo'], 'coral-internal'),
+      numberInRule('args[0].issue_number', 0, ['issue_number'], [99]),
+    ],
+  ),
+} satisfies Record<DatasetKey, OperationApprovalDataset>
+
 export const Minimal: Story = {
   args: {
     compact: true,
@@ -908,7 +1049,8 @@ export const EnvelopeMatches: Story = {
   args: {
     argumentsCollapsible: true,
     argumentsInitiallyExpanded: true,
-    dataset: 'envelopeMatches',
+    dataset: 'github',
+    envelopeMatch: 'inside',
     showArguments: true,
     showAuthorityEnvelopeMatch: true,
     showIdentity: true,
@@ -929,7 +1071,8 @@ export const EnvelopeDoesNotMatch: Story = {
   args: {
     argumentsCollapsible: true,
     argumentsInitiallyExpanded: true,
-    dataset: 'envelopeOutside',
+    dataset: 'github',
+    envelopeMatch: 'outside',
     showArguments: true,
     showApprovalAuthority: true,
     showAuthorityEnvelopeMatch: true,
@@ -1019,14 +1162,23 @@ export const MaximalEvidence: Story = {
   },
 }
 
-function OperationApprovalStory({ dataset, ...props }: OperationApprovalStoryProps) {
-  return <OperationApproval approval={datasets[dataset]} {...props} />
+function OperationApprovalStory({ dataset, envelopeMatch, ...props }: OperationApprovalStoryProps) {
+  const selectedDataset = datasets[dataset]
+
+  return (
+    <OperationApproval
+      approval={selectedDataset.approval}
+      authorityEnvelope={selectedDataset.authorityEnvelopes[envelopeMatch]}
+      {...props}
+    />
+  )
 }
 
 function OperationApproval({
   approval,
   argumentsCollapsible,
   argumentsInitiallyExpanded,
+  authorityEnvelope,
   compact,
   onApprove,
   onDecline,
@@ -1046,10 +1198,9 @@ function OperationApproval({
   showTechnicalDetails,
 }: OperationApprovalProps) {
   const hasDecisionContext = Boolean(showApprovalAuthority)
-  const envelopeEvaluation =
-    showAuthorityEnvelopeMatch && approval.authorityEnvelope
-      ? evaluateAuthorityEnvelope(approval.authorityEnvelope)
-      : undefined
+  const envelopeEvaluation = showAuthorityEnvelopeMatch
+    ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
+    : undefined
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
@@ -1213,6 +1364,8 @@ function ApprovalHeader({
       </div>
       {envelopeEvaluation?.decision === 'allow' ? (
         <Pill color="green">Allowed by Owner policy</Pill>
+      ) : envelopeEvaluation ? (
+        <Pill color="amber">Outside Owner policy</Pill>
       ) : hasContext ? (
         <Pill color="amber">Approval required</Pill>
       ) : null}
@@ -1281,7 +1434,7 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
       <div style={envelopeResultStyle}>
         <div style={envelopeResultCopyStyle}>
           <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
-            {matches ? 'Matches envelope' : 'Outside envelope'}
+            {matches ? 'Allowed by Owner policy' : 'Outside Owner policy'}
           </Typography.BodySmallStrong>
           <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
             {matches ? 'Can continue without per-call approval' : 'Requires approval'}

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -810,6 +810,7 @@ const datasets = {
       ...githubSharedRules,
       stringEqualsRule('args[0].repo', 0, ['repo'], 'coral-internal'),
       numberInRule('args[0].issue_number', 0, ['issue_number'], [99]),
+      stringEqualsRule('args[2]', 2, [], 'approval-card-review'),
     ],
   ),
   linear: createDataset(

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -18,24 +18,29 @@ type ArgumentValue =
   | { [key: string]: ArgumentValue }
 type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
 
-interface OperationApprovalProps {
+interface OperationApprovalStoryProps {
   argumentsCollapsible?: boolean
   argumentsInitiallyExpanded?: boolean
-  canApprove?: boolean
   compact?: boolean
   dataset: DatasetKey
   onApprove: () => void
   onDecline: () => void
   onViewRun: () => void
   showArguments?: boolean
+  showApprovalAuthority?: boolean
   showExpiry?: boolean
   showIdentity?: boolean
   showProgramBody?: boolean
   showProgramSnippet?: boolean
   showRequestMetadataInHeader?: boolean
+  showRequestContext?: boolean
   showRequester?: boolean
   showRunContext?: boolean
   showTechnicalDetails?: boolean
+}
+
+type OperationApprovalProps = Omit<OperationApprovalStoryProps, 'dataset'> & {
+  approval: OperationApprovalModel
 }
 
 interface ProgramEvidence {
@@ -44,25 +49,36 @@ interface ProgramEvidence {
   currentOperation: string
 }
 
-interface ApprovalDataset {
-  arguments: Array<{ label: string; value: ArgumentValue }>
-  canApprove: string
-  deadline: string
+interface ProgramContext {
+  body: ProgramEvidence
+  snippet: ProgramEvidence
+}
+
+interface RequestContext {
+  execIntent: string
+  taskId: string
+  taskIntent: string
+}
+
+interface OperationApprovalModel {
+  approvalAuthority: string
+  expiresAt: string
   identity: string
-  operationName: string
+  invocationArguments: Array<{ label: string; value: ArgumentValue }>
+  invokingPrincipal: string
+  operationCallPath: string
   policyText: string
-  programBody: ProgramEvidence
-  programSnippet: ProgramEvidence
+  programContext?: ProgramContext
   provider: string
-  providerDescription: string
-  rawArguments: ArgumentValue[]
-  requestedBy: string
+  providerReference?: string
+  rawInvocation: ArgumentValue[]
+  requestContext?: RequestContext
   runContext: {
     runId: string
     status: 'running'
     workspace: string
   }
-  technicalIds: Array<{ label: string; value: string }>
+  technicalDetails: Array<{ label: string; value: string }>
 }
 
 const meta = {
@@ -78,7 +94,7 @@ const meta = {
     onDecline: fn(),
     onViewRun: fn(),
   },
-  component: OperationApproval,
+  component: OperationApprovalStory,
   decorators: [
     (Story) => (
       <div style={storyCanvasStyle}>
@@ -92,6 +108,10 @@ const meta = {
       description: {
         component: `An Operation Approval resolves one pending Operation Invocation. It does not approve the Program Run, future Invocations, or a reusable permission profile. The containing Program Run remains running while it waits for the decision.
 
+The story-only model uses Lagoon-aligned names: \`operationCallPath\`, \`invocationArguments\`, \`invokingPrincipal\`, \`approvalAuthority\`, \`expiresAt\`, optional \`requestContext\`, and optional \`programContext\`. Task and exec intent are request context; they do not replace the exact Invocation arguments or describe the consequence of approval.
+
+Every Medium+ story keeps the same first-screen decision contract: Operation call path, provider identity, invoking principal, approval authority, expiry, exact Invocation arguments, and the unchanged Decline/Approve actions. The prototype does not invent an operation-specific consequence CTA when no trusted renderer provides one.
+
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
 - **Minimal** uses the stable operation name with very little extra detail.
@@ -99,11 +119,10 @@ Each story has a **dataset** control. The default GitHub dataset uses \`coral.pr
 - **MinimalWithRequester** adds only the requesting principal.
 - **MinimalWithRequesterAndExpiry** adds both compact approval-request fields.
 - **Medium** adds identity plus positional/raw arguments.
-- **MediumWithExpiry** adds the approval deadline to Medium disclosure.
-- **MediumWithRequester** adds the requesting principal to Medium disclosure.
-- **MediumWithRequesterAndExpiry** adds both approval-request fields to Medium disclosure.
+- **MediumWithExpiry**, **MediumWithRequester**, and **MediumWithRequesterAndExpiry** retain earlier comparison names, but now preserve the complete Medium+ decision contract.
 - **MediumExpandableExpanded** includes requester and expiry, starts open, and allows arguments to be collapsed.
 - **MediumExpandableCollapsed** includes requester and expiry behind a collapsed-by-default argument review.
+- **TaskIntentContext** adds grounded Task and MCP exec intent as secondary request context.
 - **ProgramSnippet** adds expandable arguments and highlights one current-operation call as supporting context.
 - **CollapsedProgramBody** adds expandable arguments and a collapsed, self-contained Program body.
 - **MaximalEvidence** keeps arguments expandable while exposing snippet, Program body, provider reference copy, raw args, and ids.
@@ -115,14 +134,14 @@ Use the least disclosure that still makes the concrete target clear. Program bod
   },
   tags: ['autodocs'],
   title: 'Components/OperationApproval',
-} satisfies Meta<typeof OperationApproval>
+} satisfies Meta<typeof OperationApprovalStory>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-const datasets: Record<DatasetKey, ApprovalDataset> = {
+const datasets: Record<DatasetKey, OperationApprovalModel> = {
   github: {
-    arguments: [
+    invocationArguments: [
       {
         label: 'Argument 1',
         value: {
@@ -141,13 +160,14 @@ const datasets: Record<DatasetKey, ApprovalDataset> = {
       },
       { label: 'Argument 3', value: 'notify-requester' },
     ],
-    canApprove: 'Workspace owner',
-    deadline: 'Expires at 14:42 UTC',
+    approvalAuthority: 'Workspace owner',
+    expiresAt: '14:42 UTC',
     identity: 'coral-bot',
-    operationName: 'coral.providers.github.issues.createComment',
+    operationCallPath: 'coral.providers.github.issues.createComment',
     policyText: 'Agents cannot approve their own operations.',
-    programBody: {
-      before: `const selectedIssue = { org: "withcoral", repo: "lagoon", number: 85 }
+    programContext: {
+      body: {
+        before: `const selectedIssue = { org: "withcoral", repo: "lagoon", number: 85 }
 const comment = {
   issue_number: selectedIssue.number,
   org: selectedIssue.org,
@@ -156,19 +176,20 @@ const comment = {
 }
 const options = { format: "markdown", mentions: ["@reef-team"] }
 const routing = "notify-requester"`,
-      currentOperation: 'await github.issues.createComment(comment, options, routing)',
-      after: `await audit.log({ action: "requested_github_comment", issue: selectedIssue.number })`,
-    },
-    programSnippet: {
-      before: `const body = "The approval queue now groups pending actions by Program Run and updates live."
+        currentOperation: 'await github.issues.createComment(comment, options, routing)',
+        after: `await audit.log({ action: "requested_github_comment", issue: selectedIssue.number })`,
+      },
+      snippet: {
+        before: `const body = "The approval queue now groups pending actions by Program Run and updates live."
 const comment = { org: "withcoral", repo: "lagoon", issue_number: 85, body }
 const options = { format: "markdown", mentions: ["@reef-team"] }`,
-      currentOperation: 'await github.issues.createComment(comment, options, "notify-requester")',
+        currentOperation: 'await github.issues.createComment(comment, options, "notify-requester")',
+      },
     },
     provider: 'GitHub',
-    providerDescription:
+    providerReference:
       'Creates a comment on an issue in the selected repository using the authenticated GitHub account.',
-    rawArguments: [
+    rawInvocation: [
       {
         issue_number: 85,
         body: 'The approval queue now groups pending actions by Program Run and updates live.',
@@ -181,13 +202,18 @@ const options = { format: "markdown", mentions: ["@reef-team"] }`,
       },
       'notify-requester',
     ],
-    requestedBy: 'reef-agent',
+    invokingPrincipal: 'reef-agent',
+    requestContext: {
+      execIntent: 'Post the prepared approval-card update to the Lagoon issue.',
+      taskId: 'task_01K3Q7ZX',
+      taskIntent: 'Follow up on the approval-card review for the Run Status Page.',
+    },
     runContext: {
       runId: 'run_01K3Q8DA',
       status: 'running',
       workspace: 'Lagoon',
     },
-    technicalIds: [
+    technicalDetails: [
       { label: 'Approval request', value: 'apr_01K3Q8F1 · pending · created 14:34 UTC' },
       { label: 'Operation invocation', value: 'inv_01K3Q8E4 · pending' },
       { label: 'Provider generation', value: 'github@gen_0198' },
@@ -196,7 +222,7 @@ const options = { format: "markdown", mentions: ["@reef-team"] }`,
     ],
   },
   linear: {
-    arguments: [
+    invocationArguments: [
       {
         label: 'Argument 1',
         value: {
@@ -210,13 +236,14 @@ const options = { format: "markdown", mentions: ["@reef-team"] }`,
       { label: 'Argument 2', value: { notifyAssignee: true, priority: 'normal' } },
       { label: 'Argument 3', value: 'approval-card-review' },
     ],
-    canApprove: 'Workspace owner',
-    deadline: 'Expires at 14:42 UTC',
+    approvalAuthority: 'Workspace owner',
+    expiresAt: '14:42 UTC',
     identity: 'coral-linear-bot',
-    operationName: 'coral.providers.linear.issues.update',
+    operationCallPath: 'coral.providers.linear.issues.update',
     policyText: 'Agents cannot approve their own operations.',
-    programBody: {
-      before: `const githubIssue = { repo: "withcoral/lagoon", number: 85 }
+    programContext: {
+      body: {
+        before: `const githubIssue = { repo: "withcoral/lagoon", number: 85 }
 const linearIssue = { id: "LIN-482", state: "in_review" }
 const updateInput = {
   issue_id: linearIssue.id,
@@ -226,18 +253,21 @@ const updateInput = {
   source: { provider: "github", issue: githubIssue.repo + "#" + githubIssue.number },
 }
 const options = { notifyAssignee: true, priority: "normal" }`,
-      currentOperation: 'await linear.issues.update(updateInput, options, "approval-card-review")',
-      after: `await audit.log({ action: "requested_linear_update", issue: linearIssue.id })`,
-    },
-    programSnippet: {
-      before: `const githubIssue = { repo: "withcoral/lagoon", number: 85 }
+        currentOperation:
+          'await linear.issues.update(updateInput, options, "approval-card-review")',
+        after: `await audit.log({ action: "requested_linear_update", issue: linearIssue.id })`,
+      },
+      snippet: {
+        before: `const githubIssue = { repo: "withcoral/lagoon", number: 85 }
 const updateInput = { issue_id: "LIN-482", state_id: "in_review", source: githubIssue }
 const options = { notifyAssignee: true, priority: "normal" }`,
-      currentOperation: 'await linear.issues.update(updateInput, options, "approval-card-review")',
+        currentOperation:
+          'await linear.issues.update(updateInput, options, "approval-card-review")',
+      },
     },
     provider: 'Linear',
-    providerDescription: 'Updates an issue using the authenticated Linear workspace identity.',
-    rawArguments: [
+    providerReference: 'Updates an issue using the authenticated Linear workspace identity.',
+    rawInvocation: [
       {
         issue_id: 'LIN-482',
         state_id: 'in_review',
@@ -248,13 +278,18 @@ const options = { notifyAssignee: true, priority: "normal" }`,
       { notifyAssignee: true, priority: 'normal' },
       'approval-card-review',
     ],
-    requestedBy: 'reef-agent',
+    invokingPrincipal: 'reef-agent',
+    requestContext: {
+      execIntent: 'Update the Linear review item with the related GitHub issue context.',
+      taskId: 'task_01K3Q9B2',
+      taskIntent: 'Coordinate the approval-card review across Linear and GitHub.',
+    },
     runContext: {
       runId: 'run_01K3Q8DA',
       status: 'running',
       workspace: 'Lagoon',
     },
-    technicalIds: [
+    technicalDetails: [
       { label: 'Approval request', value: 'apr_01K3Q8F1 · pending · created 14:34 UTC' },
       { label: 'Operation invocation', value: 'inv_01K3Q8E4 · pending' },
       { label: 'Provider generation', value: 'linear@gen_0198' },
@@ -263,7 +298,7 @@ const options = { notifyAssignee: true, priority: "normal" }`,
     ],
   },
   loop: {
-    arguments: [
+    invocationArguments: [
       {
         label: 'Argument 1',
         value: {
@@ -276,13 +311,14 @@ const options = { notifyAssignee: true, priority: "normal" }`,
       { label: 'Argument 2', value: { notifyAssignee: false, loopIndex: 2, total: 5 } },
       { label: 'Argument 3', value: 'loop-iteration-2' },
     ],
-    canApprove: 'Workspace owner',
-    deadline: 'Expires at 14:42 UTC',
+    approvalAuthority: 'Workspace owner',
+    expiresAt: '14:42 UTC',
     identity: 'coral-linear-bot',
-    operationName: 'coral.providers.linear.issues.update',
+    operationCallPath: 'coral.providers.linear.issues.update',
     policyText: 'Agents cannot approve their own operations.',
-    programBody: {
-      before: `const githubIssues = [91, 92, 93, 94, 95]
+    programContext: {
+      body: {
+        before: `const githubIssues = [91, 92, 93, 94, 95]
 for (const [index, issueNumber] of githubIssues.entries()) {
   const githubIssue = { repo: "withcoral/lagoon", number: issueNumber }
   const linearIssue = { id: "LIN-" + (489 + index), state: "triaged" }
@@ -292,21 +328,22 @@ for (const [index, issueNumber] of githubIssues.entries()) {
     source: { provider: "github", issue: githubIssue.repo + "#" + githubIssue.number },
   }
   const options = { notifyAssignee: false, loopIndex: index + 1, total: githubIssues.length }`,
-      currentOperation:
-        '  await linear.issues.update(updateInput, options, "loop-iteration-" + (index + 1))',
-      after: `  await audit.log({ action: "requested_loop_update", issue: linearIssue.id })
+        currentOperation:
+          '  await linear.issues.update(updateInput, options, "loop-iteration-" + (index + 1))',
+        after: `  await audit.log({ action: "requested_loop_update", issue: linearIssue.id })
 }`,
-    },
-    programSnippet: {
-      before: `for (const [index, issueNumber] of githubIssues.entries()) {
+      },
+      snippet: {
+        before: `for (const [index, issueNumber] of githubIssues.entries()) {
   const updateInput = { issue_id: "LIN-491", source: { provider: "github", issue: "withcoral/lagoon#91" } }
   const options = { loopIndex: 2, total: 5 }`,
-      currentOperation: '  await linear.issues.update(updateInput, options, "loop-iteration-2")',
-      after: '}',
+        currentOperation: '  await linear.issues.update(updateInput, options, "loop-iteration-2")',
+        after: '}',
+      },
     },
     provider: 'Linear',
-    providerDescription: 'Updates an issue using the authenticated Linear workspace identity.',
-    rawArguments: [
+    providerReference: 'Updates an issue using the authenticated Linear workspace identity.',
+    rawInvocation: [
       {
         issue_id: 'LIN-491',
         state_id: 'triaged',
@@ -316,13 +353,18 @@ for (const [index, issueNumber] of githubIssues.entries()) {
       { notifyAssignee: false, loopIndex: 2, total: 5 },
       'loop-iteration-2',
     ],
-    requestedBy: 'reef-agent',
+    invokingPrincipal: 'reef-agent',
+    requestContext: {
+      execIntent: 'Apply the prepared Linear updates from the submitted Program.',
+      taskId: 'task_01K3Q9L7',
+      taskIntent: 'Bring the tracked approval-review issues up to date.',
+    },
     runContext: {
       runId: 'run_01K3Q8DA',
       status: 'running',
       workspace: 'Lagoon',
     },
-    technicalIds: [
+    technicalDetails: [
       { label: 'Approval request', value: 'apr_01K3Q8L2 · pending · created 14:37 UTC' },
       { label: 'Operation invocation', value: 'inv_01K3Q8K6 · pending' },
       { label: 'Provider generation', value: 'linear@gen_0198' },
@@ -331,7 +373,7 @@ for (const [index, issueNumber] of githubIssues.entries()) {
     ],
   },
   savedFunction: {
-    arguments: [
+    invocationArguments: [
       {
         label: 'Argument 1',
         value: {
@@ -347,13 +389,14 @@ for (const [index, issueNumber] of githubIssues.entries()) {
       },
       { label: 'Argument 3', value: 'saved-function-call-01' },
     ],
-    canApprove: 'Workspace owner',
-    deadline: 'Expires at 14:42 UTC',
+    approvalAuthority: 'Workspace owner',
+    expiresAt: '14:42 UTC',
     identity: 'coral-bot',
-    operationName: 'coral.providers.github.issues.createComment',
+    operationCallPath: 'coral.providers.github.issues.createComment',
     policyText: 'Agents cannot approve their own operations.',
-    programBody: {
-      before: `// Submitted Program body
+    programContext: {
+      body: {
+        before: `// Submitted Program body
 await coral.functions.postApprovalFollowUp({ issueNumber: 85 })
 
 // Linked Saved Function source snapshot: coral.functions.postApprovalFollowUp
@@ -366,23 +409,24 @@ export default async function postApprovalFollowUp(input: { issueNumber: number 
     body: "Linked Saved Function prepared this comment for the current run.",
   }
   const options = { format: "markdown", functionPath: "coral.functions.postApprovalFollowUp" }`,
-      currentOperation:
-        '  await github.issues.createComment(comment, options, "saved-function-call-01")',
-      after: `    return { issue: selectedIssue.number, status: "approval_requested" }
+        currentOperation:
+          '  await github.issues.createComment(comment, options, "saved-function-call-01")',
+        after: `    return { issue: selectedIssue.number, status: "approval_requested" }
 }`,
-    },
-    programSnippet: {
-      before: `// Linked source: coral.functions.postApprovalFollowUp
+      },
+      snippet: {
+        before: `// Linked source: coral.functions.postApprovalFollowUp
 export default async function postApprovalFollowUp(input) {
   const comment = { org: "withcoral", repo: "lagoon", issue_number: input.issueNumber }`,
-      currentOperation:
-        '  await github.issues.createComment(comment, { functionPath: "coral.functions.postApprovalFollowUp" }, "saved-function-call-01")',
-      after: '}',
+        currentOperation:
+          '  await github.issues.createComment(comment, { functionPath: "coral.functions.postApprovalFollowUp" }, "saved-function-call-01")',
+        after: '}',
+      },
     },
     provider: 'GitHub',
-    providerDescription:
+    providerReference:
       'Creates a comment on an issue in the selected repository using the authenticated GitHub account.',
-    rawArguments: [
+    rawInvocation: [
       {
         issue_number: 85,
         body: 'Linked Saved Function prepared this comment for the current run.',
@@ -392,13 +436,19 @@ export default async function postApprovalFollowUp(input) {
       { format: 'markdown', functionPath: 'coral.functions.postApprovalFollowUp' },
       'saved-function-call-01',
     ],
-    requestedBy: 'reef-agent',
+    invokingPrincipal: 'reef-agent',
+    requestContext: {
+      execIntent:
+        'Call coral.functions.postApprovalFollowUp to prepare the linked GitHub follow-up.',
+      taskId: 'task_01K3Q9S8',
+      taskIntent: 'Post the approval-review follow-up using the linked Saved Function source.',
+    },
     runContext: {
       runId: 'run_01K3Q8DA',
       status: 'running',
       workspace: 'Lagoon',
     },
-    technicalIds: [
+    technicalDetails: [
       { label: 'Approval request', value: 'apr_01K3Q8S4 · pending · created 14:39 UTC' },
       { label: 'Operation invocation', value: 'inv_01K3Q8R9 · pending · linked Saved Function' },
       { label: 'Saved Function path', value: 'coral.functions.postApprovalFollowUp' },
@@ -481,13 +531,17 @@ export const Medium: Story = {
   args: {
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
+    showExpiry: true,
     showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Medium disclosure: selected dataset with provider identity and positional/raw arguments, without provider-specific interpretation.',
+          'Medium disclosure with the complete first-screen decision contract and exact positional arguments, without provider-specific interpretation.',
       },
     },
   },
@@ -497,6 +551,8 @@ export const MediumWithRequester: Story = {
   args: {
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
+    showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
     showRequester: true,
@@ -505,7 +561,7 @@ export const MediumWithRequester: Story = {
     docs: {
       description: {
         story:
-          'Medium disclosure with provider identity and requester in the header above exact positional arguments.',
+          'Earlier requester comparison, updated to preserve requester, approval authority, expiry, and exact positional arguments.',
       },
     },
   },
@@ -515,6 +571,7 @@ export const MediumWithExpiry: Story = {
   args: {
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -523,7 +580,7 @@ export const MediumWithExpiry: Story = {
     docs: {
       description: {
         story:
-          'Medium disclosure with provider identity and expiry in the header above exact positional arguments.',
+          'Earlier expiry comparison, updated to preserve requester, approval authority, expiry, and exact positional arguments.',
       },
     },
   },
@@ -533,6 +590,7 @@ export const MediumWithRequesterAndExpiry: Story = {
   args: {
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -542,7 +600,7 @@ export const MediumWithRequesterAndExpiry: Story = {
     docs: {
       description: {
         story:
-          'Medium disclosure with provider identity, requester, and expiry in the header above exact positional arguments.',
+          'Medium disclosure with requester, approval authority, and expiry in the header above exact positional arguments.',
       },
     },
   },
@@ -554,6 +612,7 @@ export const MediumExpandableExpanded: Story = {
     argumentsInitiallyExpanded: true,
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -575,6 +634,7 @@ export const MediumExpandableCollapsed: Story = {
     argumentsInitiallyExpanded: false,
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -590,14 +650,41 @@ export const MediumExpandableCollapsed: Story = {
   },
 }
 
+export const TaskIntentContext: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'github',
+    showApprovalAuthority: true,
+    showArguments: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestContext: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Medium+ disclosure with Task intent and MCP exec intent as request context. Exact invocation arguments remain the primary evidence.',
+      },
+    },
+  },
+}
+
 export const ProgramSnippet: Story = {
   args: {
     argumentsCollapsible: true,
     argumentsInitiallyExpanded: true,
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
+    showExpiry: true,
     showIdentity: true,
     showProgramSnippet: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
   },
   parameters: {
     docs: {
@@ -615,6 +702,7 @@ export const CollapsedProgramBody: Story = {
     argumentsInitiallyExpanded: true,
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
     showProgramBody: true,
@@ -635,9 +723,9 @@ export const MaximalEvidence: Story = {
   args: {
     argumentsCollapsible: true,
     argumentsInitiallyExpanded: true,
-    canApprove: true,
     dataset: 'github',
     showArguments: true,
+    showApprovalAuthority: true,
     showIdentity: true,
     showProgramBody: true,
     showProgramSnippet: true,
@@ -655,30 +743,31 @@ export const MaximalEvidence: Story = {
   },
 }
 
+function OperationApprovalStory({ dataset, ...props }: OperationApprovalStoryProps) {
+  return <OperationApproval approval={datasets[dataset]} {...props} />
+}
+
 function OperationApproval({
+  approval,
   argumentsCollapsible,
   argumentsInitiallyExpanded,
-  canApprove,
   compact,
-  dataset,
   onApprove,
   onDecline,
   onViewRun,
   showArguments,
+  showApprovalAuthority,
   showExpiry,
   showIdentity,
   showProgramBody,
   showProgramSnippet,
+  showRequestContext,
   showRequestMetadataInHeader,
   showRequester,
   showRunContext,
   showTechnicalDetails,
 }: OperationApprovalProps) {
-  const approval = datasets[dataset]
-  const argumentsId = useId()
-  const [argumentsExpanded, setArgumentsExpanded] = useState(Boolean(argumentsInitiallyExpanded))
-  const hasDecisionContext = Boolean(canApprove)
-  const technicalDetails = buildTechnicalDetails(approval)
+  const hasDecisionContext = Boolean(showApprovalAuthority)
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
@@ -686,6 +775,7 @@ function OperationApproval({
     hasDecisionContext ||
     showProgramBody ||
     showProgramSnippet ||
+    showRequestContext ||
     showRequester ||
     showRunContext ||
     showTechnicalDetails,
@@ -693,103 +783,64 @@ function OperationApproval({
 
   return (
     <section style={{ ...cardStyle, ...(compact ? compactCardStyle : {}) }}>
-      <div style={headerStyle}>
-        <span style={operationIconStyle}>
-          <Icon color="warning" name="ShieldAlert" size="18" />
-        </span>
-        <div style={titleGroupStyle}>
-          <Typography.BodyLargeStrong as="h2">{approval.operationName}</Typography.BodyLargeStrong>
-          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
-            {[`Provider: ${approval.provider}`, showIdentity && `Identity: ${approval.identity}`]
-              .filter(Boolean)
-              .join(' · ')}
-          </Typography.BodySmall>
-          {showRequestMetadataInHeader && (showRequester || showExpiry || hasDecisionContext) ? (
-            <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
-              {[
-                (showRequester || hasDecisionContext) && `Requested by: ${approval.requestedBy}`,
-                (showExpiry || hasDecisionContext) && approval.deadline,
-              ]
-                .filter(Boolean)
-                .join(' · ')}
-            </Typography.BodySmall>
-          ) : null}
-        </div>
-        {hasContext ? <Pill color="amber">Approval required</Pill> : null}
-      </div>
+      <ApprovalHeader
+        approval={approval}
+        hasContext={hasContext}
+        showApprovalAuthority={showApprovalAuthority}
+        showExpiry={showExpiry}
+        showIdentity={showIdentity}
+        showRequestMetadata={showRequestMetadataInHeader}
+        showRequester={showRequester}
+      />
 
       {showArguments ? (
-        <section style={sectionStyle}>
-          {argumentsCollapsible ? (
-            <Button.Container
-              aria-controls={argumentsId}
-              aria-expanded={argumentsExpanded}
-              fullWidth
-              onClick={() => setArgumentsExpanded((expanded) => !expanded)}
-              size="22"
-              style={argumentsDisclosureStyle}
-              variant="bare"
-            >
-              <Button.Icon name={argumentsExpanded ? 'ChevronDown' : 'ChevronRight'} />
-              <Typography.BodySmallStrong variant="tertiary">
-                Arguments ({approval.arguments.length})
-              </Typography.BodySmallStrong>
-            </Button.Container>
-          ) : (
-            <Typography.BodySmallStrong as="h3" variant="tertiary">
-              Arguments
-            </Typography.BodySmallStrong>
-          )}
-          {!argumentsCollapsible || argumentsExpanded ? (
-            <dl
-              id={argumentsId}
-              style={{
-                ...detailsStyle,
-                ...(argumentsCollapsible ? collapsibleDetailsStyle : {}),
-              }}
-            >
-              {approval.arguments.map(({ label, value }) => (
-                <DetailRow key={label} label={label} value={value} />
-              ))}
-            </dl>
-          ) : null}
-        </section>
+        <InvocationArgumentsSection
+          collapsible={argumentsCollapsible}
+          initiallyExpanded={argumentsInitiallyExpanded}
+          invocationArguments={approval.invocationArguments}
+        />
       ) : null}
 
-      {showProgramSnippet ? (
-        <section style={supportingEvidenceStyle}>
-          <Typography.BodySmallStrong as="h3" variant="tertiary">
-            Context
-          </Typography.BodySmallStrong>
-          <ProgramEvidenceBlock evidence={approval.programSnippet} />
-        </section>
+      {showRequestContext && approval.requestContext ? (
+        <RequestContextSection requestContext={approval.requestContext} />
       ) : null}
 
-      {showProgramBody ? (
-        <details open={false} style={programBodyDetailsStyle}>
-          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
-            Program body
-          </Typography.BodySmallStrong>
-          <ProgramEvidenceBlock evidence={approval.programBody} />
-        </details>
+      {approval.programContext ? (
+        <ProgramContextSection
+          programContext={approval.programContext}
+          showBody={showProgramBody}
+          showSnippet={showProgramSnippet}
+        />
       ) : null}
 
       {(showRequester || showExpiry) && !hasDecisionContext && !showRequestMetadataInHeader ? (
         <dl style={decisionDetailsStyle}>
-          {showRequester ? <DetailRow label="Requested by" value={approval.requestedBy} /> : null}
-          {showExpiry ? <DetailRow label="Expiry" value={approval.deadline} /> : null}
+          {showRequester ? (
+            <DetailRow
+              label="Requested by"
+              showDivider={showExpiry}
+              value={approval.invokingPrincipal}
+            />
+          ) : null}
+          {showExpiry ? (
+            <DetailRow label="Expiry" showDivider={false} value={`Expires ${approval.expiresAt}`} />
+          ) : null}
         </dl>
       ) : null}
 
-      {hasDecisionContext ? (
+      {hasDecisionContext && !showRequestMetadataInHeader ? (
         <section style={decisionContextStyle}>
           <dl style={decisionDetailsStyle}>
             {!showRequestMetadataInHeader ? (
-              <DetailRow label="Requested by" value={approval.requestedBy} />
+              <DetailRow label="Requested by" value={approval.invokingPrincipal} />
             ) : null}
-            <DetailRow label="Can approve" value={approval.canApprove} />
+            <DetailRow label="Can approve" value={approval.approvalAuthority} />
             {!showRequestMetadataInHeader ? (
-              <DetailRow label="Expiry" value={approval.deadline} />
+              <DetailRow
+                label="Expiry"
+                showDivider={false}
+                value={`Expires ${approval.expiresAt}`}
+              />
             ) : null}
           </dl>
           <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
@@ -798,32 +849,7 @@ function OperationApproval({
         </section>
       ) : null}
 
-      {showTechnicalDetails ? (
-        <details style={technicalDetailsStyle}>
-          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
-            Provider reference text
-          </Typography.BodySmallStrong>
-          <Typography.BodySmall as="p" style={providerDescriptionStyle} variant="tertiary">
-            Optional provider-authored context. Do not use this as the approval scope.
-          </Typography.BodySmall>
-          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
-            {approval.providerDescription}
-          </Typography.BodySmall>
-        </details>
-      ) : null}
-
-      {showTechnicalDetails ? (
-        <details style={technicalDetailsStyle}>
-          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
-            Technical details
-          </Typography.BodySmallStrong>
-          <dl style={technicalListStyle}>
-            {technicalDetails.map(({ label, value }) => (
-              <DetailRow key={label} label={label} value={value} />
-            ))}
-          </dl>
-        </details>
-      ) : null}
+      {showTechnicalDetails ? <TechnicalDetailsSection approval={approval} /> : null}
 
       {showRunContext ? (
         <div style={runContextStyle}>
@@ -842,24 +868,218 @@ function OperationApproval({
         </div>
       ) : null}
 
-      <div style={actionsStyle}>
-        <Button.Container onClick={onDecline} size="32" variant="secondary">
-          <Button.Text>Decline</Button.Text>
-        </Button.Container>
-        <Button.Container onClick={onApprove} size="32" variant="primary">
-          <Button.Text>Approve</Button.Text>
-        </Button.Container>
-      </div>
+      <ApprovalActions onApprove={onApprove} onDecline={onDecline} />
     </section>
   )
 }
 
-function buildTechnicalDetails(approval: ApprovalDataset) {
+function ApprovalHeader({
+  approval,
+  hasContext,
+  showApprovalAuthority,
+  showExpiry,
+  showIdentity,
+  showRequestMetadata,
+  showRequester,
+}: {
+  approval: OperationApprovalModel
+  hasContext: boolean
+  showApprovalAuthority?: boolean
+  showExpiry?: boolean
+  showIdentity?: boolean
+  showRequestMetadata?: boolean
+  showRequester?: boolean
+}) {
+  const requestMetadata = [
+    (showRequester || showApprovalAuthority) && `Requested by: ${approval.invokingPrincipal}`,
+    showApprovalAuthority && `Can approve: ${approval.approvalAuthority}`,
+    (showExpiry || showApprovalAuthority) && `Expires ${approval.expiresAt}`,
+  ].filter(Boolean)
+
+  return (
+    <div style={headerStyle}>
+      <span style={operationIconStyle}>
+        <Icon color="warning" name="ShieldAlert" size="18" />
+      </span>
+      <div style={titleGroupStyle}>
+        <Typography.BodyLargeStrong as="h2">
+          {approval.operationCallPath}
+        </Typography.BodyLargeStrong>
+        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+          {[`Provider: ${approval.provider}`, showIdentity && `Identity: ${approval.identity}`]
+            .filter(Boolean)
+            .join(' · ')}
+        </Typography.BodySmall>
+        {showRequestMetadata && requestMetadata.length > 0 ? (
+          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+            {requestMetadata.join(' · ')}
+          </Typography.BodySmall>
+        ) : null}
+      </div>
+      {hasContext ? <Pill color="amber">Approval required</Pill> : null}
+    </div>
+  )
+}
+
+function InvocationArgumentsSection({
+  collapsible,
+  initiallyExpanded,
+  invocationArguments,
+}: {
+  collapsible?: boolean
+  initiallyExpanded?: boolean
+  invocationArguments: OperationApprovalModel['invocationArguments']
+}) {
+  const argumentsId = useId()
+  const [expanded, setExpanded] = useState(Boolean(initiallyExpanded))
+
+  return (
+    <section style={sectionStyle}>
+      {collapsible ? (
+        <Button.Container
+          aria-controls={argumentsId}
+          aria-expanded={expanded}
+          fullWidth
+          onClick={() => setExpanded((current) => !current)}
+          size="22"
+          style={argumentsDisclosureStyle}
+          variant="bare"
+        >
+          <Button.Icon name={expanded ? 'ChevronDown' : 'ChevronRight'} />
+          <Typography.BodySmallStrong variant="tertiary">
+            Arguments ({invocationArguments.length})
+          </Typography.BodySmallStrong>
+        </Button.Container>
+      ) : (
+        <Typography.BodySmallStrong as="h3" variant="tertiary">
+          Arguments
+        </Typography.BodySmallStrong>
+      )}
+      {!collapsible || expanded ? (
+        <dl
+          id={argumentsId}
+          style={{ ...detailsStyle, ...(collapsible ? collapsibleDetailsStyle : {}) }}
+        >
+          {invocationArguments.map(({ label, value }, index) => (
+            <DetailRow
+              key={label}
+              label={label}
+              showDivider={index < invocationArguments.length - 1}
+              value={value}
+            />
+          ))}
+        </dl>
+      ) : null}
+    </section>
+  )
+}
+
+function RequestContextSection({ requestContext }: { requestContext: RequestContext }) {
+  return (
+    <section style={supportingEvidenceStyle}>
+      <Typography.BodySmallStrong as="h3" variant="tertiary">
+        Context
+      </Typography.BodySmallStrong>
+      <dl style={contextDetailsStyle}>
+        <DetailRow label="Task" value={requestContext.taskId} />
+        <DetailRow label="Task intent" value={requestContext.taskIntent} />
+        <DetailRow label="Exec intent" showDivider={false} value={requestContext.execIntent} />
+      </dl>
+    </section>
+  )
+}
+
+function ProgramContextSection({
+  programContext,
+  showBody,
+  showSnippet,
+}: {
+  programContext: ProgramContext
+  showBody?: boolean
+  showSnippet?: boolean
+}) {
+  return (
+    <>
+      {showSnippet ? (
+        <section style={supportingEvidenceStyle}>
+          <Typography.BodySmallStrong as="h3" variant="tertiary">
+            Context
+          </Typography.BodySmallStrong>
+          <ProgramEvidenceBlock evidence={programContext.snippet} />
+        </section>
+      ) : null}
+      {showBody ? (
+        <details open={false} style={programBodyDetailsStyle}>
+          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
+            Program body
+          </Typography.BodySmallStrong>
+          <ProgramEvidenceBlock evidence={programContext.body} />
+        </details>
+      ) : null}
+    </>
+  )
+}
+
+function TechnicalDetailsSection({ approval }: { approval: OperationApprovalModel }) {
+  const technicalDetails = buildTechnicalDetails(approval)
+
+  return (
+    <>
+      <details style={technicalDetailsStyle}>
+        <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
+          Provider reference text
+        </Typography.BodySmallStrong>
+        <Typography.BodySmall as="p" style={providerDescriptionStyle} variant="tertiary">
+          Optional provider-authored context. Do not use this as the approval scope.
+        </Typography.BodySmall>
+        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+          {approval.providerReference}
+        </Typography.BodySmall>
+      </details>
+      <details style={technicalDetailsStyle}>
+        <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
+          Technical details
+        </Typography.BodySmallStrong>
+        <dl style={technicalListStyle}>
+          {technicalDetails.map(({ label, value }, index) => (
+            <DetailRow
+              key={label}
+              label={label}
+              showDivider={index < technicalDetails.length - 1}
+              value={value}
+            />
+          ))}
+        </dl>
+      </details>
+    </>
+  )
+}
+
+function ApprovalActions({
+  onApprove,
+  onDecline,
+}: {
+  onApprove: () => void
+  onDecline: () => void
+}) {
+  return (
+    <div style={actionsStyle}>
+      <Button.Container onClick={onDecline} size="32" variant="secondary">
+        <Button.Text>Decline</Button.Text>
+      </Button.Container>
+      <Button.Container onClick={onApprove} size="32" variant="primary">
+        <Button.Text>Approve</Button.Text>
+      </Button.Container>
+    </div>
+  )
+}
+
+function buildTechnicalDetails(approval: OperationApprovalModel) {
   return [
-    { label: 'Operation', value: approval.operationName },
+    { label: 'Operation call path', value: approval.operationCallPath },
     { label: 'Identity', value: `${approval.provider} · ${approval.identity}` },
-    { label: 'Raw arguments', value: JSON.stringify(approval.rawArguments, null, 2) },
-    ...approval.technicalIds,
+    { label: 'Raw invocation', value: JSON.stringify(approval.rawInvocation, null, 2) },
+    ...approval.technicalDetails,
   ]
 }
 
@@ -873,9 +1093,17 @@ function ProgramEvidenceBlock({ evidence }: { evidence: ProgramEvidence }) {
   )
 }
 
-function DetailRow({ label, value }: { label: string; value: ArgumentValue }) {
+function DetailRow({
+  label,
+  showDivider = true,
+  value,
+}: {
+  label: string
+  showDivider?: boolean
+  value: ArgumentValue
+}) {
   return (
-    <div style={detailRowStyle}>
+    <div style={{ ...detailRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
       <Typography.BodySmall as="dt" variant="tertiary">
         {label}
       </Typography.BodySmall>
@@ -976,6 +1204,8 @@ const supportingEvidenceStyle: CSSProperties = {
   padding: '10px 12px',
 }
 
+const contextDetailsStyle: CSSProperties = { margin: 0 }
+
 const codeBlockStyle: CSSProperties = {
   background: theme.surface.main,
   border: `1px solid ${theme.stroke.secondary}`,
@@ -1012,6 +1242,8 @@ const detailRowStyle: CSSProperties = {
   gridTemplateColumns: '140px minmax(0, 1fr)',
   padding: '8px 0',
 }
+
+const lastDetailRowStyle: CSSProperties = { borderBottom: 0 }
 
 const detailValueStyle: CSSProperties = {
   margin: 0,

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -24,8 +24,7 @@ type EnvelopeArgsDisplay = 'interleaved' | 'none' | 'summary'
 type SectionDisplay = 'collapsed' | 'expanded' | 'hidden' | 'visible'
 
 interface OperationApprovalStoryProps {
-  argumentsCollapsible?: boolean
-  argumentsInitiallyExpanded?: boolean
+  argumentsDisplay?: SectionDisplay
   envelopeArgsDisplay?: EnvelopeArgsDisplay
   envelopeMatch: EnvelopeMatch
   compact?: boolean
@@ -34,7 +33,6 @@ interface OperationApprovalStoryProps {
   onDecline: () => void
   onUpdatePolicy: () => void
   onViewRun: () => void
-  showArguments?: boolean
   showApprovalAuthority?: boolean
   showExpiry?: boolean
   authorityEnvelopeDisplay?: SectionDisplay
@@ -51,10 +49,8 @@ interface OperationApprovalStoryProps {
 
 interface OperationApprovalDisplay {
   arguments?: {
-    collapsible?: boolean
+    display?: SectionDisplay
     envelopeDisplay?: EnvelopeArgsDisplay
-    initiallyExpanded?: boolean
-    visible?: boolean
   }
   compact?: boolean
   header?: {
@@ -204,6 +200,11 @@ const meta = {
       description: 'Control the Storybook-only deterministic Owner-policy envelope section.',
       options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
+    argumentsDisplay: {
+      control: 'inline-radio',
+      description: 'Control exact positional Invocation arguments as primary evidence.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
+    },
     envelopeArgsDisplay: {
       control: 'inline-radio',
       description:
@@ -224,10 +225,6 @@ const meta = {
       control: 'inline-radio',
       description: 'Control highlighted Program snippet as supporting context.',
       options: ['hidden', 'visible', 'collapsed', 'expanded'],
-    },
-    showArguments: {
-      control: 'boolean',
-      description: 'Show exact positional Invocation arguments as primary evidence.',
     },
     showApprovalAuthority: {
       control: 'boolean',
@@ -266,6 +263,7 @@ const meta = {
     },
   },
   args: {
+    argumentsDisplay: 'hidden',
     envelopeMatch: 'inside',
     dataset: 'github',
     onApprove: fn(),
@@ -299,7 +297,7 @@ The story-only model uses Lagoon-aligned names: \`operationCallPath\`, \`invocat
 
 Every Medium+ story keeps the same first-screen decision contract: Operation call path, provider identity, invoking principal, approval authority, expiry, exact Invocation arguments, and the unchanged Decline/Approve actions. The prototype does not invent an operation-specific consequence CTA when no trusted renderer provides one.
 
-Every story uses the same story-local \`OperationApproval\` component. Set \`requestContextDisplay\` to \`visible\` in any story to reveal Task and exec intent before Arguments; \`TaskIntentContext\` is the preset that enables it by default.
+Every story uses the same story-local \`OperationApproval\` component. Set \`argumentsDisplay\` to \`hidden\`, \`visible\`, \`collapsed\`, or \`expanded\` to control the exact Invocation evidence with the same section grammar. Set \`requestContextDisplay\` to \`visible\` in any story to reveal Task and exec intent before Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
 Every dataset supplies three Storybook-only Owner-envelope states: \`inside\` matches its exact Invocation, \`outside\` fails explicit filters in an existing envelope, and \`none\` means no existing Owner policy covers the Invocation. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each candidate envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Set \`authorityEnvelopeDisplay\` to choose how the full evaluation is disclosed. Separately, \`envelopeArgsDisplay='none'\` only hides inline annotations; \`summary\` and \`interleaved\` reveal them.
 
@@ -1085,8 +1083,8 @@ export const MinimalWithRequesterAndExpiry: Story = {
 
 export const Medium: Story = {
   args: {
+    argumentsDisplay: 'visible',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1105,8 +1103,8 @@ export const Medium: Story = {
 
 export const MediumWithRequester: Story = {
   args: {
+    argumentsDisplay: 'visible',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1125,8 +1123,8 @@ export const MediumWithRequester: Story = {
 
 export const MediumWithExpiry: Story = {
   args: {
+    argumentsDisplay: 'visible',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1144,8 +1142,8 @@ export const MediumWithExpiry: Story = {
 
 export const MediumWithRequesterAndExpiry: Story = {
   args: {
+    argumentsDisplay: 'visible',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1164,10 +1162,8 @@ export const MediumWithRequesterAndExpiry: Story = {
 
 export const MediumExpandableExpanded: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1186,10 +1182,8 @@ export const MediumExpandableExpanded: Story = {
 
 export const MediumExpandableCollapsed: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: false,
+    argumentsDisplay: 'collapsed',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1208,11 +1202,9 @@ export const MediumExpandableCollapsed: Story = {
 
 export const TaskIntentContext: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
     showApprovalAuthority: true,
-    showArguments: true,
     showExpiry: true,
     showIdentity: true,
     requestContextDisplay: 'visible',
@@ -1231,12 +1223,10 @@ export const TaskIntentContext: Story = {
 
 export const EnvelopeMatches: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
     envelopeArgsDisplay: 'interleaved',
     envelopeMatch: 'inside',
-    showArguments: true,
     authorityEnvelopeDisplay: 'visible',
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -1254,12 +1244,10 @@ export const EnvelopeMatches: Story = {
 
 export const EnvelopeDoesNotMatch: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
     envelopeArgsDisplay: 'interleaved',
     envelopeMatch: 'outside',
-    showArguments: true,
     showApprovalAuthority: true,
     authorityEnvelopeDisplay: 'visible',
     showExpiry: true,
@@ -1279,12 +1267,10 @@ export const EnvelopeDoesNotMatch: Story = {
 
 export const EnvelopePolicyUpdateProposal: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
     envelopeArgsDisplay: 'interleaved',
     envelopeMatch: 'outside',
-    showArguments: true,
     showApprovalAuthority: true,
     authorityEnvelopeDisplay: 'visible',
     showExpiry: true,
@@ -1304,12 +1290,10 @@ export const EnvelopePolicyUpdateProposal: Story = {
 
 export const EnvelopeNoExistingPolicy: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
     envelopeArgsDisplay: 'none',
     envelopeMatch: 'none',
-    showArguments: true,
     showApprovalAuthority: true,
     authorityEnvelopeDisplay: 'visible',
     showExpiry: true,
@@ -1329,10 +1313,8 @@ export const EnvelopeNoExistingPolicy: Story = {
 
 export const ProgramSnippet: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1352,10 +1334,8 @@ export const ProgramSnippet: Story = {
 
 export const CollapsedProgramBody: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
@@ -1375,10 +1355,8 @@ export const CollapsedProgramBody: Story = {
 
 export const MaximalEvidence: Story = {
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     dataset: 'github',
-    showArguments: true,
     showApprovalAuthority: true,
     showIdentity: true,
     programBodyDisplay: 'collapsed',
@@ -1401,8 +1379,7 @@ export const MaximalEvidence: Story = {
 export const LudosFavourite: Story = {
   name: "Ludo's favourite",
   args: {
-    argumentsCollapsible: true,
-    argumentsInitiallyExpanded: true,
+    argumentsDisplay: 'expanded',
     authorityEnvelopeDisplay: 'hidden',
     dataset: 'github',
     envelopeArgsDisplay: 'interleaved',
@@ -1413,7 +1390,6 @@ export const LudosFavourite: Story = {
     requestContextDisplay: 'visible',
     runContextDisplay: 'hidden',
     showApprovalAuthority: false,
-    showArguments: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
     technicalDetailsDisplay: 'hidden',
@@ -1448,8 +1424,7 @@ function combineSectionDisplays(...displays: Array<SectionDisplay | undefined>):
 }
 
 function OperationApprovalStory({
-  argumentsCollapsible,
-  argumentsInitiallyExpanded,
+  argumentsDisplay = 'hidden',
   compact,
   dataset,
   envelopeArgsDisplay = 'none',
@@ -1459,7 +1434,6 @@ function OperationApprovalStory({
   onUpdatePolicy,
   onViewRun,
   showApprovalAuthority,
-  showArguments,
   authorityEnvelopeDisplay,
   showExpiry,
   showIdentity,
@@ -1489,10 +1463,8 @@ function OperationApprovalStory({
       authorityEvaluation={authorityEvaluation}
       display={{
         arguments: {
-          collapsible: argumentsCollapsible,
+          display: argumentsDisplay,
           envelopeDisplay: envelopeArgsDisplay,
-          initiallyExpanded: argumentsInitiallyExpanded,
-          visible: showArguments,
         },
         compact,
         header: {
@@ -1532,13 +1504,7 @@ function OperationApproval({
   const showIdentity = header.showIdentity
   const showRequester = header.showRequester
   const contextDisplay = combineSectionDisplays(sections.requestContext, sections.programSnippet)
-  const argumentsSectionDisplay: SectionDisplay = !argumentsDisplay.visible
-    ? 'hidden'
-    : argumentsDisplay.collapsible
-      ? argumentsDisplay.initiallyExpanded
-        ? 'expanded'
-        : 'collapsed'
-      : 'visible'
+  const argumentsSectionDisplay = argumentsDisplay.display ?? 'hidden'
   const hasDecisionContext = Boolean(showApprovalAuthority)
   const isEnvelopeVisible =
     shouldShowSection(sections.authorityEnvelope) || envelopeArgsDisplay !== 'none'
@@ -1549,7 +1515,7 @@ function OperationApproval({
   const canReviewFuturePolicy =
     isEnvelopeVisible && envelopeEvaluation?.decision === 'requiresApproval'
   const hasContext = Boolean(
-    argumentsDisplay.visible ||
+    shouldShowSection(argumentsSectionDisplay) ||
     showExpiry ||
     shouldShowSection(sections.authorityEnvelope) ||
     envelopeArgsDisplay !== 'none' ||

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -2558,21 +2558,24 @@ const policyCheckboxLabelStyle: CSSProperties = {
 
 const policyCheckboxStyle: CSSProperties = {
   alignItems: 'center',
-  background: theme.surface.main,
-  border: `1px solid ${theme.stroke.primary}`,
-  borderRadius: '4px',
-  color: theme.surface.main,
+  background: 'transparent',
+  border: `2px solid ${theme.content.tertiary}`,
+  borderRadius: '5px',
+  color: theme.content.accentContent.primaryReverse,
   cursor: 'pointer',
   display: 'inline-flex',
-  flex: '0 0 16px',
-  height: '16px',
+  flex: '0 0 18px',
+  height: '18px',
   justifyContent: 'center',
-  width: '16px',
+  outline: 'none',
+  padding: 0,
+  transition: 'background-color 120ms ease, border-color 120ms ease, opacity 120ms ease',
+  width: '18px',
 }
 
 const policyCheckboxCheckedStyle: CSSProperties = {
-  background: theme.content.primary,
-  borderColor: theme.content.primary,
+  background: theme.stroke.focused,
+  borderColor: theme.stroke.focused,
 }
 
 const policyCheckboxDisabledStyle: CSSProperties = {

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -48,9 +48,42 @@ interface OperationApprovalStoryProps {
   showTechnicalDetails?: boolean
 }
 
-type OperationApprovalProps = Omit<OperationApprovalStoryProps, 'dataset' | 'envelopeMatch'> & {
+interface OperationApprovalDisplay {
+  arguments?: {
+    collapsible?: boolean
+    envelopeDisplay?: EnvelopeArgsDisplay
+    initiallyExpanded?: boolean
+    visible?: boolean
+  }
+  compact?: boolean
+  header?: {
+    metadataPlacement?: 'body' | 'header'
+    showApprovalAuthority?: boolean
+    showExpiry?: boolean
+    showIdentity?: boolean
+    showRequester?: boolean
+  }
+  sections?: {
+    authorityEnvelope?: boolean
+    programBody?: boolean
+    programSnippet?: boolean
+    providerReference?: boolean
+    requestContext?: boolean
+    runContext?: boolean
+    technicalDetails?: boolean
+  }
+}
+
+interface OperationApprovalProps {
+  actions: {
+    onApprove: () => void
+    onDecline: () => void
+    onUpdatePolicy: () => void
+    onViewRun: () => void
+  }
   approval: OperationApprovalModel
-  authorityEnvelope: AuthorityEnvelope
+  authorityEvaluation?: AuthorityEnvelopeEvaluation
+  display: OperationApprovalDisplay
 }
 
 interface ProgramEvidence {
@@ -1313,49 +1346,91 @@ export const MaximalEvidence: Story = {
   },
 }
 
-function OperationApprovalStory({ dataset, envelopeMatch, ...props }: OperationApprovalStoryProps) {
-  const selectedDataset = datasets[dataset]
-
-  return (
-    <OperationApproval
-      approval={selectedDataset.approval}
-      authorityEnvelope={selectedDataset.authorityEnvelopes[envelopeMatch]}
-      {...props}
-    />
-  )
-}
-
-function OperationApproval({
-  approval,
+function OperationApprovalStory({
   argumentsCollapsible,
   argumentsInitiallyExpanded,
-  authorityEnvelope,
   compact,
+  dataset,
   envelopeArgsDisplay = 'none',
+  envelopeMatch,
   onApprove,
   onDecline,
   onUpdatePolicy,
   onViewRun,
-  showArguments,
   showApprovalAuthority,
-  showExpiry,
+  showArguments,
   showAuthorityEnvelopeMatch,
+  showExpiry,
   showIdentity,
   showProgramBody,
   showProgramSnippet,
   showProviderReference,
   showRequestContext,
-  showRequestMetadataInHeader,
   showRequester,
+  showRequestMetadataInHeader,
   showRunContext,
   showTechnicalDetails,
+}: OperationApprovalStoryProps) {
+  const selectedDataset = datasets[dataset]
+  const isEnvelopeVisible = showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
+  const authorityEvaluation = isEnvelopeVisible
+    ? evaluateAuthorityEnvelope(
+        selectedDataset.approval,
+        selectedDataset.authorityEnvelopes[envelopeMatch],
+      )
+    : undefined
+
+  return (
+    <OperationApproval
+      actions={{ onApprove, onDecline, onUpdatePolicy, onViewRun }}
+      approval={selectedDataset.approval}
+      authorityEvaluation={authorityEvaluation}
+      display={{
+        arguments: {
+          collapsible: argumentsCollapsible,
+          envelopeDisplay: envelopeArgsDisplay,
+          initiallyExpanded: argumentsInitiallyExpanded,
+          visible: showArguments,
+        },
+        compact,
+        header: {
+          metadataPlacement: showRequestMetadataInHeader ? 'header' : 'body',
+          showApprovalAuthority,
+          showExpiry,
+          showIdentity,
+          showRequester,
+        },
+        sections: {
+          authorityEnvelope: showAuthorityEnvelopeMatch,
+          programBody: showProgramBody,
+          programSnippet: showProgramSnippet,
+          providerReference: showProviderReference,
+          requestContext: showRequestContext,
+          runContext: showRunContext,
+          technicalDetails: showTechnicalDetails,
+        },
+      }}
+    />
+  )
+}
+
+function OperationApproval({
+  actions,
+  approval,
+  authorityEvaluation: envelopeEvaluation,
+  display,
 }: OperationApprovalProps) {
   const [policyProposalOpen, setPolicyProposalOpen] = useState(false)
+  const { header = {}, sections = {} } = display
+  const argumentsDisplay = display.arguments ?? {}
+  const envelopeArgsDisplay = argumentsDisplay.envelopeDisplay ?? 'none'
+  const showRequestMetadataInHeader = header.metadataPlacement === 'header'
+  const showApprovalAuthority = header.showApprovalAuthority
+  const showExpiry = header.showExpiry
+  const showIdentity = header.showIdentity
+  const showRequester = header.showRequester
   const hasDecisionContext = Boolean(showApprovalAuthority)
-  const isEnvelopeVisible = showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
-  const envelopeEvaluation = isEnvelopeVisible
-    ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
-    : undefined
+  const isEnvelopeVisible = sections.authorityEnvelope || envelopeArgsDisplay !== 'none'
   const envelopeArgumentChecks =
     envelopeArgsDisplay !== 'none' && envelopeEvaluation?.envelopeMatch !== 'none'
       ? envelopeEvaluation?.checks
@@ -1363,23 +1438,23 @@ function OperationApproval({
   const canReviewFuturePolicy =
     isEnvelopeVisible && envelopeEvaluation?.decision === 'requiresApproval'
   const hasContext = Boolean(
-    showArguments ||
+    argumentsDisplay.visible ||
     showExpiry ||
-    showAuthorityEnvelopeMatch ||
+    sections.authorityEnvelope ||
     envelopeArgsDisplay !== 'none' ||
     showIdentity ||
     hasDecisionContext ||
-    showProgramBody ||
-    showProgramSnippet ||
-    showProviderReference ||
-    showRequestContext ||
+    sections.programBody ||
+    sections.programSnippet ||
+    sections.providerReference ||
+    sections.requestContext ||
     showRequester ||
-    showRunContext ||
-    showTechnicalDetails,
+    sections.runContext ||
+    sections.technicalDetails,
   )
 
   return (
-    <section style={{ ...cardStyle, ...(compact ? compactCardStyle : {}) }}>
+    <section style={{ ...cardStyle, ...(display.compact ? compactCardStyle : {}) }}>
       <ApprovalHeader
         approval={approval}
         envelopeEvaluation={envelopeEvaluation}
@@ -1391,29 +1466,29 @@ function OperationApproval({
         showRequester={showRequester}
       />
 
-      {showArguments ? (
+      {argumentsDisplay.visible ? (
         <InvocationArgumentsSection
-          collapsible={argumentsCollapsible}
+          collapsible={argumentsDisplay.collapsible}
           envelopeChecks={envelopeArgumentChecks}
           envelopeDisplay={envelopeArgsDisplay}
-          initiallyExpanded={argumentsInitiallyExpanded}
+          initiallyExpanded={argumentsDisplay.initiallyExpanded}
           invocationArguments={approval.invocationArguments}
         />
       ) : null}
 
-      {showAuthorityEnvelopeMatch && envelopeEvaluation ? (
+      {sections.authorityEnvelope && envelopeEvaluation ? (
         <EnvelopeCheckSection evaluation={envelopeEvaluation} />
       ) : null}
 
-      {(showRequestContext && approval.requestContext) ||
-      (showProgramSnippet && approval.programContext) ? (
+      {(sections.requestContext && approval.requestContext) ||
+      (sections.programSnippet && approval.programContext) ? (
         <ContextSection
-          programSnippet={showProgramSnippet ? approval.programContext?.snippet : undefined}
-          requestContext={showRequestContext ? approval.requestContext : undefined}
+          programSnippet={sections.programSnippet ? approval.programContext?.snippet : undefined}
+          requestContext={sections.requestContext ? approval.requestContext : undefined}
         />
       ) : null}
 
-      {showProgramBody && approval.programContext ? (
+      {sections.programBody && approval.programContext ? (
         <ProgramBodyDisclosure programBody={approval.programContext.body} />
       ) : null}
 
@@ -1453,13 +1528,13 @@ function OperationApproval({
         </section>
       ) : null}
 
-      {showProviderReference && approval.providerReference ? (
+      {sections.providerReference && approval.providerReference ? (
         <ProviderReferenceSection providerReference={approval.providerReference} />
       ) : null}
 
-      {showTechnicalDetails ? <TechnicalDetailsSection approval={approval} /> : null}
+      {sections.technicalDetails ? <TechnicalDetailsSection approval={approval} /> : null}
 
-      {showRunContext ? (
+      {sections.runContext ? (
         <div style={runContextStyle}>
           <div style={runCopyStyle}>
             <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
@@ -1469,7 +1544,7 @@ function OperationApproval({
               {approval.runContext.status} · {approval.runContext.workspace}
             </Typography.BodySmall>
           </div>
-          <Button.Container onClick={onViewRun} size="22" variant="bare">
+          <Button.Container onClick={actions.onViewRun} size="22" variant="bare">
             <Button.Text>View run</Button.Text>
             <Button.Icon name="ArrowUpRight" />
           </Button.Container>
@@ -1479,8 +1554,8 @@ function OperationApproval({
       {envelopeEvaluation?.decision === 'allow' ? null : (
         <ApprovalActions
           approveLabel={isEnvelopeVisible ? 'Approve once' : 'Approve'}
-          onApprove={onApprove}
-          onDecline={onDecline}
+          onApprove={actions.onApprove}
+          onDecline={actions.onDecline}
           onReviewPolicy={canReviewFuturePolicy ? () => setPolicyProposalOpen(true) : undefined}
         />
       )}
@@ -1490,7 +1565,7 @@ function OperationApproval({
           evaluation={envelopeEvaluation}
           key={`${envelopeEvaluation.envelopeId}-${envelopeEvaluation.envelopeMatch}`}
           onOpenChange={setPolicyProposalOpen}
-          onUpdatePolicy={onUpdatePolicy}
+          onUpdatePolicy={actions.onUpdatePolicy}
           open={policyProposalOpen}
         />
       ) : null}
@@ -2041,7 +2116,13 @@ function PolicyChangeCheckbox({
   const [hovered, setHovered] = useState(false)
 
   return (
-    <label htmlFor={checkboxId} style={policyCheckboxLabelStyle}>
+    <label
+      htmlFor={checkboxId}
+      style={{
+        ...policyCheckboxLabelStyle,
+        ...(disabled ? { cursor: 'not-allowed', opacity: 0.55 } : {}),
+      }}
+    >
       <Checkbox.Root
         checked={checked}
         disabled={disabled}

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1398,6 +1398,36 @@ export const MaximalEvidence: Story = {
   },
 }
 
+export const LudosFavourite: Story = {
+  name: "Ludo's favourite",
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    authorityEnvelopeDisplay: 'hidden',
+    dataset: 'github',
+    envelopeArgsDisplay: 'interleaved',
+    envelopeMatch: 'outside',
+    programBodyDisplay: 'collapsed',
+    programSnippetDisplay: 'collapsed',
+    providerReferenceDisplay: 'hidden',
+    requestContextDisplay: 'visible',
+    runContextDisplay: 'hidden',
+    showApprovalAuthority: false,
+    showArguments: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    technicalDetailsDisplay: 'hidden',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reviewer-preferred dense approval layout with request context visible, policy annotations interleaved with arguments, and low-priority reference sections hidden.',
+      },
+    },
+  },
+}
+
 function shouldShowSection(display: SectionDisplay | undefined): boolean {
   return display !== undefined && display !== 'hidden'
 }
@@ -1744,42 +1774,52 @@ function InvocationArgumentsSection({
   return (
     <section style={sectionStyle}>
       {collapsible ? (
-        <Button.Container
-          aria-controls={argumentsId}
-          aria-expanded={expanded}
-          fullWidth
-          onClick={() => setExpanded((current) => !current)}
-          size="22"
-          style={argumentsDisclosureStyle}
-          variant="bare"
+        <details
+          onToggle={(event) => setExpanded(event.currentTarget.open)}
+          open={expanded}
+          style={disclosureSectionStyle}
         >
-          <Button.Icon name={expanded ? 'ChevronDown' : 'ChevronRight'} />
-          <Typography.BodySmallStrong>
+          <Typography.BodySmallStrong as="summary" style={argumentsDisclosureStyle}>
             Arguments ({invocationArguments.length})
           </Typography.BodySmallStrong>
-        </Button.Container>
+          <dl id={argumentsId} style={detailsStyle}>
+            {invocationArguments.map(({ label, value }, index) => (
+              <InvocationArgumentRow
+                annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
+                  checkLabel.startsWith(`args[${index}]`),
+                )}
+                argumentIndex={index}
+                envelopeDisplay={envelopeDisplay}
+                key={label}
+                label={label}
+                showDivider={index < invocationArguments.length - 1}
+                value={value}
+              />
+            ))}
+          </dl>
+        </details>
       ) : (
-        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle}>
-          Arguments
-        </Typography.BodySmallStrong>
+        <>
+          <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle}>
+            Arguments
+          </Typography.BodySmallStrong>
+          <dl id={argumentsId} style={detailsStyle}>
+            {invocationArguments.map(({ label, value }, index) => (
+              <InvocationArgumentRow
+                annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
+                  checkLabel.startsWith(`args[${index}]`),
+                )}
+                argumentIndex={index}
+                envelopeDisplay={envelopeDisplay}
+                key={label}
+                label={label}
+                showDivider={index < invocationArguments.length - 1}
+                value={value}
+              />
+            ))}
+          </dl>
+        </>
       )}
-      {!collapsible || expanded ? (
-        <dl id={argumentsId} style={detailsStyle}>
-          {invocationArguments.map(({ label, value }, index) => (
-            <InvocationArgumentRow
-              annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
-                checkLabel.startsWith(`args[${index}]`),
-              )}
-              argumentIndex={index}
-              envelopeDisplay={envelopeDisplay}
-              key={label}
-              label={label}
-              showDivider={index < invocationArguments.length - 1}
-              value={value}
-            />
-          ))}
-        </dl>
-      ) : null}
     </section>
   )
 }
@@ -2633,18 +2673,8 @@ const sectionHeadingStyle: CSSProperties = {
 
 const argumentsDisclosureStyle: CSSProperties = {
   ...sectionHeadingStyle,
-  alignItems: 'center',
-  background: 'transparent',
-  border: 0,
-  borderBottom: `1px solid ${theme.stroke.secondary}`,
   color: theme.content.primary,
   cursor: 'pointer',
-  display: 'flex',
-  gap: '4px',
-  justifyContent: 'flex-start',
-  padding: '0 0 6px',
-  textAlign: 'left',
-  width: '100%',
 }
 
 const contextDetailsStyle: CSSProperties = { margin: 0 }
@@ -2687,8 +2717,8 @@ const argumentGroupStyle: CSSProperties = {
 
 const interleavedArgumentStyle: CSSProperties = {
   display: 'grid',
-  gap: '16px',
-  gridTemplateColumns: '140px minmax(0, 1fr)',
+  gap: '12px',
+  gridTemplateColumns: 'minmax(96px, 0.3fr) minmax(0, 1fr)',
   padding: '8px 0',
 }
 
@@ -2709,7 +2739,7 @@ const interleavedFieldValueStyle: CSSProperties = {
   alignItems: 'baseline',
   display: 'grid',
   gap: '12px',
-  gridTemplateColumns: '120px minmax(0, 1fr)',
+  gridTemplateColumns: 'minmax(88px, 0.28fr) minmax(0, 1fr)',
 }
 
 const envelopeArgumentStatusStyles: Record<EnvelopeCheckStatus, CSSProperties> = {
@@ -2731,7 +2761,7 @@ const argumentAnnotationsStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',
-  marginLeft: '156px',
+  marginLeft: 'min(156px, 22%)',
 }
 
 const argumentAnnotationStyle: CSSProperties = {

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1789,11 +1789,7 @@ function InvocationArgumentsSection({
   )
 
   return (
-    <SectionContainer
-      display={display}
-      summaryTone="primary"
-      title={`Arguments (${invocationArguments.length})`}
-    >
+    <SectionContainer display={display} title={`Arguments (${invocationArguments.length})`}>
       {content}
     </SectionContainer>
   )
@@ -2345,29 +2341,20 @@ function EnvelopeCheckRow({
 function SectionContainer({
   children,
   display,
-  summaryTone = 'secondary',
   title,
   visibleHeading = true,
 }: {
   children: ReactNode
   display?: SectionDisplay
-  summaryTone?: 'primary' | 'secondary'
   title: string
   visibleHeading?: boolean
 }) {
   if (!shouldShowSection(display)) return null
-  const titleStyle =
-    summaryTone === 'primary'
-      ? { color: theme.content.primary }
-      : { color: theme.content.secondary }
 
   if (sectionIsDisclosure(display)) {
     return (
       <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
-        <Typography.BodySmallStrong
-          as="summary"
-          style={{ ...disclosureSummaryStyle, ...titleStyle }}
-        >
+        <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
           {title}
         </Typography.BodySmallStrong>
         <div style={disclosureContentStyle}>{children}</div>
@@ -2378,11 +2365,7 @@ function SectionContainer({
   return (
     <section style={sectionStyle}>
       {visibleHeading ? (
-        <Typography.BodySmallStrong
-          as="h3"
-          style={{ ...sectionHeadingStyle, ...titleStyle }}
-          variant={summaryTone === 'primary' ? undefined : 'tertiary'}
-        >
+        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
           {title}
         </Typography.BodySmallStrong>
       ) : null}

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -2064,7 +2064,7 @@ function PolicyChangeCheckbox({
         }}
       >
         <Checkbox.Indicator style={policyCheckboxIndicatorStyle}>
-          <Icon name="Check" size="14" />
+          <Icon color="inherit" name="Check" size="14" />
         </Checkbox.Indicator>
       </Checkbox.Root>
       <Typography.BodySmallStrong as="span">{label}</Typography.BodySmallStrong>

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1309,10 +1309,12 @@ function OperationApproval({
 }: OperationApprovalProps) {
   const [policyProposalOpen, setPolicyProposalOpen] = useState(false)
   const hasDecisionContext = Boolean(showApprovalAuthority)
-  const envelopeEvaluation =
-    showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
-      ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
-      : undefined
+  const isEnvelopeVisible = showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
+  const envelopeEvaluation = isEnvelopeVisible
+    ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
+    : undefined
+  const canReviewFuturePolicy =
+    isEnvelopeVisible && envelopeEvaluation?.decision === 'requiresApproval'
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
@@ -1429,16 +1431,14 @@ function OperationApproval({
 
       {envelopeEvaluation?.decision === 'allow' ? null : (
         <ApprovalActions
-          approveLabel={showAuthorityEnvelopeMatch ? 'Approve once' : 'Approve'}
+          approveLabel={isEnvelopeVisible ? 'Approve once' : 'Approve'}
           onApprove={onApprove}
           onDecline={onDecline}
-          onReviewPolicy={
-            showAuthorityEnvelopeMatch ? () => setPolicyProposalOpen(true) : undefined
-          }
+          onReviewPolicy={canReviewFuturePolicy ? () => setPolicyProposalOpen(true) : undefined}
         />
       )}
 
-      {showAuthorityEnvelopeMatch && envelopeEvaluation?.decision === 'requiresApproval' ? (
+      {canReviewFuturePolicy && envelopeEvaluation ? (
         <PolicyUpdateProposalDialog
           evaluation={envelopeEvaluation}
           onOpenChange={setPolicyProposalOpen}

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1749,7 +1749,7 @@ function ApprovalHeader({
       {envelopeEvaluation?.decision === 'allow' ? (
         <Pill color="green">Allowed by Owner policy</Pill>
       ) : envelopeEvaluation?.envelopeMatch === 'none' ? (
-        <Pill color="amber">No matching Owner policy</Pill>
+        <Pill color="amber">No Owner policy yet</Pill>
       ) : envelopeEvaluation ? (
         <Pill color="amber">Outside Owner policy</Pill>
       ) : hasContext ? (
@@ -1948,7 +1948,7 @@ function EnvelopeCheckSection({
             {matches
               ? 'Allowed by Owner policy'
               : hasNoExistingEnvelope
-                ? 'No matching Owner policy'
+                ? 'No Owner policy yet'
                 : 'Outside Owner policy'}
           </Typography.BodySmallStrong>
           <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
@@ -1979,7 +1979,7 @@ function EnvelopeCheckSection({
         {matches
           ? `Allowed by envelope ${evaluation.envelopeId}`
           : hasNoExistingEnvelope
-            ? 'No existing Owner policy authorized this Invocation'
+            ? 'No Owner policy currently covers this Invocation'
             : `Envelope ${evaluation.envelopeId} did not authorize this Invocation`}
       </Typography.BodySmall>
     </SectionContainer>
@@ -2040,7 +2040,7 @@ function PolicyUpdateProposalDialog({
           <Dialog.Title>Allow similar future calls</Dialog.Title>
           <Dialog.Description>
             {isCreatingPolicy
-              ? 'No existing Owner policy matched this Invocation. This proposes a new bounded Owner policy. It does not approve this invocation.'
+              ? 'No Owner policy exists for this Invocation. This drafts a new bounded Owner policy. It does not approve this invocation.'
               : `This proposes an Owner policy update for envelope ${evaluation.envelopeId}. It does not approve this invocation.`}
           </Dialog.Description>
           <Dialog.Close />
@@ -2077,7 +2077,9 @@ function PolicyUpdateProposalDialog({
             >
               {selectionStatus === 'blocked'
                 ? 'Resolve manual or unavailable checks before changing Owner policy.'
-                : 'Select every required change to allow this Invocation.'}
+                : isCreatingPolicy
+                  ? 'Select every required addition to create a policy that covers this Invocation.'
+                  : 'Select every required change to allow this Invocation.'}
             </Typography.BodySmall>
           ) : null}
           <Dialog.Actions>
@@ -2124,10 +2126,10 @@ function PolicySelectionBanner({
           }
         : {
             detail: isCreatingPolicy
-              ? `${blockingCheck?.label ?? 'A required check'} is not included in the proposed policy.`
+              ? `${blockingCheck?.label ?? 'A required check'} is not included in the draft policy.`
               : `${blockingCheck?.label ?? 'A required check'} remains outside policy.`,
             title: isCreatingPolicy
-              ? 'Selected policy would not cover this invocation'
+              ? 'Draft policy would not cover this invocation'
               : 'Selected changes still require approval',
           }
 

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1,0 +1,1085 @@
+import type { CSSProperties } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { useId, useState } from 'react'
+import { fn } from 'storybook/test'
+
+import { Button, Typography } from '@/wax/components'
+import { Icon } from '@/wax/components/icon'
+import { Pill } from '@/wax/components/pill'
+import { theme } from '@/wax/theme/theme.css'
+
+type ArgumentValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ArgumentValue[]
+  | { [key: string]: ArgumentValue }
+type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
+
+interface OperationApprovalProps {
+  argumentsCollapsible?: boolean
+  argumentsInitiallyExpanded?: boolean
+  canApprove?: boolean
+  compact?: boolean
+  dataset: DatasetKey
+  onApprove: () => void
+  onDecline: () => void
+  onViewRun: () => void
+  showArguments?: boolean
+  showExpiry?: boolean
+  showIdentity?: boolean
+  showProgramBody?: boolean
+  showProgramSnippet?: boolean
+  showRequestMetadataInHeader?: boolean
+  showRequester?: boolean
+  showRunContext?: boolean
+  showTechnicalDetails?: boolean
+}
+
+interface ProgramEvidence {
+  after?: string
+  before?: string
+  currentOperation: string
+}
+
+interface ApprovalDataset {
+  arguments: Array<{ label: string; value: ArgumentValue }>
+  canApprove: string
+  deadline: string
+  identity: string
+  operationName: string
+  policyText: string
+  programBody: ProgramEvidence
+  programSnippet: ProgramEvidence
+  provider: string
+  providerDescription: string
+  rawArguments: ArgumentValue[]
+  requestedBy: string
+  runContext: {
+    runId: string
+    status: 'running'
+    workspace: string
+  }
+  technicalIds: Array<{ label: string; value: string }>
+}
+
+const meta = {
+  argTypes: {
+    dataset: {
+      control: 'select',
+      options: ['github', 'linear', 'loop', 'savedFunction'],
+    },
+  },
+  args: {
+    dataset: 'github',
+    onApprove: fn(),
+    onDecline: fn(),
+    onViewRun: fn(),
+  },
+  component: OperationApproval,
+  decorators: [
+    (Story) => (
+      <div style={storyCanvasStyle}>
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        component: `An Operation Approval resolves one pending Operation Invocation. It does not approve the Program Run, future Invocations, or a reusable permission profile. The containing Program Run remains running while it waits for the decision.
+
+Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
+
+- **Minimal** uses the stable operation name with very little extra detail.
+- **MinimalWithExpiry** adds only the approval deadline.
+- **MinimalWithRequester** adds only the requesting principal.
+- **MinimalWithRequesterAndExpiry** adds both compact approval-request fields.
+- **Medium** adds identity plus positional/raw arguments.
+- **MediumWithExpiry** adds the approval deadline to Medium disclosure.
+- **MediumWithRequester** adds the requesting principal to Medium disclosure.
+- **MediumWithRequesterAndExpiry** adds both approval-request fields to Medium disclosure.
+- **MediumExpandableExpanded** includes requester and expiry, starts open, and allows arguments to be collapsed.
+- **MediumExpandableCollapsed** includes requester and expiry behind a collapsed-by-default argument review.
+- **ProgramSnippet** adds expandable arguments and highlights one current-operation call as supporting context.
+- **CollapsedProgramBody** adds expandable arguments and a collapsed, self-contained Program body.
+- **MaximalEvidence** keeps arguments expandable while exposing snippet, Program body, provider reference copy, raw args, and ids.
+
+Use the least disclosure that still makes the concrete target clear. Program body helps explain surrounding intent and flow, but it is supporting evidence, not the source of truth for concrete arguments. Provider-authored descriptions are uncontrolled reference material and never carry the core approval explanation.`,
+      },
+    },
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  title: 'Components/OperationApproval',
+} satisfies Meta<typeof OperationApproval>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const datasets: Record<DatasetKey, ApprovalDataset> = {
+  github: {
+    arguments: [
+      {
+        label: 'Argument 1',
+        value: {
+          issue_number: 85,
+          body: 'The approval queue now groups pending actions by Program Run and updates live.',
+          org: 'withcoral',
+          repo: 'lagoon',
+        },
+      },
+      {
+        label: 'Argument 2',
+        value: {
+          format: 'markdown',
+          mentions: ['@reef-team'],
+        },
+      },
+      { label: 'Argument 3', value: 'notify-requester' },
+    ],
+    canApprove: 'Workspace owner',
+    deadline: 'Expires at 14:42 UTC',
+    identity: 'coral-bot',
+    operationName: 'coral.providers.github.issues.createComment',
+    policyText: 'Agents cannot approve their own operations.',
+    programBody: {
+      before: `const selectedIssue = { org: "withcoral", repo: "lagoon", number: 85 }
+const comment = {
+  issue_number: selectedIssue.number,
+  org: selectedIssue.org,
+  repo: selectedIssue.repo,
+  body: "The approval queue now groups pending actions by Program Run and updates live.",
+}
+const options = { format: "markdown", mentions: ["@reef-team"] }
+const routing = "notify-requester"`,
+      currentOperation: 'await github.issues.createComment(comment, options, routing)',
+      after: `await audit.log({ action: "requested_github_comment", issue: selectedIssue.number })`,
+    },
+    programSnippet: {
+      before: `const body = "The approval queue now groups pending actions by Program Run and updates live."
+const comment = { org: "withcoral", repo: "lagoon", issue_number: 85, body }
+const options = { format: "markdown", mentions: ["@reef-team"] }`,
+      currentOperation: 'await github.issues.createComment(comment, options, "notify-requester")',
+    },
+    provider: 'GitHub',
+    providerDescription:
+      'Creates a comment on an issue in the selected repository using the authenticated GitHub account.',
+    rawArguments: [
+      {
+        issue_number: 85,
+        body: 'The approval queue now groups pending actions by Program Run and updates live.',
+        org: 'withcoral',
+        repo: 'lagoon',
+      },
+      {
+        format: 'markdown',
+        mentions: ['@reef-team'],
+      },
+      'notify-requester',
+    ],
+    requestedBy: 'reef-agent',
+    runContext: {
+      runId: 'run_01K3Q8DA',
+      status: 'running',
+      workspace: 'Lagoon',
+    },
+    technicalIds: [
+      { label: 'Approval request', value: 'apr_01K3Q8F1 · pending · created 14:34 UTC' },
+      { label: 'Operation invocation', value: 'inv_01K3Q8E4 · pending' },
+      { label: 'Provider generation', value: 'github@gen_0198' },
+      { label: 'Event cursor', value: 'evt_00000047' },
+      { label: 'Trace', value: '8f5c1f45b2ef4d65' },
+    ],
+  },
+  linear: {
+    arguments: [
+      {
+        label: 'Argument 1',
+        value: {
+          issue_id: 'LIN-482',
+          state_id: 'in_review',
+          comment: 'Linked GitHub issue with the run-status approval follow-up.',
+          labels: ['run-status', 'needs-review'],
+          source: { provider: 'github', issue: 'withcoral/lagoon#85' },
+        },
+      },
+      { label: 'Argument 2', value: { notifyAssignee: true, priority: 'normal' } },
+      { label: 'Argument 3', value: 'approval-card-review' },
+    ],
+    canApprove: 'Workspace owner',
+    deadline: 'Expires at 14:42 UTC',
+    identity: 'coral-linear-bot',
+    operationName: 'coral.providers.linear.issues.update',
+    policyText: 'Agents cannot approve their own operations.',
+    programBody: {
+      before: `const githubIssue = { repo: "withcoral/lagoon", number: 85 }
+const linearIssue = { id: "LIN-482", state: "in_review" }
+const updateInput = {
+  issue_id: linearIssue.id,
+  state_id: linearIssue.state,
+  comment: "Linked GitHub issue with the run-status approval follow-up.",
+  labels: ["run-status", "needs-review"],
+  source: { provider: "github", issue: githubIssue.repo + "#" + githubIssue.number },
+}
+const options = { notifyAssignee: true, priority: "normal" }`,
+      currentOperation: 'await linear.issues.update(updateInput, options, "approval-card-review")',
+      after: `await audit.log({ action: "requested_linear_update", issue: linearIssue.id })`,
+    },
+    programSnippet: {
+      before: `const githubIssue = { repo: "withcoral/lagoon", number: 85 }
+const updateInput = { issue_id: "LIN-482", state_id: "in_review", source: githubIssue }
+const options = { notifyAssignee: true, priority: "normal" }`,
+      currentOperation: 'await linear.issues.update(updateInput, options, "approval-card-review")',
+    },
+    provider: 'Linear',
+    providerDescription: 'Updates an issue using the authenticated Linear workspace identity.',
+    rawArguments: [
+      {
+        issue_id: 'LIN-482',
+        state_id: 'in_review',
+        comment: 'Linked GitHub issue with the run-status approval follow-up.',
+        labels: ['run-status', 'needs-review'],
+        source: { provider: 'github', issue: 'withcoral/lagoon#85' },
+      },
+      { notifyAssignee: true, priority: 'normal' },
+      'approval-card-review',
+    ],
+    requestedBy: 'reef-agent',
+    runContext: {
+      runId: 'run_01K3Q8DA',
+      status: 'running',
+      workspace: 'Lagoon',
+    },
+    technicalIds: [
+      { label: 'Approval request', value: 'apr_01K3Q8F1 · pending · created 14:34 UTC' },
+      { label: 'Operation invocation', value: 'inv_01K3Q8E4 · pending' },
+      { label: 'Provider generation', value: 'linear@gen_0198' },
+      { label: 'Event cursor', value: 'evt_00000047' },
+      { label: 'Trace', value: '8f5c1f45b2ef4d65' },
+    ],
+  },
+  loop: {
+    arguments: [
+      {
+        label: 'Argument 1',
+        value: {
+          issue_id: 'LIN-491',
+          state_id: 'triaged',
+          note: 'Iteration 2/5: linked GitHub issue with matching approval-card feedback.',
+          source: { provider: 'github', issue: 'withcoral/lagoon#91' },
+        },
+      },
+      { label: 'Argument 2', value: { notifyAssignee: false, loopIndex: 2, total: 5 } },
+      { label: 'Argument 3', value: 'loop-iteration-2' },
+    ],
+    canApprove: 'Workspace owner',
+    deadline: 'Expires at 14:42 UTC',
+    identity: 'coral-linear-bot',
+    operationName: 'coral.providers.linear.issues.update',
+    policyText: 'Agents cannot approve their own operations.',
+    programBody: {
+      before: `const githubIssues = [91, 92, 93, 94, 95]
+for (const [index, issueNumber] of githubIssues.entries()) {
+  const githubIssue = { repo: "withcoral/lagoon", number: issueNumber }
+  const linearIssue = { id: "LIN-" + (489 + index), state: "triaged" }
+  const updateInput = {
+    issue_id: linearIssue.id,
+    state_id: linearIssue.state,
+    source: { provider: "github", issue: githubIssue.repo + "#" + githubIssue.number },
+  }
+  const options = { notifyAssignee: false, loopIndex: index + 1, total: githubIssues.length }`,
+      currentOperation:
+        '  await linear.issues.update(updateInput, options, "loop-iteration-" + (index + 1))',
+      after: `  await audit.log({ action: "requested_loop_update", issue: linearIssue.id })
+}`,
+    },
+    programSnippet: {
+      before: `for (const [index, issueNumber] of githubIssues.entries()) {
+  const updateInput = { issue_id: "LIN-491", source: { provider: "github", issue: "withcoral/lagoon#91" } }
+  const options = { loopIndex: 2, total: 5 }`,
+      currentOperation: '  await linear.issues.update(updateInput, options, "loop-iteration-2")',
+      after: '}',
+    },
+    provider: 'Linear',
+    providerDescription: 'Updates an issue using the authenticated Linear workspace identity.',
+    rawArguments: [
+      {
+        issue_id: 'LIN-491',
+        state_id: 'triaged',
+        note: 'Iteration 2/5: linked GitHub issue with matching approval-card feedback.',
+        source: { provider: 'github', issue: 'withcoral/lagoon#91' },
+      },
+      { notifyAssignee: false, loopIndex: 2, total: 5 },
+      'loop-iteration-2',
+    ],
+    requestedBy: 'reef-agent',
+    runContext: {
+      runId: 'run_01K3Q8DA',
+      status: 'running',
+      workspace: 'Lagoon',
+    },
+    technicalIds: [
+      { label: 'Approval request', value: 'apr_01K3Q8L2 · pending · created 14:37 UTC' },
+      { label: 'Operation invocation', value: 'inv_01K3Q8K6 · pending' },
+      { label: 'Provider generation', value: 'linear@gen_0198' },
+      { label: 'Event cursor', value: 'evt_00000052' },
+      { label: 'Trace', value: '8f5c1f45b2ef4d65' },
+    ],
+  },
+  savedFunction: {
+    arguments: [
+      {
+        label: 'Argument 1',
+        value: {
+          issue_number: 85,
+          body: 'Linked Saved Function prepared this comment for the current run.',
+          org: 'withcoral',
+          repo: 'lagoon',
+        },
+      },
+      {
+        label: 'Argument 2',
+        value: { format: 'markdown', functionPath: 'coral.functions.postApprovalFollowUp' },
+      },
+      { label: 'Argument 3', value: 'saved-function-call-01' },
+    ],
+    canApprove: 'Workspace owner',
+    deadline: 'Expires at 14:42 UTC',
+    identity: 'coral-bot',
+    operationName: 'coral.providers.github.issues.createComment',
+    policyText: 'Agents cannot approve their own operations.',
+    programBody: {
+      before: `// Submitted Program body
+await coral.functions.postApprovalFollowUp({ issueNumber: 85 })
+
+// Linked Saved Function source snapshot: coral.functions.postApprovalFollowUp
+export default async function postApprovalFollowUp(input: { issueNumber: number }) {
+  const selectedIssue = { org: "withcoral", repo: "lagoon", number: input.issueNumber }
+  const comment = {
+    org: selectedIssue.org,
+    repo: selectedIssue.repo,
+    issue_number: selectedIssue.number,
+    body: "Linked Saved Function prepared this comment for the current run.",
+  }
+  const options = { format: "markdown", functionPath: "coral.functions.postApprovalFollowUp" }`,
+      currentOperation:
+        '  await github.issues.createComment(comment, options, "saved-function-call-01")',
+      after: `    return { issue: selectedIssue.number, status: "approval_requested" }
+}`,
+    },
+    programSnippet: {
+      before: `// Linked source: coral.functions.postApprovalFollowUp
+export default async function postApprovalFollowUp(input) {
+  const comment = { org: "withcoral", repo: "lagoon", issue_number: input.issueNumber }`,
+      currentOperation:
+        '  await github.issues.createComment(comment, { functionPath: "coral.functions.postApprovalFollowUp" }, "saved-function-call-01")',
+      after: '}',
+    },
+    provider: 'GitHub',
+    providerDescription:
+      'Creates a comment on an issue in the selected repository using the authenticated GitHub account.',
+    rawArguments: [
+      {
+        issue_number: 85,
+        body: 'Linked Saved Function prepared this comment for the current run.',
+        org: 'withcoral',
+        repo: 'lagoon',
+      },
+      { format: 'markdown', functionPath: 'coral.functions.postApprovalFollowUp' },
+      'saved-function-call-01',
+    ],
+    requestedBy: 'reef-agent',
+    runContext: {
+      runId: 'run_01K3Q8DA',
+      status: 'running',
+      workspace: 'Lagoon',
+    },
+    technicalIds: [
+      { label: 'Approval request', value: 'apr_01K3Q8S4 · pending · created 14:39 UTC' },
+      { label: 'Operation invocation', value: 'inv_01K3Q8R9 · pending · linked Saved Function' },
+      { label: 'Saved Function path', value: 'coral.functions.postApprovalFollowUp' },
+      {
+        label: 'Saved Function source',
+        value: 'accepted Run snapshot · current edits cannot change it',
+      },
+      { label: 'Provider generation', value: 'github@gen_0198' },
+      { label: 'Event cursor', value: 'evt_00000058' },
+      { label: 'Trace', value: '8f5c1f45b2ef4d65' },
+    ],
+  },
+}
+
+export const Minimal: Story = {
+  args: {
+    compact: true,
+    dataset: 'github',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Minimal disclosure: selected dataset operation name plus provider, Approve, and Decline. No argument or Program evidence is shown.',
+      },
+    },
+  },
+}
+
+export const MinimalWithExpiry: Story = {
+  args: {
+    compact: true,
+    dataset: 'github',
+    showExpiry: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Minimal disclosure with the stable operation name, provider, approval deadline, and decision actions.',
+      },
+    },
+  },
+}
+
+export const MinimalWithRequester: Story = {
+  args: {
+    compact: true,
+    dataset: 'github',
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Minimal disclosure with the stable operation name, provider, requesting principal, and decision actions.',
+      },
+    },
+  },
+}
+
+export const MinimalWithRequesterAndExpiry: Story = {
+  args: {
+    compact: true,
+    dataset: 'github',
+    showExpiry: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Minimal disclosure with the stable operation name, provider, requesting principal, approval deadline, and decision actions.',
+      },
+    },
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    dataset: 'github',
+    showArguments: true,
+    showIdentity: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Medium disclosure: selected dataset with provider identity and positional/raw arguments, without provider-specific interpretation.',
+      },
+    },
+  },
+}
+
+export const MediumWithRequester: Story = {
+  args: {
+    dataset: 'github',
+    showArguments: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Medium disclosure with provider identity and requester in the header above exact positional arguments.',
+      },
+    },
+  },
+}
+
+export const MediumWithExpiry: Story = {
+  args: {
+    dataset: 'github',
+    showArguments: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Medium disclosure with provider identity and expiry in the header above exact positional arguments.',
+      },
+    },
+  },
+}
+
+export const MediumWithRequesterAndExpiry: Story = {
+  args: {
+    dataset: 'github',
+    showArguments: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Medium disclosure with provider identity, requester, and expiry in the header above exact positional arguments.',
+      },
+    },
+  },
+}
+
+export const MediumExpandableExpanded: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'github',
+    showArguments: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Safer expandable disclosure: requester and expiry sit in the header, while exact positional arguments start open.',
+      },
+    },
+  },
+}
+
+export const MediumExpandableCollapsed: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: false,
+    dataset: 'github',
+    showArguments: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Collapsed-by-default experiment with requester and expiry in the header. Approval actions remain unchanged.',
+      },
+    },
+  },
+}
+
+export const ProgramSnippet: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'github',
+    showArguments: true,
+    showIdentity: true,
+    showProgramSnippet: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selected dataset plus one highlighted current operation call. The Program evidence is self-contained enough to show call location, not another argument table.',
+      },
+    },
+  },
+}
+
+export const CollapsedProgramBody: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'github',
+    showArguments: true,
+    showExpiry: true,
+    showIdentity: true,
+    showProgramBody: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Selected dataset with requester and expiry in the header plus a collapsed, self-contained Program body. The highlighted line identifies the current operation call when expanded.',
+      },
+    },
+  },
+}
+
+export const MaximalEvidence: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    canApprove: true,
+    dataset: 'github',
+    showArguments: true,
+    showIdentity: true,
+    showProgramBody: true,
+    showProgramSnippet: true,
+    showRequestMetadataInHeader: true,
+    showRunContext: true,
+    showTechnicalDetails: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Maximal evidence for the selected dataset. Snippet, Program body, raw arguments, provider reference copy, and ids are available, but arguments remain the primary decision surface.',
+      },
+    },
+  },
+}
+
+function OperationApproval({
+  argumentsCollapsible,
+  argumentsInitiallyExpanded,
+  canApprove,
+  compact,
+  dataset,
+  onApprove,
+  onDecline,
+  onViewRun,
+  showArguments,
+  showExpiry,
+  showIdentity,
+  showProgramBody,
+  showProgramSnippet,
+  showRequestMetadataInHeader,
+  showRequester,
+  showRunContext,
+  showTechnicalDetails,
+}: OperationApprovalProps) {
+  const approval = datasets[dataset]
+  const argumentsId = useId()
+  const [argumentsExpanded, setArgumentsExpanded] = useState(Boolean(argumentsInitiallyExpanded))
+  const hasDecisionContext = Boolean(canApprove)
+  const technicalDetails = buildTechnicalDetails(approval)
+  const hasContext = Boolean(
+    showArguments ||
+    showExpiry ||
+    showIdentity ||
+    hasDecisionContext ||
+    showProgramBody ||
+    showProgramSnippet ||
+    showRequester ||
+    showRunContext ||
+    showTechnicalDetails,
+  )
+
+  return (
+    <section style={{ ...cardStyle, ...(compact ? compactCardStyle : {}) }}>
+      <div style={headerStyle}>
+        <span style={operationIconStyle}>
+          <Icon color="warning" name="ShieldAlert" size="18" />
+        </span>
+        <div style={titleGroupStyle}>
+          <Typography.BodyLargeStrong as="h2">{approval.operationName}</Typography.BodyLargeStrong>
+          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+            {[`Provider: ${approval.provider}`, showIdentity && `Identity: ${approval.identity}`]
+              .filter(Boolean)
+              .join(' · ')}
+          </Typography.BodySmall>
+          {showRequestMetadataInHeader && (showRequester || showExpiry || hasDecisionContext) ? (
+            <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+              {[
+                (showRequester || hasDecisionContext) && `Requested by: ${approval.requestedBy}`,
+                (showExpiry || hasDecisionContext) && approval.deadline,
+              ]
+                .filter(Boolean)
+                .join(' · ')}
+            </Typography.BodySmall>
+          ) : null}
+        </div>
+        {hasContext ? <Pill color="amber">Approval required</Pill> : null}
+      </div>
+
+      {showArguments ? (
+        <section style={sectionStyle}>
+          {argumentsCollapsible ? (
+            <Button.Container
+              aria-controls={argumentsId}
+              aria-expanded={argumentsExpanded}
+              fullWidth
+              onClick={() => setArgumentsExpanded((expanded) => !expanded)}
+              size="22"
+              style={argumentsDisclosureStyle}
+              variant="bare"
+            >
+              <Button.Icon name={argumentsExpanded ? 'ChevronDown' : 'ChevronRight'} />
+              <Typography.BodySmallStrong variant="tertiary">
+                Arguments ({approval.arguments.length})
+              </Typography.BodySmallStrong>
+            </Button.Container>
+          ) : (
+            <Typography.BodySmallStrong as="h3" variant="tertiary">
+              Arguments
+            </Typography.BodySmallStrong>
+          )}
+          {!argumentsCollapsible || argumentsExpanded ? (
+            <dl
+              id={argumentsId}
+              style={{
+                ...detailsStyle,
+                ...(argumentsCollapsible ? collapsibleDetailsStyle : {}),
+              }}
+            >
+              {approval.arguments.map(({ label, value }) => (
+                <DetailRow key={label} label={label} value={value} />
+              ))}
+            </dl>
+          ) : null}
+        </section>
+      ) : null}
+
+      {showProgramSnippet ? (
+        <section style={supportingEvidenceStyle}>
+          <Typography.BodySmallStrong as="h3" variant="tertiary">
+            Context
+          </Typography.BodySmallStrong>
+          <ProgramEvidenceBlock evidence={approval.programSnippet} />
+        </section>
+      ) : null}
+
+      {showProgramBody ? (
+        <details open={false} style={programBodyDetailsStyle}>
+          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
+            Program body
+          </Typography.BodySmallStrong>
+          <ProgramEvidenceBlock evidence={approval.programBody} />
+        </details>
+      ) : null}
+
+      {(showRequester || showExpiry) && !hasDecisionContext && !showRequestMetadataInHeader ? (
+        <dl style={decisionDetailsStyle}>
+          {showRequester ? <DetailRow label="Requested by" value={approval.requestedBy} /> : null}
+          {showExpiry ? <DetailRow label="Expiry" value={approval.deadline} /> : null}
+        </dl>
+      ) : null}
+
+      {hasDecisionContext ? (
+        <section style={decisionContextStyle}>
+          <dl style={decisionDetailsStyle}>
+            {!showRequestMetadataInHeader ? (
+              <DetailRow label="Requested by" value={approval.requestedBy} />
+            ) : null}
+            <DetailRow label="Can approve" value={approval.canApprove} />
+            {!showRequestMetadataInHeader ? (
+              <DetailRow label="Expiry" value={approval.deadline} />
+            ) : null}
+          </dl>
+          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+            {approval.policyText}
+          </Typography.BodySmall>
+        </section>
+      ) : null}
+
+      {showTechnicalDetails ? (
+        <details style={technicalDetailsStyle}>
+          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
+            Provider reference text
+          </Typography.BodySmallStrong>
+          <Typography.BodySmall as="p" style={providerDescriptionStyle} variant="tertiary">
+            Optional provider-authored context. Do not use this as the approval scope.
+          </Typography.BodySmall>
+          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+            {approval.providerDescription}
+          </Typography.BodySmall>
+        </details>
+      ) : null}
+
+      {showTechnicalDetails ? (
+        <details style={technicalDetailsStyle}>
+          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
+            Technical details
+          </Typography.BodySmallStrong>
+          <dl style={technicalListStyle}>
+            {technicalDetails.map(({ label, value }) => (
+              <DetailRow key={label} label={label} value={value} />
+            ))}
+          </dl>
+        </details>
+      ) : null}
+
+      {showRunContext ? (
+        <div style={runContextStyle}>
+          <div style={runCopyStyle}>
+            <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
+              Run {approval.runContext.runId}
+            </Typography.BodySmallStrong>
+            <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+              {approval.runContext.status} · {approval.runContext.workspace}
+            </Typography.BodySmall>
+          </div>
+          <Button.Container onClick={onViewRun} size="22" variant="bare">
+            <Button.Text>View run</Button.Text>
+            <Button.Icon name="ArrowUpRight" />
+          </Button.Container>
+        </div>
+      ) : null}
+
+      <div style={actionsStyle}>
+        <Button.Container onClick={onDecline} size="32" variant="secondary">
+          <Button.Text>Decline</Button.Text>
+        </Button.Container>
+        <Button.Container onClick={onApprove} size="32" variant="primary">
+          <Button.Text>Approve</Button.Text>
+        </Button.Container>
+      </div>
+    </section>
+  )
+}
+
+function buildTechnicalDetails(approval: ApprovalDataset) {
+  return [
+    { label: 'Operation', value: approval.operationName },
+    { label: 'Identity', value: `${approval.provider} · ${approval.identity}` },
+    { label: 'Raw arguments', value: JSON.stringify(approval.rawArguments, null, 2) },
+    ...approval.technicalIds,
+  ]
+}
+
+function ProgramEvidenceBlock({ evidence }: { evidence: ProgramEvidence }) {
+  return (
+    <pre style={codeBlockStyle}>
+      {evidence.before ? `${evidence.before}\n` : null}
+      <mark style={currentOperationStyle}>{evidence.currentOperation}</mark>
+      {evidence.after ? `\n${evidence.after}` : null}
+    </pre>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: ArgumentValue }) {
+  return (
+    <div style={detailRowStyle}>
+      <Typography.BodySmall as="dt" variant="tertiary">
+        {label}
+      </Typography.BodySmall>
+      <Typography.BodySmall as="dd" style={detailValueStyle} variant="primary">
+        {renderArgumentValue(value)}
+      </Typography.BodySmall>
+    </div>
+  )
+}
+
+function renderArgumentValue(value: ArgumentValue) {
+  if (typeof value === 'object' && value !== null) {
+    return <pre style={nestedValueStyle}>{JSON.stringify(value, null, 2)}</pre>
+  }
+
+  return String(value)
+}
+
+const storyCanvasStyle: CSSProperties = {
+  alignItems: 'flex-start',
+  background: theme.surface.main,
+  boxSizing: 'border-box',
+  display: 'flex',
+  justifyContent: 'center',
+  padding: '20px',
+}
+
+const cardStyle: CSSProperties = {
+  background: theme.surface.card,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '12px',
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  maxWidth: '720px',
+  padding: '16px',
+  width: '100%',
+}
+
+const compactCardStyle: CSSProperties = { gap: '12px', maxWidth: '560px' }
+
+const headerStyle: CSSProperties = {
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: '12px',
+  minWidth: 0,
+}
+
+const operationIconStyle: CSSProperties = {
+  alignItems: 'center',
+  background: theme.content.warningBackground,
+  borderRadius: '8px',
+  display: 'flex',
+  flex: '0 0 auto',
+  height: '32px',
+  justifyContent: 'center',
+  width: '32px',
+}
+
+const titleGroupStyle: CSSProperties = {
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  gap: '2px',
+  minWidth: 0,
+}
+
+const zeroMarginStyle: CSSProperties = { margin: 0 }
+
+const sectionStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+}
+
+const argumentsDisclosureStyle: CSSProperties = {
+  alignItems: 'center',
+  background: 'transparent',
+  border: 0,
+  borderBottom: `1px solid ${theme.stroke.secondary}`,
+  cursor: 'pointer',
+  display: 'flex',
+  gap: '4px',
+  justifyContent: 'flex-start',
+  padding: '0 0 6px',
+  textAlign: 'left',
+  width: '100%',
+}
+
+const supportingEvidenceStyle: CSSProperties = {
+  background: theme.surface.mainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '8px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+  padding: '10px 12px',
+}
+
+const codeBlockStyle: CSSProperties = {
+  background: theme.surface.main,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '8px',
+  color: theme.content.secondary,
+  fontFamily: 'monospace',
+  fontSize: '12px',
+  lineHeight: 1.5,
+  margin: 0,
+  overflowX: 'auto',
+  padding: '10px 12px',
+  whiteSpace: 'pre-wrap',
+}
+
+const currentOperationStyle: CSSProperties = {
+  background: theme.content.warningBackground,
+  borderRadius: '4px',
+  color: theme.content.primary,
+  padding: '1px 3px',
+}
+
+const detailsStyle: CSSProperties = {
+  borderTop: `1px solid ${theme.stroke.secondary}`,
+  margin: 0,
+}
+
+const collapsibleDetailsStyle: CSSProperties = { borderTop: 0 }
+
+const detailRowStyle: CSSProperties = {
+  alignItems: 'baseline',
+  borderBottom: `1px solid ${theme.stroke.secondary}`,
+  display: 'grid',
+  gap: '16px',
+  gridTemplateColumns: '140px minmax(0, 1fr)',
+  padding: '8px 0',
+}
+
+const detailValueStyle: CSSProperties = {
+  margin: 0,
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+}
+
+const nestedValueStyle: CSSProperties = {
+  ...codeBlockStyle,
+  fontSize: '11px',
+  maxWidth: '100%',
+}
+
+const decisionContextStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+}
+
+const decisionDetailsStyle: CSSProperties = {
+  borderTop: `1px solid ${theme.stroke.secondary}`,
+  margin: 0,
+}
+
+const technicalDetailsStyle: CSSProperties = {
+  borderTop: `1px solid ${theme.stroke.secondary}`,
+  paddingTop: '12px',
+}
+
+const programBodyDetailsStyle: CSSProperties = {
+  ...technicalDetailsStyle,
+  background: theme.surface.mainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '8px',
+  padding: '10px 12px',
+}
+
+const providerDescriptionStyle: CSSProperties = { margin: '8px 0' }
+
+const technicalSummaryStyle: CSSProperties = {
+  color: theme.content.secondary,
+  cursor: 'pointer',
+}
+
+const technicalListStyle: CSSProperties = { margin: '8px 0 0' }
+
+const runContextStyle: CSSProperties = {
+  alignItems: 'center',
+  background: theme.surface.mainContent,
+  borderRadius: '8px',
+  display: 'flex',
+  gap: '12px',
+  justifyContent: 'space-between',
+  padding: '10px 12px',
+}
+
+const runCopyStyle: CSSProperties = {
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  gap: '2px',
+  minWidth: 0,
+}
+
+const actionsStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '8px',
+  justifyContent: 'flex-end',
+}

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -19,10 +19,12 @@ type ArgumentValue =
   | { [key: string]: ArgumentValue }
 type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
 type EnvelopeMatch = 'inside' | 'outside'
+type EnvelopeArgsDisplay = 'interleaved' | 'none' | 'summary'
 
 interface OperationApprovalStoryProps {
   argumentsCollapsible?: boolean
   argumentsInitiallyExpanded?: boolean
+  envelopeArgsDisplay?: EnvelopeArgsDisplay
   envelopeMatch: EnvelopeMatch
   compact?: boolean
   dataset: DatasetKey
@@ -33,7 +35,6 @@ interface OperationApprovalStoryProps {
   showApprovalAuthority?: boolean
   showExpiry?: boolean
   showAuthorityEnvelopeMatch?: boolean
-  showEnvelopeOnArgs?: boolean
   showIdentity?: boolean
   showProgramBody?: boolean
   showProgramSnippet?: boolean
@@ -154,9 +155,10 @@ const meta = {
       control: 'boolean',
       description: 'Execute and show a Storybook-only deterministic Owner-policy envelope.',
     },
-    showEnvelopeOnArgs: {
-      control: 'boolean',
-      description: 'Annotate exact argument rows with checks from the selected Owner envelope.',
+    envelopeArgsDisplay: {
+      control: 'inline-radio',
+      description: 'Show selected Owner-envelope checks beside exact invocation arguments.',
+      options: ['none', 'summary', 'interleaved'],
     },
     showRequestContext: {
       control: 'boolean',
@@ -176,7 +178,7 @@ const meta = {
     showRequestContext: false,
     showProviderReference: false,
     showAuthorityEnvelopeMatch: false,
-    showEnvelopeOnArgs: false,
+    envelopeArgsDisplay: 'none',
   },
   component: OperationApprovalStory,
   decorators: [
@@ -198,7 +200,7 @@ Every Medium+ story keeps the same first-screen decision contract: Operation cal
 
 Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
-Every dataset supplies two Storybook-only Owner envelopes: \`inside\` matches its exact Invocation and \`outside\` fails explicit argument filters. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the full evaluation or \`showEnvelopeOnArgs\` to annotate the affected positional arguments inline.
+Every dataset supplies two Storybook-only Owner envelopes: \`inside\` matches its exact Invocation and \`outside\` fails explicit argument filters. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the full evaluation. Use \`envelopeArgsDisplay\` to show no argument annotations, a positional-argument summary, or policy checks interleaved with their exact fields.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
@@ -1069,10 +1071,10 @@ export const EnvelopeMatches: Story = {
     argumentsCollapsible: true,
     argumentsInitiallyExpanded: true,
     dataset: 'github',
+    envelopeArgsDisplay: 'interleaved',
     envelopeMatch: 'inside',
     showArguments: true,
     showAuthorityEnvelopeMatch: true,
-    showEnvelopeOnArgs: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
     showRequester: true,
@@ -1092,11 +1094,11 @@ export const EnvelopeDoesNotMatch: Story = {
     argumentsCollapsible: true,
     argumentsInitiallyExpanded: true,
     dataset: 'github',
+    envelopeArgsDisplay: 'interleaved',
     envelopeMatch: 'outside',
     showArguments: true,
     showApprovalAuthority: true,
     showAuthorityEnvelopeMatch: true,
-    showEnvelopeOnArgs: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -1201,6 +1203,7 @@ function OperationApproval({
   argumentsInitiallyExpanded,
   authorityEnvelope,
   compact,
+  envelopeArgsDisplay = 'none',
   onApprove,
   onDecline,
   onViewRun,
@@ -1208,7 +1211,6 @@ function OperationApproval({
   showApprovalAuthority,
   showExpiry,
   showAuthorityEnvelopeMatch,
-  showEnvelopeOnArgs,
   showIdentity,
   showProgramBody,
   showProgramSnippet,
@@ -1221,14 +1223,14 @@ function OperationApproval({
 }: OperationApprovalProps) {
   const hasDecisionContext = Boolean(showApprovalAuthority)
   const envelopeEvaluation =
-    showAuthorityEnvelopeMatch || showEnvelopeOnArgs
+    showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
       ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
       : undefined
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
     showAuthorityEnvelopeMatch ||
-    showEnvelopeOnArgs ||
+    envelopeArgsDisplay !== 'none' ||
     showIdentity ||
     hasDecisionContext ||
     showProgramBody ||
@@ -1256,13 +1258,16 @@ function OperationApproval({
       {showArguments ? (
         <InvocationArgumentsSection
           collapsible={argumentsCollapsible}
-          envelopeChecks={showEnvelopeOnArgs ? envelopeEvaluation?.checks : undefined}
+          envelopeChecks={envelopeArgsDisplay !== 'none' ? envelopeEvaluation?.checks : undefined}
+          envelopeDisplay={envelopeArgsDisplay}
           initiallyExpanded={argumentsInitiallyExpanded}
           invocationArguments={approval.invocationArguments}
         />
       ) : null}
 
-      {envelopeEvaluation ? <EnvelopeCheckSection evaluation={envelopeEvaluation} /> : null}
+      {showAuthorityEnvelopeMatch && envelopeEvaluation ? (
+        <EnvelopeCheckSection evaluation={envelopeEvaluation} />
+      ) : null}
 
       {(showRequestContext && approval.requestContext) ||
       (showProgramSnippet && approval.programContext) ? (
@@ -1401,11 +1406,13 @@ function ApprovalHeader({
 function InvocationArgumentsSection({
   collapsible,
   envelopeChecks,
+  envelopeDisplay,
   initiallyExpanded,
   invocationArguments,
 }: {
   collapsible?: boolean
   envelopeChecks?: AuthorityEnvelopeEvaluation['checks']
+  envelopeDisplay: EnvelopeArgsDisplay
   initiallyExpanded?: boolean
   invocationArguments: OperationApprovalModel['invocationArguments']
 }) {
@@ -1441,6 +1448,8 @@ function InvocationArgumentsSection({
               annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
                 checkLabel.startsWith(`args[${index}]`),
               )}
+              argumentIndex={index}
+              envelopeDisplay={envelopeDisplay}
               key={label}
               label={label}
               showDivider={index < invocationArguments.length - 1}
@@ -1455,40 +1464,128 @@ function InvocationArgumentsSection({
 
 function InvocationArgumentRow({
   annotations,
+  argumentIndex,
+  envelopeDisplay,
   label,
   showDivider,
   value,
 }: {
   annotations?: AuthorityEnvelopeEvaluation['checks']
+  argumentIndex: number
+  envelopeDisplay: EnvelopeArgsDisplay
   label: string
   showDivider: boolean
   value: ArgumentValue
 }) {
   const argumentStatus = aggregateEnvelopeStatus(annotations)
+  const isInterleavedObject = envelopeDisplay === 'interleaved' && isArgumentRecord(value)
 
   return (
     <div
       style={{
         ...argumentGroupStyle,
-        ...(argumentStatus ? envelopeArgumentBackgrounds[argumentStatus] : {}),
+        ...(argumentStatus && !isInterleavedObject
+          ? envelopeArgumentBackgrounds[argumentStatus]
+          : {}),
         ...(!showDivider ? lastDetailRowStyle : {}),
       }}
     >
-      <DetailRow label={label} showDivider={false} value={value} />
-      {annotations && annotations.length > 0 ? (
+      {isInterleavedObject ? (
+        <InterleavedArgumentFields
+          annotations={annotations}
+          argumentIndex={argumentIndex}
+          argumentLabel={label}
+          value={value}
+        />
+      ) : (
+        <DetailRow label={label} showDivider={false} value={value} />
+      )}
+      {envelopeDisplay !== 'interleaved' && annotations && annotations.length > 0 ? (
         <div style={argumentAnnotationsStyle}>
-          {annotations.map(({ label: checkLabel, policy, status }) => (
-            <div key={checkLabel} style={argumentAnnotationStyle}>
-              <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
-                Policy: {checkLabel} {policy}
-              </Typography.BodySmall>
-              <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
-            </div>
+          {annotations.map((annotation) => (
+            <EnvelopeArgumentAnnotation annotation={annotation} key={annotation.label} />
+          ))}
+        </div>
+      ) : null}
+      {envelopeDisplay === 'interleaved' && !isInterleavedObject && annotations?.length ? (
+        <div style={argumentAnnotationsStyle}>
+          {annotations.map((annotation) => (
+            <EnvelopeArgumentAnnotation annotation={annotation} key={annotation.label} />
           ))}
         </div>
       ) : null}
     </div>
   )
+}
+
+function InterleavedArgumentFields({
+  annotations,
+  argumentIndex,
+  argumentLabel,
+  value,
+}: {
+  annotations?: AuthorityEnvelopeEvaluation['checks']
+  argumentIndex: number
+  argumentLabel: string
+  value: Record<string, ArgumentValue>
+}) {
+  return (
+    <div style={interleavedArgumentStyle}>
+      <Typography.BodySmall as="p" style={interleavedArgumentLabelStyle} variant="tertiary">
+        {argumentLabel}
+      </Typography.BodySmall>
+      <div>
+        {Object.entries(value).map(([field, fieldValue], index, fields) => {
+          const fieldAnnotations = annotations?.filter(({ label }) =>
+            label.startsWith(`args[${argumentIndex}].${field}`),
+          )
+          const fieldStatus = aggregateEnvelopeStatus(fieldAnnotations)
+
+          return (
+            <div
+              key={field}
+              style={{
+                ...interleavedFieldStyle,
+                ...(fieldStatus ? envelopeInterleavedBackgrounds[fieldStatus] : {}),
+                ...(index === fields.length - 1 ? lastDetailRowStyle : {}),
+              }}
+            >
+              <div style={interleavedFieldValueStyle}>
+                <Typography.BodySmallStrong as="span" variant="tertiary">
+                  {field}
+                </Typography.BodySmallStrong>
+                <Typography.BodySmall as="div" style={detailValueStyle} variant="primary">
+                  {renderArgumentValue(fieldValue)}
+                </Typography.BodySmall>
+              </div>
+              {fieldAnnotations?.map((annotation) => (
+                <EnvelopeArgumentAnnotation annotation={annotation} key={annotation.label} />
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function EnvelopeArgumentAnnotation({
+  annotation: { label, policy, status },
+}: {
+  annotation: AuthorityEnvelopeEvaluation['checks'][number]
+}) {
+  return (
+    <div style={argumentAnnotationStyle}>
+      <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+        Policy: {label} {policy}
+      </Typography.BodySmall>
+      <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
+    </div>
+  )
+}
+
+function isArgumentRecord(value: ArgumentValue): value is Record<string, ArgumentValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function aggregateEnvelopeStatus(
@@ -1840,6 +1937,33 @@ const argumentGroupStyle: CSSProperties = {
   borderBottom: `1px solid ${theme.stroke.secondary}`,
 }
 
+const interleavedArgumentStyle: CSSProperties = {
+  display: 'grid',
+  gap: '16px',
+  gridTemplateColumns: '140px minmax(0, 1fr)',
+  padding: '8px 0',
+}
+
+const interleavedArgumentLabelStyle: CSSProperties = {
+  margin: 0,
+  paddingTop: '8px',
+}
+
+const interleavedFieldStyle: CSSProperties = {
+  borderBottom: `1px solid ${theme.stroke.secondary}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  padding: '8px',
+}
+
+const interleavedFieldValueStyle: CSSProperties = {
+  alignItems: 'baseline',
+  display: 'grid',
+  gap: '12px',
+  gridTemplateColumns: '120px minmax(0, 1fr)',
+}
+
 const envelopeArgumentBackgrounds: Record<EnvelopeCheckStatus, CSSProperties> = {
   fail: {
     background: theme.content.errorBackground,
@@ -1856,6 +1980,12 @@ const envelopeArgumentBackgrounds: Record<EnvelopeCheckStatus, CSSProperties> = 
     borderRadius: '6px',
     padding: '0 8px 8px',
   },
+}
+
+const envelopeInterleavedBackgrounds: Record<EnvelopeCheckStatus, CSSProperties> = {
+  fail: { background: theme.content.errorBackground, borderRadius: '6px' },
+  pass: { background: theme.content.successBackground, borderRadius: '6px' },
+  unknown: { background: theme.content.warningBackground, borderRadius: '6px' },
 }
 
 const argumentAnnotationsStyle: CSSProperties = {

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -18,7 +18,7 @@ type ArgumentValue =
   | ArgumentValue[]
   | { [key: string]: ArgumentValue }
 type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
-type EnvelopeMatch = 'inside' | 'outside'
+type EnvelopeMatch = 'inside' | 'none' | 'outside'
 type EnvelopeArgsDisplay = 'interleaved' | 'none' | 'summary'
 
 interface OperationApprovalStoryProps {
@@ -100,6 +100,7 @@ interface AuthorityEnvelopeEvaluation {
   }>
   decision: 'allow' | 'requiresApproval'
   envelopeId: string
+  envelopeMatch: EnvelopeMatch
   expiresAt: string
   installedBy: string
 }
@@ -109,6 +110,7 @@ interface AuthorityEnvelope {
   evaluatedAt: string
   expiresAt: string
   installedBy: string
+  match: EnvelopeMatch
   operationCallPath: string
   rules: AuthorityEnvelopeRule[]
 }
@@ -153,9 +155,10 @@ const meta = {
   argTypes: {
     envelopeMatch: {
       control: 'inline-radio',
-      description: 'Choose the Owner envelope evaluated against the selected dataset.',
+      description:
+        "Choose an existing matching/outside envelope, or 'none' when no Owner envelope exists.",
       name: 'Match envelope',
-      options: ['inside', 'outside'],
+      options: ['inside', 'outside', 'none'],
     },
     dataset: {
       control: 'select',
@@ -167,7 +170,8 @@ const meta = {
     },
     envelopeArgsDisplay: {
       control: 'inline-radio',
-      description: 'Show selected Owner-envelope checks beside exact invocation arguments.',
+      description:
+        "Choose how Owner-policy checks annotate arguments; 'none' here only hides annotations.",
       options: ['none', 'summary', 'interleaved'],
     },
     showRequestContext: {
@@ -211,7 +215,7 @@ Every Medium+ story keeps the same first-screen decision contract: Operation cal
 
 Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
-Every dataset supplies two Storybook-only Owner envelopes: \`inside\` matches its exact Invocation and \`outside\` fails explicit argument filters. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the full evaluation. Use \`envelopeArgsDisplay\` to show no argument annotations, a positional-argument summary, or policy checks interleaved with their exact fields.
+Every dataset supplies three Storybook-only Owner-envelope states: \`inside\` matches its exact Invocation, \`outside\` fails explicit filters in an existing envelope, and \`none\` means no existing Owner policy covers the Invocation. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each candidate envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the full evaluation. Separately, \`envelopeArgsDisplay='none'\` only hides inline annotations; \`summary\` and \`interleaved\` reveal them.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
@@ -227,6 +231,7 @@ Each story has a **dataset** control. The default GitHub dataset uses \`coral.pr
 - **EnvelopeMatches** shows an exact Invocation that passes every known Owner-policy check.
 - **EnvelopeDoesNotMatch** shows exact failed and unknown checks and retains per-call approval.
 - **EnvelopePolicyUpdateProposal** keeps one-time approval separate from reviewing a bounded future Owner-policy change.
+- **EnvelopeNoExistingPolicy** proposes a new bounded Owner policy as a purely additive diff.
 - **ProgramSnippet** adds expandable arguments and highlights one current-operation call as supporting context.
 - **CollapsedProgramBody** adds expandable arguments and a collapsed, self-contained Program body.
 - **MaximalEvidence** keeps arguments expandable while exposing snippet, Program body, provider reference copy, raw args, and ids.
@@ -273,8 +278,12 @@ function evaluateAuthorityEnvelope(
 
   return {
     checks,
-    decision: checks.every(({ status }) => status === 'pass') ? 'allow' : 'requiresApproval',
+    decision:
+      envelope.match !== 'none' && checks.every(({ status }) => status === 'pass')
+        ? 'allow'
+        : 'requiresApproval',
     envelopeId: envelope.envelopeId,
+    envelopeMatch: envelope.match,
     expiresAt: envelope.expiresAt,
     installedBy: envelope.installedBy,
   }
@@ -810,12 +819,14 @@ function createAuthorityEnvelope(
   envelopeId: string,
   approval: OperationApprovalModel,
   rules: AuthorityEnvelopeRule[],
+  match: EnvelopeMatch,
 ): AuthorityEnvelope {
   return {
     envelopeId,
     evaluatedAt: '2026-09-02T12:00:00Z',
     expiresAt: '2026-09-30T23:59:00Z',
-    installedBy: 'Workspace Owner',
+    installedBy: match === 'none' ? 'No existing policy' : 'Workspace Owner',
+    match,
     operationCallPath: approval.operationCallPath,
     rules,
   }
@@ -830,8 +841,14 @@ function createDataset(
   return {
     approval,
     authorityEnvelopes: {
-      inside: createAuthorityEnvelope(`env_${datasetKey}_inside`, approval, insideRules),
-      outside: createAuthorityEnvelope(`env_${datasetKey}_outside`, approval, outsideRules),
+      inside: createAuthorityEnvelope(`env_${datasetKey}_inside`, approval, insideRules, 'inside'),
+      none: createAuthorityEnvelope(`env_new_${datasetKey}`, approval, insideRules, 'none'),
+      outside: createAuthorityEnvelope(
+        `env_${datasetKey}_outside`,
+        approval,
+        outsideRules,
+        'outside',
+      ),
     },
   }
 }
@@ -1199,6 +1216,31 @@ export const EnvelopePolicyUpdateProposal: Story = {
   },
 }
 
+export const EnvelopeNoExistingPolicy: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'github',
+    envelopeArgsDisplay: 'none',
+    envelopeMatch: 'none',
+    showArguments: true,
+    showApprovalAuthority: true,
+    showAuthorityEnvelopeMatch: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No existing Owner policy covers the Invocation, so no policy checks annotate its arguments. The future-call action proposes a new bounded policy with additive diff lines only.',
+      },
+    },
+  },
+}
+
 export const ProgramSnippet: Story = {
   args: {
     argumentsCollapsible: true,
@@ -1313,6 +1355,10 @@ function OperationApproval({
   const envelopeEvaluation = isEnvelopeVisible
     ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
     : undefined
+  const envelopeArgumentChecks =
+    envelopeArgsDisplay !== 'none' && envelopeEvaluation?.envelopeMatch !== 'none'
+      ? envelopeEvaluation?.checks
+      : undefined
   const canReviewFuturePolicy =
     isEnvelopeVisible && envelopeEvaluation?.decision === 'requiresApproval'
   const hasContext = Boolean(
@@ -1347,7 +1393,7 @@ function OperationApproval({
       {showArguments ? (
         <InvocationArgumentsSection
           collapsible={argumentsCollapsible}
-          envelopeChecks={envelopeArgsDisplay !== 'none' ? envelopeEvaluation?.checks : undefined}
+          envelopeChecks={envelopeArgumentChecks}
           envelopeDisplay={envelopeArgsDisplay}
           initiallyExpanded={argumentsInitiallyExpanded}
           invocationArguments={approval.invocationArguments}
@@ -1497,6 +1543,8 @@ function ApprovalHeader({
       </div>
       {envelopeEvaluation?.decision === 'allow' ? (
         <Pill color="green">Allowed by Owner policy</Pill>
+      ) : envelopeEvaluation?.envelopeMatch === 'none' ? (
+        <Pill color="amber">No matching Owner policy</Pill>
       ) : envelopeEvaluation ? (
         <Pill color="amber">Outside Owner policy</Pill>
       ) : hasContext ? (
@@ -1702,6 +1750,7 @@ function aggregateEnvelopeStatus(
 
 function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEvaluation }) {
   const matches = evaluation.decision === 'allow'
+  const hasNoExistingEnvelope = evaluation.envelopeMatch === 'none'
 
   return (
     <section style={sectionStyle}>
@@ -1711,7 +1760,11 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
       <div style={envelopeResultStyle}>
         <div style={envelopeResultCopyStyle}>
           <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
-            {matches ? 'Allowed by Owner policy' : 'Outside Owner policy'}
+            {matches
+              ? 'Allowed by Owner policy'
+              : hasNoExistingEnvelope
+                ? 'No matching Owner policy'
+                : 'Outside Owner policy'}
           </Typography.BodySmallStrong>
           <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
             {matches
@@ -1721,24 +1774,28 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
         </div>
         <Pill color={matches ? 'green' : 'amber'}>{matches ? 'Allowed' : 'Review'}</Pill>
       </div>
-      <dl style={contextDetailsStyle}>
-        <DetailRow label="Installed by" value={evaluation.installedBy} />
-        <DetailRow label="Envelope expiry" value={evaluation.expiresAt} />
-        {evaluation.checks.map(({ label, observed, policy, status }, index) => (
-          <EnvelopeCheckRow
-            key={label}
-            label={label}
-            observed={observed}
-            policy={policy}
-            showDivider={index < evaluation.checks.length - 1}
-            status={status}
-          />
-        ))}
-      </dl>
+      {hasNoExistingEnvelope ? null : (
+        <dl style={contextDetailsStyle}>
+          <DetailRow label="Installed by" value={evaluation.installedBy} />
+          <DetailRow label="Envelope expiry" value={evaluation.expiresAt} />
+          {evaluation.checks.map(({ label, observed, policy, status }, index) => (
+            <EnvelopeCheckRow
+              key={label}
+              label={label}
+              observed={observed}
+              policy={policy}
+              showDivider={index < evaluation.checks.length - 1}
+              status={status}
+            />
+          ))}
+        </dl>
+      )}
       <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
         {matches
           ? `Allowed by envelope ${evaluation.envelopeId}`
-          : `Envelope ${evaluation.envelopeId} did not authorize this Invocation`}
+          : hasNoExistingEnvelope
+            ? 'No existing Owner policy authorized this Invocation'
+            : `Envelope ${evaluation.envelopeId} did not authorize this Invocation`}
       </Typography.BodySmall>
     </section>
   )
@@ -1755,8 +1812,13 @@ function PolicyUpdateProposalDialog({
   onUpdatePolicy: () => void
   open: boolean
 }) {
-  const proposedChecks = evaluation.checks.filter(({ status }) => status !== 'pass')
-  const canUpdatePolicy = proposedChecks.every(({ proposal }) => proposal?.kind === 'automatic')
+  const isCreatingPolicy = evaluation.envelopeMatch === 'none'
+  const proposedChecks = isCreatingPolicy
+    ? evaluation.checks
+    : evaluation.checks.filter(({ status }) => status !== 'pass')
+  const canUpdatePolicy = isCreatingPolicy
+    ? proposedChecks.every(({ status }) => status === 'pass')
+    : proposedChecks.every(({ proposal }) => proposal?.kind === 'automatic')
 
   return (
     <Dialog.Root onOpenChange={onOpenChange} open={open}>
@@ -1765,14 +1827,20 @@ function PolicyUpdateProposalDialog({
         <Dialog.Popup size="l">
           <Dialog.Title>Allow similar future calls</Dialog.Title>
           <Dialog.Description>
-            This proposes an Owner policy update for envelope {evaluation.envelopeId}. It does not
-            approve this invocation.
+            {isCreatingPolicy
+              ? 'No existing Owner policy matched this Invocation. This proposes a new bounded Owner policy. It does not approve this invocation.'
+              : `This proposes an Owner policy update for envelope ${evaluation.envelopeId}. It does not approve this invocation.`}
           </Dialog.Description>
           <Dialog.Close />
           <section style={policyProposalListStyle}>
             {proposedChecks.map(({ label, observed, policy, proposal, status }, index) => (
               <PolicyUpdateProposalRow
                 key={label}
+                candidatePolicy={
+                  isCreatingPolicy
+                    ? formatCandidatePolicyLine(evaluation.envelopeId, label, observed, policy)
+                    : undefined
+                }
                 label={label}
                 observed={observed}
                 policy={policy}
@@ -1802,7 +1870,7 @@ function PolicyUpdateProposalDialog({
                 onOpenChange(false)
               }}
             >
-              Update policy
+              {isCreatingPolicy ? 'Create policy' : 'Update policy'}
             </Button.TextButton>
           </Dialog.Actions>
         </Dialog.Popup>
@@ -1812,6 +1880,7 @@ function PolicyUpdateProposalDialog({
 }
 
 function PolicyUpdateProposalRow({
+  candidatePolicy,
   label,
   observed,
   policy,
@@ -1819,6 +1888,7 @@ function PolicyUpdateProposalRow({
   showDivider,
   status,
 }: {
+  candidatePolicy?: string
   label: string
   observed: string
   policy: string
@@ -1843,21 +1913,29 @@ function PolicyUpdateProposalRow({
       <Typography.BodySmall as="p" style={policyObservedStyle} variant="secondary">
         Observed: {observed}
       </Typography.BodySmall>
-      <PolicyProposalDiff currentPolicy={`${label} ${policy}`} proposal={resolvedProposal} />
+      <PolicyProposalDiff
+        addedPolicy={candidatePolicy}
+        currentPolicy={`${label} ${policy}`}
+        proposal={resolvedProposal}
+      />
     </div>
   )
 }
 
 function PolicyProposalDiff({
+  addedPolicy,
   currentPolicy,
   proposal,
 }: {
+  addedPolicy?: string
   currentPolicy: string
   proposal: PolicyProposal
 }) {
   return (
     <div aria-label="Proposed policy diff" style={policyDiffStyle}>
-      {proposal.kind === 'automatic' ? (
+      {addedPolicy ? (
+        <code style={{ ...policyDiffLineStyle, ...policyDiffAddedStyle }}>+ {addedPolicy}</code>
+      ) : proposal.kind === 'automatic' ? (
         <>
           <code style={{ ...policyDiffLineStyle, ...policyDiffRemovedStyle }}>
             - {currentPolicy}
@@ -1877,6 +1955,17 @@ function PolicyProposalDiff({
       )}
     </div>
   )
+}
+
+function formatCandidatePolicyLine(
+  envelopeId: string,
+  label: string,
+  observed: string,
+  policy: string,
+) {
+  if (label === 'Operation call path') return `envelope ${envelopeId} allows ${observed}`
+  if (label === 'Policy expiry') return policy
+  return `${label} ${policy}`
 }
 
 function EnvelopeCheckRow({

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -30,6 +30,7 @@ interface OperationApprovalStoryProps {
   dataset: DatasetKey
   onApprove: () => void
   onDecline: () => void
+  onUpdatePolicy: () => void
   onViewRun: () => void
   showArguments?: boolean
   showApprovalAuthority?: boolean
@@ -183,6 +184,7 @@ const meta = {
     dataset: 'github',
     onApprove: fn(),
     onDecline: fn(),
+    onUpdatePolicy: fn(),
     onViewRun: fn(),
     showRequestContext: false,
     showProviderReference: false,
@@ -1289,6 +1291,7 @@ function OperationApproval({
   envelopeArgsDisplay = 'none',
   onApprove,
   onDecline,
+  onUpdatePolicy,
   onViewRun,
   showArguments,
   showApprovalAuthority,
@@ -1350,10 +1353,7 @@ function OperationApproval({
       ) : null}
 
       {showAuthorityEnvelopeMatch && envelopeEvaluation ? (
-        <EnvelopeCheckSection
-          evaluation={envelopeEvaluation}
-          onReviewPolicy={() => setPolicyProposalOpen(true)}
-        />
+        <EnvelopeCheckSection evaluation={envelopeEvaluation} />
       ) : null}
 
       {(showRequestContext && approval.requestContext) ||
@@ -1432,6 +1432,9 @@ function OperationApproval({
           approveLabel={showAuthorityEnvelopeMatch ? 'Approve once' : 'Approve'}
           onApprove={onApprove}
           onDecline={onDecline}
+          onReviewPolicy={
+            showAuthorityEnvelopeMatch ? () => setPolicyProposalOpen(true) : undefined
+          }
         />
       )}
 
@@ -1439,6 +1442,7 @@ function OperationApproval({
         <PolicyUpdateProposalDialog
           evaluation={envelopeEvaluation}
           onOpenChange={setPolicyProposalOpen}
+          onUpdatePolicy={onUpdatePolicy}
           open={policyProposalOpen}
         />
       ) : null}
@@ -1696,13 +1700,7 @@ function aggregateEnvelopeStatus(
   return 'pass'
 }
 
-function EnvelopeCheckSection({
-  evaluation,
-  onReviewPolicy,
-}: {
-  evaluation: AuthorityEnvelopeEvaluation
-  onReviewPolicy: () => void
-}) {
+function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEvaluation }) {
   const matches = evaluation.decision === 'allow'
 
   return (
@@ -1723,11 +1721,6 @@ function EnvelopeCheckSection({
         </div>
         <Pill color={matches ? 'green' : 'amber'}>{matches ? 'Allowed' : 'Review'}</Pill>
       </div>
-      {!matches ? (
-        <Button.TextButton onClick={onReviewPolicy} variant="secondary">
-          Allow similar future calls…
-        </Button.TextButton>
-      ) : null}
       <dl style={contextDetailsStyle}>
         <DetailRow label="Installed by" value={evaluation.installedBy} />
         <DetailRow label="Envelope expiry" value={evaluation.expiresAt} />
@@ -1754,13 +1747,16 @@ function EnvelopeCheckSection({
 function PolicyUpdateProposalDialog({
   evaluation,
   onOpenChange,
+  onUpdatePolicy,
   open,
 }: {
   evaluation: AuthorityEnvelopeEvaluation
   onOpenChange: (open: boolean) => void
+  onUpdatePolicy: () => void
   open: boolean
 }) {
   const proposedChecks = evaluation.checks.filter(({ status }) => status !== 'pass')
+  const canUpdatePolicy = proposedChecks.every(({ proposal }) => proposal?.kind === 'automatic')
 
   return (
     <Dialog.Root onOpenChange={onOpenChange} open={open}>
@@ -1770,7 +1766,7 @@ function PolicyUpdateProposalDialog({
           <Dialog.Title>Allow similar future calls</Dialog.Title>
           <Dialog.Description>
             This proposes an Owner policy update for envelope {evaluation.envelopeId}. It does not
-            approve this Invocation; use Approve once separately if you want it to continue.
+            approve this invocation.
           </Dialog.Description>
           <Dialog.Close />
           <section style={policyProposalListStyle}>
@@ -1786,9 +1782,27 @@ function PolicyUpdateProposalDialog({
               />
             ))}
           </section>
+          {!canUpdatePolicy ? (
+            <Typography.BodySmall
+              as="p"
+              style={{ ...zeroMarginStyle, color: theme.content.warning }}
+              variant="secondary"
+            >
+              Resolve manual or unavailable checks before updating Owner policy.
+            </Typography.BodySmall>
+          ) : null}
           <Dialog.Actions>
             <Button.TextButton onClick={() => onOpenChange(false)} variant="secondary">
-              Close proposal
+              Cancel
+            </Button.TextButton>
+            <Button.TextButton
+              disabled={!canUpdatePolicy}
+              onClick={() => {
+                onUpdatePolicy()
+                onOpenChange(false)
+              }}
+            >
+              Update policy
             </Button.TextButton>
           </Dialog.Actions>
         </Dialog.Popup>
@@ -1826,18 +1840,41 @@ function PolicyUpdateProposalRow({
         <Typography.BodySmallStrong as="h3">{label}</Typography.BodySmallStrong>
         <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
       </div>
-      <dl style={policyProposalDetailsStyle}>
-        <DetailRow label="Current policy" value={`${label} ${policy}`} />
-        <DetailRow label="Observed value" value={observed} />
-        <DetailRow
-          label="Proposed change"
-          showDivider={Boolean(resolvedProposal.reason)}
-          value={resolvedProposal.proposedPolicyChange}
-        />
-        {resolvedProposal.reason ? (
-          <DetailRow label="Reason" showDivider={false} value={resolvedProposal.reason} />
-        ) : null}
-      </dl>
+      <Typography.BodySmall as="p" style={policyObservedStyle} variant="secondary">
+        Observed: {observed}
+      </Typography.BodySmall>
+      <PolicyProposalDiff currentPolicy={`${label} ${policy}`} proposal={resolvedProposal} />
+    </div>
+  )
+}
+
+function PolicyProposalDiff({
+  currentPolicy,
+  proposal,
+}: {
+  currentPolicy: string
+  proposal: PolicyProposal
+}) {
+  return (
+    <div aria-label="Proposed policy diff" style={policyDiffStyle}>
+      {proposal.kind === 'automatic' ? (
+        <>
+          <code style={{ ...policyDiffLineStyle, ...policyDiffRemovedStyle }}>
+            - {currentPolicy}
+          </code>
+          <code style={{ ...policyDiffLineStyle, ...policyDiffAddedStyle }}>
+            + {proposal.proposedPolicyChange}
+          </code>
+        </>
+      ) : (
+        <>
+          <code style={policyDiffLineStyle}> {currentPolicy}</code>
+          <code style={{ ...policyDiffLineStyle, ...policyDiffCommentStyle }}>
+            # {proposal.proposedPolicyChange}
+            {proposal.reason ? `: ${proposal.reason}` : ''}
+          </code>
+        </>
+      )}
     </div>
   )
 }
@@ -1958,19 +1995,28 @@ function ApprovalActions({
   approveLabel = 'Approve',
   onApprove,
   onDecline,
+  onReviewPolicy,
 }: {
   approveLabel?: string
   onApprove: () => void
   onDecline: () => void
+  onReviewPolicy?: () => void
 }) {
   return (
-    <div style={actionsStyle}>
-      <Button.Container onClick={onDecline} size="32" variant="secondary">
-        <Button.Text>Decline</Button.Text>
-      </Button.Container>
-      <Button.Container onClick={onApprove} size="32" variant="primary">
-        <Button.Text>{approveLabel}</Button.Text>
-      </Button.Container>
+    <div style={actionFooterStyle}>
+      {onReviewPolicy ? (
+        <Button.Container onClick={onReviewPolicy} size="32" variant="secondary">
+          <Button.Text>Allow similar future calls…</Button.Text>
+        </Button.Container>
+      ) : null}
+      <div style={actionsStyle}>
+        <Button.Container onClick={onDecline} size="32" variant="secondary">
+          <Button.Text>Decline</Button.Text>
+        </Button.Container>
+        <Button.Container onClick={onApprove} size="32" variant="primary">
+          <Button.Text>{approveLabel}</Button.Text>
+        </Button.Container>
+      </div>
     </div>
   )
 }
@@ -2262,8 +2308,41 @@ const policyProposalHeadingStyle: CSSProperties = {
   justifyContent: 'space-between',
 }
 
-const policyProposalDetailsStyle: CSSProperties = {
-  margin: '4px 0 0',
+const policyObservedStyle: CSSProperties = {
+  margin: '4px 0 8px',
+}
+
+const policyDiffStyle: CSSProperties = {
+  background: theme.surface.main,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '8px',
+  overflow: 'hidden',
+}
+
+const policyDiffLineStyle: CSSProperties = {
+  color: theme.content.secondary,
+  display: 'block',
+  fontFamily: 'monospace',
+  fontSize: '11px',
+  lineHeight: 1.5,
+  overflowWrap: 'anywhere',
+  padding: '5px 8px',
+  whiteSpace: 'pre-wrap',
+}
+
+const policyDiffRemovedStyle: CSSProperties = {
+  background: theme.content.errorBackground,
+  color: theme.content.error,
+}
+
+const policyDiffAddedStyle: CSSProperties = {
+  background: theme.content.successBackground,
+  color: theme.content.success,
+}
+
+const policyDiffCommentStyle: CSSProperties = {
+  background: theme.content.warningBackground,
+  color: theme.content.warning,
 }
 
 const nestedValueStyle: CSSProperties = {
@@ -2324,4 +2403,11 @@ const actionsStyle: CSSProperties = {
   flexWrap: 'wrap',
   gap: '8px',
   justifyContent: 'flex-end',
+}
+
+const actionFooterStyle: CSSProperties = {
+  alignItems: 'flex-end',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
 }

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -127,6 +127,7 @@ const envelopeStatusLabels: Record<EnvelopeCheckStatus, string> = {
 
 interface AuthorityEnvelopeEvaluation {
   checks: Array<{
+    draftRole: 'coverage' | 'narrowing'
     label: string
     observed: string
     policy: string
@@ -344,17 +345,20 @@ function evaluateAuthorityEnvelope(
   )
   const checks: AuthorityEnvelopeEvaluation['checks'] = [
     {
+      draftRole: 'coverage',
       label: 'Operation call path',
       observed: approval.operationCallPath,
       policy: `== ${JSON.stringify(envelope.operationCallPath)}`,
       status: arkStatus(operationPolicy(approval.operationCallPath)),
     },
     ...envelope.rules.map(({ evaluate, label, policy }) => ({
+      draftRole: 'narrowing' as const,
       label,
       policy,
       ...evaluate(approval),
     })),
     {
+      draftRole: 'narrowing',
       label: 'Policy expiry',
       observed: `Evaluated ${envelope.evaluatedAt}`,
       policy: `expires ${envelope.expiresAt}`,
@@ -2019,9 +2023,26 @@ function PolicyUpdateProposalDialog({
       (isCreatingPolicy ? status === 'pass' : proposal?.kind === 'automatic') &&
       !selectedChanges.has(label),
   )
+  const missingCoverageCheck = isCreatingPolicy
+    ? proposedChecks.find(
+        ({ draftRole, label, status }) =>
+          draftRole === 'coverage' && status === 'pass' && !selectedChanges.has(label),
+      )
+    : undefined
+  const omittedNarrowingChecks = isCreatingPolicy
+    ? unselectedChecks.filter(({ draftRole }) => draftRole === 'narrowing')
+    : []
   const selectionStatus =
-    unsafeChecks.length > 0 ? 'blocked' : unselectedChecks.length > 0 ? 'incomplete' : 'allows'
-  const canUpdatePolicy = selectionStatus === 'allows'
+    unsafeChecks.length > 0
+      ? 'blocked'
+      : missingCoverageCheck
+        ? 'incomplete'
+        : omittedNarrowingChecks.length > 0
+          ? 'broader'
+          : unselectedChecks.length > 0
+            ? 'incomplete'
+            : 'allows'
+  const canUpdatePolicy = selectionStatus === 'allows' || selectionStatus === 'broader'
 
   function toggleChange(label: string, checked: boolean) {
     setSelectedChanges((current) => {
@@ -2045,29 +2066,37 @@ function PolicyUpdateProposalDialog({
           </Dialog.Description>
           <Dialog.Close />
           <PolicySelectionBanner
-            blockingCheck={unsafeChecks[0] ?? unselectedChecks[0]}
+            blockingCheck={
+              unsafeChecks[0] ??
+              missingCoverageCheck ??
+              omittedNarrowingChecks[0] ??
+              unselectedChecks[0]
+            }
             isCreatingPolicy={isCreatingPolicy}
             status={selectionStatus}
           />
           <section style={policyProposalListStyle}>
-            {proposedChecks.map(({ label, observed, policy, proposal, status }, index) => (
-              <PolicyUpdateProposalRow
-                checked={selectedChanges.has(label)}
-                key={label}
-                candidatePolicy={
-                  isCreatingPolicy
-                    ? formatCandidatePolicyLine(evaluation.envelopeId, label, observed, policy)
-                    : undefined
-                }
-                label={label}
-                observed={observed}
-                onCheckedChange={(checked) => toggleChange(label, checked)}
-                policy={policy}
-                proposal={proposal}
-                showDivider={index < proposedChecks.length - 1}
-                status={status}
-              />
-            ))}
+            {proposedChecks.map(
+              ({ draftRole, label, observed, policy, proposal, status }, index) => (
+                <PolicyUpdateProposalRow
+                  checked={selectedChanges.has(label)}
+                  draftRole={draftRole}
+                  key={label}
+                  candidatePolicy={
+                    isCreatingPolicy
+                      ? formatCandidatePolicyLine(evaluation.envelopeId, label, observed, policy)
+                      : undefined
+                  }
+                  label={label}
+                  observed={observed}
+                  onCheckedChange={(checked) => toggleChange(label, checked)}
+                  policy={policy}
+                  proposal={proposal}
+                  showDivider={index < proposedChecks.length - 1}
+                  status={status}
+                />
+              ),
+            )}
           </section>
           {!canUpdatePolicy ? (
             <Typography.BodySmall
@@ -2078,7 +2107,7 @@ function PolicyUpdateProposalDialog({
               {selectionStatus === 'blocked'
                 ? 'Resolve manual or unavailable checks before changing Owner policy.'
                 : isCreatingPolicy
-                  ? 'Select every required addition to create a policy that covers this Invocation.'
+                  ? 'Include the Operation call path to create a policy that covers this Invocation.'
                   : 'Select every required change to allow this Invocation.'}
             </Typography.BodySmall>
           ) : null}
@@ -2109,29 +2138,36 @@ function PolicySelectionBanner({
 }: {
   blockingCheck?: AuthorityEnvelopeEvaluation['checks'][number]
   isCreatingPolicy: boolean
-  status: 'allows' | 'blocked' | 'incomplete'
+  status: 'allows' | 'blocked' | 'broader' | 'incomplete'
 }) {
   const copy =
     status === 'allows'
       ? {
-          detail: 'The exact Operation Invocation would be covered by the selected policy.',
+          detail: isCreatingPolicy
+            ? 'All proposed constraints are included, so similar future calls remain narrowly bounded.'
+            : 'The exact Operation Invocation would be covered by the selected policy.',
           title: isCreatingPolicy
             ? 'Selected policy would allow this invocation'
             : 'Selected changes would allow this invocation',
         }
-      : status === 'blocked'
+      : status === 'broader'
         ? {
-            detail: `${blockingCheck?.label ?? 'A required check'} cannot be changed automatically.`,
-            title: 'Cannot create a safe automatic policy update',
+            detail: `${blockingCheck?.label ?? 'A narrowing constraint'} is not constrained; similar future calls may use other values.`,
+            title: 'Draft policy would allow this invocation, but is broader',
           }
-        : {
-            detail: isCreatingPolicy
-              ? `${blockingCheck?.label ?? 'A required check'} is not included in the draft policy.`
-              : `${blockingCheck?.label ?? 'A required check'} remains outside policy.`,
-            title: isCreatingPolicy
-              ? 'Draft policy would not cover this invocation'
-              : 'Selected changes still require approval',
-          }
+        : status === 'blocked'
+          ? {
+              detail: `${blockingCheck?.label ?? 'A required check'} cannot be changed automatically.`,
+              title: 'Cannot create a safe automatic policy update',
+            }
+          : {
+              detail: isCreatingPolicy
+                ? `${blockingCheck?.label ?? 'A required check'} is not included in the draft policy.`
+                : `${blockingCheck?.label ?? 'A required check'} remains outside policy.`,
+              title: isCreatingPolicy
+                ? 'Draft policy would not cover this invocation'
+                : 'Selected changes still require approval',
+            }
 
   return (
     <div
@@ -2154,6 +2190,7 @@ function PolicySelectionBanner({
 function PolicyUpdateProposalRow({
   candidatePolicy,
   checked,
+  draftRole,
   label,
   observed,
   onCheckedChange,
@@ -2164,6 +2201,7 @@ function PolicyUpdateProposalRow({
 }: {
   candidatePolicy?: string
   checked: boolean
+  draftRole: AuthorityEnvelopeEvaluation['checks'][number]['draftRole']
   label: string
   observed: string
   onCheckedChange: (checked: boolean) => void
@@ -2183,7 +2221,13 @@ function PolicyUpdateProposalRow({
   const selectable = isCreatingPolicy ? status === 'pass' : resolvedProposal.kind === 'automatic'
   const statusColor = isCreatingPolicy && selectable ? (checked ? 'green' : 'amber') : undefined
   const statusLabel =
-    isCreatingPolicy && selectable ? (checked ? 'Included' : 'Not included') : null
+    isCreatingPolicy && selectable
+      ? checked
+        ? 'Included'
+        : draftRole === 'coverage'
+          ? 'Not included'
+          : 'Not constrained'
+      : null
 
   return (
     <div style={{ ...policyProposalRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
@@ -2791,7 +2835,7 @@ const policySelectionBannerStyle: CSSProperties = {
 }
 
 const policySelectionBannerStatusStyles: Record<
-  'allows' | 'blocked' | 'incomplete',
+  'allows' | 'blocked' | 'broader' | 'incomplete',
   CSSProperties
 > = {
   allows: {
@@ -2801,6 +2845,10 @@ const policySelectionBannerStatusStyles: Record<
   blocked: {
     background: theme.content.errorBackground,
     borderColor: theme.content.error,
+  },
+  broader: {
+    background: theme.content.warningBackground,
+    borderColor: theme.content.warning,
   },
   incomplete: {
     background: theme.content.warningBackground,

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1532,6 +1532,13 @@ function OperationApproval({
   const showIdentity = header.showIdentity
   const showRequester = header.showRequester
   const contextDisplay = combineSectionDisplays(sections.requestContext, sections.programSnippet)
+  const argumentsSectionDisplay: SectionDisplay = !argumentsDisplay.visible
+    ? 'hidden'
+    : argumentsDisplay.collapsible
+      ? argumentsDisplay.initiallyExpanded
+        ? 'expanded'
+        : 'collapsed'
+      : 'visible'
   const hasDecisionContext = Boolean(showApprovalAuthority)
   const isEnvelopeVisible =
     shouldShowSection(sections.authorityEnvelope) || envelopeArgsDisplay !== 'none'
@@ -1585,15 +1592,12 @@ function OperationApproval({
         />
       ) : null}
 
-      {argumentsDisplay.visible ? (
-        <InvocationArgumentsSection
-          collapsible={argumentsDisplay.collapsible}
-          envelopeChecks={envelopeArgumentChecks}
-          envelopeDisplay={envelopeArgsDisplay}
-          initiallyExpanded={argumentsDisplay.initiallyExpanded}
-          invocationArguments={approval.invocationArguments}
-        />
-      ) : null}
+      <InvocationArgumentsSection
+        display={argumentsSectionDisplay}
+        envelopeChecks={envelopeArgumentChecks}
+        envelopeDisplay={envelopeArgsDisplay}
+        invocationArguments={approval.invocationArguments}
+      />
 
       {shouldShowSection(sections.authorityEnvelope) && envelopeEvaluation ? (
         <EnvelopeCheckSection
@@ -1756,71 +1760,42 @@ function ApprovalHeader({
 }
 
 function InvocationArgumentsSection({
-  collapsible,
+  display,
   envelopeChecks,
   envelopeDisplay,
-  initiallyExpanded,
   invocationArguments,
 }: {
-  collapsible?: boolean
+  display: SectionDisplay
   envelopeChecks?: AuthorityEnvelopeEvaluation['checks']
   envelopeDisplay: EnvelopeArgsDisplay
-  initiallyExpanded?: boolean
   invocationArguments: OperationApprovalModel['invocationArguments']
 }) {
-  const argumentsId = useId()
-  const [expanded, setExpanded] = useState(Boolean(initiallyExpanded))
+  const content = (
+    <dl style={detailsStyle}>
+      {invocationArguments.map(({ label, value }, index) => (
+        <InvocationArgumentRow
+          annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
+            checkLabel.startsWith(`args[${index}]`),
+          )}
+          argumentIndex={index}
+          envelopeDisplay={envelopeDisplay}
+          key={label}
+          label={label}
+          showDivider={index < invocationArguments.length - 1}
+          value={value}
+        />
+      ))}
+    </dl>
+  )
 
   return (
-    <section style={sectionStyle}>
-      {collapsible ? (
-        <details
-          onToggle={(event) => setExpanded(event.currentTarget.open)}
-          open={expanded}
-          style={disclosureSectionStyle}
-        >
-          <Typography.BodySmallStrong as="summary" style={argumentsDisclosureStyle}>
-            Arguments ({invocationArguments.length})
-          </Typography.BodySmallStrong>
-          <dl id={argumentsId} style={detailsStyle}>
-            {invocationArguments.map(({ label, value }, index) => (
-              <InvocationArgumentRow
-                annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
-                  checkLabel.startsWith(`args[${index}]`),
-                )}
-                argumentIndex={index}
-                envelopeDisplay={envelopeDisplay}
-                key={label}
-                label={label}
-                showDivider={index < invocationArguments.length - 1}
-                value={value}
-              />
-            ))}
-          </dl>
-        </details>
-      ) : (
-        <>
-          <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle}>
-            Arguments
-          </Typography.BodySmallStrong>
-          <dl id={argumentsId} style={detailsStyle}>
-            {invocationArguments.map(({ label, value }, index) => (
-              <InvocationArgumentRow
-                annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
-                  checkLabel.startsWith(`args[${index}]`),
-                )}
-                argumentIndex={index}
-                envelopeDisplay={envelopeDisplay}
-                key={label}
-                label={label}
-                showDivider={index < invocationArguments.length - 1}
-                value={value}
-              />
-            ))}
-          </dl>
-        </>
-      )}
-    </section>
+    <SectionContainer
+      display={display}
+      summaryTone="primary"
+      title={`Arguments (${invocationArguments.length})`}
+    >
+      {content}
+    </SectionContainer>
   )
 }
 
@@ -2370,20 +2345,29 @@ function EnvelopeCheckRow({
 function SectionContainer({
   children,
   display,
+  summaryTone = 'secondary',
   title,
   visibleHeading = true,
 }: {
   children: ReactNode
   display?: SectionDisplay
+  summaryTone?: 'primary' | 'secondary'
   title: string
   visibleHeading?: boolean
 }) {
   if (!shouldShowSection(display)) return null
+  const titleStyle =
+    summaryTone === 'primary'
+      ? { color: theme.content.primary }
+      : { color: theme.content.secondary }
 
   if (sectionIsDisclosure(display)) {
     return (
       <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
-        <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
+        <Typography.BodySmallStrong
+          as="summary"
+          style={{ ...disclosureSummaryStyle, ...titleStyle }}
+        >
           {title}
         </Typography.BodySmallStrong>
         <div style={disclosureContentStyle}>{children}</div>
@@ -2394,7 +2378,11 @@ function SectionContainer({
   return (
     <section style={sectionStyle}>
       {visibleHeading ? (
-        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+        <Typography.BodySmallStrong
+          as="h3"
+          style={{ ...sectionHeadingStyle, ...titleStyle }}
+          variant={summaryTone === 'primary' ? undefined : 'tertiary'}
+        >
           {title}
         </Typography.BodySmallStrong>
       ) : null}
@@ -2671,12 +2659,6 @@ const sectionHeadingStyle: CSSProperties = {
   paddingBottom: '6px',
 }
 
-const argumentsDisclosureStyle: CSSProperties = {
-  ...sectionHeadingStyle,
-  color: theme.content.primary,
-  cursor: 'pointer',
-}
-
 const contextDetailsStyle: CSSProperties = { margin: 0 }
 
 const codeBlockStyle: CSSProperties = {
@@ -2761,12 +2743,12 @@ const argumentAnnotationsStyle: CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',
-  marginLeft: 'min(156px, 22%)',
 }
 
 const argumentAnnotationStyle: CSSProperties = {
-  alignItems: 'center',
+  alignItems: 'flex-start',
   display: 'flex',
+  flexWrap: 'wrap',
   gap: '8px',
   justifyContent: 'space-between',
   minWidth: 0,

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -16,7 +16,13 @@ type ArgumentValue =
   | null
   | ArgumentValue[]
   | { [key: string]: ArgumentValue }
-type DatasetKey = 'github' | 'linear' | 'loop' | 'savedFunction'
+type DatasetKey =
+  | 'envelopeMatches'
+  | 'envelopeOutside'
+  | 'github'
+  | 'linear'
+  | 'loop'
+  | 'savedFunction'
 
 interface OperationApprovalStoryProps {
   argumentsCollapsible?: boolean
@@ -29,6 +35,7 @@ interface OperationApprovalStoryProps {
   showArguments?: boolean
   showApprovalAuthority?: boolean
   showExpiry?: boolean
+  showEnvelopeCheck?: boolean
   showIdentity?: boolean
   showProgramBody?: boolean
   showProgramSnippet?: boolean
@@ -61,8 +68,23 @@ interface RequestContext {
   taskIntent: string
 }
 
+type EnvelopeCheckStatus = 'fail' | 'pass' | 'unknown'
+
+interface AuthorityEnvelopeEvaluation {
+  checks: Array<{
+    detail: string
+    label: string
+    status: EnvelopeCheckStatus
+  }>
+  decision: 'allow' | 'requiresApproval'
+  envelopeId: string
+  expiresAt: string
+  installedBy: string
+}
+
 interface OperationApprovalModel {
   approvalAuthority: string
+  authorityEnvelopeEvaluation?: AuthorityEnvelopeEvaluation
   expiresAt: string
   identity: string
   invocationArguments: Array<{ label: string; value: ArgumentValue }>
@@ -86,7 +108,11 @@ const meta = {
   argTypes: {
     dataset: {
       control: 'select',
-      options: ['github', 'linear', 'loop', 'savedFunction'],
+      options: ['github', 'linear', 'loop', 'savedFunction', 'envelopeMatches', 'envelopeOutside'],
+    },
+    showEnvelopeCheck: {
+      control: 'boolean',
+      description: 'Show a Storybook-only deterministic Owner-policy envelope evaluation.',
     },
     showRequestContext: {
       control: 'boolean',
@@ -104,6 +130,7 @@ const meta = {
     onViewRun: fn(),
     showRequestContext: false,
     showProviderReference: false,
+    showEnvelopeCheck: false,
   },
   component: OperationApprovalStory,
   decorators: [
@@ -125,6 +152,8 @@ Every Medium+ story keeps the same first-screen decision contract: Operation cal
 
 Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
+The envelope stories use Storybook-only mock evaluation data. They explore deterministic authorization from a Workspace Owner-installed policy; they do not model an agent approving another agent or introduce a production API contract. A passing envelope applies only to the exact Invocation shown.
+
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
 - **Minimal** uses the stable operation name with very little extra detail.
@@ -136,6 +165,8 @@ Each story has a **dataset** control. The default GitHub dataset uses \`coral.pr
 - **MediumExpandableExpanded** includes requester and expiry, starts open, and allows arguments to be collapsed.
 - **MediumExpandableCollapsed** includes requester and expiry behind a collapsed-by-default argument review.
 - **TaskIntentContext** adds grounded Task and MCP exec intent as secondary request context.
+- **EnvelopeMatches** shows an exact Invocation that passes every known Owner-policy check.
+- **EnvelopeDoesNotMatch** shows exact failed and unknown checks and retains per-call approval.
 - **ProgramSnippet** adds expandable arguments and highlights one current-operation call as supporting context.
 - **CollapsedProgramBody** adds expandable arguments and a collapsed, self-contained Program body.
 - **MaximalEvidence** keeps arguments expandable while exposing snippet, Program body, provider reference copy, raw args, and ids.
@@ -152,7 +183,122 @@ Use the least disclosure that still makes the concrete target clear. Program bod
 export default meta
 type Story = StoryObj<typeof meta>
 
+function createEnvelopeDataset({
+  body,
+  evaluation,
+  repo,
+}: {
+  body: string
+  evaluation: AuthorityEnvelopeEvaluation
+  repo: string
+}): OperationApprovalModel {
+  const invocationArguments: OperationApprovalModel['invocationArguments'] = [
+    {
+      label: 'Argument 1',
+      value: { body, issue_number: 85, org: 'withcoral', repo },
+    },
+    { label: 'Argument 2', value: { format: 'markdown' } },
+    { label: 'Argument 3', value: 'notify-requester' },
+  ]
+
+  return {
+    approvalAuthority: 'Workspace owner',
+    authorityEnvelopeEvaluation: evaluation,
+    expiresAt: '2026-09-02 16:00 UTC',
+    identity: 'coral-bot',
+    invocationArguments,
+    invokingPrincipal: 'triage-bot',
+    operationCallPath: 'coral.providers.github.issues.createComment',
+    policyText: 'Agents cannot approve their own operations.',
+    provider: 'GitHub',
+    providerReference:
+      'Creates a comment on an issue in the selected repository using the authenticated GitHub account.',
+    rawInvocation: invocationArguments.map(({ value }) => value),
+    requestContext: {
+      execIntent: 'Post the prepared triage note to the selected GitHub issue.',
+      taskId: 'task_01K4B7TP',
+      taskIntent: 'Triage the approval-policy follow-up for the Lagoon workspace.',
+    },
+    runContext: {
+      runId: 'run_01K4B7V2',
+      status: 'running',
+      workspace: 'Lagoon',
+    },
+    technicalDetails: [
+      { label: 'Operation invocation', value: 'inv_01K4B7X4 · pending' },
+      { label: 'Provider generation', value: 'github@gen_0198' },
+      { label: 'Credential route', value: 'route_github_coral_bot' },
+    ],
+  }
+}
+
 const datasets: Record<DatasetKey, OperationApprovalModel> = {
+  envelopeMatches: createEnvelopeDataset({
+    body: 'Approval envelope exploration is ready for review.',
+    evaluation: {
+      checks: [
+        {
+          detail: 'github.issues.createComment is allowed',
+          label: 'Operation',
+          status: 'pass',
+        },
+        {
+          detail: 'withcoral/lagoon matches the allowed repository',
+          label: 'Repository',
+          status: 'pass',
+        },
+        { detail: 'Issue #85 is open', label: 'Issue state', status: 'pass' },
+        { detail: '50 of 2,000 characters', label: 'Body length', status: 'pass' },
+        { detail: 'No mass mentions', label: 'Mention policy', status: 'pass' },
+        { detail: '7 of 20 comments used today', label: 'Daily quota', status: 'pass' },
+        {
+          detail: 'Expires 2026-09-30 23:59 UTC',
+          label: 'Policy expiry',
+          status: 'pass',
+        },
+      ],
+      decision: 'allow',
+      envelopeId: 'env_01K4B6ZA',
+      expiresAt: '2026-09-30 23:59 UTC',
+      installedBy: 'Workspace Owner',
+    },
+    repo: 'lagoon',
+  }),
+  envelopeOutside: createEnvelopeDataset({
+    body: '@channel Approval envelope exploration is ready for review.',
+    evaluation: {
+      checks: [
+        {
+          detail: 'github.issues.createComment is allowed',
+          label: 'Operation',
+          status: 'pass',
+        },
+        {
+          detail: 'withcoral/private-roadmap is outside the allowed repository',
+          label: 'Repository',
+          status: 'fail',
+        },
+        {
+          detail: 'Issue state was unavailable; this check did not pass',
+          label: 'Issue state',
+          status: 'unknown',
+        },
+        { detail: '59 of 2,000 characters', label: 'Body length', status: 'pass' },
+        { detail: 'Body contains @channel', label: 'Mention policy', status: 'fail' },
+        { detail: '7 of 20 comments used today', label: 'Daily quota', status: 'pass' },
+        {
+          detail: 'Expires 2026-09-30 23:59 UTC',
+          label: 'Policy expiry',
+          status: 'pass',
+        },
+      ],
+      decision: 'requiresApproval',
+      envelopeId: 'env_01K4B6ZA',
+      expiresAt: '2026-09-30 23:59 UTC',
+      installedBy: 'Workspace Owner',
+    },
+    repo: 'private-roadmap',
+  }),
   github: {
     invocationArguments: [
       {
@@ -686,6 +832,50 @@ export const TaskIntentContext: Story = {
   },
 }
 
+export const EnvelopeMatches: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'envelopeMatches',
+    showArguments: true,
+    showEnvelopeCheck: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The exact Invocation passes every known check in a Workspace Owner-installed envelope and can continue without per-call approval.',
+      },
+    },
+  },
+}
+
+export const EnvelopeDoesNotMatch: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'envelopeOutside',
+    showArguments: true,
+    showApprovalAuthority: true,
+    showEnvelopeCheck: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same Operation and invoking agent remain approval-required because exact checks fail or cannot be evaluated.',
+      },
+    },
+  },
+}
+
 export const ProgramSnippet: Story = {
   args: {
     argumentsCollapsible: true,
@@ -772,6 +962,7 @@ function OperationApproval({
   showArguments,
   showApprovalAuthority,
   showExpiry,
+  showEnvelopeCheck,
   showIdentity,
   showProgramBody,
   showProgramSnippet,
@@ -786,6 +977,7 @@ function OperationApproval({
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
+    showEnvelopeCheck ||
     showIdentity ||
     hasDecisionContext ||
     showProgramBody ||
@@ -801,6 +993,7 @@ function OperationApproval({
     <section style={{ ...cardStyle, ...(compact ? compactCardStyle : {}) }}>
       <ApprovalHeader
         approval={approval}
+        envelopeEvaluation={showEnvelopeCheck ? approval.authorityEnvelopeEvaluation : undefined}
         hasContext={hasContext}
         showApprovalAuthority={showApprovalAuthority}
         showExpiry={showExpiry}
@@ -815,6 +1008,10 @@ function OperationApproval({
           initiallyExpanded={argumentsInitiallyExpanded}
           invocationArguments={approval.invocationArguments}
         />
+      ) : null}
+
+      {showEnvelopeCheck && approval.authorityEnvelopeEvaluation ? (
+        <EnvelopeCheckSection evaluation={approval.authorityEnvelopeEvaluation} />
       ) : null}
 
       {(showRequestContext && approval.requestContext) ||
@@ -888,13 +1085,16 @@ function OperationApproval({
         </div>
       ) : null}
 
-      <ApprovalActions onApprove={onApprove} onDecline={onDecline} />
+      {showEnvelopeCheck && approval.authorityEnvelopeEvaluation?.decision === 'allow' ? null : (
+        <ApprovalActions onApprove={onApprove} onDecline={onDecline} />
+      )}
     </section>
   )
 }
 
 function ApprovalHeader({
   approval,
+  envelopeEvaluation,
   hasContext,
   showApprovalAuthority,
   showExpiry,
@@ -903,6 +1103,7 @@ function ApprovalHeader({
   showRequester,
 }: {
   approval: OperationApprovalModel
+  envelopeEvaluation?: AuthorityEnvelopeEvaluation
   hasContext: boolean
   showApprovalAuthority?: boolean
   showExpiry?: boolean
@@ -936,7 +1137,11 @@ function ApprovalHeader({
           </Typography.BodySmall>
         ) : null}
       </div>
-      {hasContext ? <Pill color="amber">Approval required</Pill> : null}
+      {envelopeEvaluation?.decision === 'allow' ? (
+        <Pill color="green">Allowed by Owner policy</Pill>
+      ) : hasContext ? (
+        <Pill color="amber">Approval required</Pill>
+      ) : null}
     </div>
   )
 }
@@ -988,6 +1193,76 @@ function InvocationArgumentsSection({
         </dl>
       ) : null}
     </section>
+  )
+}
+
+function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEvaluation }) {
+  const matches = evaluation.decision === 'allow'
+
+  return (
+    <section style={sectionStyle}>
+      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+        Envelope check
+      </Typography.BodySmallStrong>
+      <div style={envelopeResultStyle}>
+        <div style={envelopeResultCopyStyle}>
+          <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
+            {matches ? 'Matches envelope' : 'Outside envelope'}
+          </Typography.BodySmallStrong>
+          <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+            {matches ? 'Can continue without per-call approval' : 'Requires approval'}
+          </Typography.BodySmall>
+        </div>
+        <Pill color={matches ? 'green' : 'amber'}>{matches ? 'Allowed' : 'Review'}</Pill>
+      </div>
+      <dl style={contextDetailsStyle}>
+        <DetailRow label="Installed by" value={evaluation.installedBy} />
+        <DetailRow label="Envelope expiry" value={evaluation.expiresAt} />
+        {evaluation.checks.map(({ detail, label, status }, index) => (
+          <EnvelopeCheckRow
+            key={label}
+            detail={detail}
+            label={label}
+            showDivider={index < evaluation.checks.length - 1}
+            status={status}
+          />
+        ))}
+      </dl>
+      <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+        {matches
+          ? `Allowed by envelope ${evaluation.envelopeId}`
+          : `Envelope ${evaluation.envelopeId} did not authorize this Invocation`}
+      </Typography.BodySmall>
+    </section>
+  )
+}
+
+function EnvelopeCheckRow({
+  detail,
+  label,
+  showDivider,
+  status,
+}: {
+  detail: string
+  label: string
+  showDivider: boolean
+  status: EnvelopeCheckStatus
+}) {
+  const statusLabel = status === 'pass' ? 'Pass' : status === 'fail' ? 'Fails' : 'Unknown'
+  const statusColor = status === 'pass' ? 'green' : status === 'fail' ? 'red' : 'amber'
+
+  return (
+    <div style={{ ...detailRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
+      <Typography.BodySmall as="dt" variant="tertiary">
+        {label}
+      </Typography.BodySmall>
+      <div style={envelopeCheckValueStyle}>
+        <Typography.BodySmall as="dd" style={detailValueStyle} variant="primary">
+          {detail}
+        </Typography.BodySmall>
+        <Pill color={statusColor}>{statusLabel}</Pill>
+      </div>
+    </div>
   )
 }
 
@@ -1258,6 +1533,29 @@ const detailValueStyle: CSSProperties = {
   margin: 0,
   minWidth: 0,
   overflowWrap: 'anywhere',
+}
+
+const envelopeResultStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  gap: '12px',
+  justifyContent: 'space-between',
+  padding: '2px 0 6px',
+}
+
+const envelopeResultCopyStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2px',
+  minWidth: 0,
+}
+
+const envelopeCheckValueStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  gap: '8px',
+  justifyContent: 'space-between',
+  minWidth: 0,
 }
 
 const nestedValueStyle: CSSProperties = {

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Checkbox } from '@base-ui/react/checkbox'
@@ -37,16 +37,16 @@ interface OperationApprovalStoryProps {
   showArguments?: boolean
   showApprovalAuthority?: boolean
   showExpiry?: boolean
-  showAuthorityEnvelopeMatch?: boolean
+  authorityEnvelopeDisplay?: SectionDisplay
   showIdentity?: boolean
-  showProgramBody?: boolean
-  showProgramSnippet?: boolean
-  showProviderReference?: boolean
+  programBodyDisplay?: SectionDisplay
+  programSnippetDisplay?: SectionDisplay
+  providerReferenceDisplay?: SectionDisplay
   showRequestMetadataInHeader?: boolean
-  showRequestContext?: boolean
+  requestContextDisplay?: SectionDisplay
   showRequester?: boolean
-  showRunContext?: boolean
-  showTechnicalDetails?: boolean
+  runContextDisplay?: SectionDisplay
+  technicalDetailsDisplay?: SectionDisplay
 }
 
 interface OperationApprovalDisplay {
@@ -199,9 +199,10 @@ const meta = {
       control: 'select',
       options: ['github', 'linear', 'loop', 'savedFunction'],
     },
-    showAuthorityEnvelopeMatch: {
-      control: 'boolean',
-      description: 'Execute and show a Storybook-only deterministic Owner-policy envelope.',
+    authorityEnvelopeDisplay: {
+      control: 'inline-radio',
+      description: 'Control the Storybook-only deterministic Owner-policy envelope section.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
     envelopeArgsDisplay: {
       control: 'inline-radio',
@@ -209,17 +210,20 @@ const meta = {
         "Choose how Owner-policy checks annotate arguments; 'none' here only hides annotations.",
       options: ['none', 'summary', 'interleaved'],
     },
-    showRequestContext: {
-      control: 'boolean',
-      description: 'Show Task, Task intent, and exec intent as secondary request context.',
+    requestContextDisplay: {
+      control: 'inline-radio',
+      description: 'Control Task, Task intent, and exec intent as secondary request context.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
-    showProgramBody: {
-      control: 'boolean',
-      description: 'Show submitted Program body as supporting context.',
+    programBodyDisplay: {
+      control: 'inline-radio',
+      description: 'Control submitted Program body as supporting context.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
-    showProgramSnippet: {
-      control: 'boolean',
-      description: 'Show highlighted Program snippet as supporting context.',
+    programSnippetDisplay: {
+      control: 'inline-radio',
+      description: 'Control highlighted Program snippet as supporting context.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
     showArguments: {
       control: 'boolean',
@@ -245,17 +249,20 @@ const meta = {
       control: 'boolean',
       description: 'Place requester, approval authority, and expiry in the header.',
     },
-    showRunContext: {
-      control: 'boolean',
-      description: 'Show secondary Program Run context and the View run action.',
+    runContextDisplay: {
+      control: 'inline-radio',
+      description: 'Control secondary Program Run context and the View run action.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
-    showTechnicalDetails: {
-      control: 'boolean',
-      description: 'Show the collapsed technical details disclosure.',
+    technicalDetailsDisplay: {
+      control: 'inline-radio',
+      description: 'Control the technical details section.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
-    showProviderReference: {
-      control: 'boolean',
-      description: 'Show optional provider-authored reference copy as a quiet disclosure.',
+    providerReferenceDisplay: {
+      control: 'inline-radio',
+      description: 'Control optional provider-authored reference copy.',
+      options: ['hidden', 'visible', 'collapsed', 'expanded'],
     },
   },
   args: {
@@ -265,11 +272,13 @@ const meta = {
     onDecline: fn(),
     onUpdatePolicy: fn(),
     onViewRun: fn(),
-    showProgramBody: false,
-    showProgramSnippet: false,
-    showRequestContext: false,
-    showProviderReference: false,
-    showAuthorityEnvelopeMatch: false,
+    programBodyDisplay: 'hidden',
+    programSnippetDisplay: 'hidden',
+    requestContextDisplay: 'hidden',
+    providerReferenceDisplay: 'hidden',
+    authorityEnvelopeDisplay: 'hidden',
+    runContextDisplay: 'hidden',
+    technicalDetailsDisplay: 'hidden',
     envelopeArgsDisplay: 'none',
   },
   component: OperationApprovalStory,
@@ -290,9 +299,9 @@ The story-only model uses Lagoon-aligned names: \`operationCallPath\`, \`invocat
 
 Every Medium+ story keeps the same first-screen decision contract: Operation call path, provider identity, invoking principal, approval authority, expiry, exact Invocation arguments, and the unchanged Decline/Approve actions. The prototype does not invent an operation-specific consequence CTA when no trusted renderer provides one.
 
-Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
+Every story uses the same story-local \`OperationApproval\` component. Set \`requestContextDisplay\` to \`visible\` in any story to reveal Task and exec intent before Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
-Every dataset supplies three Storybook-only Owner-envelope states: \`inside\` matches its exact Invocation, \`outside\` fails explicit filters in an existing envelope, and \`none\` means no existing Owner policy covers the Invocation. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each candidate envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the full evaluation. Separately, \`envelopeArgsDisplay='none'\` only hides inline annotations; \`summary\` and \`interleaved\` reveal them.
+Every dataset supplies three Storybook-only Owner-envelope states: \`inside\` matches its exact Invocation, \`outside\` fails explicit filters in an existing envelope, and \`none\` means no existing Owner policy covers the Invocation. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each candidate envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Set \`authorityEnvelopeDisplay\` to choose how the full evaluation is disclosed. Separately, \`envelopeArgsDisplay='none'\` only hides inline annotations; \`summary\` and \`interleaved\` reveal them.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
@@ -1206,7 +1215,7 @@ export const TaskIntentContext: Story = {
     showArguments: true,
     showExpiry: true,
     showIdentity: true,
-    showRequestContext: true,
+    requestContextDisplay: 'visible',
     showRequestMetadataInHeader: true,
     showRequester: true,
   },
@@ -1228,7 +1237,7 @@ export const EnvelopeMatches: Story = {
     envelopeArgsDisplay: 'interleaved',
     envelopeMatch: 'inside',
     showArguments: true,
-    showAuthorityEnvelopeMatch: true,
+    authorityEnvelopeDisplay: 'visible',
     showIdentity: true,
     showRequestMetadataInHeader: true,
     showRequester: true,
@@ -1252,7 +1261,7 @@ export const EnvelopeDoesNotMatch: Story = {
     envelopeMatch: 'outside',
     showArguments: true,
     showApprovalAuthority: true,
-    showAuthorityEnvelopeMatch: true,
+    authorityEnvelopeDisplay: 'visible',
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -1277,7 +1286,7 @@ export const EnvelopePolicyUpdateProposal: Story = {
     envelopeMatch: 'outside',
     showArguments: true,
     showApprovalAuthority: true,
-    showAuthorityEnvelopeMatch: true,
+    authorityEnvelopeDisplay: 'visible',
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -1302,7 +1311,7 @@ export const EnvelopeNoExistingPolicy: Story = {
     envelopeMatch: 'none',
     showArguments: true,
     showApprovalAuthority: true,
-    showAuthorityEnvelopeMatch: true,
+    authorityEnvelopeDisplay: 'visible',
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -1327,7 +1336,7 @@ export const ProgramSnippet: Story = {
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
-    showProgramSnippet: true,
+    programSnippetDisplay: 'visible',
     showRequestMetadataInHeader: true,
     showRequester: true,
   },
@@ -1350,7 +1359,7 @@ export const CollapsedProgramBody: Story = {
     showApprovalAuthority: true,
     showExpiry: true,
     showIdentity: true,
-    showProgramBody: true,
+    programBodyDisplay: 'collapsed',
     showRequestMetadataInHeader: true,
     showRequester: true,
   },
@@ -1372,12 +1381,12 @@ export const MaximalEvidence: Story = {
     showArguments: true,
     showApprovalAuthority: true,
     showIdentity: true,
-    showProgramBody: true,
-    showProgramSnippet: true,
-    showProviderReference: true,
+    programBodyDisplay: 'collapsed',
+    programSnippetDisplay: 'visible',
+    providerReferenceDisplay: 'collapsed',
     showRequestMetadataInHeader: true,
-    showRunContext: true,
-    showTechnicalDetails: true,
+    runContextDisplay: 'visible',
+    technicalDetailsDisplay: 'collapsed',
   },
   parameters: {
     docs: {
@@ -1387,13 +1396,6 @@ export const MaximalEvidence: Story = {
       },
     },
   },
-}
-
-function sectionDisplay(
-  show: boolean | undefined,
-  defaultWhenShown: SectionDisplay = 'visible',
-): SectionDisplay {
-  return show ? defaultWhenShown : 'hidden'
 }
 
 function shouldShowSection(display: SectionDisplay | undefined): boolean {
@@ -1406,6 +1408,13 @@ function sectionIsDisclosure(display: SectionDisplay | undefined): boolean {
 
 function sectionInitiallyOpen(display: SectionDisplay | undefined): boolean {
   return display === 'expanded'
+}
+
+function combineSectionDisplays(...displays: Array<SectionDisplay | undefined>): SectionDisplay {
+  if (displays.includes('expanded')) return 'expanded'
+  if (displays.includes('visible')) return 'visible'
+  if (displays.includes('collapsed')) return 'collapsed'
+  return 'hidden'
 }
 
 function OperationApprovalStory({
@@ -1421,20 +1430,21 @@ function OperationApprovalStory({
   onViewRun,
   showApprovalAuthority,
   showArguments,
-  showAuthorityEnvelopeMatch,
+  authorityEnvelopeDisplay,
   showExpiry,
   showIdentity,
-  showProgramBody,
-  showProgramSnippet,
-  showProviderReference,
-  showRequestContext,
+  programBodyDisplay,
+  programSnippetDisplay,
+  providerReferenceDisplay,
+  requestContextDisplay,
   showRequester,
   showRequestMetadataInHeader,
-  showRunContext,
-  showTechnicalDetails,
+  runContextDisplay,
+  technicalDetailsDisplay,
 }: OperationApprovalStoryProps) {
   const selectedDataset = datasets[dataset]
-  const isEnvelopeVisible = showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
+  const isEnvelopeVisible =
+    shouldShowSection(authorityEnvelopeDisplay) || envelopeArgsDisplay !== 'none'
   const authorityEvaluation = isEnvelopeVisible
     ? evaluateAuthorityEnvelope(
         selectedDataset.approval,
@@ -1463,13 +1473,13 @@ function OperationApprovalStory({
           showRequester,
         },
         sections: {
-          authorityEnvelope: sectionDisplay(showAuthorityEnvelopeMatch),
-          programBody: sectionDisplay(showProgramBody, 'collapsed'),
-          programSnippet: sectionDisplay(showProgramSnippet),
-          providerReference: sectionDisplay(showProviderReference, 'collapsed'),
-          requestContext: sectionDisplay(showRequestContext),
-          runContext: sectionDisplay(showRunContext),
-          technicalDetails: sectionDisplay(showTechnicalDetails, 'collapsed'),
+          authorityEnvelope: authorityEnvelopeDisplay ?? 'hidden',
+          programBody: programBodyDisplay ?? 'hidden',
+          programSnippet: programSnippetDisplay ?? 'hidden',
+          providerReference: providerReferenceDisplay ?? 'hidden',
+          requestContext: requestContextDisplay ?? 'hidden',
+          runContext: runContextDisplay ?? 'hidden',
+          technicalDetails: technicalDetailsDisplay ?? 'hidden',
         },
       }}
     />
@@ -1491,6 +1501,7 @@ function OperationApproval({
   const showExpiry = header.showExpiry
   const showIdentity = header.showIdentity
   const showRequester = header.showRequester
+  const contextDisplay = combineSectionDisplays(sections.requestContext, sections.programSnippet)
   const hasDecisionContext = Boolean(showApprovalAuthority)
   const isEnvelopeVisible =
     shouldShowSection(sections.authorityEnvelope) || envelopeArgsDisplay !== 'none'
@@ -1532,6 +1543,7 @@ function OperationApproval({
       {(shouldShowSection(sections.requestContext) && approval.requestContext) ||
       (shouldShowSection(sections.programSnippet) && approval.programContext) ? (
         <ContextSection
+          display={contextDisplay}
           programSnippet={
             shouldShowSection(sections.programSnippet)
               ? approval.programContext?.snippet
@@ -1554,7 +1566,10 @@ function OperationApproval({
       ) : null}
 
       {shouldShowSection(sections.authorityEnvelope) && envelopeEvaluation ? (
-        <EnvelopeCheckSection evaluation={envelopeEvaluation} />
+        <EnvelopeCheckSection
+          display={sections.authorityEnvelope}
+          evaluation={envelopeEvaluation}
+        />
       ) : null}
 
       {shouldShowSection(sections.programBody) && approval.programContext ? (
@@ -1612,20 +1627,22 @@ function OperationApproval({
       ) : null}
 
       {shouldShowSection(sections.runContext) ? (
-        <div style={runContextStyle}>
-          <div style={runCopyStyle}>
-            <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
-              Run {approval.runContext.runId}
-            </Typography.BodySmallStrong>
-            <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
-              {approval.runContext.status} · {approval.runContext.workspace}
-            </Typography.BodySmall>
+        <SectionContainer display={sections.runContext} title="Run context" visibleHeading={false}>
+          <div style={runContextStyle}>
+            <div style={runCopyStyle}>
+              <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
+                Run {approval.runContext.runId}
+              </Typography.BodySmallStrong>
+              <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+                {approval.runContext.status} · {approval.runContext.workspace}
+              </Typography.BodySmall>
+            </div>
+            <Button.Container onClick={actions.onViewRun} size="22" variant="bare">
+              <Button.Text>View run</Button.Text>
+              <Button.Icon name="ArrowUpRight" />
+            </Button.Container>
           </div>
-          <Button.Container onClick={actions.onViewRun} size="22" variant="bare">
-            <Button.Text>View run</Button.Text>
-            <Button.Icon name="ArrowUpRight" />
-          </Button.Container>
-        </div>
+        </SectionContainer>
       ) : null}
 
       {envelopeEvaluation?.decision === 'allow' ? null : (
@@ -1902,15 +1919,18 @@ function aggregateEnvelopeStatus(
   return 'pass'
 }
 
-function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEvaluation }) {
+function EnvelopeCheckSection({
+  display,
+  evaluation,
+}: {
+  display?: SectionDisplay
+  evaluation: AuthorityEnvelopeEvaluation
+}) {
   const matches = evaluation.decision === 'allow'
   const hasNoExistingEnvelope = evaluation.envelopeMatch === 'none'
 
   return (
-    <section style={sectionStyle}>
-      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
-        Envelope check
-      </Typography.BodySmallStrong>
+    <SectionContainer display={display} title="Envelope check">
       <div style={envelopeResultStyle}>
         <div style={envelopeResultCopyStyle}>
           <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
@@ -1951,7 +1971,7 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
             ? 'No existing Owner policy authorized this Invocation'
             : `Envelope ${evaluation.envelopeId} did not authorize this Invocation`}
       </Typography.BodySmall>
-    </section>
+    </SectionContainer>
   )
 }
 
@@ -2307,21 +2327,56 @@ function EnvelopeCheckRow({
   )
 }
 
+function SectionContainer({
+  children,
+  display,
+  title,
+  visibleHeading = true,
+}: {
+  children: ReactNode
+  display?: SectionDisplay
+  title: string
+  visibleHeading?: boolean
+}) {
+  if (!shouldShowSection(display)) return null
+
+  if (sectionIsDisclosure(display)) {
+    return (
+      <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
+        <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
+          {title}
+        </Typography.BodySmallStrong>
+        <div style={disclosureContentStyle}>{children}</div>
+      </details>
+    )
+  }
+
+  return (
+    <section style={sectionStyle}>
+      {visibleHeading ? (
+        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+          {title}
+        </Typography.BodySmallStrong>
+      ) : null}
+      {children}
+    </section>
+  )
+}
+
 function ContextSection({
+  display,
   programSnippet,
   requestContext,
 }: {
+  display?: SectionDisplay
   programSnippet?: ProgramEvidence
   requestContext?: RequestContext
 }) {
   return (
-    <section style={sectionStyle}>
-      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
-        Context
-      </Typography.BodySmallStrong>
+    <SectionContainer display={display} title="Context">
       {requestContext ? <RequestContextDetails requestContext={requestContext} /> : null}
       {programSnippet ? <ProgramEvidenceBlock evidence={programSnippet} /> : null}
-    </section>
+    </SectionContainer>
   )
 }
 

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -33,6 +33,7 @@ interface OperationApprovalStoryProps {
   showApprovalAuthority?: boolean
   showExpiry?: boolean
   showAuthorityEnvelopeMatch?: boolean
+  showEnvelopeOnArgs?: boolean
   showIdentity?: boolean
   showProgramBody?: boolean
   showProgramSnippet?: boolean
@@ -67,6 +68,18 @@ interface RequestContext {
 }
 
 type EnvelopeCheckStatus = 'fail' | 'pass' | 'unknown'
+
+const envelopeStatusColors: Record<EnvelopeCheckStatus, 'amber' | 'green' | 'red'> = {
+  fail: 'red',
+  pass: 'green',
+  unknown: 'amber',
+}
+
+const envelopeStatusLabels: Record<EnvelopeCheckStatus, string> = {
+  fail: 'Fails',
+  pass: 'Pass',
+  unknown: 'Unknown',
+}
 
 interface AuthorityEnvelopeEvaluation {
   checks: Array<{
@@ -141,6 +154,10 @@ const meta = {
       control: 'boolean',
       description: 'Execute and show a Storybook-only deterministic Owner-policy envelope.',
     },
+    showEnvelopeOnArgs: {
+      control: 'boolean',
+      description: 'Annotate exact argument rows with checks from the selected Owner envelope.',
+    },
     showRequestContext: {
       control: 'boolean',
       description: 'Show Task and exec intent as secondary request context.',
@@ -159,6 +176,7 @@ const meta = {
     showRequestContext: false,
     showProviderReference: false,
     showAuthorityEnvelopeMatch: false,
+    showEnvelopeOnArgs: false,
   },
   component: OperationApprovalStory,
   decorators: [
@@ -180,7 +198,7 @@ Every Medium+ story keeps the same first-screen decision contract: Operation cal
 
 Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
-Every dataset supplies two Storybook-only Owner envelopes: \`inside\` matches its exact Invocation and \`outside\` fails explicit argument filters. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the evaluation.
+Every dataset supplies two Storybook-only Owner envelopes: \`inside\` matches its exact Invocation and \`outside\` fails explicit argument filters. The \`dataset\` and \`envelopeMatch\` controls select those two dimensions independently. ArkType executes each envelope’s operation, argument-path, and expiry rules; it is not proposed as Coral’s production authorization engine. These stories do not model an agent approving another agent, and a passing envelope applies only to the exact Invocation shown. Toggle \`showAuthorityEnvelopeMatch\` to reveal the full evaluation or \`showEnvelopeOnArgs\` to annotate the affected positional arguments inline.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 
@@ -1053,6 +1071,7 @@ export const EnvelopeMatches: Story = {
     envelopeMatch: 'inside',
     showArguments: true,
     showAuthorityEnvelopeMatch: true,
+    showEnvelopeOnArgs: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
     showRequester: true,
@@ -1076,6 +1095,7 @@ export const EnvelopeDoesNotMatch: Story = {
     showArguments: true,
     showApprovalAuthority: true,
     showAuthorityEnvelopeMatch: true,
+    showEnvelopeOnArgs: true,
     showExpiry: true,
     showIdentity: true,
     showRequestMetadataInHeader: true,
@@ -1187,6 +1207,7 @@ function OperationApproval({
   showApprovalAuthority,
   showExpiry,
   showAuthorityEnvelopeMatch,
+  showEnvelopeOnArgs,
   showIdentity,
   showProgramBody,
   showProgramSnippet,
@@ -1198,13 +1219,15 @@ function OperationApproval({
   showTechnicalDetails,
 }: OperationApprovalProps) {
   const hasDecisionContext = Boolean(showApprovalAuthority)
-  const envelopeEvaluation = showAuthorityEnvelopeMatch
-    ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
-    : undefined
+  const envelopeEvaluation =
+    showAuthorityEnvelopeMatch || showEnvelopeOnArgs
+      ? evaluateAuthorityEnvelope(approval, authorityEnvelope)
+      : undefined
   const hasContext = Boolean(
     showArguments ||
     showExpiry ||
     showAuthorityEnvelopeMatch ||
+    showEnvelopeOnArgs ||
     showIdentity ||
     hasDecisionContext ||
     showProgramBody ||
@@ -1232,6 +1255,7 @@ function OperationApproval({
       {showArguments ? (
         <InvocationArgumentsSection
           collapsible={argumentsCollapsible}
+          envelopeChecks={showEnvelopeOnArgs ? envelopeEvaluation?.checks : undefined}
           initiallyExpanded={argumentsInitiallyExpanded}
           invocationArguments={approval.invocationArguments}
         />
@@ -1375,10 +1399,12 @@ function ApprovalHeader({
 
 function InvocationArgumentsSection({
   collapsible,
+  envelopeChecks,
   initiallyExpanded,
   invocationArguments,
 }: {
   collapsible?: boolean
+  envelopeChecks?: AuthorityEnvelopeEvaluation['checks']
   initiallyExpanded?: boolean
   invocationArguments: OperationApprovalModel['invocationArguments']
 }) {
@@ -1410,7 +1436,10 @@ function InvocationArgumentsSection({
       {!collapsible || expanded ? (
         <dl id={argumentsId} style={detailsStyle}>
           {invocationArguments.map(({ label, value }, index) => (
-            <DetailRow
+            <InvocationArgumentRow
+              annotations={envelopeChecks?.filter(({ label: checkLabel }) =>
+                checkLabel.startsWith(`args[${index}]`),
+              )}
               key={label}
               label={label}
               showDivider={index < invocationArguments.length - 1}
@@ -1421,6 +1450,53 @@ function InvocationArgumentsSection({
       ) : null}
     </section>
   )
+}
+
+function InvocationArgumentRow({
+  annotations,
+  label,
+  showDivider,
+  value,
+}: {
+  annotations?: AuthorityEnvelopeEvaluation['checks']
+  label: string
+  showDivider: boolean
+  value: ArgumentValue
+}) {
+  const argumentStatus = aggregateEnvelopeStatus(annotations)
+
+  return (
+    <div
+      style={{
+        ...argumentGroupStyle,
+        ...(argumentStatus ? envelopeArgumentBackgrounds[argumentStatus] : {}),
+        ...(!showDivider ? lastDetailRowStyle : {}),
+      }}
+    >
+      <DetailRow label={label} showDivider={false} value={value} />
+      {annotations && annotations.length > 0 ? (
+        <div style={argumentAnnotationsStyle}>
+          {annotations.map(({ label: checkLabel, policy, status }) => (
+            <div key={checkLabel} style={argumentAnnotationStyle}>
+              <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+                Policy: {checkLabel} {policy}
+              </Typography.BodySmall>
+              <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function aggregateEnvelopeStatus(
+  annotations: AuthorityEnvelopeEvaluation['checks'] | undefined,
+): EnvelopeCheckStatus | undefined {
+  if (!annotations || annotations.length === 0) return undefined
+  if (annotations.some(({ status }) => status === 'fail')) return 'fail'
+  if (annotations.some(({ status }) => status === 'unknown')) return 'unknown'
+  return 'pass'
 }
 
 function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEvaluation }) {
@@ -1478,9 +1554,6 @@ function EnvelopeCheckRow({
   showDivider: boolean
   status: EnvelopeCheckStatus
 }) {
-  const statusLabel = status === 'pass' ? 'Pass' : status === 'fail' ? 'Fails' : 'Unknown'
-  const statusColor = status === 'pass' ? 'green' : status === 'fail' ? 'red' : 'amber'
-
   return (
     <div style={{ ...detailRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
       <Typography.BodySmall as="dt" variant="tertiary">
@@ -1495,7 +1568,7 @@ function EnvelopeCheckRow({
             Observed: {observed}
           </Typography.BodySmall>
         </div>
-        <Pill color={statusColor}>{statusLabel}</Pill>
+        <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
       </div>
     </div>
   )
@@ -1760,6 +1833,43 @@ const detailRowStyle: CSSProperties = {
   gap: '16px',
   gridTemplateColumns: '140px minmax(0, 1fr)',
   padding: '8px 0',
+}
+
+const argumentGroupStyle: CSSProperties = {
+  borderBottom: `1px solid ${theme.stroke.secondary}`,
+}
+
+const envelopeArgumentBackgrounds: Record<EnvelopeCheckStatus, CSSProperties> = {
+  fail: {
+    background: theme.content.errorBackground,
+    borderRadius: '6px',
+    padding: '0 8px 8px',
+  },
+  pass: {
+    background: theme.content.successBackground,
+    borderRadius: '6px',
+    padding: '0 8px 8px',
+  },
+  unknown: {
+    background: theme.content.warningBackground,
+    borderRadius: '6px',
+    padding: '0 8px 8px',
+  },
+}
+
+const argumentAnnotationsStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px',
+  marginLeft: '156px',
+}
+
+const argumentAnnotationStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  gap: '8px',
+  justifyContent: 'space-between',
+  minWidth: 0,
 }
 
 const lastDetailRowStyle: CSSProperties = { borderBottom: 0 }

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -87,12 +87,17 @@ const meta = {
       control: 'select',
       options: ['github', 'linear', 'loop', 'savedFunction'],
     },
+    showRequestContext: {
+      control: 'boolean',
+      description: 'Show Task and exec intent as secondary request context.',
+    },
   },
   args: {
     dataset: 'github',
     onApprove: fn(),
     onDecline: fn(),
     onViewRun: fn(),
+    showRequestContext: false,
   },
   component: OperationApprovalStory,
   decorators: [
@@ -111,6 +116,8 @@ const meta = {
 The story-only model uses Lagoon-aligned names: \`operationCallPath\`, \`invocationArguments\`, \`invokingPrincipal\`, \`approvalAuthority\`, \`expiresAt\`, optional \`requestContext\`, and optional \`programContext\`. Task and exec intent are request context; they do not replace the exact Invocation arguments or describe the consequence of approval.
 
 Every Medium+ story keeps the same first-screen decision contract: Operation call path, provider identity, invoking principal, approval authority, expiry, exact Invocation arguments, and the unchanged Decline/Approve actions. The prototype does not invent an operation-specific consequence CTA when no trusted renderer provides one.
+
+Every story uses the same story-local \`OperationApproval\` component. Toggle \`showRequestContext\` in any story to reveal Task and exec intent below Arguments; \`TaskIntentContext\` is the preset that enables it by default.
 
 Each story has a **dataset** control. The default GitHub dataset uses \`coral.providers.github.issues.createComment\`; the Linear dataset uses \`coral.providers.linear.issues.update\` inside a program that also reads GitHub context; the loop dataset puts one pending \`coral.providers.linear.issues.update\` Invocation inside a \`for\` loop; the saved-function dataset shows one pending Operation from a linked \`coral.functions.postApprovalFollowUp\` source snapshot. Within a selected dataset, the stories keep the operation/request stable so reviewers can compare disclosure and rendering choices without changing provider, operation, requester, identity, or run context.
 

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -2425,22 +2425,10 @@ function ProgramBodySection({
   display?: SectionDisplay
   programBody: ProgramEvidence
 }) {
-  const content = <ProgramEvidenceBlock evidence={programBody} />
-
-  return sectionIsDisclosure(display) ? (
-    <details open={sectionInitiallyOpen(display)} style={disclosureSectionStyle}>
-      <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
-        Program body
-      </Typography.BodySmallStrong>
-      <div style={disclosureContentStyle}>{content}</div>
-    </details>
-  ) : (
-    <section style={sectionStyle}>
-      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
-        Program body
-      </Typography.BodySmallStrong>
-      {content}
-    </section>
+  return (
+    <SectionContainer display={display} title="Program body">
+      <ProgramEvidenceBlock evidence={programBody} />
+    </SectionContainer>
   )
 }
 

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1754,12 +1754,12 @@ function InvocationArgumentsSection({
           variant="bare"
         >
           <Button.Icon name={expanded ? 'ChevronDown' : 'ChevronRight'} />
-          <Typography.BodySmallStrong variant="tertiary">
+          <Typography.BodySmallStrong>
             Arguments ({invocationArguments.length})
           </Typography.BodySmallStrong>
         </Button.Container>
       ) : (
-        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
+        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle}>
           Arguments
         </Typography.BodySmallStrong>
       )}
@@ -2637,6 +2637,7 @@ const argumentsDisclosureStyle: CSSProperties = {
   background: 'transparent',
   border: 0,
   borderBottom: `1px solid ${theme.stroke.secondary}`,
+  color: theme.content.primary,
   cursor: 'pointer',
   display: 'flex',
   gap: '4px',

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -127,7 +127,6 @@ const envelopeStatusLabels: Record<EnvelopeCheckStatus, string> = {
 
 interface AuthorityEnvelopeEvaluation {
   checks: Array<{
-    draftRole: 'coverage' | 'narrowing'
     label: string
     observed: string
     policy: string
@@ -345,20 +344,17 @@ function evaluateAuthorityEnvelope(
   )
   const checks: AuthorityEnvelopeEvaluation['checks'] = [
     {
-      draftRole: 'coverage',
       label: 'Operation call path',
       observed: approval.operationCallPath,
       policy: `== ${JSON.stringify(envelope.operationCallPath)}`,
       status: arkStatus(operationPolicy(approval.operationCallPath)),
     },
     ...envelope.rules.map(({ evaluate, label, policy }) => ({
-      draftRole: 'narrowing' as const,
       label,
       policy,
       ...evaluate(approval),
     })),
     {
-      draftRole: 'narrowing',
       label: 'Policy expiry',
       observed: `Evaluated ${envelope.evaluatedAt}`,
       policy: `expires ${envelope.expiresAt}`,
@@ -2002,9 +1998,13 @@ function PolicyUpdateProposalDialog({
   open: boolean
 }) {
   const isCreatingPolicy = evaluation.envelopeMatch === 'none'
-  const proposedChecks = isCreatingPolicy
-    ? evaluation.checks
-    : evaluation.checks.filter(({ status }) => status !== 'pass')
+  const proposedChecks = evaluation.checks.filter(
+    ({ label, status }) =>
+      label !== 'Operation call path' && (isCreatingPolicy || status !== 'pass'),
+  )
+  const fixedScopeFailure = evaluation.checks.find(
+    ({ label, status }) => label === 'Operation call path' && status !== 'pass',
+  )
   const [selectedChanges, setSelectedChanges] = useState(
     () =>
       new Set(
@@ -2015,33 +2015,26 @@ function PolicyUpdateProposalDialog({
           .map(({ label }) => label),
       ),
   )
-  const unsafeChecks = proposedChecks.filter(({ proposal, status }) =>
-    isCreatingPolicy ? status !== 'pass' : proposal?.kind !== 'automatic',
-  )
+  const unsafeChecks = [
+    ...(fixedScopeFailure ? [fixedScopeFailure] : []),
+    ...proposedChecks.filter(({ proposal, status }) =>
+      isCreatingPolicy ? status !== 'pass' : proposal?.kind !== 'automatic',
+    ),
+  ]
   const unselectedChecks = proposedChecks.filter(
     ({ label, proposal, status }) =>
       (isCreatingPolicy ? status === 'pass' : proposal?.kind === 'automatic') &&
       !selectedChanges.has(label),
   )
-  const missingCoverageCheck = isCreatingPolicy
-    ? proposedChecks.find(
-        ({ draftRole, label, status }) =>
-          draftRole === 'coverage' && status === 'pass' && !selectedChanges.has(label),
-      )
-    : undefined
-  const omittedNarrowingChecks = isCreatingPolicy
-    ? unselectedChecks.filter(({ draftRole }) => draftRole === 'narrowing')
-    : []
+  const omittedNarrowingChecks = isCreatingPolicy ? unselectedChecks : []
   const selectionStatus =
     unsafeChecks.length > 0
       ? 'blocked'
-      : missingCoverageCheck
-        ? 'incomplete'
-        : omittedNarrowingChecks.length > 0
-          ? 'broader'
-          : unselectedChecks.length > 0
-            ? 'incomplete'
-            : 'allows'
+      : omittedNarrowingChecks.length > 0
+        ? 'broader'
+        : unselectedChecks.length > 0
+          ? 'incomplete'
+          : 'allows'
   const canUpdatePolicy = selectionStatus === 'allows' || selectionStatus === 'broader'
 
   function toggleChange(label: string, checked: boolean) {
@@ -2066,37 +2059,27 @@ function PolicyUpdateProposalDialog({
           </Dialog.Description>
           <Dialog.Close />
           <PolicySelectionBanner
-            blockingCheck={
-              unsafeChecks[0] ??
-              missingCoverageCheck ??
-              omittedNarrowingChecks[0] ??
-              unselectedChecks[0]
-            }
+            blockingCheck={unsafeChecks[0] ?? omittedNarrowingChecks[0] ?? unselectedChecks[0]}
             isCreatingPolicy={isCreatingPolicy}
             status={selectionStatus}
           />
           <section style={policyProposalListStyle}>
-            {proposedChecks.map(
-              ({ draftRole, label, observed, policy, proposal, status }, index) => (
-                <PolicyUpdateProposalRow
-                  checked={selectedChanges.has(label)}
-                  draftRole={draftRole}
-                  key={label}
-                  candidatePolicy={
-                    isCreatingPolicy
-                      ? formatCandidatePolicyLine(evaluation.envelopeId, label, observed, policy)
-                      : undefined
-                  }
-                  label={label}
-                  observed={observed}
-                  onCheckedChange={(checked) => toggleChange(label, checked)}
-                  policy={policy}
-                  proposal={proposal}
-                  showDivider={index < proposedChecks.length - 1}
-                  status={status}
-                />
-              ),
-            )}
+            {proposedChecks.map(({ label, observed, policy, proposal, status }, index) => (
+              <PolicyUpdateProposalRow
+                checked={selectedChanges.has(label)}
+                key={label}
+                candidatePolicy={
+                  isCreatingPolicy ? formatCandidatePolicyLine(label, policy) : undefined
+                }
+                label={label}
+                observed={observed}
+                onCheckedChange={(checked) => toggleChange(label, checked)}
+                policy={policy}
+                proposal={proposal}
+                showDivider={index < proposedChecks.length - 1}
+                status={status}
+              />
+            ))}
           </section>
           {!canUpdatePolicy ? (
             <Typography.BodySmall
@@ -2106,9 +2089,7 @@ function PolicyUpdateProposalDialog({
             >
               {selectionStatus === 'blocked'
                 ? 'Resolve manual or unavailable checks before changing Owner policy.'
-                : isCreatingPolicy
-                  ? 'Include the Operation call path to create a policy that covers this Invocation.'
-                  : 'Select every required change to allow this Invocation.'}
+                : 'Select every required change to allow this Invocation.'}
             </Typography.BodySmall>
           ) : null}
           <Dialog.Actions>
@@ -2190,7 +2171,6 @@ function PolicySelectionBanner({
 function PolicyUpdateProposalRow({
   candidatePolicy,
   checked,
-  draftRole,
   label,
   observed,
   onCheckedChange,
@@ -2201,7 +2181,6 @@ function PolicyUpdateProposalRow({
 }: {
   candidatePolicy?: string
   checked: boolean
-  draftRole: AuthorityEnvelopeEvaluation['checks'][number]['draftRole']
   label: string
   observed: string
   onCheckedChange: (checked: boolean) => void
@@ -2221,13 +2200,7 @@ function PolicyUpdateProposalRow({
   const selectable = isCreatingPolicy ? status === 'pass' : resolvedProposal.kind === 'automatic'
   const statusColor = isCreatingPolicy && selectable ? (checked ? 'green' : 'amber') : undefined
   const statusLabel =
-    isCreatingPolicy && selectable
-      ? checked
-        ? 'Included'
-        : draftRole === 'coverage'
-          ? 'Not included'
-          : 'Not constrained'
-      : null
+    isCreatingPolicy && selectable ? (checked ? 'Included' : 'Not constrained') : null
 
   return (
     <div style={{ ...policyProposalRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
@@ -2342,13 +2315,7 @@ function PolicyProposalDiff({
   )
 }
 
-function formatCandidatePolicyLine(
-  envelopeId: string,
-  label: string,
-  observed: string,
-  policy: string,
-) {
-  if (label === 'Operation call path') return `envelope ${envelopeId} allows ${observed}`
+function formatCandidatePolicyLine(label: string, policy: string) {
   if (label === 'Policy expiry') return policy
   return `${label} ${policy}`
 }

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -32,6 +32,7 @@ interface OperationApprovalStoryProps {
   showIdentity?: boolean
   showProgramBody?: boolean
   showProgramSnippet?: boolean
+  showProviderReference?: boolean
   showRequestMetadataInHeader?: boolean
   showRequestContext?: boolean
   showRequester?: boolean
@@ -91,6 +92,10 @@ const meta = {
       control: 'boolean',
       description: 'Show Task and exec intent as secondary request context.',
     },
+    showProviderReference: {
+      control: 'boolean',
+      description: 'Show optional provider-authored reference copy as a quiet disclosure.',
+    },
   },
   args: {
     dataset: 'github',
@@ -98,6 +103,7 @@ const meta = {
     onDecline: fn(),
     onViewRun: fn(),
     showRequestContext: false,
+    showProviderReference: false,
   },
   component: OperationApprovalStory,
   decorators: [
@@ -736,6 +742,7 @@ export const MaximalEvidence: Story = {
     showIdentity: true,
     showProgramBody: true,
     showProgramSnippet: true,
+    showProviderReference: true,
     showRequestMetadataInHeader: true,
     showRunContext: true,
     showTechnicalDetails: true,
@@ -768,6 +775,7 @@ function OperationApproval({
   showIdentity,
   showProgramBody,
   showProgramSnippet,
+  showProviderReference,
   showRequestContext,
   showRequestMetadataInHeader,
   showRequester,
@@ -782,6 +790,7 @@ function OperationApproval({
     hasDecisionContext ||
     showProgramBody ||
     showProgramSnippet ||
+    showProviderReference ||
     showRequestContext ||
     showRequester ||
     showRunContext ||
@@ -808,16 +817,16 @@ function OperationApproval({
         />
       ) : null}
 
-      {showRequestContext && approval.requestContext ? (
-        <RequestContextSection requestContext={approval.requestContext} />
+      {(showRequestContext && approval.requestContext) ||
+      (showProgramSnippet && approval.programContext) ? (
+        <ContextSection
+          programSnippet={showProgramSnippet ? approval.programContext?.snippet : undefined}
+          requestContext={showRequestContext ? approval.requestContext : undefined}
+        />
       ) : null}
 
-      {approval.programContext ? (
-        <ProgramContextSection
-          programContext={approval.programContext}
-          showBody={showProgramBody}
-          showSnippet={showProgramSnippet}
-        />
+      {showProgramBody && approval.programContext ? (
+        <ProgramBodyDisclosure programBody={approval.programContext.body} />
       ) : null}
 
       {(showRequester || showExpiry) && !hasDecisionContext && !showRequestMetadataInHeader ? (
@@ -854,6 +863,10 @@ function OperationApproval({
             {approval.policyText}
           </Typography.BodySmall>
         </section>
+      ) : null}
+
+      {showProviderReference && approval.providerReference ? (
+        <ProviderReferenceSection providerReference={approval.providerReference} />
       ) : null}
 
       {showTechnicalDetails ? <TechnicalDetailsSection approval={approval} /> : null}
@@ -958,15 +971,12 @@ function InvocationArgumentsSection({
           </Typography.BodySmallStrong>
         </Button.Container>
       ) : (
-        <Typography.BodySmallStrong as="h3" variant="tertiary">
+        <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
           Arguments
         </Typography.BodySmallStrong>
       )}
       {!collapsible || expanded ? (
-        <dl
-          id={argumentsId}
-          style={{ ...detailsStyle, ...(collapsible ? collapsibleDetailsStyle : {}) }}
-        >
+        <dl id={argumentsId} style={detailsStyle}>
           {invocationArguments.map(({ label, value }, index) => (
             <DetailRow
               key={label}
@@ -981,49 +991,62 @@ function InvocationArgumentsSection({
   )
 }
 
-function RequestContextSection({ requestContext }: { requestContext: RequestContext }) {
+function ContextSection({
+  programSnippet,
+  requestContext,
+}: {
+  programSnippet?: ProgramEvidence
+  requestContext?: RequestContext
+}) {
   return (
-    <section style={supportingEvidenceStyle}>
-      <Typography.BodySmallStrong as="h3" variant="tertiary">
+    <section style={sectionStyle}>
+      <Typography.BodySmallStrong as="h3" style={sectionHeadingStyle} variant="tertiary">
         Context
       </Typography.BodySmallStrong>
-      <dl style={contextDetailsStyle}>
-        <DetailRow label="Task" value={requestContext.taskId} />
-        <DetailRow label="Task intent" value={requestContext.taskIntent} />
-        <DetailRow label="Exec intent" showDivider={false} value={requestContext.execIntent} />
-      </dl>
+      {requestContext ? <RequestContextDetails requestContext={requestContext} /> : null}
+      {programSnippet ? <ProgramEvidenceBlock evidence={programSnippet} /> : null}
     </section>
   )
 }
 
-function ProgramContextSection({
-  programContext,
-  showBody,
-  showSnippet,
-}: {
-  programContext: ProgramContext
-  showBody?: boolean
-  showSnippet?: boolean
-}) {
+function RequestContextDetails({ requestContext }: { requestContext: RequestContext }) {
   return (
-    <>
-      {showSnippet ? (
-        <section style={supportingEvidenceStyle}>
-          <Typography.BodySmallStrong as="h3" variant="tertiary">
-            Context
-          </Typography.BodySmallStrong>
-          <ProgramEvidenceBlock evidence={programContext.snippet} />
-        </section>
-      ) : null}
-      {showBody ? (
-        <details open={false} style={programBodyDetailsStyle}>
-          <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
-            Program body
-          </Typography.BodySmallStrong>
-          <ProgramEvidenceBlock evidence={programContext.body} />
-        </details>
-      ) : null}
-    </>
+    <dl style={contextDetailsStyle}>
+      <DetailRow label="Task" value={requestContext.taskId} />
+      <DetailRow label="Task intent" value={requestContext.taskIntent} />
+      <DetailRow label="Exec intent" showDivider={false} value={requestContext.execIntent} />
+    </dl>
+  )
+}
+
+function ProgramBodyDisclosure({ programBody }: { programBody: ProgramEvidence }) {
+  return (
+    <details open={false} style={disclosureSectionStyle}>
+      <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
+        Program body
+      </Typography.BodySmallStrong>
+      <div style={disclosureContentStyle}>
+        <ProgramEvidenceBlock evidence={programBody} />
+      </div>
+    </details>
+  )
+}
+
+function ProviderReferenceSection({ providerReference }: { providerReference: string }) {
+  return (
+    <details style={disclosureSectionStyle}>
+      <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
+        Reference
+      </Typography.BodySmallStrong>
+      <div style={disclosureContentStyle}>
+        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="tertiary">
+          Optional provider-authored text; it does not define this approval’s exact effect.
+        </Typography.BodySmall>
+        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+          {providerReference}
+        </Typography.BodySmall>
+      </div>
+    </details>
   )
 }
 
@@ -1031,34 +1054,21 @@ function TechnicalDetailsSection({ approval }: { approval: OperationApprovalMode
   const technicalDetails = buildTechnicalDetails(approval)
 
   return (
-    <>
-      <details style={technicalDetailsStyle}>
-        <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
-          Provider reference text
-        </Typography.BodySmallStrong>
-        <Typography.BodySmall as="p" style={providerDescriptionStyle} variant="tertiary">
-          Optional provider-authored context. Do not use this as the approval scope.
-        </Typography.BodySmall>
-        <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
-          {approval.providerReference}
-        </Typography.BodySmall>
-      </details>
-      <details style={technicalDetailsStyle}>
-        <Typography.BodySmallStrong as="summary" style={technicalSummaryStyle}>
-          Technical details
-        </Typography.BodySmallStrong>
-        <dl style={technicalListStyle}>
-          {technicalDetails.map(({ label, value }, index) => (
-            <DetailRow
-              key={label}
-              label={label}
-              showDivider={index < technicalDetails.length - 1}
-              value={value}
-            />
-          ))}
-        </dl>
-      </details>
-    </>
+    <details style={disclosureSectionStyle}>
+      <Typography.BodySmallStrong as="summary" style={disclosureSummaryStyle}>
+        Technical details
+      </Typography.BodySmallStrong>
+      <dl style={technicalListStyle}>
+        {technicalDetails.map(({ label, value }, index) => (
+          <DetailRow
+            key={label}
+            label={label}
+            showDivider={index < technicalDetails.length - 1}
+            value={value}
+          />
+        ))}
+      </dl>
+    </details>
   )
 }
 
@@ -1187,7 +1197,14 @@ const sectionStyle: CSSProperties = {
   gap: '6px',
 }
 
+const sectionHeadingStyle: CSSProperties = {
+  borderBottom: `1px solid ${theme.stroke.secondary}`,
+  margin: 0,
+  paddingBottom: '6px',
+}
+
 const argumentsDisclosureStyle: CSSProperties = {
+  ...sectionHeadingStyle,
   alignItems: 'center',
   background: 'transparent',
   border: 0,
@@ -1199,16 +1216,6 @@ const argumentsDisclosureStyle: CSSProperties = {
   padding: '0 0 6px',
   textAlign: 'left',
   width: '100%',
-}
-
-const supportingEvidenceStyle: CSSProperties = {
-  background: theme.surface.mainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: '8px',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '6px',
-  padding: '10px 12px',
 }
 
 const contextDetailsStyle: CSSProperties = { margin: 0 }
@@ -1234,12 +1241,7 @@ const currentOperationStyle: CSSProperties = {
   padding: '1px 3px',
 }
 
-const detailsStyle: CSSProperties = {
-  borderTop: `1px solid ${theme.stroke.secondary}`,
-  margin: 0,
-}
-
-const collapsibleDetailsStyle: CSSProperties = { borderTop: 0 }
+const detailsStyle: CSSProperties = { margin: 0 }
 
 const detailRowStyle: CSSProperties = {
   alignItems: 'baseline',
@@ -1275,24 +1277,19 @@ const decisionDetailsStyle: CSSProperties = {
   margin: 0,
 }
 
-const technicalDetailsStyle: CSSProperties = {
-  borderTop: `1px solid ${theme.stroke.secondary}`,
-  paddingTop: '12px',
-}
+const disclosureSectionStyle: CSSProperties = { margin: 0 }
 
-const programBodyDetailsStyle: CSSProperties = {
-  ...technicalDetailsStyle,
-  background: theme.surface.mainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: '8px',
-  padding: '10px 12px',
-}
-
-const providerDescriptionStyle: CSSProperties = { margin: '8px 0' }
-
-const technicalSummaryStyle: CSSProperties = {
+const disclosureSummaryStyle: CSSProperties = {
+  ...sectionHeadingStyle,
   color: theme.content.secondary,
   cursor: 'pointer',
+}
+
+const disclosureContentStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  paddingTop: '8px',
 }
 
 const technicalListStyle: CSSProperties = { margin: '8px 0 0' }

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -5,7 +5,7 @@ import { type } from 'arktype'
 import { useId, useState } from 'react'
 import { fn } from 'storybook/test'
 
-import { Button, Typography } from '@/wax/components'
+import { Button, Dialog, Typography } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
 import { Pill } from '@/wax/components/pill'
 import { theme } from '@/wax/theme/theme.css'
@@ -69,6 +69,13 @@ interface RequestContext {
 }
 
 type EnvelopeCheckStatus = 'fail' | 'pass' | 'unknown'
+type PolicyProposalKind = 'automatic' | 'manual' | 'unavailable'
+
+interface PolicyProposal {
+  kind: PolicyProposalKind
+  proposedPolicyChange: string
+  reason?: string
+}
 
 const envelopeStatusColors: Record<EnvelopeCheckStatus, 'amber' | 'green' | 'red'> = {
   fail: 'red',
@@ -87,6 +94,7 @@ interface AuthorityEnvelopeEvaluation {
     label: string
     observed: string
     policy: string
+    proposal?: PolicyProposal
     status: EnvelopeCheckStatus
   }>
   decision: 'allow' | 'requiresApproval'
@@ -107,6 +115,7 @@ interface AuthorityEnvelope {
 interface AuthorityEnvelopeRule {
   evaluate: (approval: OperationApprovalModel) => {
     observed: string
+    proposal?: PolicyProposal
     status: EnvelopeCheckStatus
   }
   label: string
@@ -215,6 +224,7 @@ Each story has a **dataset** control. The default GitHub dataset uses \`coral.pr
 - **TaskIntentContext** adds grounded Task and MCP exec intent as secondary request context.
 - **EnvelopeMatches** shows an exact Invocation that passes every known Owner-policy check.
 - **EnvelopeDoesNotMatch** shows exact failed and unknown checks and retains per-call approval.
+- **EnvelopePolicyUpdateProposal** keeps one-time approval separate from reviewing a bounded future Owner-policy change.
 - **ProgramSnippet** adds expandable arguments and highlights one current-operation call as supporting context.
 - **CollapsedProgramBody** adds expandable arguments and a collapsed, self-contained Program body.
 - **MaximalEvidence** keeps arguments expandable while exposing snippet, Program body, provider reference copy, raw args, and ids.
@@ -602,6 +612,7 @@ function createArgumentRule({
   label,
   path,
   policy,
+  propose,
   validate,
 }: {
   argumentIndex: number
@@ -609,6 +620,7 @@ function createArgumentRule({
   label: string
   path: string[]
   policy: string
+  propose?: (value: ArgumentValue) => PolicyProposal
   validate: (value: ArgumentValue) => unknown
 }): AuthorityEnvelopeRule {
   return {
@@ -616,8 +628,20 @@ function createArgumentRule({
       const observed = readInvocationArgument(approval, argumentIndex, path)
 
       return observed === undefined
-        ? { observed: 'Unavailable', status: 'unknown' }
-        : { observed: formatObserved(observed), status: arkStatus(validate(observed)) }
+        ? {
+            observed: 'Unavailable',
+            proposal: {
+              kind: 'unavailable',
+              proposedPolicyChange: 'Cannot propose automatically',
+              reason: 'The argument value must be available before changing Owner policy.',
+            },
+            status: 'unknown',
+          }
+        : {
+            observed: formatObserved(observed),
+            proposal: propose?.(observed),
+            status: arkStatus(validate(observed)),
+          }
     },
     label,
     policy,
@@ -631,6 +655,7 @@ function stringEqualsRule(label: string, argumentIndex: number, path: string[], 
     label,
     path,
     policy: `== ${JSON.stringify(expected)}`,
+    propose: (observed) => automaticSetExpansion(label, [expected], observed),
     validate: (value) => schema(value),
   })
 }
@@ -642,6 +667,7 @@ function stringInRule(label: string, argumentIndex: number, path: string[], allo
     label,
     path,
     policy: `in ${JSON.stringify(allowed)}`,
+    propose: (observed) => automaticSetExpansion(label, allowed, observed),
     validate: (value) => schema(value),
   })
 }
@@ -653,6 +679,7 @@ function numberInRule(label: string, argumentIndex: number, path: string[], allo
     label,
     path,
     policy: `in ${JSON.stringify(allowed)}`,
+    propose: (observed) => automaticSetExpansion(label, allowed, observed),
     validate: (value) => schema(value),
   })
 }
@@ -669,6 +696,11 @@ function booleanEqualsRule(
     label,
     path,
     policy: `== ${String(expected)}`,
+    propose: () => ({
+      kind: 'manual',
+      proposedPolicyChange: 'Manual policy change required',
+      reason: 'Changing a boolean policy can remove the constraint entirely.',
+    }),
     validate: (value) => schema(value),
   })
 }
@@ -684,6 +716,11 @@ function stringLengthRule(label: string, argumentIndex: number, path: string[], 
     label,
     path,
     policy: `length <= ${maximum.toLocaleString()}`,
+    propose: () => ({
+      kind: 'manual',
+      proposedPolicyChange: 'Manual policy change required',
+      reason: 'Size limits should be reviewed rather than expanded from one observed value.',
+    }),
     validate: (value) => schema(value),
   })
 }
@@ -707,6 +744,11 @@ function stringExcludesRule(
     label,
     path,
     policy: `excludes ${JSON.stringify(excluded)}`,
+    propose: () => ({
+      kind: 'manual',
+      proposedPolicyChange: 'Manual policy change required',
+      reason: 'Excluded mentions are a semantic safety constraint and cannot auto-expand.',
+    }),
     validate: (value) => schema(value),
   })
 }
@@ -723,8 +765,24 @@ function stringArrayIncludesRule(
     label,
     path,
     policy: `includes ${JSON.stringify(required)}`,
+    propose: () => ({
+      kind: 'manual',
+      proposedPolicyChange: 'Manual policy change required',
+      reason: 'Required-list constraints need explicit Owner review.',
+    }),
     validate: (value) => schema(value),
   })
+}
+
+function automaticSetExpansion(
+  label: string,
+  allowed: Array<string | number>,
+  observed: ArgumentValue,
+): PolicyProposal {
+  return {
+    kind: 'automatic',
+    proposedPolicyChange: `${label} in ${JSON.stringify([...allowed, observed])}`,
+  }
 }
 
 function readInvocationArgument(
@@ -1114,6 +1172,31 @@ export const EnvelopeDoesNotMatch: Story = {
   },
 }
 
+export const EnvelopePolicyUpdateProposal: Story = {
+  args: {
+    argumentsCollapsible: true,
+    argumentsInitiallyExpanded: true,
+    dataset: 'github',
+    envelopeArgsDisplay: 'interleaved',
+    envelopeMatch: 'outside',
+    showArguments: true,
+    showApprovalAuthority: true,
+    showAuthorityEnvelopeMatch: true,
+    showExpiry: true,
+    showIdentity: true,
+    showRequestMetadataInHeader: true,
+    showRequester: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Outside-envelope approval with a separate review step for bounded future Owner-policy changes. The proposal does not approve the pending Invocation.',
+      },
+    },
+  },
+}
+
 export const ProgramSnippet: Story = {
   args: {
     argumentsCollapsible: true,
@@ -1221,6 +1304,7 @@ function OperationApproval({
   showRunContext,
   showTechnicalDetails,
 }: OperationApprovalProps) {
+  const [policyProposalOpen, setPolicyProposalOpen] = useState(false)
   const hasDecisionContext = Boolean(showApprovalAuthority)
   const envelopeEvaluation =
     showAuthorityEnvelopeMatch || envelopeArgsDisplay !== 'none'
@@ -1266,7 +1350,10 @@ function OperationApproval({
       ) : null}
 
       {showAuthorityEnvelopeMatch && envelopeEvaluation ? (
-        <EnvelopeCheckSection evaluation={envelopeEvaluation} />
+        <EnvelopeCheckSection
+          evaluation={envelopeEvaluation}
+          onReviewPolicy={() => setPolicyProposalOpen(true)}
+        />
       ) : null}
 
       {(showRequestContext && approval.requestContext) ||
@@ -1341,8 +1428,20 @@ function OperationApproval({
       ) : null}
 
       {envelopeEvaluation?.decision === 'allow' ? null : (
-        <ApprovalActions onApprove={onApprove} onDecline={onDecline} />
+        <ApprovalActions
+          approveLabel={showAuthorityEnvelopeMatch ? 'Approve once' : 'Approve'}
+          onApprove={onApprove}
+          onDecline={onDecline}
+        />
       )}
+
+      {showAuthorityEnvelopeMatch && envelopeEvaluation?.decision === 'requiresApproval' ? (
+        <PolicyUpdateProposalDialog
+          evaluation={envelopeEvaluation}
+          onOpenChange={setPolicyProposalOpen}
+          open={policyProposalOpen}
+        />
+      ) : null}
     </section>
   )
 }
@@ -1597,7 +1696,13 @@ function aggregateEnvelopeStatus(
   return 'pass'
 }
 
-function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEvaluation }) {
+function EnvelopeCheckSection({
+  evaluation,
+  onReviewPolicy,
+}: {
+  evaluation: AuthorityEnvelopeEvaluation
+  onReviewPolicy: () => void
+}) {
   const matches = evaluation.decision === 'allow'
 
   return (
@@ -1618,6 +1723,11 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
         </div>
         <Pill color={matches ? 'green' : 'amber'}>{matches ? 'Allowed' : 'Review'}</Pill>
       </div>
+      {!matches ? (
+        <Button.TextButton onClick={onReviewPolicy} variant="secondary">
+          Allow similar future calls…
+        </Button.TextButton>
+      ) : null}
       <dl style={contextDetailsStyle}>
         <DetailRow label="Installed by" value={evaluation.installedBy} />
         <DetailRow label="Envelope expiry" value={evaluation.expiresAt} />
@@ -1638,6 +1748,97 @@ function EnvelopeCheckSection({ evaluation }: { evaluation: AuthorityEnvelopeEva
           : `Envelope ${evaluation.envelopeId} did not authorize this Invocation`}
       </Typography.BodySmall>
     </section>
+  )
+}
+
+function PolicyUpdateProposalDialog({
+  evaluation,
+  onOpenChange,
+  open,
+}: {
+  evaluation: AuthorityEnvelopeEvaluation
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}) {
+  const proposedChecks = evaluation.checks.filter(({ status }) => status !== 'pass')
+
+  return (
+    <Dialog.Root onOpenChange={onOpenChange} open={open}>
+      <Dialog.Portal>
+        <Dialog.Backdrop />
+        <Dialog.Popup size="l">
+          <Dialog.Title>Allow similar future calls</Dialog.Title>
+          <Dialog.Description>
+            This proposes an Owner policy update for envelope {evaluation.envelopeId}. It does not
+            approve this Invocation; use Approve once separately if you want it to continue.
+          </Dialog.Description>
+          <Dialog.Close />
+          <section style={policyProposalListStyle}>
+            {proposedChecks.map(({ label, observed, policy, proposal, status }, index) => (
+              <PolicyUpdateProposalRow
+                key={label}
+                label={label}
+                observed={observed}
+                policy={policy}
+                proposal={proposal}
+                showDivider={index < proposedChecks.length - 1}
+                status={status}
+              />
+            ))}
+          </section>
+          <Dialog.Actions>
+            <Button.TextButton onClick={() => onOpenChange(false)} variant="secondary">
+              Close proposal
+            </Button.TextButton>
+          </Dialog.Actions>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function PolicyUpdateProposalRow({
+  label,
+  observed,
+  policy,
+  proposal,
+  showDivider,
+  status,
+}: {
+  label: string
+  observed: string
+  policy: string
+  proposal?: PolicyProposal
+  showDivider: boolean
+  status: EnvelopeCheckStatus
+}) {
+  const resolvedProposal =
+    proposal ??
+    ({
+      kind: 'unavailable',
+      proposedPolicyChange: 'Cannot propose automatically',
+      reason: 'This check is not a mechanically expandable argument filter.',
+    } satisfies PolicyProposal)
+
+  return (
+    <div style={{ ...policyProposalRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
+      <div style={policyProposalHeadingStyle}>
+        <Typography.BodySmallStrong as="h3">{label}</Typography.BodySmallStrong>
+        <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
+      </div>
+      <dl style={policyProposalDetailsStyle}>
+        <DetailRow label="Current policy" value={`${label} ${policy}`} />
+        <DetailRow label="Observed value" value={observed} />
+        <DetailRow
+          label="Proposed change"
+          showDivider={Boolean(resolvedProposal.reason)}
+          value={resolvedProposal.proposedPolicyChange}
+        />
+        {resolvedProposal.reason ? (
+          <DetailRow label="Reason" showDivider={false} value={resolvedProposal.reason} />
+        ) : null}
+      </dl>
+    </div>
   )
 }
 
@@ -1754,9 +1955,11 @@ function TechnicalDetailsSection({ approval }: { approval: OperationApprovalMode
 }
 
 function ApprovalActions({
+  approveLabel = 'Approve',
   onApprove,
   onDecline,
 }: {
+  approveLabel?: string
   onApprove: () => void
   onDecline: () => void
 }) {
@@ -1766,7 +1969,7 @@ function ApprovalActions({
         <Button.Text>Decline</Button.Text>
       </Button.Container>
       <Button.Container onClick={onApprove} size="32" variant="primary">
-        <Button.Text>Approve</Button.Text>
+        <Button.Text>{approveLabel}</Button.Text>
       </Button.Container>
     </div>
   )
@@ -2039,6 +2242,28 @@ const envelopeCheckCopyStyle: CSSProperties = {
   flexDirection: 'column',
   gap: '2px',
   minWidth: 0,
+}
+
+const policyProposalListStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: '16px',
+}
+
+const policyProposalRowStyle: CSSProperties = {
+  borderBottom: `1px solid ${theme.stroke.secondary}`,
+  padding: '12px 0',
+}
+
+const policyProposalHeadingStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  gap: '12px',
+  justifyContent: 'space-between',
+}
+
+const policyProposalDetailsStyle: CSSProperties = {
+  margin: '4px 0 0',
 }
 
 const nestedValueStyle: CSSProperties = {

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1508,6 +1508,14 @@ function OperationApproval({
         showRequester={showRequester}
       />
 
+      {(sections.requestContext && approval.requestContext) ||
+      (sections.programSnippet && approval.programContext) ? (
+        <ContextSection
+          programSnippet={sections.programSnippet ? approval.programContext?.snippet : undefined}
+          requestContext={sections.requestContext ? approval.requestContext : undefined}
+        />
+      ) : null}
+
       {argumentsDisplay.visible ? (
         <InvocationArgumentsSection
           collapsible={argumentsDisplay.collapsible}
@@ -1520,14 +1528,6 @@ function OperationApproval({
 
       {sections.authorityEnvelope && envelopeEvaluation ? (
         <EnvelopeCheckSection evaluation={envelopeEvaluation} />
-      ) : null}
-
-      {(sections.requestContext && approval.requestContext) ||
-      (sections.programSnippet && approval.programContext) ? (
-        <ContextSection
-          programSnippet={sections.programSnippet ? approval.programContext?.snippet : undefined}
-          requestContext={sections.requestContext ? approval.requestContext : undefined}
-        />
       ) : null}
 
       {sections.programBody && approval.programContext ? (

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { Checkbox } from '@base-ui/react/checkbox'
 import { type } from 'arktype'
 import { useId, useState } from 'react'
 import { fn } from 'storybook/test'
@@ -1816,9 +1817,36 @@ function PolicyUpdateProposalDialog({
   const proposedChecks = isCreatingPolicy
     ? evaluation.checks
     : evaluation.checks.filter(({ status }) => status !== 'pass')
-  const canUpdatePolicy = isCreatingPolicy
-    ? proposedChecks.every(({ status }) => status === 'pass')
-    : proposedChecks.every(({ proposal }) => proposal?.kind === 'automatic')
+  const [selectedChanges, setSelectedChanges] = useState(
+    () =>
+      new Set(
+        proposedChecks
+          .filter(({ proposal, status }) =>
+            isCreatingPolicy ? status === 'pass' : proposal?.kind === 'automatic',
+          )
+          .map(({ label }) => label),
+      ),
+  )
+  const unsafeChecks = proposedChecks.filter(({ proposal, status }) =>
+    isCreatingPolicy ? status !== 'pass' : proposal?.kind !== 'automatic',
+  )
+  const unselectedChecks = proposedChecks.filter(
+    ({ label, proposal, status }) =>
+      (isCreatingPolicy ? status === 'pass' : proposal?.kind === 'automatic') &&
+      !selectedChanges.has(label),
+  )
+  const selectionStatus =
+    unsafeChecks.length > 0 ? 'blocked' : unselectedChecks.length > 0 ? 'incomplete' : 'allows'
+  const canUpdatePolicy = selectionStatus === 'allows'
+
+  function toggleChange(label: string, checked: boolean) {
+    setSelectedChanges((current) => {
+      const next = new Set(current)
+      if (checked) next.add(label)
+      else next.delete(label)
+      return next
+    })
+  }
 
   return (
     <Dialog.Root onOpenChange={onOpenChange} open={open}>
@@ -1832,9 +1860,14 @@ function PolicyUpdateProposalDialog({
               : `This proposes an Owner policy update for envelope ${evaluation.envelopeId}. It does not approve this invocation.`}
           </Dialog.Description>
           <Dialog.Close />
+          <PolicySelectionBanner
+            blockingCheck={unsafeChecks[0] ?? unselectedChecks[0]}
+            status={selectionStatus}
+          />
           <section style={policyProposalListStyle}>
             {proposedChecks.map(({ label, observed, policy, proposal, status }, index) => (
               <PolicyUpdateProposalRow
+                checked={selectedChanges.has(label)}
                 key={label}
                 candidatePolicy={
                   isCreatingPolicy
@@ -1843,6 +1876,7 @@ function PolicyUpdateProposalDialog({
                 }
                 label={label}
                 observed={observed}
+                onCheckedChange={(checked) => toggleChange(label, checked)}
                 policy={policy}
                 proposal={proposal}
                 showDivider={index < proposedChecks.length - 1}
@@ -1856,7 +1890,9 @@ function PolicyUpdateProposalDialog({
               style={{ ...zeroMarginStyle, color: theme.content.warning }}
               variant="secondary"
             >
-              Resolve manual or unavailable checks before updating Owner policy.
+              {selectionStatus === 'blocked'
+                ? 'Resolve manual or unavailable checks before changing Owner policy.'
+                : 'Select every required change to allow this Invocation.'}
             </Typography.BodySmall>
           ) : null}
           <Dialog.Actions>
@@ -1870,7 +1906,7 @@ function PolicyUpdateProposalDialog({
                 onOpenChange(false)
               }}
             >
-              {isCreatingPolicy ? 'Create policy' : 'Update policy'}
+              {isCreatingPolicy ? 'Create selected policy' : 'Apply selected policy changes'}
             </Button.TextButton>
           </Dialog.Actions>
         </Dialog.Popup>
@@ -1879,18 +1915,63 @@ function PolicyUpdateProposalDialog({
   )
 }
 
+function PolicySelectionBanner({
+  blockingCheck,
+  status,
+}: {
+  blockingCheck?: AuthorityEnvelopeEvaluation['checks'][number]
+  status: 'allows' | 'blocked' | 'incomplete'
+}) {
+  const copy =
+    status === 'allows'
+      ? {
+          detail: 'The exact Operation Invocation would be covered by the selected policy.',
+          title: 'Selected changes would allow this invocation',
+        }
+      : status === 'blocked'
+        ? {
+            detail: `${blockingCheck?.label ?? 'A required check'} cannot be changed automatically.`,
+            title: 'Cannot create a safe automatic policy update',
+          }
+        : {
+            detail: `${blockingCheck?.label ?? 'A required check'} remains outside policy.`,
+            title: 'Selected changes still require approval',
+          }
+
+  return (
+    <div
+      aria-live="polite"
+      style={{
+        ...policySelectionBannerStyle,
+        ...policySelectionBannerStatusStyles[status],
+      }}
+    >
+      <Typography.BodySmallStrong as="p" style={zeroMarginStyle}>
+        {copy.title}
+      </Typography.BodySmallStrong>
+      <Typography.BodySmall as="p" style={zeroMarginStyle} variant="secondary">
+        {copy.detail}
+      </Typography.BodySmall>
+    </div>
+  )
+}
+
 function PolicyUpdateProposalRow({
   candidatePolicy,
+  checked,
   label,
   observed,
+  onCheckedChange,
   policy,
   proposal,
   showDivider,
   status,
 }: {
   candidatePolicy?: string
+  checked: boolean
   label: string
   observed: string
+  onCheckedChange: (checked: boolean) => void
   policy: string
   proposal?: PolicyProposal
   showDivider: boolean
@@ -1903,11 +1984,18 @@ function PolicyUpdateProposalRow({
       proposedPolicyChange: 'Cannot propose automatically',
       reason: 'This check is not a mechanically expandable argument filter.',
     } satisfies PolicyProposal)
+  const isCreatingPolicy = candidatePolicy !== undefined
+  const selectable = isCreatingPolicy ? status === 'pass' : resolvedProposal.kind === 'automatic'
 
   return (
     <div style={{ ...policyProposalRowStyle, ...(!showDivider ? lastDetailRowStyle : {}) }}>
       <div style={policyProposalHeadingStyle}>
-        <Typography.BodySmallStrong as="h3">{label}</Typography.BodySmallStrong>
+        <PolicyChangeCheckbox
+          checked={checked}
+          disabled={!selectable}
+          label={label}
+          onCheckedChange={onCheckedChange}
+        />
         <Pill color={envelopeStatusColors[status]}>{envelopeStatusLabels[status]}</Pill>
       </div>
       <Typography.BodySmall as="p" style={policyObservedStyle} variant="secondary">
@@ -1919,6 +2007,41 @@ function PolicyUpdateProposalRow({
         proposal={resolvedProposal}
       />
     </div>
+  )
+}
+
+function PolicyChangeCheckbox({
+  checked,
+  disabled,
+  label,
+  onCheckedChange,
+}: {
+  checked: boolean
+  disabled: boolean
+  label: string
+  onCheckedChange: (checked: boolean) => void
+}) {
+  const checkboxId = useId()
+
+  return (
+    <label htmlFor={checkboxId} style={policyCheckboxLabelStyle}>
+      <Checkbox.Root
+        checked={checked}
+        disabled={disabled}
+        id={checkboxId}
+        onCheckedChange={onCheckedChange}
+        style={{
+          ...policyCheckboxStyle,
+          ...(checked ? policyCheckboxCheckedStyle : {}),
+          ...(disabled ? policyCheckboxDisabledStyle : {}),
+        }}
+      >
+        <Checkbox.Indicator style={policyCheckboxIndicatorStyle}>
+          <Icon name="Check" size="14" />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      <Typography.BodySmallStrong as="span">{label}</Typography.BodySmallStrong>
+    </label>
   )
 }
 
@@ -2385,6 +2508,34 @@ const policyProposalListStyle: CSSProperties = {
   marginTop: '16px',
 }
 
+const policySelectionBannerStyle: CSSProperties = {
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: '8px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2px',
+  marginTop: '16px',
+  padding: '10px 12px',
+}
+
+const policySelectionBannerStatusStyles: Record<
+  'allows' | 'blocked' | 'incomplete',
+  CSSProperties
+> = {
+  allows: {
+    background: theme.content.successBackground,
+    borderColor: theme.content.success,
+  },
+  blocked: {
+    background: theme.content.errorBackground,
+    borderColor: theme.content.error,
+  },
+  incomplete: {
+    background: theme.content.warningBackground,
+    borderColor: theme.content.warning,
+  },
+}
+
 const policyProposalRowStyle: CSSProperties = {
   borderBottom: `1px solid ${theme.stroke.secondary}`,
   padding: '12px 0',
@@ -2395,6 +2546,44 @@ const policyProposalHeadingStyle: CSSProperties = {
   display: 'flex',
   gap: '12px',
   justifyContent: 'space-between',
+}
+
+const policyCheckboxLabelStyle: CSSProperties = {
+  alignItems: 'center',
+  cursor: 'pointer',
+  display: 'flex',
+  gap: '8px',
+  minWidth: 0,
+}
+
+const policyCheckboxStyle: CSSProperties = {
+  alignItems: 'center',
+  background: theme.surface.main,
+  border: `1px solid ${theme.stroke.primary}`,
+  borderRadius: '4px',
+  color: theme.surface.main,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  flex: '0 0 16px',
+  height: '16px',
+  justifyContent: 'center',
+  width: '16px',
+}
+
+const policyCheckboxCheckedStyle: CSSProperties = {
+  background: theme.content.primary,
+  borderColor: theme.content.primary,
+}
+
+const policyCheckboxDisabledStyle: CSSProperties = {
+  cursor: 'not-allowed',
+  opacity: 0.45,
+}
+
+const policyCheckboxIndicatorStyle: CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'center',
 }
 
 const policyObservedStyle: CSSProperties = {

--- a/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
+++ b/apps/coral-ui/app/components/operation-approval/operation-approval.stories.tsx
@@ -2037,6 +2037,8 @@ function PolicyChangeCheckbox({
   onCheckedChange: (checked: boolean) => void
 }) {
   const checkboxId = useId()
+  const [focused, setFocused] = useState(false)
+  const [hovered, setHovered] = useState(false)
 
   return (
     <label htmlFor={checkboxId} style={policyCheckboxLabelStyle}>
@@ -2044,10 +2046,20 @@ function PolicyChangeCheckbox({
         checked={checked}
         disabled={disabled}
         id={checkboxId}
+        onBlur={() => setFocused(false)}
         onCheckedChange={onCheckedChange}
+        onFocus={() => setFocused(true)}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
         style={{
           ...policyCheckboxStyle,
           ...(checked ? policyCheckboxCheckedStyle : {}),
+          ...(hovered && !disabled
+            ? checked
+              ? policyCheckboxCheckedHoverStyle
+              : policyCheckboxHoverStyle
+            : {}),
+          ...(focused ? policyCheckboxFocusedStyle : {}),
           ...(disabled ? policyCheckboxDisabledStyle : {}),
         }}
       >
@@ -2573,8 +2585,8 @@ const policyCheckboxLabelStyle: CSSProperties = {
 
 const policyCheckboxStyle: CSSProperties = {
   alignItems: 'center',
-  background: 'transparent',
-  border: `2px solid ${theme.content.tertiary}`,
+  background: theme.button.secondary.default,
+  border: `2px solid ${theme.input.stroke.hover}`,
   borderRadius: '5px',
   color: theme.content.accentContent.primaryReverse,
   cursor: 'pointer',
@@ -2589,8 +2601,22 @@ const policyCheckboxStyle: CSSProperties = {
 }
 
 const policyCheckboxCheckedStyle: CSSProperties = {
-  background: theme.stroke.focused,
-  borderColor: theme.stroke.focused,
+  background: theme.button.primary.default,
+  borderColor: theme.button.primary.default,
+}
+
+const policyCheckboxHoverStyle: CSSProperties = {
+  background: theme.button.secondary.hover,
+  borderColor: theme.stroke.primary,
+}
+
+const policyCheckboxCheckedHoverStyle: CSSProperties = {
+  background: theme.button.primary.hover,
+  borderColor: theme.button.primary.hover,
+}
+
+const policyCheckboxFocusedStyle: CSSProperties = {
+  boxShadow: `0 0 0 2px ${theme.surface.floating}, 0 0 0 4px ${theme.input.stroke.focus}`,
 }
 
 const policyCheckboxDisabledStyle: CSSProperties = {
@@ -2633,7 +2659,7 @@ const policyDiffRemovedStyle: CSSProperties = {
 
 const policyDiffAddedStyle: CSSProperties = {
   background: theme.content.successBackground,
-  color: theme.content.success,
+  color: theme.content.accentContent.secondary,
 }
 
 const policyDiffCommentStyle: CSSProperties = {

--- a/apps/coral-ui/package-lock.json
+++ b/apps/coral-ui/package-lock.json
@@ -49,6 +49,7 @@
         "@vanilla-extract/css": "^1.20.1",
         "@vanilla-extract/vite-plugin": "^5.2.2",
         "@vitejs/plugin-react": "^6.0.2",
+        "arktype": "^2.2.3",
         "babel-plugin-react-compiler": "^1.0.0",
         "chromatic": "^17.4.1",
         "oxfmt": "^0.55.0",
@@ -64,6 +65,23 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ark/schema": {
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.56.2.tgz",
+      "integrity": "sha512-Qx4D2JFbBWpntiHZaTv7bGG4H/M2rigiknezKg/WVyDSaLdE4YCcWAOoFB7pjjDqHbbV2OqRfntm1nnXvwMexg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ark/util": "0.56.2"
+      }
+    },
+    "node_modules/@ark/util": {
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.56.2.tgz",
+      "integrity": "sha512-9kU2sUE38FZEGG7l3hamYMBieLYEJh2L1mrYD2eXpT+78EnQSV1bhjxJhnxGBMSTbtwpBSDNSK+K60WvaI/DTQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4552,6 +4570,28 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/arkregex": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.8.tgz",
+      "integrity": "sha512-PJcx6G1kQTgLKPUbeYlYecDRaKq15AMSGVajlKFYWlPeJRQL+j3dKE6tyMs40HZ99djS1l9Vhl3ezAHy9JBIqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ark/util": "0.56.2"
+      }
+    },
+    "node_modules/arktype": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.2.3.tgz",
+      "integrity": "sha512-7W+0RLTUNJiBFIIZXwOQxSR8Z273IAd6IvqBeG9+gHnQKFsIx2C0iOtGTmMrPnlX4qLXyc5+ll7A0BIj9WrbTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ark/schema": "0.56.2",
+        "@ark/util": "0.56.2",
+        "arkregex": "0.0.8"
       }
     },
     "node_modules/array-back": {

--- a/apps/coral-ui/package.json
+++ b/apps/coral-ui/package.json
@@ -63,6 +63,7 @@
     "@vanilla-extract/css": "^1.20.1",
     "@vanilla-extract/vite-plugin": "^5.2.2",
     "@vitejs/plugin-react": "^6.0.2",
+    "arktype": "^2.2.3",
     "babel-plugin-react-compiler": "^1.0.0",
     "chromatic": "^17.4.1",
     "oxfmt": "^0.55.0",


### PR DESCRIPTION
feat(coral-ui): prototype operation approval card states

refactor(coral-ui): structure operation approval story model

- align the story-only approval model and component boundary with Lagoon terminology
- add Task and exec request context to every dataset
- split the prototype into semantic in-file subcomponents
- render detail-row dividers only between rows