### PR TITLE
feat(search): rescue unmatched query words by their stem on Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,7 @@ dependencies = [
  "reqwest 0.13.4",
  "ring",
  "rusqlite",
+ "rust-stemmers",
  "sea-query",
  "sea-query-sqlx",
  "serde",
@@ -5940,6 +5941,16 @@ dependencies = [
  "hashlink 0.10.0",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ regex = "1"
 ring = "0.17.14"
 rmcp = { version = "1.8.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
+rust-stemmers = "1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -38,6 +38,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 sea-query.workspace = true
 sea-query-sqlx.workspace = true
+rust-stemmers.workspace = true
 sha2.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true

--- a/crates/coral-app/src/search/store/postgres/catalog.rs
+++ b/crates/coral-app/src/search/store/postgres/catalog.rs
@@ -15,7 +15,9 @@
 //! total order.
 
 use std::collections::BTreeSet;
+use std::sync::LazyLock;
 
+use rust_stemmers::{Algorithm, Stemmer};
 use sqlx::{Postgres, Row as _, Transaction};
 
 use super::{PostgresSearchError, PostgresSearchStore};
@@ -61,6 +63,11 @@ const DOCUMENT_FREQUENCY_CAP: f64 = 0.05;
 /// When every word is above the cap, keep this many rarest words as
 /// candidate keys instead of searching for nothing.
 const RARE_WORD_KEEP: usize = 3;
+/// Snowball English, for the stem rescue of a typed word that reaches no
+/// lexeme by prefix (`documents` → `document`, `opened` → `open`). The stem
+/// is used as a prefix, so an over-short stem widens the reach and never
+/// loses the intended lexeme.
+static STEMMER: LazyLock<Stemmer> = LazyLock::new(|| Stemmer::create(Algorithm::English));
 
 // Recorded alternatives to the document-frequency cap (2026-09-10; neither
 // is implemented, both were sized against the replay harness):
@@ -476,7 +483,8 @@ impl CatalogQueryPlan {
             }
         } else {
             let (stats, total_docs, avgdl) = fetch_word_stats(tx, &self.words).await?;
-            scoring_plan(&stats, total_docs, avgdl, &self.variant_words)
+            let rescues = self.rescue_words(tx, &stats, total_docs).await?;
+            scoring_plan(&stats, total_docs, avgdl, &self.variant_words, &rescues)
         };
         if scoring.scored.is_empty() && self.wordless_patterns.is_empty() {
             // Every word was a compact variant the corpus lacks: nothing is
@@ -508,6 +516,55 @@ impl CatalogQueryPlan {
             .fetch_all(&mut **tx)
             .await?;
         rows.iter().map(hit_from_row).collect()
+    }
+
+    /// Extra scored words for typed words that reach nothing: no exact lexeme
+    /// and no lexeme starting with them. Each rung asks the lexicon, never the
+    /// documents, and a rescue word enters the plan with the statistics of
+    /// what it reaches, so it competes on the same terms as a typed word.
+    async fn rescue_words(
+        &self,
+        tx: &mut Transaction<'static, Postgres>,
+        stats: &[WordStat],
+        total_docs: i64,
+    ) -> Result<Vec<WordStat>, PostgresSearchError> {
+        let unmatched = stats
+            .iter()
+            .filter(|stat| stat.ndoc == 0 && !self.variant_words.contains(&stat.word))
+            .map(|stat| stat.word.clone())
+            .collect::<Vec<_>>();
+        if unmatched.is_empty() {
+            return Ok(Vec::new());
+        }
+        let reached_nothing = fetch_prefix_presence(tx, &unmatched)
+            .await?
+            .into_iter()
+            .filter(|prefix| prefix.lexemes == 0)
+            .map(|prefix| prefix.word)
+            .collect::<Vec<_>>();
+        if reached_nothing.is_empty() {
+            return Ok(Vec::new());
+        }
+        let stems = stem_rescues(&reached_nothing, &self.words)
+            .into_iter()
+            .map(|(_, stem)| stem)
+            .collect::<Vec<_>>();
+        if stems.is_empty() {
+            return Ok(Vec::new());
+        }
+        // The stem is a prefix, so its document frequency is the number of
+        // documents any lexeme it starts reaches — what its tsquery branch
+        // would admit — not a sum over the lexicon, which counts a document
+        // once per matching lexeme.
+        Ok(fetch_prefix_document_counts(tx, &stems)
+            .await?
+            .into_iter()
+            .filter(|(_, ndoc)| *ndoc > 0)
+            .map(|(word, ndoc)| WordStat {
+                word,
+                ndoc: ndoc.min(total_docs.max(0)),
+            })
+            .collect())
     }
 
     fn sql(&self, scoring: &ScoringPlan, class: CatalogDocumentClass) -> String {
@@ -635,6 +692,88 @@ async fn fetch_word_stats(
     Ok((stats, total_docs, avgdl))
 }
 
+/// What the lexicon holds under a prefix: how many lexemes start with the
+/// word, and the sum of their document frequencies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LexiconPrefix {
+    word: String,
+    ndoc: i64,
+    lexemes: i64,
+}
+
+/// Prefix presence per word, from the lexicon alone (the `text_pattern_ops`
+/// btree on `catalog_terms`), in one statement.
+async fn fetch_prefix_presence(
+    tx: &mut Transaction<'static, Postgres>,
+    words: &[String],
+) -> Result<Vec<LexiconPrefix>, PostgresSearchError> {
+    let patterns = words
+        .iter()
+        .map(|word| prefix_pattern(word))
+        .collect::<Vec<_>>();
+    let rows = sqlx::query(
+        "SELECT w.term, coalesce(sum(t.ndoc), 0)::bigint AS ndoc, count(t.term)::bigint AS lexemes
+         FROM unnest($1::text[], $2::text[]) AS w(term, pattern)
+         LEFT JOIN catalog_terms AS t ON t.term LIKE w.pattern
+         GROUP BY w.term",
+    )
+    .bind(words)
+    .bind(&patterns)
+    .fetch_all(&mut **tx)
+    .await?;
+    rows.iter()
+        .map(|row| {
+            Ok(LexiconPrefix {
+                word: row.try_get("term")?,
+                ndoc: row.try_get("ndoc")?,
+                lexemes: row.try_get("lexemes")?,
+            })
+        })
+        .collect()
+}
+
+/// Documents reached by each prefix through the tsvector index, in one
+/// statement: the document frequency a prefix key deserves.
+async fn fetch_prefix_document_counts(
+    tx: &mut Transaction<'static, Postgres>,
+    prefixes: &[String],
+) -> Result<Vec<(String, i64)>, PostgresSearchError> {
+    let queries = prefixes
+        .iter()
+        .map(|prefix| format!("{prefix}:*"))
+        .collect::<Vec<_>>();
+    let rows = sqlx::query(
+        "SELECT p.prefix,
+                (SELECT count(*) FROM catalog_documents AS d
+                 WHERE d.tsv @@ to_tsquery('simple', p.query))::bigint AS ndoc
+         FROM unnest($1::text[], $2::text[]) AS p(prefix, query)",
+    )
+    .bind(prefixes)
+    .bind(&queries)
+    .fetch_all(&mut **tx)
+    .await?;
+    rows.iter()
+        .map(|row| Ok((row.try_get("prefix")?, row.try_get("ndoc")?)))
+        .collect()
+}
+
+/// Stem rescue: `(word, stem)` for each word that reaches nothing, when the
+/// stem is a shorter, distinct word the plan does not already carry.
+fn stem_rescues(reached_nothing: &[String], known_words: &[String]) -> Vec<(String, String)> {
+    let mut stems: Vec<(String, String)> = Vec::new();
+    for word in reached_nothing {
+        let stem = STEMMER.stem(word).into_owned();
+        if stem != *word
+            && stem.chars().count() >= MIN_TERM_CHARS
+            && !known_words.contains(&stem)
+            && !stems.iter().any(|(_, existing)| existing == &stem)
+        {
+            stems.push((word.clone(), stem));
+        }
+    }
+    stems
+}
+
 /// Splits words into candidate keys (document-frequency cap applied) and the
 /// scoring set (every word, with FTS5's IDF formula and clamp).
 ///
@@ -643,16 +782,19 @@ async fn fetch_word_stats(
 /// a survivor of the cap — an absent variant of the whole query would
 /// otherwise keep every real word from reaching the rarest-few fallback and
 /// select no candidates at all. A word the caller typed keeps its substring
-/// and prefix reach whatever its statistics say.
+/// and prefix reach whatever its statistics say. Rescue words arrive with
+/// the statistics of what they reach and join before the cap is applied.
 fn scoring_plan(
     stats: &[WordStat],
     total_docs: i64,
     avgdl: f64,
     variant_words: &[String],
+    rescues: &[WordStat],
 ) -> ScoringPlan {
     let stats = stats
         .iter()
         .filter(|stat| stat.ndoc > 0 || !variant_words.contains(&stat.word))
+        .chain(rescues.iter())
         .collect::<Vec<_>>();
     let total = total_docs.max(0);
     let cap = DOCUMENT_FREQUENCY_CAP * precise_f64(total.max(1));
@@ -786,7 +928,7 @@ fn lexeme_words(term: &str) -> Vec<String> {
 pub(super) mod plan_tests {
     use super::{
         CatalogQueryPlan, ScoredWord, ScoringPlan, WordStat, contains_pattern,
-        inverse_document_frequency, scoring_plan,
+        inverse_document_frequency, scoring_plan, stem_rescues,
     };
     use crate::search::catalog::index::{CatalogDocumentClass, NormalizedSearchTerm};
 
@@ -901,7 +1043,7 @@ pub(super) mod plan_tests {
             },
         ];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &[]);
 
         assert_eq!(plan.candidate_words, vec!["slack"]);
         // The common word still scores, with its true IDF, not a clamp.
@@ -926,7 +1068,7 @@ pub(super) mod plan_tests {
             })
             .collect::<Vec<_>>();
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &[]);
 
         assert_eq!(
             plan.candidate_words,
@@ -955,7 +1097,7 @@ pub(super) mod plan_tests {
             ndoc: 0,
         }];
 
-        let plan = scoring_plan(&stats, 0, 0.0, &[]);
+        let plan = scoring_plan(&stats, 0, 0.0, &[], &[]);
 
         let word = plan.scored.first().expect("the only word survives");
         assert!((word.idf - 1e-6).abs() < f64::EPSILON);
@@ -995,7 +1137,7 @@ pub(super) mod plan_tests {
             stat("githubevents", 0),
         ];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &["githubevents".to_string()]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &["githubevents".to_string()], &[]);
 
         assert_eq!(
             plan.candidate_words,
@@ -1020,7 +1162,7 @@ pub(super) mod plan_tests {
             stat("requests", 200),
         ];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &["pullrequests".to_string()]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &["pullrequests".to_string()], &[]);
 
         assert_eq!(plan.candidate_words, vec!["pullrequests"]);
         assert_eq!(plan.scored.len(), 3);
@@ -1032,8 +1174,55 @@ pub(super) mod plan_tests {
         // `benchmark_runs`; only variants are subject to the absence rule.
         let stats = [stat("enchmark", 0), stat("github", 970)];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &[]);
 
         assert_eq!(plan.candidate_words, vec!["enchmark"]);
+    }
+
+    #[test]
+    fn stems_are_shorter_distinct_words_the_plan_does_not_carry() {
+        let reached_nothing = [
+            "documents".to_string(),
+            "opened".to_string(),
+            "issues".to_string(),
+            "abc".to_string(),
+            "states".to_string(),
+        ];
+        let known = ["state".to_string()];
+
+        assert_eq!(
+            stem_rescues(&reached_nothing, &known)
+                .iter()
+                .map(|(word, stem)| (word.as_str(), stem.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("documents", "document"),
+                ("opened", "open"),
+                ("issues", "issu")
+            ],
+            "`abc` stems to itself and `state` is already a word"
+        );
+    }
+
+    #[test]
+    fn rescue_words_join_the_plan_with_their_own_statistics() {
+        // `documents` reached nothing; its stem reaches 12 documents.
+        let stats = [stat("documents", 0), stat("github", 970)];
+        let rescues = [stat("document", 12)];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &rescues);
+
+        // The typed word keeps its substring key; the rescue joins it.
+        assert_eq!(plan.candidate_words, vec!["documents", "document"]);
+        assert_eq!(
+            plan.scored
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["documents", "github", "document"]
+        );
+        let rescue = plan.scored.last().expect("rescue scores");
+        let expected = ((1_000.0_f64 - 12.0 + 0.5) / 12.5).ln();
+        assert!((rescue.idf - expected).abs() < 1e-12);
     }
 }

--- a/crates/coral-app/src/search/store/postgres/migrations/0002_catalog_terms_lookup_indexes.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0002_catalog_terms_lookup_indexes.sql
@@ -1,0 +1,16 @@
+-- Lexicon lookups for query-word rescue. A typed word that matches no lexeme
+-- exactly and prefixes none is asked two cheaper questions against the
+-- lexicon (`catalog_terms`, tens of thousands of rows) rather than against
+-- the documents: does any lexeme start with this (or with its stem), and is
+-- any lexeme similar to it. `term LIKE 'word%'` needs `text_pattern_ops`
+-- under a non-C collation to use a btree; `term % 'word'` needs a trigram
+-- GIN.
+--
+-- Runs with `search_path` set to the Workspace's surrogate schema plus the
+-- schema that holds `pg_trgm`, so names are unqualified on purpose. Not
+-- idempotent on purpose (see 0001).
+CREATE INDEX catalog_terms_term_pattern
+    ON catalog_terms (term text_pattern_ops);
+
+CREATE INDEX catalog_terms_term_trgm
+    ON catalog_terms USING gin (term gin_trgm_ops);

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -24,7 +24,7 @@ use tokio::runtime::Handle;
 use crate::state::db::{DbError, connect_postgres_pool};
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 1;
+pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 2;
 
 struct SearchPostgresMigration {
     version: i32,
@@ -36,10 +36,16 @@ const REGISTRY_BOOTSTRAP_SQL: &str = include_str!("migrations/0001_search_regist
 /// Per-Workspace schema stream, versioned in the registry ledger. Each step
 /// runs in one transaction with its ledger bump, so a partial failure leaves
 /// the schema at its recorded version and the step is never replayed.
-const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[SearchPostgresMigration {
-    version: 1,
-    sql: include_str!("migrations/0001_catalog_documents.sql"),
-}];
+const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[
+    SearchPostgresMigration {
+        version: 1,
+        sql: include_str!("migrations/0001_catalog_documents.sql"),
+    },
+    SearchPostgresMigration {
+        version: 2,
+        sql: include_str!("migrations/0002_catalog_terms_lookup_indexes.sql"),
+    },
+];
 
 const SEARCH_POOL_MAX_CONNECTIONS: u32 = 4;
 /// Serializes registry bootstrap across processes; per-Workspace work locks

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -561,6 +561,50 @@ async fn common_word_queries_still_retrieve_against_postgres() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run word-form rescue against Postgres"]
+async fn a_word_form_the_corpus_lacks_is_rescued_by_its_stem_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("stem");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&rescue_snapshot())
+            .expect("refresh");
+
+        // The fixture holds `issue` and `issues` in one table among forty
+        // fillers; the form `issued` reaches neither until its stem `issu`
+        // does. The fillers keep the document-frequency cap above the two
+        // lexemes the stem reaches, as a real corpus does.
+        let rescued = catalog
+            .search(&["issued".to_string()], 10, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+        assert_eq!(
+            rescued.first().map(|hit| hit.doc_id.as_str()),
+            Some("catalog:table:linear.issue_labels"),
+            "the stem must reach the lexemes the word form missed"
+        );
+        // A word with no usable stem still finds nothing.
+        let nothing = catalog
+            .search(&["zzqxv".to_string()], 10, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+        assert!(nothing.is_empty());
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
 async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     let Some(storage) = open_storage().await else {
@@ -579,6 +623,60 @@ async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     .await;
 
     delete_workspaces(&storage, &[workspace]).await;
+}
+
+/// Forty filler tables plus two named tables, so that a rescued word that
+/// reaches one document stays under the 5 % candidate cap as it would in a
+/// real corpus.
+fn rescue_snapshot() -> crate::search::catalog::index::CatalogIndexSnapshot {
+    use crate::search::catalog::index::{
+        CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
+    };
+    let table = |doc_id: &str, source: &str, surface: &str, title: &str, description: &str| {
+        CatalogIndexDocument {
+            doc_id: doc_id.to_string(),
+            doc_kind: CatalogIndexDocumentKind::CatalogTable,
+            source_name: source.to_string(),
+            catalog_name: None,
+            surface_kind: "table".to_string(),
+            surface_name: surface.to_string(),
+            field_name: String::new(),
+            field_role: String::new(),
+            qualified_name: format!("{source}.{surface}"),
+            title: title.to_string(),
+            description: description.to_string(),
+            searchable_text: format!("{source} {surface}"),
+        }
+    };
+    let mut documents = (0..40)
+        .map(|index| {
+            table(
+                &format!("catalog:table:fixture.filler_{index:02}"),
+                "fixture",
+                &format!("filler_{index:02}"),
+                "filler",
+                "A filler table",
+            )
+        })
+        .collect::<Vec<_>>();
+    documents.push(table(
+        "catalog:table:linear.issue_labels",
+        "linear",
+        "issue_labels",
+        "issue labels",
+        "Labels attached to issues",
+    ));
+    documents.push(table(
+        "catalog:table:github.organization_members",
+        "github",
+        "organization_members",
+        "organization members",
+        "Members of an organization",
+    ));
+    CatalogIndexSnapshot {
+        fingerprint: "rescue-v1".to_string(),
+        documents,
+    }
 }
 
 async fn test_pool() -> sqlx::PgPool {


### PR DESCRIPTION
Benchmark branch (one of three: stem, fuzzy, both) for the word-form and spelling gap in Postgres catalog search. Stacked on #2259.

## Why

A typed query word that matches no lexeme exactly and prefixes none contributes nothing to retrieval or scoring: `documents` misses `document`, `opened` misses `open`, `analyzing` misses `analyz…`. On the 402 recorded agent queries, 806 of 4,691 query words (17 %) reach nothing this way; a Snowball stem reaches a lexeme for 109 of them, across 87 queries. The SQLite trigram side has the same asymmetry (`issues` is not a substring of `issue`).

## What

- **Migration `0002_catalog_terms_lookup_indexes.sql`** (schema version 2): a `text_pattern_ops` btree and a trigram GIN on `catalog_terms`, so the questions below are answered against the lexicon (tens of thousands of rows), never against the documents.
- **Rescue plumbing in the plan**: after the statistics lookup, typed words with no exact lexeme are probed for prefix presence in one statement; those that prefix nothing are candidates for rescue. Rescue words join `scoring_plan` with the statistics of what they reach, before the 5 % cap and the rarest-words fallback, so they key candidates and score on the same terms as typed words. Compact variants are never rescued (the absence rule already handles them); the typed word keeps its substring key.
- **Stem rung**: the Snowball English stem (`rust-stemmers`) of each such word, when it is a shorter, distinct word the plan does not already carry, used as a prefix. Its document frequency is the number of documents its `stem:*` tsquery reaches, counted through the tsvector index (not a sum over the lexicon, which counts a document once per matching lexeme). A stem that reaches nothing is dropped.

## Measured (offline replay, 402 queries, `round4.py`)

| | top-3 | #1 | top-k | med rank | SQL median / p90 |
|---|---|---|---|---|---|
| without | 53 % | 29 % | 82 % | 2.0 | 54 / 364 ms |
| stem rescue | 53 % | 29 % | 81 % | 2.0 | 71 / 378 ms |

The stem fired in 87 queries and changed 68 ranked lists: the used table moved up in 4 and down in 9. No gain on this traffic; kept as a branch for the paid run, where the customer-schema case (BrE identifiers, plural/singular forms) is the question.

## Validation

`make rust-checks` and `make postgres-tests` green (the Postgres suite includes `a_word_form_the_corpus_lacks_is_rescued_by_its_stem_against_postgres`: `issued` reaches `issue`/`issues` only through its stem, on a 42-document fixture so the rescued prefix stays under the cap).

Before benchmarking against an existing database: this branch's schema version 2 collides with the *old* version-2 ledger entry in the `duel` database (`search_ws_1` there has the pre-split `tsv`). Drop the registry row and schema first so the boot creates it fresh:

```sql
DELETE FROM search_registry.workspaces; DROP SCHEMA search_ws_1 CASCADE;
```

https://claude.ai/code/session_01WeuXrBPjT8Q5nPTruS8xjX
