### PR TITLE
feat(search): rescue words the stem cannot by similar lexemes on Postgres

### DIFF
--- a/crates/coral-app/src/search/store/postgres/catalog.rs
+++ b/crates/coral-app/src/search/store/postgres/catalog.rs
@@ -68,6 +68,11 @@ const RARE_WORD_KEEP: usize = 3;
 /// is used as a prefix, so an over-short stem widens the reach and never
 /// loses the intended lexeme.
 static STEMMER: LazyLock<Stemmer> = LazyLock::new(|| Stemmer::create(Algorithm::English));
+/// Trigram similarity floor for a rescue lexeme: `pg_trgm`'s default, pinned
+/// in the query so a server setting cannot move it.
+const FUZZY_SIMILARITY_FLOOR: f32 = 0.3;
+/// Most similar lexemes considered per word that reaches nothing.
+const FUZZY_LEXEMES_PER_WORD: i64 = 3;
 
 // Recorded alternatives to the document-frequency cap (2026-09-10; neither
 // is implemented, both were sized against the replay harness):
@@ -545,26 +550,48 @@ impl CatalogQueryPlan {
         if reached_nothing.is_empty() {
             return Ok(Vec::new());
         }
-        let stems = stem_rescues(&reached_nothing, &self.words)
-            .into_iter()
-            .map(|(_, stem)| stem)
-            .collect::<Vec<_>>();
-        if stems.is_empty() {
-            return Ok(Vec::new());
+        let mut rescues = Vec::new();
+        let mut rescued_words = BTreeSet::new();
+        let stems = stem_rescues(&reached_nothing, &self.words);
+        if !stems.is_empty() {
+            // The stem is a prefix, so its document frequency is the number
+            // of documents any lexeme it starts reaches — what its tsquery
+            // branch would admit — not a sum over the lexicon, which counts a
+            // document once per matching lexeme.
+            let stem_words = stems
+                .iter()
+                .map(|(_, stem)| stem.clone())
+                .collect::<Vec<_>>();
+            for (stem, ndoc) in fetch_prefix_document_counts(tx, &stem_words).await? {
+                if ndoc == 0 {
+                    continue;
+                }
+                for (word, _) in stems.iter().filter(|(_, candidate)| *candidate == stem) {
+                    rescued_words.insert(word.clone());
+                }
+                rescues.push(WordStat {
+                    word: stem,
+                    ndoc: ndoc.min(total_docs.max(0)),
+                });
+            }
         }
-        // The stem is a prefix, so its document frequency is the number of
-        // documents any lexeme it starts reaches — what its tsquery branch
-        // would admit — not a sum over the lexicon, which counts a document
-        // once per matching lexeme.
-        Ok(fetch_prefix_document_counts(tx, &stems)
-            .await?
-            .into_iter()
-            .filter(|(_, ndoc)| *ndoc > 0)
-            .map(|(word, ndoc)| WordStat {
-                word,
-                ndoc: ndoc.min(total_docs.max(0)),
-            })
-            .collect())
+        // Nothing starts with the word or its stem; ask the lexicon what it
+        // looks like.
+        let still_nothing = reached_nothing
+            .iter()
+            .filter(|word| !rescued_words.contains(*word))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !still_nothing.is_empty() {
+            for stat in fetch_similar_lexemes(tx, &still_nothing).await? {
+                if !self.words.contains(&stat.word)
+                    && !rescues.iter().any(|rescue| rescue.word == stat.word)
+                {
+                    rescues.push(stat);
+                }
+            }
+        }
+        Ok(rescues)
     }
 
     fn sql(&self, scoring: &ScoringPlan, class: CatalogDocumentClass) -> String {
@@ -772,6 +799,45 @@ fn stem_rescues(reached_nothing: &[String], known_words: &[String]) -> Vec<(Stri
         }
     }
     stems
+}
+
+/// Fuzzy rescue: the lexemes most similar to each word that reaches nothing,
+/// through the lexicon's trigram index, each with its own document
+/// frequency. Spelling variants (`organisation` → `organization`, `colour` →
+/// `color`) and dropped letters sit above the floor; transpositions do not.
+async fn fetch_similar_lexemes(
+    tx: &mut Transaction<'static, Postgres>,
+    words: &[String],
+) -> Result<Vec<WordStat>, PostgresSearchError> {
+    let rows = sqlx::query(
+        "SELECT t.term, t.ndoc
+         FROM unnest($1::text[]) AS w(term)
+         JOIN LATERAL (
+             SELECT term, ndoc
+             FROM catalog_terms
+             WHERE term % w.term AND similarity(term, w.term) >= $2
+             ORDER BY similarity(term, w.term) DESC, term
+             LIMIT $3
+         ) AS t ON true",
+    )
+    .bind(words)
+    .bind(FUZZY_SIMILARITY_FLOOR)
+    .bind(FUZZY_LEXEMES_PER_WORD)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut similar: Vec<WordStat> = Vec::new();
+    for row in &rows {
+        let term: String = row.try_get("term")?;
+        if similar.iter().any(|stat| stat.word == term) {
+            continue;
+        }
+        let ndoc: i32 = row.try_get("ndoc")?;
+        similar.push(WordStat {
+            word: term,
+            ndoc: i64::from(ndoc),
+        });
+    }
+    Ok(similar)
 }
 
 /// Splits words into candidate keys (document-frequency cap applied) and the

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -605,6 +605,52 @@ async fn a_word_form_the_corpus_lacks_is_rescued_by_its_stem_against_postgres() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run spelling rescue against Postgres"]
+async fn a_spelling_the_corpus_lacks_is_rescued_by_a_similar_lexeme_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("fuzzy");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&rescue_snapshot())
+            .expect("refresh");
+
+        // The fixture spells `organization`; `organisation` matches no lexeme
+        // exactly or by prefix, and its closest lexeme is the one it meant.
+        let rescued = catalog
+            .search(
+                &["organisation".to_string()],
+                10,
+                CatalogDocumentClass::Entries,
+            )
+            .expect("search")
+            .hits;
+        assert_eq!(
+            rescued.first().map(|hit| hit.doc_id.as_str()),
+            Some("catalog:table:github.organization_members"),
+            "the similar lexeme must reach the table the spelling missed"
+        );
+        // A word nothing resembles still finds nothing.
+        let nothing = catalog
+            .search(&["zzqxv".to_string()], 10, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+        assert!(nothing.is_empty());
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
 async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     let Some(storage) = open_storage().await else {


### PR DESCRIPTION
Benchmark branch (one of three: stem, fuzzy, both). Stacked on the stem branch; this PR is the fuzzy rung on top of it.

## What

A typed word that reaches nothing by itself is first stemmed (the stem branch); a word whose stem also reaches nothing asks the lexicon for the up to three lexemes above pg_trgm's 0.3 similarity floor, each joining the plan as a rescue word with its own document frequency. Word forms go to the stem, spellings and dropped letters to the similarity lookup; a word the stem rescued is never fuzzed, and a lexeme already in the plan is not added twice. Both rungs use the lexicon indexes from migration 0002 and never touch the documents.

## Validation

`make rust-checks` and `make postgres-tests` green; both rescue tests (`issued` → `issue`/`issues` by stem, `organisation` → `organization` by similarity) pass on the shared 42-document fixture. Not replayed offline.

Same database note as the stem branch: drop the `duel` registry row and schema before pointing this binary at it.

https://claude.ai/code/session_01WeuXrBPjT8Q5nPTruS8xjX
