### PR TITLE
fix(desktop): pass config dir to MCP clients

### DIFF
--- a/apps/desktop/src/main/coral-config.test.ts
+++ b/apps/desktop/src/main/coral-config.test.ts
@@ -2,9 +2,20 @@ import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { ensureDesktopCoralConfig } from './coral-config'
+import { desktopRuntimeCoralConfigOptions, ensureDesktopCoralConfig } from './coral-config'
 
 describe('ensureDesktopCoralConfig', () => {
+  it('uses the stable Desktop config directory in packaged builds', () => {
+    expect(desktopRuntimeCoralConfigOptions(true)).toEqual({})
+  })
+
+  it('keeps unpackaged sidecars in their fixed-port development config directory', () => {
+    expect(desktopRuntimeCoralConfigOptions(false, { CORAL_DEV_SIDECAR_PORT: '9001' })).toEqual({
+      bindAddr: '127.0.0.1:9001',
+      directory: 'coral-dev-9001',
+    })
+  })
+
   it('creates an isolated ephemeral-loopback server configuration', async () => {
     const userData = await mkdtemp(join(tmpdir(), 'coral-desktop-'))
     const configDir = await ensureDesktopCoralConfig(userData)

--- a/apps/desktop/src/main/coral-config.ts
+++ b/apps/desktop/src/main/coral-config.ts
@@ -1,9 +1,22 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-interface DesktopCoralConfigOptions {
+export interface DesktopCoralConfigOptions {
   bindAddr?: string
   directory?: string
+}
+
+export function desktopRuntimeCoralConfigOptions(
+  isPackaged: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): DesktopCoralConfigOptions {
+  if (isPackaged) return {}
+
+  const devPort = env.CORAL_DEV_SIDECAR_PORT || '8778'
+  return {
+    bindAddr: `127.0.0.1:${devPort}`,
+    directory: `coral-dev-${devPort}`,
+  }
 }
 
 export function desktopCoralConfigDir(userDataDir: string, directory = 'coral'): string {

--- a/apps/desktop/src/main/mcp-config.test.ts
+++ b/apps/desktop/src/main/mcp-config.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getPath: vi.fn(),
+  ensureDesktopCoralConfig: vi.fn(),
+  externalCoralPath: vi.fn(),
+  getAgentTypes: vi.fn(),
+  listInstalledServers: vi.fn(),
+  removeServer: vi.fn(),
+  upsertServer: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: mocks.getPath,
+  },
+}))
+
+vi.mock('add-mcp', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('add-mcp')>()
+  return {
+    ...actual,
+    getAgentTypes: mocks.getAgentTypes,
+    listInstalledServers: mocks.listInstalledServers,
+    removeServer: mocks.removeServer,
+    upsertServer: mocks.upsertServer,
+  }
+})
+
+vi.mock('./coral-config', () => ({
+  desktopRuntimeCoralConfigOptions: vi.fn(() => ({})),
+  ensureDesktopCoralConfig: mocks.ensureDesktopCoralConfig,
+}))
+
+vi.mock('./sidecar', () => ({
+  externalCoralPath: mocks.externalCoralPath,
+}))
+
+const { configureMcpClient, mcpClients } = await import('./mcp-config')
+const { agents } = await import('add-mcp')
+
+describe('desktop MCP client configuration', () => {
+  const userData = '/Users/simon/Library/Application Support/@withcoral/desktop'
+  const configDir = `${userData}/coral`
+  const coralCommand = '/Applications/Coral.app/Contents/Resources/coral/coral'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getPath.mockReturnValue(userData)
+    mocks.ensureDesktopCoralConfig.mockResolvedValue(configDir)
+    mocks.externalCoralPath.mockResolvedValue(coralCommand)
+    mocks.getAgentTypes.mockReturnValue(['claude-code'])
+    mocks.listInstalledServers.mockResolvedValue([
+      {
+        agentType: 'claude-code',
+        detected: true,
+        displayName: 'Claude Code',
+        servers: [],
+      },
+    ])
+    mocks.upsertServer.mockReturnValue({ success: true })
+  })
+
+  it('installs Coral stdio with Desktop’s config directory in the agent environment', async () => {
+    await configureMcpClient('claude-code', 'default')
+
+    expect(mocks.upsertServer).toHaveBeenCalledWith(
+      'claude-code',
+      'coral',
+      {
+        args: ['mcp-stdio', '--workspace=default'],
+        command: coralCommand,
+        env: { CORAL_CONFIG_DIR: configDir },
+      },
+      { local: false },
+    )
+  })
+
+  it('keeps Desktop’s config directory when add-mcp transforms the Claude Code config', () => {
+    expect(
+      agents['claude-code'].transformConfig(
+        'coral',
+        {
+          args: ['mcp-stdio', '--workspace=default'],
+          command: coralCommand,
+          env: { CORAL_CONFIG_DIR: configDir },
+        },
+        { local: false },
+      ),
+    ).toMatchObject({ env: { CORAL_CONFIG_DIR: configDir } })
+  })
+
+  it('recognizes an installed Coral server that includes Desktop’s config directory', async () => {
+    mocks.listInstalledServers.mockResolvedValue([
+      {
+        agentType: 'claude-code',
+        detected: true,
+        displayName: 'Claude Code',
+        servers: [
+          {
+            agentType: 'claude-code',
+            serverName: 'coral',
+            config: {
+              args: ['mcp-stdio', '--workspace=default'],
+              command: coralCommand,
+              env: { CORAL_CONFIG_DIR: configDir },
+            },
+          },
+        ],
+      },
+    ])
+
+    await expect(mcpClients()).resolves.toEqual([
+      { configuredWorkspace: 'default', id: 'claude-code', name: 'Claude Code' },
+    ])
+  })
+
+  it('treats an old Coral server without Desktop’s config directory as updateable', async () => {
+    mocks.listInstalledServers.mockResolvedValue([
+      {
+        agentType: 'claude-code',
+        detected: true,
+        displayName: 'Claude Code',
+        servers: [
+          {
+            agentType: 'claude-code',
+            serverName: 'coral',
+            config: {
+              args: ['mcp-stdio', '--workspace=default'],
+              command: coralCommand,
+            },
+          },
+        ],
+      },
+    ])
+
+    await expect(mcpClients()).resolves.toEqual([{ id: 'claude-code', name: 'Claude Code' }])
+    await expect(configureMcpClient('claude-code', 'default')).resolves.toBeUndefined()
+    expect(mocks.upsertServer).toHaveBeenCalledWith(
+      'claude-code',
+      'coral',
+      {
+        args: ['mcp-stdio', '--workspace=default'],
+        command: coralCommand,
+        env: { CORAL_CONFIG_DIR: configDir },
+      },
+      { local: false },
+    )
+  })
+})

--- a/apps/desktop/src/main/mcp-config.ts
+++ b/apps/desktop/src/main/mcp-config.ts
@@ -10,7 +10,9 @@ import {
   type McpServerConfig,
 } from 'add-mcp'
 import { isDeepStrictEqual } from 'node:util'
+import { app } from 'electron'
 import type { McpClientDescriptor, McpLaunchConfig } from '../shared/types'
+import { desktopRuntimeCoralConfigOptions, ensureDesktopCoralConfig } from './coral-config'
 import { externalCoralPath } from './sidecar'
 
 const DEFAULT_WORKSPACE = 'default'
@@ -19,6 +21,8 @@ type CoralEntry =
   | { kind: 'absent' }
   | { kind: 'collision' }
   | { kind: 'local'; workspace: string }
+
+type LocalInvocation = McpServerConfig & { args: string[]; command: string }
 
 function descriptor(
   client: Pick<AgentServers, 'agentType' | 'displayName'>,
@@ -61,16 +65,24 @@ function stringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : undefined
 }
 
-function localInvocation(
-  config: Record<string, unknown>,
-): { args: string[]; command: string } | undefined {
+function stringRecord(value: unknown): Record<string, string> | undefined {
+  return value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.values(value).every((item) => typeof item === 'string')
+    ? (value as Record<string, string>)
+    : undefined
+}
+
+function localInvocation(config: Record<string, unknown>): LocalInvocation | undefined {
   const commandArray = stringArray(config.command)
   const command =
     commandArray?.[0] ??
     (typeof config.command === 'string' ? config.command : undefined) ??
     (typeof config.cmd === 'string' ? config.cmd : undefined)
   const args = commandArray ? commandArray.slice(1) : stringArray(config.args)
-  return command && args ? { args, command } : undefined
+  const env = stringRecord(config.env) ?? stringRecord(config.envs) ?? stringRecord(config.environment)
+  return command && args ? { ...(env ? { env } : {}), args, command } : undefined
 }
 
 function workspaceFromCanonicalArgs(args: readonly string[]): string | undefined {
@@ -88,14 +100,22 @@ function persistedShape(value: unknown): unknown {
   return json === undefined ? undefined : JSON.parse(json)
 }
 
-function isCanonicalCoralConfig(server: InstalledServer, invocation: McpServerConfig): boolean {
-  const expected = agents[server.agentType].transformConfig('coral', invocation, {
+function isCanonicalCoralConfig(
+  server: InstalledServer,
+  invocation: LocalInvocation,
+  configDir: string,
+): boolean {
+  const expectedInvocation: LocalInvocation = {
+    ...invocation,
+    env: { CORAL_CONFIG_DIR: configDir },
+  }
+  const expected = agents[server.agentType].transformConfig('coral', expectedInvocation, {
     local: false,
   })
   return isDeepStrictEqual(persistedShape(server.config), persistedShape(expected))
 }
 
-function coralEntry(servers: readonly InstalledServer[]): CoralEntry {
+function coralEntry(servers: readonly InstalledServer[], configDir: string): CoralEntry {
   const server = servers.find(({ serverName }) => serverName === 'coral')
   if (!server) return { kind: 'absent' }
 
@@ -106,13 +126,16 @@ function coralEntry(servers: readonly InstalledServer[]): CoralEntry {
   }
 
   const workspace = workspaceFromCanonicalArgs(invocation.args)
-  if (!workspace || !isCanonicalCoralConfig(server, invocation)) {
+  if (!workspace) {
     return { kind: 'collision' }
   }
+  if (invocation.env?.CORAL_CONFIG_DIR !== configDir) return { kind: 'absent' }
+  if (!isCanonicalCoralConfig(server, invocation, configDir)) return { kind: 'collision' }
   return { kind: 'local', workspace }
 }
 
 export async function mcpClients(): Promise<McpClientDescriptor[]> {
+  const configDir = await desktopRuntimeCoralConfigDir()
   return (await stdioClients())
     .sort(
       (left, right) =>
@@ -121,15 +144,24 @@ export async function mcpClients(): Promise<McpClientDescriptor[]> {
         left.agentType.localeCompare(right.agentType),
     )
     .map((client) => {
-      const entry = coralEntry(client.servers)
+      const entry = coralEntry(client.servers, configDir)
       return descriptor(client, entry.kind === 'local' ? entry.workspace : undefined)
     })
 }
 
+async function desktopRuntimeCoralConfigDir(): Promise<string> {
+  return ensureDesktopCoralConfig(
+    app.getPath('userData'),
+    desktopRuntimeCoralConfigOptions(app.isPackaged),
+  )
+}
+
 async function mcpLaunchConfig(workspaceName?: string): Promise<McpLaunchConfig> {
+  const configDir = await desktopRuntimeCoralConfigDir()
   return {
     args: workspaceName ? ['mcp-stdio', `--workspace=${workspaceName}`] : ['mcp-stdio'],
     command: await externalCoralPath(),
+    env: { CORAL_CONFIG_DIR: configDir },
   }
 }
 
@@ -137,8 +169,8 @@ export async function getMcpLaunchConfig(): Promise<McpLaunchConfig> {
   return mcpLaunchConfig()
 }
 
-function requireManageableCoralEntry(client: AgentServers): void {
-  if (coralEntry(client.servers).kind === 'collision') {
+async function requireManageableCoralEntry(client: AgentServers): Promise<void> {
+  if (coralEntry(client.servers, await desktopRuntimeCoralConfigDir()).kind === 'collision') {
     throw new Error(
       `${client.displayName} already has an incompatible global MCP server named "coral".`,
     )
@@ -148,7 +180,7 @@ function requireManageableCoralEntry(client: AgentServers): void {
 export async function configureMcpClient(clientId: unknown, workspaceName: unknown): Promise<void> {
   const workspace = requireWorkspaceArgument(workspaceName)
   const client = await requireStdioClient(clientId)
-  requireManageableCoralEntry(client)
+  await requireManageableCoralEntry(client)
 
   const serverConfig: McpServerConfig = await mcpLaunchConfig(workspace)
   const result = upsertServer(client.agentType, 'coral', serverConfig, { local: false })
@@ -161,7 +193,7 @@ export async function configureMcpClient(clientId: unknown, workspaceName: unkno
 
 export async function removeMcpClient(clientId: unknown): Promise<void> {
   const client = await requireStdioClient(clientId)
-  requireManageableCoralEntry(client)
+  await requireManageableCoralEntry(client)
 
   const result = removeServer(client.agentType, 'coral', { local: false })
   if (!result.success) {

--- a/apps/desktop/src/main/sidecar.test.ts
+++ b/apps/desktop/src/main/sidecar.test.ts
@@ -17,6 +17,7 @@ vi.mock('electron', () => ({
 }))
 // Stubbed so the test never creates a real config directory on disk.
 vi.mock('./coral-config', () => ({
+  desktopRuntimeCoralConfigOptions: vi.fn(() => ({})),
   ensureDesktopCoralConfig: mocks.ensureDesktopCoralConfig,
 }))
 

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -4,7 +4,7 @@ import { constants } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { app } from 'electron'
-import { ensureDesktopCoralConfig } from './coral-config'
+import { desktopRuntimeCoralConfigOptions, ensureDesktopCoralConfig } from './coral-config'
 
 export interface CoralSidecar {
   url: string
@@ -128,13 +128,10 @@ export function killAllTrackedChildren(): void {
 }
 
 export async function startCoralSidecar(): Promise<CoralSidecar> {
-  const devPort = process.env.CORAL_DEV_SIDECAR_PORT || '8778'
-  const configDir = app.isPackaged
-    ? await ensureDesktopCoralConfig(app.getPath('userData'))
-    : await ensureDesktopCoralConfig(app.getPath('userData'), {
-        bindAddr: `127.0.0.1:${devPort}`,
-        directory: `coral-dev-${devPort}`,
-      })
+  const configDir = await ensureDesktopCoralConfig(
+    app.getPath('userData'),
+    desktopRuntimeCoralConfigOptions(app.isPackaged),
+  )
   const command = sidecarCommand()
   const child = spawn(command.command, command.args, {
     cwd: command.cwd,

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -9,6 +9,7 @@ export interface McpClientDescriptor {
 export interface McpLaunchConfig {
   args: string[]
   command: string
+  env?: Record<string, string>
 }
 
 export type DesktopUpdateState =


### PR DESCRIPTION
Summary
- Pass Desktop's Coral config directory into MCP client installs via CORAL_CONFIG_DIR.
- Share Desktop runtime config-dir selection between the sidecar and MCP config writer.
- Add regression coverage for new installs, existing env-aware installs, and old env-less installs being updateable.

Validation
- npm run check --prefix apps/desktop
- npm test --prefix apps/desktop