### PR TITLE
fix(desktop): point MCP clients at Desktop's own Coral state

### DIFF
--- a/apps/coral-ui/app/components/onboarding/onboarding-next-steps-page.tsx
+++ b/apps/coral-ui/app/components/onboarding/onboarding-next-steps-page.tsx
@@ -1,4 +1,5 @@
 import { McpClientsList, type McpClientsConnectionState } from '@/components/mcp-clients-list'
+import type { McpLaunchConfig } from '@/lib/coral-desktop'
 import { Inputs, ScrollArea, Tabs, Typography } from '@/wax/components'
 import { CopyButton } from '@/wax/components/button'
 
@@ -8,13 +9,46 @@ import type { OnboardingStepState } from './onboarding-steps'
 
 export const CORAL_SKILL_INSTALL_COMMAND = 'npx skills add withcoral/skills --skill coral --global'
 
-export function coralAgentSetupPrompt(runtime: 'desktop' | 'web'): string {
+/**
+ * How an agent should launch the server, exactly.
+ *
+ * Desktop keeps its own Coral state, so a server started without
+ * `CORAL_CONFIG_DIR` resolves a different directory: the agent would read
+ * sources this app never shows, and none of its queries would reach the Traces
+ * view. The launch config is absent only if the app is older than the bridge
+ * that carries it, where naming the executable is still the useful half.
+ */
+function desktopInvocationGuidance(launchConfig?: McpLaunchConfig): string[] {
+  if (!launchConfig) {
+    return [
+      "Use Coral Desktop's bundled Coral executable for the local stdio MCP server. Resolve its actual path rather than assuming `coral` is on my agent's PATH.",
+    ]
+  }
+
+  const env = Object.entries(launchConfig.env)
+    .map(([name, value]) => `${name}=${value}`)
+    .join(' ')
+  return [
+    "Use Coral Desktop's bundled Coral runtime for the local stdio MCP server, configured exactly as below. Do not substitute a `coral` from my PATH, and do not drop the environment variable.",
+    '',
+    `- command: ${launchConfig.command}`,
+    `- arguments: ${launchConfig.args.join(' ')}`,
+    `- environment: ${env}`,
+    '',
+    'CORAL_CONFIG_DIR points the server at the same Coral state the desktop app runs against. Without it the server reads a different set of sources and workspaces, and nothing it does shows up in the app.',
+  ]
+}
+
+export function coralAgentSetupPrompt(
+  runtime: 'desktop' | 'web',
+  launchConfig?: McpLaunchConfig,
+): string {
   const runtimeGuidance =
     runtime === 'desktop'
       ? [
           'I have completed Coral onboarding and connected at least one source. I am running Coral Desktop with its bundled Coral runtime.',
           '',
-          "Use Coral Desktop's bundled Coral executable for the local stdio MCP server. Resolve its actual path rather than assuming `coral` is on my agent's PATH.",
+          ...desktopInvocationGuidance(launchConfig),
           '',
           'Set it up as follows:',
         ]
@@ -63,19 +97,22 @@ export type OnboardingNextStepsPageProps = {
   onContinue?: () => void
   step: OnboardingStepState
 } & (
-  | ({ runtime: 'desktop' } & ConnectClientsProps)
-  | ({ runtime: 'web' } & Partial<Record<keyof ConnectClientsProps, never>>)
+  | ({ mcpLaunchConfig?: McpLaunchConfig; runtime: 'desktop' } & ConnectClientsProps)
+  | ({ mcpLaunchConfig?: never; runtime: 'web' } & Partial<
+      Record<keyof ConnectClientsProps, never>
+    >)
 )
 
 export function OnboardingNextStepsPage({
   completing = false,
   mcpClients,
+  mcpLaunchConfig,
   onContinue,
   runtime,
   step,
   workspaces,
 }: OnboardingNextStepsPageProps) {
-  const agentSetupPrompt = coralAgentSetupPrompt(runtime)
+  const agentSetupPrompt = coralAgentSetupPrompt(runtime, mcpLaunchConfig)
 
   return (
     <OnboardingPage

--- a/apps/coral-ui/app/routes/onboarding.tsx
+++ b/apps/coral-ui/app/routes/onboarding.tsx
@@ -22,6 +22,7 @@ import { runSourcesAction } from './sources-action'
 import { loadSourcesRouteData } from './sources-loader'
 import {
   loadDesktopMcpClients,
+  loadDesktopMcpLaunchConfig,
   updateDesktopMcpClient,
   type DesktopMcpClientData,
 } from './settings-loader'
@@ -78,10 +79,11 @@ export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
   const loaderData = await serverLoader()
   if (loaderData.runtime !== 'desktop') return loaderData
 
-  return {
-    ...loaderData,
-    mcpClients: await loadDesktopMcpClients(),
-  }
+  const [mcpClients, mcpLaunchConfig] = await Promise.all([
+    loadDesktopMcpClients(),
+    loadDesktopMcpLaunchConfig(),
+  ])
+  return { ...loaderData, mcpClients, mcpLaunchConfig }
 }
 
 clientLoader.hydrate = true as const
@@ -137,6 +139,7 @@ function OnboardingExperience({
         },
         pendingClientIds: typeof pendingClientId === 'string' ? [pendingClientId] : [],
       }}
+      mcpLaunchConfig={'mcpLaunchConfig' in loaderData ? loaderData.mcpLaunchConfig : undefined}
     />
   )
 }

--- a/apps/coral-ui/app/routes/settings-loader.ts
+++ b/apps/coral-ui/app/routes/settings-loader.ts
@@ -5,6 +5,7 @@ import {
   desktopErrorMessage,
   isCoralDesktopBuild,
   type McpClientDescriptor,
+  type McpLaunchConfig,
 } from '@/lib/coral-desktop'
 import { remoteMcpClientInstructions, webMcpClients } from '@/lib/mcp-clients'
 import { mcpConnectionFromEnv } from '@/lib/mcp-connection'
@@ -55,6 +56,19 @@ export async function clientLoader({
   return {
     mcpClients: await loadDesktopMcpClients(),
     runtime: 'desktop',
+  }
+}
+
+/**
+ * How Desktop wants a client to launch the server, for instructions a person or
+ * an agent follows by hand. Absent when the bridge cannot answer, which the
+ * instructions degrade around rather than fail on.
+ */
+export async function loadDesktopMcpLaunchConfig(): Promise<McpLaunchConfig | undefined> {
+  try {
+    return await coralDesktopApi()?.getMcpLaunchConfig()
+  } catch {
+    return undefined
   }
 }
 

--- a/apps/coral-ui/app/views/onboarding/onboarding.tsx
+++ b/apps/coral-ui/app/views/onboarding/onboarding.tsx
@@ -4,6 +4,7 @@ import { Await, useNavigate, useNavigation, useRevalidator, useSubmit } from 're
 import type { SourcesActionData } from '@/routes/sources-action'
 
 import type { McpClientsConnectionState } from '@/components/mcp-clients-list'
+import type { McpLaunchConfig } from '@/lib/coral-desktop'
 import { OnboardingNextStepsPage } from '@/components/onboarding/onboarding-next-steps-page'
 import { OnboardingSampleQueryPage } from '@/components/onboarding/onboarding-sample-query-page'
 import type { SampleQueryLoadState } from '@/components/onboarding/onboarding-sample-query-page'
@@ -20,6 +21,7 @@ export function OnboardingView({
   actionData,
   loaderData,
   mcpClients,
+  mcpLaunchConfig,
 }: {
   actionData: CompleteGuiOnboardingError | SourcesActionData
   loaderData: {
@@ -32,6 +34,7 @@ export function OnboardingView({
     workspaces: ReadonlyArray<{ name: string }>
   }
   mcpClients: McpClientsConnectionState
+  mcpLaunchConfig?: McpLaunchConfig
 }) {
   const navigate = useNavigate()
   const navigation = useNavigation()
@@ -94,6 +97,7 @@ export function OnboardingView({
         <OnboardingNextStepsStep
           completing={completing}
           mcpClients={mcpClients}
+          mcpLaunchConfig={mcpLaunchConfig}
           onContinue={() =>
             submit({ intent: COMPLETE_ONBOARDING_INTENT }, { method: 'post', replace: true })
           }
@@ -112,6 +116,7 @@ export function OnboardingView({
 function OnboardingNextStepsStep({
   completing,
   mcpClients,
+  mcpLaunchConfig,
   onContinue,
   runtime,
   step,
@@ -119,6 +124,7 @@ function OnboardingNextStepsStep({
 }: {
   completing: boolean
   mcpClients: McpClientsConnectionState
+  mcpLaunchConfig?: McpLaunchConfig
   onContinue: () => void
   runtime: 'desktop' | 'web'
   step: OnboardingStepState
@@ -130,6 +136,7 @@ function OnboardingNextStepsStep({
         <OnboardingNextStepsPage
           completing={completing}
           mcpClients={mcpClients}
+          mcpLaunchConfig={mcpLaunchConfig}
           onContinue={onContinue}
           runtime="desktop"
           step={step}

--- a/apps/desktop/src/main/mcp-config.test.ts
+++ b/apps/desktop/src/main/mcp-config.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const USER_DATA = '/home/coral/.config/Coral'
+const CONFIG_DIR = `${USER_DATA}/coral`
+const CORAL_BIN = '/Applications/Coral.app/Contents/Resources/coral/coral'
+
+const mocks = vi.hoisted(() => ({
+  listInstalledServers: vi.fn(),
+  upsertServer: vi.fn(),
+}))
+
+vi.mock('electron', () => ({ app: { isPackaged: true, getPath: () => USER_DATA } }))
+vi.mock('./coral-config', () => ({
+  desktopCoralConfigDir: (userDataDir: string, directory = 'coral') => `${userDataDir}/${directory}`,
+  ensureDesktopCoralConfig: vi.fn(),
+}))
+vi.mock('./sidecar', async () => {
+  const actual = await vi.importActual<typeof import('./sidecar')>('./sidecar')
+  return { ...actual, externalCoralPath: async () => CORAL_BIN }
+})
+vi.mock('add-mcp', async () => {
+  const actual = await vi.importActual<typeof import('add-mcp')>('add-mcp')
+  return {
+    ...actual,
+    listInstalledServers: mocks.listInstalledServers,
+    upsertServer: mocks.upsertServer,
+  }
+})
+
+import { agents } from 'add-mcp'
+
+import { configureMcpClient, getMcpLaunchConfig, mcpClients } from './mcp-config'
+
+/** One installed client whose global `coral` entry holds `config`. */
+function installed(config: unknown) {
+  mocks.listInstalledServers.mockResolvedValue([
+    {
+      agentType: 'claude-code',
+      displayName: 'Claude Code',
+      detected: true,
+      servers: [{ agentType: 'claude-code', serverName: 'coral', config }],
+    },
+  ])
+}
+
+function claudeCodeConfig(env?: Record<string, string>) {
+  return agents['claude-code'].transformConfig(
+    'coral',
+    { command: CORAL_BIN, args: ['mcp-stdio', '--workspace=default'], ...(env ? { env } : {}) },
+    { local: false },
+  )
+}
+
+describe('desktop MCP client configuration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.upsertServer.mockReturnValue({ success: true })
+  })
+
+  it('points a configured client at the state directory Desktop runs against', async () => {
+    mocks.listInstalledServers.mockResolvedValue([
+      { agentType: 'claude-code', displayName: 'Claude Code', detected: true, servers: [] },
+    ])
+
+    await configureMcpClient('claude-code', 'default')
+
+    expect(mocks.upsertServer).toHaveBeenCalledWith(
+      'claude-code',
+      'coral',
+      {
+        args: ['mcp-stdio', '--workspace=default'],
+        command: CORAL_BIN,
+        env: { CORAL_CONFIG_DIR: CONFIG_DIR },
+      },
+      { local: false },
+    )
+  })
+
+  it('reports the workspace of an entry it wrote', async () => {
+    installed(claudeCodeConfig({ CORAL_CONFIG_DIR: CONFIG_DIR }))
+
+    await expect(mcpClients()).resolves.toEqual([
+      { configuredWorkspace: 'default', id: 'claude-code', name: 'Claude Code' },
+    ])
+  })
+
+  // An entry written before Desktop pointed clients at its own state must stay
+  // manageable, or the app refuses to touch the entry it wrote itself.
+  it('still manages an entry written without the state directory', async () => {
+    installed(claudeCodeConfig())
+
+    await expect(mcpClients()).resolves.toEqual([
+      { configuredWorkspace: 'default', id: 'claude-code', name: 'Claude Code' },
+    ])
+
+    await configureMcpClient('claude-code', 'default')
+    expect(mocks.upsertServer).toHaveBeenCalledWith(
+      'claude-code',
+      'coral',
+      expect.objectContaining({ env: { CORAL_CONFIG_DIR: CONFIG_DIR } }),
+      { local: false },
+    )
+  })
+
+  it('leaves an entry pointed at another state directory alone', async () => {
+    installed(claudeCodeConfig({ CORAL_CONFIG_DIR: '/somewhere/else' }))
+
+    await expect(mcpClients()).resolves.toEqual([{ id: 'claude-code', name: 'Claude Code' }])
+    await expect(configureMcpClient('claude-code', 'default')).rejects.toThrow(
+      'already has an incompatible global MCP server named "coral"',
+    )
+  })
+
+  it('carries the state directory in the launch config it hands out', async () => {
+    await expect(getMcpLaunchConfig()).resolves.toEqual({
+      args: ['mcp-stdio'],
+      command: CORAL_BIN,
+      env: { CORAL_CONFIG_DIR: CONFIG_DIR },
+    })
+  })
+})

--- a/apps/desktop/src/main/mcp-config.ts
+++ b/apps/desktop/src/main/mcp-config.ts
@@ -11,7 +11,7 @@ import {
 } from 'add-mcp'
 import { isDeepStrictEqual } from 'node:util'
 import type { McpClientDescriptor, McpLaunchConfig } from '../shared/types'
-import { externalCoralPath } from './sidecar'
+import { desktopCoralStateDir, externalCoralPath } from './sidecar'
 
 const DEFAULT_WORKSPACE = 'default'
 
@@ -88,11 +88,31 @@ function persistedShape(value: unknown): unknown {
   return json === undefined ? undefined : JSON.parse(json)
 }
 
+function desktopCoralEnv(): Record<string, string> {
+  return { CORAL_CONFIG_DIR: desktopCoralStateDir() }
+}
+
+/**
+ * Whether this entry is one Desktop wrote, and so one it may rewrite.
+ *
+ * Entries written before Desktop pointed clients at its own state carry no
+ * `CORAL_CONFIG_DIR`, and are recognised here so the app can still show and
+ * upgrade them. Rejecting them would strand a user with an entry Desktop
+ * refuses to touch and no way to fix it but hand-editing the client's config.
+ */
 function isCanonicalCoralConfig(server: InstalledServer, invocation: McpServerConfig): boolean {
-  const expected = agents[server.agentType].transformConfig('coral', invocation, {
-    local: false,
-  })
-  return isDeepStrictEqual(persistedShape(server.config), persistedShape(expected))
+  const persisted = persistedShape(server.config)
+  const candidates: McpServerConfig[] = [
+    { ...invocation, env: desktopCoralEnv() },
+    // The shape Desktop wrote before it pointed clients at its own state.
+    invocation,
+  ]
+  return candidates.some((candidate) =>
+    isDeepStrictEqual(
+      persisted,
+      persistedShape(agents[server.agentType].transformConfig('coral', candidate, { local: false })),
+    ),
+  )
 }
 
 function coralEntry(servers: readonly InstalledServer[]): CoralEntry {
@@ -126,10 +146,19 @@ export async function mcpClients(): Promise<McpClientDescriptor[]> {
     })
 }
 
+/**
+ * The invocation Desktop writes into a client's config.
+ *
+ * `CORAL_CONFIG_DIR` is what makes the server the client launches the same
+ * Coral this app shows. Without it the binary resolves its own default
+ * directory, and the agent reads a different set of sources and workspaces
+ * while its queries never reach the Traces view.
+ */
 async function mcpLaunchConfig(workspaceName?: string): Promise<McpLaunchConfig> {
   return {
     args: workspaceName ? ['mcp-stdio', `--workspace=${workspaceName}`] : ['mcp-stdio'],
     command: await externalCoralPath(),
+    env: desktopCoralEnv(),
   }
 }
 

--- a/apps/desktop/src/main/sidecar.test.ts
+++ b/apps/desktop/src/main/sidecar.test.ts
@@ -17,6 +17,7 @@ vi.mock('electron', () => ({
 }))
 // Stubbed so the test never creates a real config directory on disk.
 vi.mock('./coral-config', () => ({
+  desktopCoralConfigDir: (userDataDir: string, directory = 'coral') => `${userDataDir}/${directory}`,
   ensureDesktopCoralConfig: mocks.ensureDesktopCoralConfig,
 }))
 

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -4,7 +4,7 @@ import { constants } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { app } from 'electron'
-import { ensureDesktopCoralConfig } from './coral-config'
+import { desktopCoralConfigDir, ensureDesktopCoralConfig } from './coral-config'
 
 export interface CoralSidecar {
   url: string
@@ -116,6 +116,28 @@ function envWithLoopbackNoProxy(configDir: string): NodeJS.ProcessEnv {
   return env
 }
 
+/**
+ * Where Desktop keeps its own Coral state, isolated from a terminal user's
+ * standalone CLI state. A dev build additionally keys the directory by its
+ * sidecar port, so two checkouts running side by side do not share one runtime.
+ */
+function desktopCoralConfigOptions(): { bindAddr?: string; directory?: string } {
+  if (app.isPackaged) return {}
+  const devPort = process.env.CORAL_DEV_SIDECAR_PORT || '8778'
+  return { bindAddr: `127.0.0.1:${devPort}`, directory: `coral-dev-${devPort}` }
+}
+
+/**
+ * The state directory the sidecar runs against, resolved without creating it.
+ *
+ * Anything Desktop launches, or teaches another program to launch, has to be
+ * pointed here: a Coral process that resolves its own default directory reads
+ * different sources, workspaces and traces than the ones this app shows.
+ */
+export function desktopCoralStateDir(): string {
+  return desktopCoralConfigDir(app.getPath('userData'), desktopCoralConfigOptions().directory)
+}
+
 // Every spawned sidecar process, tracked from spawn time so teardown can
 // force-kill even one that is still starting up — its handle is otherwise only
 // exposed once the start promise resolves.
@@ -128,13 +150,10 @@ export function killAllTrackedChildren(): void {
 }
 
 export async function startCoralSidecar(): Promise<CoralSidecar> {
-  const devPort = process.env.CORAL_DEV_SIDECAR_PORT || '8778'
-  const configDir = app.isPackaged
-    ? await ensureDesktopCoralConfig(app.getPath('userData'))
-    : await ensureDesktopCoralConfig(app.getPath('userData'), {
-        bindAddr: `127.0.0.1:${devPort}`,
-        directory: `coral-dev-${devPort}`,
-      })
+  const configDir = await ensureDesktopCoralConfig(
+    app.getPath('userData'),
+    desktopCoralConfigOptions(),
+  )
   const command = sidecarCommand()
   const child = spawn(command.command, command.args, {
     cwd: command.cwd,

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -9,6 +9,8 @@ export interface McpClientDescriptor {
 export interface McpLaunchConfig {
   args: string[]
   command: string
+  /** Always carries CORAL_CONFIG_DIR: the state directory this app runs against. */
+  env: Record<string, string>
 }
 
 export type DesktopUpdateState =


### PR DESCRIPTION
## Intent

Nothing an agent does through Coral shows up in the desktop app. Its Traces tab lists only what the app itself triggered; MCP operations never appear, and the sources the agent sees are not the ones the app shows.

Desktop keeps its own Coral state (#2198): the sidecar is launched with `CORAL_CONFIG_DIR` pointed at `<userData>/coral`, with the directive that "Desktop-launched Coral processes must receive the Desktop-owned `CORAL_CONFIG_DIR`". An MCP stdio server is not Desktop-launched — the client launches it — and `configureMcpClient` wrote the entry with no `env`. So the app told Claude Code to run the app's *bundled binary* against the *standalone CLI's* state: a different `config.toml`, a different `coral.db`, different workspaces, and a different local trace store.

On the reporting machine the two directories had diverged completely: one source (`github`) in Desktop's state, eight (`claude`, `codex`, `github_v4`, `linear`, …) in the standalone one, and 50 trace files the app could never read.

## The fix

`mcpLaunchConfig` now carries `env: { CORAL_CONFIG_DIR }`, resolved from `desktopCoralStateDir()` — the same directory the sidecar runs against, extracted from `startCoralSidecar` so the two cannot drift, dev port suffix included.

`isCanonicalCoralConfig` accepts an entry that matches either the new shape or the env-less one Desktop used to write. Without that, every existing entry would read as a foreign `coral` server: the app would report a collision, refuse to reconfigure or remove it, and leave hand-editing the client's config as the only way out. Entries are rewritten only when a person configures the client, never behind their back, and an entry pointed at some third directory is still left alone.

The AI-assisted onboarding prompt is the other door into the same split. It now hands the agent the exact command, arguments and environment instead of "resolve the executable yourself", so an agent-driven setup lands on Desktop's state too. It degrades to the old wording when the bridge cannot answer.

## Verification

New `apps/desktop/src/main/mcp-config.test.ts` covers the five cases: a configured client gets the state directory; an entry Desktop wrote is recognised; a legacy env-less entry stays manageable and is upgraded on the next configure (this one fails without the compatibility candidate); an entry pointed elsewhere is left alone; the launch config carries the directory.

Checked live against the reporting machine, with the desktop app and its sidecar running:

- `coral mcp-stdio --workspace=default` with `CORAL_CONFIG_DIR` set to Desktop's directory starts clean against the same state the sidecar holds — no lock contention, no errors, `serverInfo` "Coral / default".
- Its spans land in Desktop's trace store, and the Query Stream list shows the MCP operations with every one openable.
- A keychain-backed source still resolves its credential when the server is launched by the client rather than by the app: a real `github.org_repos` query returned rows, no prompt.

`npm run check`, `npm run typecheck` and `npm test` pass for both `apps/desktop` and `apps/coral-ui`.

## Note for existing users

Nothing moves on upgrade. An existing client entry keeps working against the standalone directory until someone presses Configure in the app, at which point that client switches to Desktop's state and will see the sources configured there. Sources added in the CLI's directory do not follow.

Opening MCP traces in the app also needs #2298, which fixes the Query Stream detail lookup for workspace-scoped callers. The two are independent and can merge in either order.

https://claude.ai/code/session_01SSuFqMSoeC45VBwqYtnz6w
