### PR TITLE
fix(app): open the Query Stream traces the list shows

### DIFF
--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -439,6 +439,39 @@ impl TraceScope {
     }
 }
 
+/// The workspace a set of spans settles on.
+///
+/// Most spans record no workspace of their own; the ones that do are what
+/// attributes the work around them. A set that names exactly one workspace
+/// belongs to it, and a set that names two belongs wholly to neither.
+#[derive(Debug, Default)]
+enum WorkspaceEvidence {
+    #[default]
+    None,
+    One(String),
+    Conflict,
+}
+
+impl WorkspaceEvidence {
+    fn record(&mut self, workspace: Option<&str>) {
+        let Some(workspace) = workspace.filter(|workspace| !workspace.trim().is_empty()) else {
+            return;
+        };
+        match self {
+            Self::None => *self = Self::One(workspace.to_string()),
+            Self::One(current) if current != workspace => *self = Self::Conflict,
+            Self::One(_) | Self::Conflict => {}
+        }
+    }
+
+    fn unique(&self) -> Option<&str> {
+        match self {
+            Self::One(workspace) => Some(workspace),
+            Self::None | Self::Conflict => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct TraceStoreFile {
     path: PathBuf,
@@ -828,11 +861,11 @@ impl TraceStore {
         query_stream::list(self, limit, offset, scope)
     }
 
-    fn get_trace_sync(
+    /// Reads every retained span of `trace_id`, before any scope is applied.
+    fn read_trace_spans_sync(
         &self,
         trace_id: &str,
-        scope: &TraceScope,
-    ) -> Result<TraceDetailRecord, TraceStoreError> {
+    ) -> Result<Vec<TraceSpanRecord>, TraceStoreError> {
         let mut spans_by_id = HashMap::new();
         self.prune_expired()?;
         let files = self.jsonl_files_by_modified()?;
@@ -856,7 +889,15 @@ impl TraceStore {
                 break;
             }
         }
-        let mut spans = spans_by_id.into_values().collect::<Vec<_>>();
+        Ok(spans_by_id.into_values().collect())
+    }
+
+    fn get_trace_sync(
+        &self,
+        trace_id: &str,
+        scope: &TraceScope,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        let mut spans = self.read_trace_spans_sync(trace_id)?;
         // The scope projects the trace rather than admitting it: a caller sees
         // the spans their own workspaces recorded and no others, so a trace
         // that two workspaces share carries no query text across the boundary.
@@ -868,28 +909,36 @@ impl TraceStore {
         if spans.is_empty() {
             return Err(TraceStoreError::NotFound(trace_id.to_string()));
         }
-
-        spans.sort_by(|left, right| {
-            left.start_time_unix_nanos
-                .cmp(&right.start_time_unix_nanos)
-                .then_with(|| left.span_id.cmp(&right.span_id))
-        });
+        sort_trace_spans(&mut spans);
 
         let summary = summary_from_spans(trace_id, &spans);
         Ok(TraceDetailRecord { summary, spans })
     }
 
+    /// Reads one Query Stream operation and the spans behind it.
+    ///
+    /// The list attributes an operation to a workspace from the evidence its
+    /// whole span tree carries, because the span that names the operation is
+    /// rarely the one that names the workspace. The detail therefore reads the
+    /// trace whole and scopes it the same way, or every operation the list
+    /// admitted on a descendant's evidence would answer the click that follows
+    /// it with a trace that was never recorded.
     fn get_query_stream_trace_sync(
         &self,
         trace_id: &str,
         scope: &TraceScope,
     ) -> Result<TraceDetailRecord, TraceStoreError> {
-        let mut detail = self.get_trace_sync(trace_id, scope)?;
-        let Some(summary) = query_stream::summary(&detail.spans, scope) else {
+        let mut spans = self.read_trace_spans_sync(trace_id)?;
+        let Some(summary) = query_stream::summary(&spans, scope) else {
             return Err(TraceStoreError::NotFound(trace_id.to_string()));
         };
-        detail.summary = summary;
-        Ok(detail)
+        scope_trace_spans(&mut spans, scope);
+        if spans.is_empty() {
+            return Err(TraceStoreError::NotFound(trace_id.to_string()));
+        }
+        sort_trace_spans(&mut spans);
+
+        Ok(TraceDetailRecord { summary, spans })
     }
 
     pub(crate) fn list_query_history_sync(
@@ -1873,6 +1922,41 @@ fn parse_attributes(attributes_json: &str) -> Option<JsonValue> {
 
 fn attributes_match_workspace(attributes_json: &str, workspace_name: &str) -> bool {
     workspace_attribute(attributes_json).is_some_and(|workspace| workspace == workspace_name)
+}
+
+fn sort_trace_spans(spans: &mut [TraceSpanRecord]) {
+    spans.sort_by(|left, right| {
+        left.start_time_unix_nanos
+            .cmp(&right.start_time_unix_nanos)
+            .then_with(|| left.span_id.cmp(&right.span_id))
+    });
+}
+
+/// Applies `scope` to the spans of one trace.
+///
+/// A trace is admitted whole when its spans settle on a single workspace the
+/// scope admits: most spans record no workspace of their own, and the few that
+/// do are what attributes the work around them. Admitting span by span instead
+/// would hand back a trace stripped of the ancestry that names its operation.
+///
+/// Spans naming two workspaces are the exception. There the scope projects
+/// rather than admits, so a trace two workspaces share carries no query text
+/// across the boundary and each owner sees only what their own workspaces
+/// recorded. A trace with nothing in scope reads exactly like one that was
+/// never recorded, which is the answer a caller who may not know it exists
+/// must get.
+fn scope_trace_spans(spans: &mut Vec<TraceSpanRecord>, scope: &TraceScope) {
+    if scope.admits_every_span() {
+        return;
+    }
+    let mut evidence = WorkspaceEvidence::default();
+    for span in spans.iter() {
+        evidence.record(workspace_attribute(&span.attributes_json).as_deref());
+    }
+    if scope.admits(evidence.unique()) {
+        return;
+    }
+    spans.retain(|span| scope.admits_span(&span.attributes_json));
 }
 
 fn workspace_attribute(attributes_json: &str) -> Option<String> {

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -5,15 +5,14 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 mod classification;
 
 use classification::{
-    QueryStreamMetadata, QueryStreamPrimaryOperation, QueryStreamWorkspaceEvidence,
-    is_unmarked_mcp_protocol_attributes, operation_text_from_attributes,
-    operation_text_is_semantic, query_stream_metadata,
+    QueryStreamMetadata, QueryStreamPrimaryOperation, is_unmarked_mcp_protocol_attributes,
+    operation_text_from_attributes, operation_text_is_semantic, query_stream_metadata,
 };
 
 use super::{
     StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceScope, TraceSpanRecord,
-    TraceStore, TraceStoreError, TraceSummaryRecord, attr_string, attr_u64, parse_attributes,
-    read_list_spans_file, status_from_attributes, usize_to_u32,
+    TraceStore, TraceStoreError, TraceSummaryRecord, WorkspaceEvidence, attr_string, attr_u64,
+    parse_attributes, read_list_spans_file, status_from_attributes, usize_to_u32,
 };
 use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
@@ -240,7 +239,7 @@ struct StreamingQueryStreamAggregate {
     span_count: usize,
     primary_descendant_operation: Option<QueryStreamPrimaryOperation>,
     text_enrichment: Option<QueryStreamTextEnrichment>,
-    workspace_evidence: QueryStreamWorkspaceEvidence,
+    workspace_evidence: WorkspaceEvidence,
 }
 
 impl StreamingQueryStreamAggregate {
@@ -250,7 +249,7 @@ impl StreamingQueryStreamAggregate {
             span_count: 0,
             primary_descendant_operation: None,
             text_enrichment: None,
-            workspace_evidence: QueryStreamWorkspaceEvidence::default(),
+            workspace_evidence: WorkspaceEvidence::default(),
         }
     }
 

--- a/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
@@ -222,31 +222,3 @@ impl QueryStreamPrimaryOperation {
         (self.depth, self.start_time_unix_nanos, &self.span_id)
     }
 }
-
-#[derive(Debug, Default)]
-pub(super) enum QueryStreamWorkspaceEvidence {
-    #[default]
-    None,
-    One(String),
-    Conflict,
-}
-
-impl QueryStreamWorkspaceEvidence {
-    pub(super) fn record(&mut self, workspace: Option<&str>) {
-        let Some(workspace) = workspace.filter(|workspace| !workspace.trim().is_empty()) else {
-            return;
-        };
-        match self {
-            Self::None => *self = Self::One(workspace.to_string()),
-            Self::One(current) if current != workspace => *self = Self::Conflict,
-            Self::One(_) | Self::Conflict => {}
-        }
-    }
-
-    pub(super) fn unique(&self) -> Option<&str> {
-        match self {
-            Self::One(workspace) => Some(workspace),
-            Self::None | Self::Conflict => None,
-        }
-    }
-}

--- a/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/storage_tests.rs
@@ -397,3 +397,72 @@ fn query_stream_keeps_scanning_when_file_mtime_is_coarse() {
         "hidden-newer"
     );
 }
+
+/// The span that names an operation is rarely the one that names a workspace:
+/// a gRPC server span roots the trace, and the `coral.query` beneath it is
+/// what records the workspace the work ran for. The list attributes the whole
+/// operation from that one span, so the detail behind it must do the same, or
+/// every row the list shows answers the click that follows it with a trace
+/// that was never recorded.
+#[test]
+fn query_stream_opens_a_trace_its_descendant_attributes() {
+    let files = TraceFiles::new();
+    let base_time = SystemTime::now() - Duration::from_secs(10);
+
+    let root = span("descendant-attributed", "grpc-root")
+        .named("coral.v1.CatalogService/ListCatalog")
+        .attrs(json!({"rpc.method": "ListCatalog", "status": "ok"}))
+        .times(
+            unix_nanos(base_time),
+            unix_nanos(base_time + Duration::from_millis(900)),
+        )
+        .build();
+    let query = span("descendant-attributed", "query-span")
+        .named("coral.query")
+        .child_of(&root)
+        .attrs(json!({
+            "workspace": "alpha",
+            "sql": "SELECT 42",
+            "row_count": 1,
+            "status": "ok",
+        }))
+        .times(
+            unix_nanos(base_time + Duration::from_millis(100)),
+            unix_nanos(base_time + Duration::from_millis(800)),
+        )
+        .build();
+    // The plan spans a query fans out are the bulk of any real trace and carry
+    // no workspace of their own.
+    let plan = span("descendant-attributed", "plan-span")
+        .named("optimize_logical_plan")
+        .child_of(&query)
+        .times(
+            unix_nanos(base_time + Duration::from_millis(200)),
+            unix_nanos(base_time + Duration::from_millis(700)),
+        )
+        .build();
+    files.write("spans-descendant-attributed.jsonl", &[root, query, plan]);
+
+    let summaries = files.list(10, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.into_iter().next().expect("listed summary");
+
+    let detail = files
+        .get("descendant-attributed", Some("alpha"))
+        .expect("the workspace that listed the operation opens it");
+    assert_eq!(detail.summary, summary);
+    assert_eq!(
+        detail
+            .spans
+            .iter()
+            .map(|span| span.span_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["grpc-root", "query-span", "plan-span"],
+        "the ancestry that names the operation travels with it",
+    );
+
+    assert!(files.list(10, 0, Some("beta")).is_empty());
+    files
+        .get("descendant-attributed", Some("beta"))
+        .expect_err("a workspace the trace never names reads it as absent");
+}

--- a/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
@@ -9,7 +9,8 @@ use super::super::tests::{
     write_record_file_lines,
 };
 use super::super::{
-    StoredTraceStatus, TraceScope, TraceSpanRecord, TraceStore, TraceSummaryRecord,
+    StoredTraceStatus, TraceDetailRecord, TraceScope, TraceSpanRecord, TraceStore, TraceStoreError,
+    TraceSummaryRecord,
 };
 
 pub(super) fn span(trace_id: &str, span_id: &str) -> TestSpan {
@@ -141,5 +142,14 @@ impl TraceFiles {
         TraceStore::new(self.temp.path().to_path_buf())
             .list_query_stream_sync(limit, offset, &scope(workspace_name))
             .expect("list query stream")
+    }
+
+    pub(super) fn get(
+        &self,
+        trace_id: &str,
+        workspace_name: Option<&str>,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        TraceStore::new(self.temp.path().to_path_buf())
+            .get_query_stream_trace_sync(trace_id, &scope(workspace_name))
     }
 }


### PR DESCRIPTION
## Intent

The desktop app lists Query Stream operations but cannot open any of them: clicking a row answers with `[not_found] trace '...' not found`. Every row is affected, so the Traces tab is effectively a dead list.

The two sides disagree about what "belongs to a workspace". The UI sends `workspace: default`, so the service builds `TraceScope::Workspaces(["default"])`, and:

- the **list** attributes an operation from evidence anywhere in its span tree — `StreamingQueryStreamAggregate::workspace()` falls back to `workspace_evidence.unique()`, so a descendant carrying the attribute attributes the whole operation;
- the **detail** filtered span by span — `get_trace_sync` retained only spans literally carrying `workspace`.

The span that names an operation is rarely the one that names the workspace. In a real 88-span trace from the reporter's store, exactly two spans carry `workspace`: a `coral.query` and one of its siblings. The root is `coral.v1.CatalogService/ListCatalog`, unattributed. The retain therefore dropped 86 of 88 spans, and the surviving `coral.query` was left with a parent that was no longer present — an `unresolved_local_parent`, which the projector deliberately hides. No entry, no summary, `NotFound`.

## The fix

`get_query_stream_trace_sync` now reads the trace whole, asks the same projector the list uses whether the scope admits the operation, and only then applies the scope to the spans it returns. `read_trace_spans_sync` is the unscoped file scan split out of `get_trace_sync` so both detail paths share it.

`scope_trace_spans` admits a trace whole when its spans settle on one workspace the scope admits. Spans naming two workspaces stay the exception: there the scope projects rather than admits, so a trace two workspaces share still carries no query text across the boundary and a trace with nothing in scope still reads as absent. `WorkspaceEvidence` moves up from `query_stream::classification` (was `QueryStreamWorkspaceEvidence`) now that both the projector and the detail path read it.

`get_trace_sync`, and with it the `All` view, is unchanged: its stricter rule is deliberate, and a test asserts that listing never reports a span its detail will not show.

## Verification

New `query_stream_opens_a_trace_its_descendant_attributes` builds the shape the reporter hit — a gRPC root with no workspace, a `coral.query` child carrying one, and an unattributed plan span beneath that. It fails against the previous code with `NotFound("descendant-attributed")` and passes now; a workspace the trace never names still reads it as absent.

Checked against the reporting store's own JSONL as well: the trace that returned `NotFound` opens with all 88 spans, and its summary matches the row the list shows.

`make rust-checks` passes.

## Left alone

The `All` list view still counts only workspace-attributed spans, so it would report `span_count: 2` for that 88-span trace. That is pre-existing and self-consistent within the view, and the desktop UI only ever requests `QUERY_STREAM` (`apps/coral-ui/app/routes/trace-detail-loader.ts:50`). Unifying the two views means reworking the bounded-scan early-stop proof, which is worth its own change.

https://claude.ai/code/session_01SSuFqMSoeC45VBwqYtnz6w
