### PR TITLE
fix(coral-ui): report a failed trace read inside the detail panel

### DIFF
--- a/apps/coral-ui/app/views/traces/trace-detail.tsx
+++ b/apps/coral-ui/app/views/traces/trace-detail.tsx
@@ -661,7 +661,6 @@ function TraceDetailContent({
   olderTraceId,
   onClose,
   onSelectTrace,
-  traceId,
 }: {
   detail: TraceDetailData | null
   extraTabs?: (detail: TraceDetailData) => ExtraDetailTab[]
@@ -671,15 +670,10 @@ function TraceDetailContent({
   olderTraceId?: string | null
   onClose: () => void
   onSelectTrace?: (traceId: string) => void
-  traceId: string
 }) {
   const [activeTab, setActiveTab] = useState<string>('timeline')
   const [expandedHttpSpanId, setExpandedHttpSpanId] = useState<string | null>(null)
   const [navigableSpanIds, setNavigableSpanIds] = useState<string[]>([])
-  useEffect(() => {
-    setActiveTab('timeline')
-    setExpandedHttpSpanId(null)
-  }, [traceId])
 
   const selectAdjacentSpan = useCallback(
     (direction: -1 | 1) => {
@@ -917,6 +911,7 @@ export function TraceDetail({
   return (
     <div className={s.detailOverlay}>
       <TraceDetailContent
+        key={traceId}
         detail={detail}
         extraTabs={extraTabs}
         initialSummary={initialSummary}
@@ -932,7 +927,6 @@ export function TraceDetail({
         onSelectTrace={(nextTraceId) =>
           navigate(traceLocation(workspaceId, nextTraceId, location.search))
         }
-        traceId={traceId}
       />
     </div>
   )

--- a/apps/coral-ui/app/views/traces/trace-detail.tsx
+++ b/apps/coral-ui/app/views/traces/trace-detail.tsx
@@ -770,24 +770,16 @@ function TraceDetailContent({
     [detail, extraTabs],
   )
 
-  if (loadError)
-    return (
-      <div className={s.detailEmpty}>
-        <KeyboardShortcut handler={handleEscapeShortcut} shortcut="Escape" />
-        <EmptyPage description={loadError} iconName="CircleAlert" title="Tracing unavailable" />
-        <Button.TextButton onClick={onClose} variant="secondary">
-          Back to query stream
-        </Button.TextButton>
-      </div>
-    )
   if (!summary) {
     return (
       <div className={s.detailEmpty}>
         <KeyboardShortcut handler={handleEscapeShortcut} shortcut="Escape" />
         <EmptyPage
-          title="No spans for this trace"
-          description="This trace did not include an operation summary or spans to display."
-          iconName="Activity"
+          description={
+            loadError ?? 'This trace did not include an operation summary or spans to display.'
+          }
+          iconName={loadError ? 'CircleAlert' : 'Activity'}
+          title={loadError ? 'Tracing unavailable' : 'No spans for this trace'}
         />
         <Button.TextButton onClick={onClose} variant="secondary">
           Back to query stream
@@ -891,6 +883,8 @@ function TraceDetailContent({
               spans={detail.spans}
               summary={summary}
             />
+          ) : loadError ? (
+            <EmptyPage description={loadError} iconName="CircleAlert" title="Spans unavailable" />
           ) : null)}
         {activeExtraTab?.content}
       </div>

--- a/apps/coral-ui/app/views/traces/traces.stories.tsx
+++ b/apps/coral-ui/app/views/traces/traces.stories.tsx
@@ -10,6 +10,7 @@ import {
   TraceSummarySchema,
 } from '@/generated/coral/v1/traces_pb'
 
+import { TraceDetail } from './trace-detail'
 import { TracesIndex } from './traces-index'
 import type { TraceSummaryData } from './trace-utils'
 
@@ -60,7 +61,10 @@ const traces = [
   }),
 ]
 
+type TraceDetailProps = React.ComponentProps<typeof TraceDetail>
+
 const TraceStoryContext = createContext<React.ComponentProps<typeof TracesIndex> | null>(null)
+const TraceDetailStoryContext = createContext<TraceDetailProps | null>(null)
 
 function TraceStoryRoute() {
   const args = useContext(TraceStoryContext)
@@ -68,18 +72,35 @@ function TraceStoryRoute() {
   return <TracesIndex {...args} />
 }
 
+function TraceDetailStoryRoute() {
+  const props = useContext(TraceDetailStoryContext)
+  if (!props) throw new Error('trace detail story props are unavailable')
+  return <TraceDetail {...props} />
+}
+
 const RoutesStub = createRoutesStub([
   {
     Component: TraceStoryRoute,
+    children: [{ Component: TraceDetailStoryRoute, path: ':traceId' }],
     path: '/workspaces/:workspaceId/traces',
   },
 ])
 
-function TraceStory(args: React.ComponentProps<typeof TracesIndex>) {
+function TraceStory({
+  detail,
+  ...args
+}: React.ComponentProps<typeof TracesIndex> & { detail?: TraceDetailProps }) {
+  const path = detail
+    ? `/workspaces/default/traces/${detail.traceId}`
+    : '/workspaces/default/traces'
   return (
-    <TraceStoryContext value={args}>
-      <RoutesStub initialEntries={['/workspaces/default/traces']} />
-    </TraceStoryContext>
+    <div style={{ height: '100dvh' }}>
+      <TraceStoryContext value={args}>
+        <TraceDetailStoryContext value={detail ?? null}>
+          <RoutesStub initialEntries={[path]} />
+        </TraceDetailStoryContext>
+      </TraceStoryContext>
+    </div>
   )
 }
 
@@ -93,11 +114,7 @@ const meta = {
   },
   component: TracesIndex,
   parameters: { layout: 'fullscreen' },
-  render: (args) => (
-    <div style={{ height: '100dvh' }}>
-      <TraceStory {...args} />
-    </div>
-  ),
+  render: (args) => <TraceStory {...args} />,
   tags: ['autodocs'],
   title: 'Views/Traces',
 } satisfies Meta<typeof TracesIndex>
@@ -113,4 +130,21 @@ export const Disconnected: Story = {
   args: {
     loadError: 'Could not connect to Coral. Retrying automatically.',
   },
+}
+
+/**
+ * The detail read can fail for a row the list showed. The row keeps the
+ * header, stats and query text, so the failure replaces the spans only.
+ */
+export const DetailSpansUnavailable: Story = {
+  render: (args) => (
+    <TraceStory
+      {...args}
+      detail={{
+        detail: null,
+        loadError: `[not_found] trace '${traces[0].traceId}' not found`,
+        traceId: traces[0].traceId,
+      }}
+    />
+  ),
 }


### PR DESCRIPTION
## Summary

Says on the tin. In the previous version, we replaced the whole screen with just the error message, so we got stuck in that page.

## Test plan

New version: the error is confined just to a small area; users can still navigate back, change trace, etc

<img width="1484" height="666" alt="image" src="https://github.com/user-attachments/assets/f0701c95-9db9-41e0-9734-d73ff8e4cd16" />
