### PR TITLE
docs(xtask): mention packaging in release-macos-sign-notarize overview

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@
 //!   - `perf-check` runs command-level performance regression checks.
 //!   - `benchmark` runs developer benchmarks.
 //!   - `generate-schemas` refreshes checked-in generated JSON schemas.
-//!   - `release-macos-sign-notarize` signs and notarizes macOS release
+//!   - `release-macos-sign-notarize` signs, packages, and notarizes macOS release
 //!     artifacts.
 //!   - `release-desktop-macos-package` packages, signs, notarizes, and verifies
 //!     the prepared macOS desktop app.


### PR DESCRIPTION
Match the clap help text: sign, package, then notarize.