### PR TITLE
feat(search): rescue unmatched query words by similar lexemes on Postgres

### DIFF
--- a/crates/coral-app/src/search/store/postgres/catalog.rs
+++ b/crates/coral-app/src/search/store/postgres/catalog.rs
@@ -61,6 +61,11 @@ const DOCUMENT_FREQUENCY_CAP: f64 = 0.05;
 /// When every word is above the cap, keep this many rarest words as
 /// candidate keys instead of searching for nothing.
 const RARE_WORD_KEEP: usize = 3;
+/// Trigram similarity floor for a rescue lexeme: `pg_trgm`'s default, pinned
+/// in the query so a server setting cannot move it.
+const FUZZY_SIMILARITY_FLOOR: f32 = 0.3;
+/// Most similar lexemes considered per word that reaches nothing.
+const FUZZY_LEXEMES_PER_WORD: i64 = 3;
 
 // Recorded alternatives to the document-frequency cap (2026-09-10; neither
 // is implemented, both were sized against the replay harness):
@@ -476,7 +481,8 @@ impl CatalogQueryPlan {
             }
         } else {
             let (stats, total_docs, avgdl) = fetch_word_stats(tx, &self.words).await?;
-            scoring_plan(&stats, total_docs, avgdl, &self.variant_words)
+            let rescues = self.rescue_words(tx, &stats).await?;
+            scoring_plan(&stats, total_docs, avgdl, &self.variant_words, &rescues)
         };
         if scoring.scored.is_empty() && self.wordless_patterns.is_empty() {
             // Every word was a compact variant the corpus lacks: nothing is
@@ -508,6 +514,40 @@ impl CatalogQueryPlan {
             .fetch_all(&mut **tx)
             .await?;
         rows.iter().map(hit_from_row).collect()
+    }
+
+    /// Extra scored words for typed words that reach nothing: no exact lexeme
+    /// and no lexeme starting with them. The rung asks the lexicon, never the
+    /// documents, and a rescue word enters the plan with the statistics of
+    /// what it reaches, so it competes on the same terms as a typed word.
+    async fn rescue_words(
+        &self,
+        tx: &mut Transaction<'static, Postgres>,
+        stats: &[WordStat],
+    ) -> Result<Vec<WordStat>, PostgresSearchError> {
+        let unmatched = stats
+            .iter()
+            .filter(|stat| stat.ndoc == 0 && !self.variant_words.contains(&stat.word))
+            .map(|stat| stat.word.clone())
+            .collect::<Vec<_>>();
+        if unmatched.is_empty() {
+            return Ok(Vec::new());
+        }
+        let reached_nothing = fetch_prefix_presence(tx, &unmatched)
+            .await?
+            .into_iter()
+            .filter(|prefix| prefix.lexemes == 0)
+            .map(|prefix| prefix.word)
+            .collect::<Vec<_>>();
+        if reached_nothing.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Nothing starts with the word; ask the lexicon what it looks like.
+        Ok(fetch_similar_lexemes(tx, &reached_nothing)
+            .await?
+            .into_iter()
+            .filter(|stat| !self.words.contains(&stat.word))
+            .collect())
     }
 
     fn sql(&self, scoring: &ScoringPlan, class: CatalogDocumentClass) -> String {
@@ -635,6 +675,85 @@ async fn fetch_word_stats(
     Ok((stats, total_docs, avgdl))
 }
 
+/// What the lexicon holds under a prefix: how many lexemes start with the
+/// word, and the sum of their document frequencies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LexiconPrefix {
+    word: String,
+    ndoc: i64,
+    lexemes: i64,
+}
+
+/// Prefix presence per word, from the lexicon alone (the `text_pattern_ops`
+/// btree on `catalog_terms`), in one statement.
+async fn fetch_prefix_presence(
+    tx: &mut Transaction<'static, Postgres>,
+    words: &[String],
+) -> Result<Vec<LexiconPrefix>, PostgresSearchError> {
+    let patterns = words
+        .iter()
+        .map(|word| prefix_pattern(word))
+        .collect::<Vec<_>>();
+    let rows = sqlx::query(
+        "SELECT w.term, coalesce(sum(t.ndoc), 0)::bigint AS ndoc, count(t.term)::bigint AS lexemes
+         FROM unnest($1::text[], $2::text[]) AS w(term, pattern)
+         LEFT JOIN catalog_terms AS t ON t.term LIKE w.pattern
+         GROUP BY w.term",
+    )
+    .bind(words)
+    .bind(&patterns)
+    .fetch_all(&mut **tx)
+    .await?;
+    rows.iter()
+        .map(|row| {
+            Ok(LexiconPrefix {
+                word: row.try_get("term")?,
+                ndoc: row.try_get("ndoc")?,
+                lexemes: row.try_get("lexemes")?,
+            })
+        })
+        .collect()
+}
+
+/// Fuzzy rescue: the lexemes most similar to each word that reaches nothing,
+/// through the lexicon's trigram index, each with its own document
+/// frequency. Spelling variants (`organisation` → `organization`, `colour` →
+/// `color`) and dropped letters sit above the floor; transpositions do not.
+async fn fetch_similar_lexemes(
+    tx: &mut Transaction<'static, Postgres>,
+    words: &[String],
+) -> Result<Vec<WordStat>, PostgresSearchError> {
+    let rows = sqlx::query(
+        "SELECT t.term, t.ndoc
+         FROM unnest($1::text[]) AS w(term)
+         JOIN LATERAL (
+             SELECT term, ndoc
+             FROM catalog_terms
+             WHERE term % w.term AND similarity(term, w.term) >= $2
+             ORDER BY similarity(term, w.term) DESC, term
+             LIMIT $3
+         ) AS t ON true",
+    )
+    .bind(words)
+    .bind(FUZZY_SIMILARITY_FLOOR)
+    .bind(FUZZY_LEXEMES_PER_WORD)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut similar: Vec<WordStat> = Vec::new();
+    for row in &rows {
+        let term: String = row.try_get("term")?;
+        if similar.iter().any(|stat| stat.word == term) {
+            continue;
+        }
+        let ndoc: i32 = row.try_get("ndoc")?;
+        similar.push(WordStat {
+            word: term,
+            ndoc: i64::from(ndoc),
+        });
+    }
+    Ok(similar)
+}
+
 /// Splits words into candidate keys (document-frequency cap applied) and the
 /// scoring set (every word, with FTS5's IDF formula and clamp).
 ///
@@ -643,16 +762,19 @@ async fn fetch_word_stats(
 /// a survivor of the cap — an absent variant of the whole query would
 /// otherwise keep every real word from reaching the rarest-few fallback and
 /// select no candidates at all. A word the caller typed keeps its substring
-/// and prefix reach whatever its statistics say.
+/// and prefix reach whatever its statistics say. Rescue words arrive with
+/// the statistics of what they reach and join before the cap is applied.
 fn scoring_plan(
     stats: &[WordStat],
     total_docs: i64,
     avgdl: f64,
     variant_words: &[String],
+    rescues: &[WordStat],
 ) -> ScoringPlan {
     let stats = stats
         .iter()
         .filter(|stat| stat.ndoc > 0 || !variant_words.contains(&stat.word))
+        .chain(rescues.iter())
         .collect::<Vec<_>>();
     let total = total_docs.max(0);
     let cap = DOCUMENT_FREQUENCY_CAP * precise_f64(total.max(1));
@@ -901,7 +1023,7 @@ pub(super) mod plan_tests {
             },
         ];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &[]);
 
         assert_eq!(plan.candidate_words, vec!["slack"]);
         // The common word still scores, with its true IDF, not a clamp.
@@ -926,7 +1048,7 @@ pub(super) mod plan_tests {
             })
             .collect::<Vec<_>>();
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &[]);
 
         assert_eq!(
             plan.candidate_words,
@@ -955,7 +1077,7 @@ pub(super) mod plan_tests {
             ndoc: 0,
         }];
 
-        let plan = scoring_plan(&stats, 0, 0.0, &[]);
+        let plan = scoring_plan(&stats, 0, 0.0, &[], &[]);
 
         let word = plan.scored.first().expect("the only word survives");
         assert!((word.idf - 1e-6).abs() < f64::EPSILON);
@@ -995,7 +1117,7 @@ pub(super) mod plan_tests {
             stat("githubevents", 0),
         ];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &["githubevents".to_string()]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &["githubevents".to_string()], &[]);
 
         assert_eq!(
             plan.candidate_words,
@@ -1020,7 +1142,7 @@ pub(super) mod plan_tests {
             stat("requests", 200),
         ];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &["pullrequests".to_string()]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &["pullrequests".to_string()], &[]);
 
         assert_eq!(plan.candidate_words, vec!["pullrequests"]);
         assert_eq!(plan.scored.len(), 3);
@@ -1032,8 +1154,30 @@ pub(super) mod plan_tests {
         // `benchmark_runs`; only variants are subject to the absence rule.
         let stats = [stat("enchmark", 0), stat("github", 970)];
 
-        let plan = scoring_plan(&stats, 1_000, 23.0, &[]);
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &[]);
 
         assert_eq!(plan.candidate_words, vec!["enchmark"]);
+    }
+
+    #[test]
+    fn rescue_words_join_the_plan_with_their_own_statistics() {
+        // `documents` reached nothing; a similar lexeme reaches 12 documents.
+        let stats = [stat("documents", 0), stat("github", 970)];
+        let rescues = [stat("document", 12)];
+
+        let plan = scoring_plan(&stats, 1_000, 23.0, &[], &rescues);
+
+        // The typed word keeps its substring key; the rescue joins it.
+        assert_eq!(plan.candidate_words, vec!["documents", "document"]);
+        assert_eq!(
+            plan.scored
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["documents", "github", "document"]
+        );
+        let rescue = plan.scored.last().expect("rescue scores");
+        let expected = ((1_000.0_f64 - 12.0 + 0.5) / 12.5).ln();
+        assert!((rescue.idf - expected).abs() < 1e-12);
     }
 }

--- a/crates/coral-app/src/search/store/postgres/migrations/0002_catalog_terms_lookup_indexes.sql
+++ b/crates/coral-app/src/search/store/postgres/migrations/0002_catalog_terms_lookup_indexes.sql
@@ -1,0 +1,16 @@
+-- Lexicon lookups for query-word rescue. A typed word that matches no lexeme
+-- exactly and prefixes none is asked two cheaper questions against the
+-- lexicon (`catalog_terms`, tens of thousands of rows) rather than against
+-- the documents: does any lexeme start with this (or with its stem), and is
+-- any lexeme similar to it. `term LIKE 'word%'` needs `text_pattern_ops`
+-- under a non-C collation to use a btree; `term % 'word'` needs a trigram
+-- GIN.
+--
+-- Runs with `search_path` set to the Workspace's surrogate schema plus the
+-- schema that holds `pg_trgm`, so names are unqualified on purpose. Not
+-- idempotent on purpose (see 0001).
+CREATE INDEX catalog_terms_term_pattern
+    ON catalog_terms (term text_pattern_ops);
+
+CREATE INDEX catalog_terms_term_trgm
+    ON catalog_terms USING gin (term gin_trgm_ops);

--- a/crates/coral-app/src/search/store/postgres/mod.rs
+++ b/crates/coral-app/src/search/store/postgres/mod.rs
@@ -24,7 +24,7 @@ use tokio::runtime::Handle;
 use crate::state::db::{DbError, connect_postgres_pool};
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 1;
+pub(crate) const SEARCH_POSTGRES_SCHEMA_VERSION: i32 = 2;
 
 struct SearchPostgresMigration {
     version: i32,
@@ -36,10 +36,16 @@ const REGISTRY_BOOTSTRAP_SQL: &str = include_str!("migrations/0001_search_regist
 /// Per-Workspace schema stream, versioned in the registry ledger. Each step
 /// runs in one transaction with its ledger bump, so a partial failure leaves
 /// the schema at its recorded version and the step is never replayed.
-const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[SearchPostgresMigration {
-    version: 1,
-    sql: include_str!("migrations/0001_catalog_documents.sql"),
-}];
+const WORKSPACE_MIGRATIONS: &[SearchPostgresMigration] = &[
+    SearchPostgresMigration {
+        version: 1,
+        sql: include_str!("migrations/0001_catalog_documents.sql"),
+    },
+    SearchPostgresMigration {
+        version: 2,
+        sql: include_str!("migrations/0002_catalog_terms_lookup_indexes.sql"),
+    },
+];
 
 const SEARCH_POOL_MAX_CONNECTIONS: u32 = 4;
 /// Serializes registry bootstrap across processes; per-Workspace work locks

--- a/crates/coral-app/src/search/store/postgres/tests.rs
+++ b/crates/coral-app/src/search/store/postgres/tests.rs
@@ -561,6 +561,52 @@ async fn common_word_queries_still_retrieve_against_postgres() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run spelling rescue against Postgres"]
+async fn a_spelling_the_corpus_lacks_is_rescued_by_a_similar_lexeme_against_postgres() {
+    let Some(storage) = open_storage().await else {
+        return;
+    };
+    let workspace = unique_workspace("fuzzy");
+
+    let storage_for_test = storage.clone();
+    let workspace_for_test = workspace.clone();
+    blocking(move || {
+        let store = storage_for_test
+            .open_workspace(&workspace_for_test)
+            .expect("open");
+        let catalog = store.catalog();
+        catalog
+            .refresh_projection(&rescue_snapshot())
+            .expect("refresh");
+
+        // The fixture spells `organization`; `organisation` matches no lexeme
+        // exactly or by prefix, and its closest lexeme is the one it meant.
+        let rescued = catalog
+            .search(
+                &["organisation".to_string()],
+                10,
+                CatalogDocumentClass::Entries,
+            )
+            .expect("search")
+            .hits;
+        assert_eq!(
+            rescued.first().map(|hit| hit.doc_id.as_str()),
+            Some("catalog:table:github.organization_members"),
+            "the similar lexeme must reach the table the spelling missed"
+        );
+        // A word nothing resembles still finds nothing.
+        let nothing = catalog
+            .search(&["zzqxv".to_string()], 10, CatalogDocumentClass::Entries)
+            .expect("search")
+            .hits;
+        assert!(nothing.is_empty());
+    })
+    .await;
+
+    delete_workspaces(&storage, &[workspace]).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run match semantics against Postgres"]
 async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     let Some(storage) = open_storage().await else {
@@ -579,6 +625,60 @@ async fn match_semantics_follow_the_benchmark_strata_against_postgres() {
     .await;
 
     delete_workspaces(&storage, &[workspace]).await;
+}
+
+/// Forty filler tables plus two named tables, so that a rescued word that
+/// reaches one document stays under the 5 % candidate cap as it would in a
+/// real corpus.
+fn rescue_snapshot() -> crate::search::catalog::index::CatalogIndexSnapshot {
+    use crate::search::catalog::index::{
+        CatalogIndexDocument, CatalogIndexDocumentKind, CatalogIndexSnapshot,
+    };
+    let table = |doc_id: &str, source: &str, surface: &str, title: &str, description: &str| {
+        CatalogIndexDocument {
+            doc_id: doc_id.to_string(),
+            doc_kind: CatalogIndexDocumentKind::CatalogTable,
+            source_name: source.to_string(),
+            catalog_name: None,
+            surface_kind: "table".to_string(),
+            surface_name: surface.to_string(),
+            field_name: String::new(),
+            field_role: String::new(),
+            qualified_name: format!("{source}.{surface}"),
+            title: title.to_string(),
+            description: description.to_string(),
+            searchable_text: format!("{source} {surface}"),
+        }
+    };
+    let mut documents = (0..40)
+        .map(|index| {
+            table(
+                &format!("catalog:table:fixture.filler_{index:02}"),
+                "fixture",
+                &format!("filler_{index:02}"),
+                "filler",
+                "A filler table",
+            )
+        })
+        .collect::<Vec<_>>();
+    documents.push(table(
+        "catalog:table:linear.issue_labels",
+        "linear",
+        "issue_labels",
+        "issue labels",
+        "Labels attached to issues",
+    ));
+    documents.push(table(
+        "catalog:table:github.organization_members",
+        "github",
+        "organization_members",
+        "organization members",
+        "Members of an organization",
+    ));
+    CatalogIndexSnapshot {
+        fingerprint: "rescue-v1".to_string(),
+        documents,
+    }
 }
 
 async fn test_pool() -> sqlx::PgPool {


### PR DESCRIPTION
Benchmark branch (one of three: stem, fuzzy, both) for the word-form and spelling gap in Postgres catalog search. Stacked on #2259.

## Why

A typed query word that matches no lexeme exactly and prefixes none contributes nothing, and no dictionary of spellings is general enough for customers outside one domain: `organisation` misses `organization`, `colour` misses `color`, `isues` misses `issues`. The benchmark corpus is American-spelled and the recorded agent queries are too (0 of 402 use a British spelling), so the offline replay cannot measure this; the paid run on a customer-shaped corpus can.

## What

- **Migration `0002_catalog_terms_lookup_indexes.sql`** (schema version 2): a `text_pattern_ops` btree and a trigram GIN on `catalog_terms`, so the questions below are answered against the lexicon, never against the documents.
- **Rescue plumbing in the plan**: after the statistics lookup, typed words with no exact lexeme are probed for prefix presence in one statement; those that prefix nothing are candidates for rescue. Rescue words join `scoring_plan` with their own statistics, before the 5 % cap and the rarest-words fallback. Compact variants are never rescued; the typed word keeps its substring key.
- **Fuzzy rung**: for each such word, the up to three lexemes above pg_trgm's 0.3 similarity floor (`term % word`, ordered by `similarity`, through the trigram GIN on the lexicon), each added as a rescue word with its own document frequency. The floor is pinned in the query so a server setting cannot move it. Measured on the lexicon: `organisation`→`organization` 0.63, `colour`→`color` 0.44, `analyze`→`analyse` 0.45, `licence`→`license` 0.45, `centre`→`center` 0.40, `isues`→`issues` 0.63; the transposition `isseus` scores 0.27 and is not rescued.

## Validation

`make rust-checks` and `make postgres-tests` green (the Postgres suite includes `a_spelling_the_corpus_lacks_is_rescued_by_a_similar_lexeme_against_postgres`: `organisation` reaches `github.organization_members` on a 42-document fixture; `zzqxv` still finds nothing). Not replayed offline: the recorded traffic has no case for it to change.

Before benchmarking against an existing database: this branch's schema version 2 collides with the *old* version-2 ledger entry in the `duel` database. Drop the registry row and schema first so the boot creates it fresh:

```sql
DELETE FROM search_registry.workspaces; DROP SCHEMA search_ws_1 CASCADE;
```

https://claude.ai/code/session_01WeuXrBPjT8Q5nPTruS8xjX
